### PR TITLE
feat(wam): transitive_closure2 strict R+ contract parity

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -54,6 +54,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | ISO-PYTHON | ISO three-form (finish) | Python | S | — |
 | ISO-FSHARP | ISO three-form (finish) | F# | S | — |
 | KERN-FSHARP ⚡ | Finish F# native kernel acceleration | F# | L | gate+TC2 done (`FS-HYBRID-KERNEL-GATE-TC`); 5 kinds remain |
+| TC2-CONTRACT-PARITY ⚡ | Fleet-wide `transitive_closure2` strict R+ contract | multi | M | contract+oracle+handler align |
 | EMIT-ILASM | Lowered emitter | ILAsm | L | — |
 | EMIT-JVM | Lowered emitter | JVM | L | — |
 | EMIT-KOTLIN ✅ | Lowered emitter | Kotlin | M | done — flat facts/unify (`cursor/emit-kotlin-lowered-f421`) |
@@ -483,6 +484,19 @@ plumbing there.
 - **Remaining (5 kinds, optional acceleration):** `transitive_distance3`, `transitive_parent_distance4`, `transitive_step_parent_distance5`, `weighted_shortest_path3`, `astar_shortest_path4` — add to the allow-list only when a real handler exists (mustache *or* inline). Until then they must stay WAM.
 - **Tests:** `tests/core/test_wam_fsharp_kernel_gate_tc.pl`
 - **Acceptance (gate+TC2):** `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_kernel_gate_tc.pl` (dotnet build/run for native TC2 + five WAM-fallback kinds).
+
+---
+
+## Lever: Shared recursive-kernel contract parity
+
+### TC2-CONTRACT-PARITY: Fleet-wide `transitive_closure2` strict R+
+- **Lever:** Shared recursive-kernel contract parity  **Target:** multi  **Size:** M  **Depends on:** —
+- **Contract:** [`docs/design/WAM_TRANSITIVE_CLOSURE2_CONTRACT.md`](design/WAM_TRANSITIVE_CLOSURE2_CONTRACT.md) — path of ≥1 edges; Source only via self-loop/cycle; set semantics; bound succeeds once; stream ABI preserved; cross-target compare uses sorted sets.
+- **Oracle / fixtures:** `tests/fixtures/tc2_contract_oracle.pl` (finite BFS; not cyclic Prolog recursion).
+- **Handler align (R+):** F#/Haskell Mustache TC2 kernels, C inline handler, R `runtime.R.mustache`, LLVM stream + bound `Source==Target` via `@wam_tc2_rplus_reaches`. Rust/Scala/Go/Elixir already matched.
+- **Template organization:** Mustache kept for F#/Haskell TC2 (non-trivial); C/Rust/Scala/LLVM/Go stay inline to match surrounding target style (documented in the contract).
+- **Tests:** `tests/test_wam_tc2_contract_parity.pl` (+ F# gate suite for native dispatch/retry ABI).
+- **Acceptance:** `swipl -q -g run_tests -t halt tests/test_wam_tc2_contract_parity.pl` and `tests/core/test_wam_fsharp_kernel_gate_tc.pl`.
 
 ---
 

--- a/docs/design/WAM_TRANSITIVE_CLOSURE2_CONTRACT.md
+++ b/docs/design/WAM_TRANSITIVE_CLOSURE2_CONTRACT.md
@@ -1,0 +1,91 @@
+# Hybrid WAM — `transitive_closure2` contract (strict R+)
+
+Fleet-wide semantics for the shared recursive-kernel kind
+`transitive_closure2` (detector shape `tc(X,Y) :- edge(X,Y).` /
+`tc(X,Y) :- edge(X,Z), tc(Z,Y).`).
+
+This document is the authoritative contract. Target handlers (native /
+foreign) and their tests must agree with it. Enumeration **order** is
+non-semantic unless a target documents otherwise.
+
+## Relation
+
+Use **strict transitive closure R+** of the configured binary edge
+predicate:
+
+- A `Target` is a solution for `Source` iff there exists a path of
+  **one or more** edges from `Source` to `Target`.
+- `Source` is a solution when a **self-loop** or a **nonempty cycle**
+  returns to `Source`. It is **not** a solution merely because
+  traversal starts there (that would be reflexive R*).
+- Duplicate edges and multiple paths do not create duplicate solutions:
+  each reachable `Target` is emitted **exactly once** (set semantics).
+
+## Modes
+
+| Call | Contract |
+|---|---|
+| `tc(+Source, -Target)` | Stream every reachable Target exactly once; fail if the set is empty. |
+| `tc(+Source, +Target)` | Succeed **once** iff a ≥1-edge path exists; otherwise fail cleanly. |
+| Unbound / non-atom Source | Fail cleanly (no enumeration of all graph sources in this contract). |
+
+`tc/2` remains a **stream-valued relation** at the Prolog interface.
+Native kernels may collect a deterministic set internally, then stream
+through the target’s foreign multi-solution / retry mechanism
+(`FFIStreamRetry`, `finish_foreign_results`, `ForeignMulti`, …).
+
+## Continuations
+
+Bound calls and stream retries must preserve registers, bindings, trail,
+continuation PC, cut barrier, B0 stack, and choice points per the
+target’s existing foreign-stream ABI. Do not invent a parallel retry
+protocol for TC2.
+
+## Ordering policy
+
+- Cross-target comparisons use **normalized sorted sets**.
+- Each target should be deterministic for a fixed fact snapshot when
+  practical (stable BFS/DFS discovery). Do **not** add a sort solely for
+  cross-target string equality without documenting the cost.
+
+## What this is not
+
+| Mechanism | Why it is out of scope for this contract |
+|---|---|
+| Generic WAM recursive `tc/2` (`no_kernels(true)`) | Correctness path via clause recursion; on cyclic graphs it represents **path proofs** (may duplicate or not terminate). Use as an oracle only on **acyclic** fixtures after set-normalization. |
+| `reachableToRoot*` (F# LMDB/CSR) | Demand-pruning BFS over reverse/category_child edges; includes root. |
+| `category_ancestor` / `bidirectional_ancestor` | Depth/budget/heuristic-bound ancestor search, not R+ closure. |
+
+## Implementation style (per target)
+
+Inline versus Mustache is a target-local engineering choice:
+
+- Prefer Mustache for large handler bodies or substantial generated
+  fragments (Haskell/F# already do this for TC2).
+- Small composable fragments may stay inline (C/Rust/Scala/Go style).
+- Shared Mustache `{{match}}`/`{{case}}` libraries are appropriate when
+  multiple kernels reuse meaningful generation logic — not for trivial
+  one-liners.
+- Follow the surrounding target’s organization unless a move materially
+  improves readability; document reasons when introducing or
+  substantially reorganizing a kernel template.
+
+## Reference implementations (already R+)
+
+Rust (`collect_native_transitive_closure_nodes`), Scala
+(`emit_scala_kernel_handler` for `transitive_closure2`), Go, and Elixir
+discover nodes **only via outgoing edges** (visited/seen is not seeded
+with Source). Align other handlers to that pattern.
+
+## Fixtures / oracle
+
+See `tests/fixtures/tc2_contract_oracle.pl` (finite BFS oracle + fixture
+matrix) and `tests/test_wam_tc2_contract_parity.pl`.
+
+## History
+
+- 2026-07-16: Contract introduced (`TC2-CONTRACT-PARITY`). Discovery found
+  Rust/Scala/Go/Elixir already R+; Haskell/F#/C/R (and LLVM stream)
+  excluded Source unconditionally; LLVM bound distance fast-path treated
+  `Source==Target` as success with zero edges (R*-like) — out of TC2
+  stream scope but noted for LLVM follow-up.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -33,6 +33,7 @@
 #define WAM_META_DISJ_RIGHT -7
 #define WAM_META_ITE_THEN -8
 #define WAM_META_ITE_ELSE -9
+#define WAM_FOREIGN_STREAM_NEXT -10
 
 typedef struct WamState WamState;
 typedef bool (*WamForeignHandler)(WamState *state, const char *pred, int arity);
@@ -74,6 +75,12 @@ typedef struct {
     int ite_top;
     int arity;
     WamValue a_regs[32]; // Reduced from MAX_REGS to save memory (typical max arity)
+    /* Owned only when next_pc == WAM_FOREIGN_STREAM_NEXT. */
+    WamValue *foreign_results;
+    int foreign_result_count;
+    int foreign_result_index;
+    int foreign_result_reg;
+    int foreign_resume_pc;
 } ChoicePoint;
 
 typedef struct {
@@ -1007,6 +1014,7 @@ static inline void push_choice_point(WamState *state, int next_pc, int arity) {
         state->B_array = realloc(state->B_array, sizeof(ChoicePoint) * state->B_cap);
     }
     ChoicePoint *cp = &state->B_array[state->B];
+    memset(cp, 0, sizeof(ChoicePoint));
     cp->next_pc = next_pc;
     cp->cp = state->CP;
     cp->heap_size = state->H;
@@ -1045,6 +1053,9 @@ static inline void restore_choice_point(WamState *state, ChoicePoint *cp) {
 }
 static inline void pop_choice_point(WamState *state) {
     if (state->B > 0) {
+        ChoicePoint *cp = &state->B_array[state->B - 1];
+        free(cp->foreign_results);
+        cp->foreign_results = NULL;
         state->B--;
         if (state->B > 0) {
             state->HB = state->B_array[state->B - 1].heap_size;

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -6141,9 +6141,14 @@ bool wam_transitive_closure_handler(WamState *state, const char *pred, int arity
         return false;
     }
 
+    /* Strict R+ (docs/design/WAM_TRANSITIVE_CLOSURE2_CONTRACT.md):
+     * do NOT seed visited with start. Nodes enter visited only when
+     * discovered via an outgoing edge, so Source is a solution iff a
+     * self-loop or nonempty cycle reaches it. Inline C handler kept
+     * (small; matches surrounding wam_*_handler style). Single-solution
+     * ABI unchanged — first R+ hit only. */
     const char *visited[64];
     int visited_len = 0;
-    visited[visited_len++] = start;
     const char *result = NULL;
     if (!wam_transitive_closure_dfs(state, start, target, 0, visited, visited_len, &result)) {
         return false;

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -2583,6 +2583,8 @@ compile_step_wam_to_c(_Options, CCode) :-
                         recovered = wam_resume_disjunction(state);
                     } else if (next_pc == WAM_META_ITE_ELSE) {
                         recovered = wam_resume_if_then_else(state);
+                    } else if (next_pc == WAM_FOREIGN_STREAM_NEXT) {
+                        recovered = wam_resume_foreign_stream(state);
                     } else {
                         state->P = next_pc; // Explicitly jump to alternative
                         recovered = true;
@@ -3967,6 +3969,10 @@ void wam_state_init(WamState *state) {
 
 void wam_free_state(WamState *state) {
     wam_aggregate_clear_all(state);
+    for (int i = 0; i < state->B; i++) {
+        free(state->B_array[i].foreign_results);
+        state->B_array[i].foreign_results = NULL;
+    }
     for (int i = 0; i < state->atom_table_size; i++) {
         AtomEntry *e = state->atom_table[i];
         while (e) {
@@ -6094,36 +6100,100 @@ bool wam_bidirectional_ancestor_handler(WamState *state, const char *pred, int a
     return ok;
 }
 
-static bool wam_transitive_closure_dfs(WamState *state,
-                                       const char *start,
-                                       const char *target,
-                                       int depth,
-                                       const char **visited,
-                                       int visited_len,
-                                       const char **result_out) {
-    for (int i = 0; i < state->category_edge_count; i++) {
-        CategoryEdge *edge = &state->category_edges[i];
-        if (strcmp(edge->child, start) != 0) continue;
-        if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
-        if (!target || strcmp(edge->parent, target) == 0) {
-            *result_out = edge->parent;
-            return true;
+static bool wam_collect_transitive_closure(WamState *state,
+                                           const char *start,
+                                           WamValue **results_out,
+                                           int *result_count_out) {
+    int capacity = state->category_edge_count;
+    if (capacity <= 0 || capacity == INT_MAX) return false;
+
+    const char **visited = malloc(sizeof(const char *) * (size_t)capacity);
+    const char **queue = malloc(sizeof(const char *) * (size_t)(capacity + 1));
+    WamValue *results = malloc(sizeof(WamValue) * (size_t)capacity);
+    if (!visited || !queue || !results) {
+        free(visited);
+        free(queue);
+        free(results);
+        return false;
+    }
+
+    int visited_len = 0;
+    int head = 0;
+    int tail = 0;
+    int result_count = 0;
+    queue[tail++] = start;
+
+    while (head < tail) {
+        const char *node = queue[head++];
+        for (int i = 0; i < state->category_edge_count; i++) {
+            CategoryEdge *edge = &state->category_edges[i];
+            if (strcmp(edge->child, node) != 0) continue;
+            if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
+
+            /* Strict R+: nodes enter visited/results only after traversing
+             * an edge. Incremental insertion also suppresses duplicate
+             * facts and multiple paths before they reach the stream. */
+            visited[visited_len++] = edge->parent;
+            queue[tail++] = edge->parent;
+            results[result_count++] = val_atom(edge->parent);
         }
     }
 
-    if (depth >= 64 || visited_len >= 64) return false;
-
-    for (int i = 0; i < state->category_edge_count; i++) {
-        CategoryEdge *edge = &state->category_edges[i];
-        if (strcmp(edge->child, start) != 0) continue;
-        if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
-        visited[visited_len] = edge->parent;
-        if (wam_transitive_closure_dfs(state, edge->parent, target, depth + 1,
-                                       visited, visited_len + 1, result_out)) {
-            return true;
-        }
+    free(visited);
+    free(queue);
+    if (result_count == 0) {
+        free(results);
+        return false;
     }
+    *results_out = results;
+    *result_count_out = result_count;
+    return true;
+}
+
+static bool wam_bind_foreign_atom_stream(WamState *state,
+                                         int result_reg,
+                                         WamValue *results,
+                                         int result_count,
+                                         int resume_pc) {
+    WamValue first = results[0];
+    if (result_count > 1) {
+        push_choice_point(state, WAM_FOREIGN_STREAM_NEXT, result_reg + 1);
+        ChoicePoint *cp = &state->B_array[state->B - 1];
+        cp->foreign_results = results;
+        cp->foreign_result_count = result_count;
+        cp->foreign_result_index = 1;
+        cp->foreign_result_reg = result_reg;
+        cp->foreign_resume_pc = resume_pc;
+    } else {
+        free(results);
+    }
+
+    if (wam_unify(state, &state->A[result_reg], &first)) return true;
+    if (result_count > 1) pop_choice_point(state);
     return false;
+}
+
+static bool wam_resume_foreign_stream(WamState *state) {
+    if (state->B <= 0) return false;
+    ChoicePoint *cp = &state->B_array[state->B - 1];
+    if (cp->next_pc != WAM_FOREIGN_STREAM_NEXT ||
+        !cp->foreign_results ||
+        cp->foreign_result_index < 0 ||
+        cp->foreign_result_index >= cp->foreign_result_count) {
+        if (cp->next_pc == WAM_FOREIGN_STREAM_NEXT) pop_choice_point(state);
+        return false;
+    }
+
+    int index = cp->foreign_result_index++;
+    int result_reg = cp->foreign_result_reg;
+    int resume_pc = cp->foreign_resume_pc;
+    WamValue result = cp->foreign_results[index];
+    if (cp->foreign_result_index >= cp->foreign_result_count) {
+        pop_choice_point(state);
+    }
+    if (!wam_unify(state, &state->A[result_reg], &result)) return false;
+    state->P = resume_pc;
+    return true;
 }
 
 bool wam_transitive_closure_handler(WamState *state, const char *pred, int arity) {
@@ -6141,22 +6211,28 @@ bool wam_transitive_closure_handler(WamState *state, const char *pred, int arity
         return false;
     }
 
-    /* Strict R+ (docs/design/WAM_TRANSITIVE_CLOSURE2_CONTRACT.md):
-     * do NOT seed visited with start. Nodes enter visited only when
-     * discovered via an outgoing edge, so Source is a solution iff a
-     * self-loop or nonempty cycle reaches it. Inline C handler kept
-     * (small; matches surrounding wam_*_handler style). Single-solution
-     * ABI unchanged — first R+ hit only. */
-    const char *visited[64];
-    int visited_len = 0;
-    const char *result = NULL;
-    if (!wam_transitive_closure_dfs(state, start, target, 0, visited, visited_len, &result)) {
+    WamValue *results = NULL;
+    int result_count = 0;
+    if (!wam_collect_transitive_closure(state, start, &results, &result_count)) {
         return false;
     }
-    if (target) return true;
 
-    WamValue result_value = val_atom(result);
-    return wam_unify(state, &state->A[1], &result_value);
+    if (target) {
+        bool found = false;
+        for (int i = 0; i < result_count; i++) {
+            if (strcmp(results[i].data.atom, target) == 0) {
+                found = true;
+                break;
+            }
+        }
+        free(results);
+        return found;
+    }
+
+    /* The ordinary C choice-point stack owns remaining results. This keeps
+     * tc(+Source,-Target) stream-valued without a parallel retry protocol. */
+    return wam_bind_foreign_atom_stream(state, 1, results, result_count,
+                                        state->P + 1);
 }
 
 static bool wam_transitive_distance_bfs(WamState *state,

--- a/templates/targets/fsharp_wam/kernel_transitive_closure.fs.mustache
+++ b/templates/targets/fsharp_wam/kernel_transitive_closure.fs.mustache
@@ -1,25 +1,24 @@
 /// Native foreign acceleration for the shared transitive_closure2 pattern.
 /// Auto-generated from kernel detection. Edge predicate: {{edge_pred}}.
 ///
-/// This is NOT "F# transitive closure support from scratch":
-///   - Ordinary recursive tc/2 already works through the generic WAM
-///     (use no_kernels(true) for that correctness path).
-///   - Lookup-function style matches nativeKernel_category_ancestor so
-///     Eager / LMDB / CSR ILookupSource backends all work.
-///   - HashSet visited-set cycle protection mirrors reachableToRootVia,
-///     but semantics differ: we follow this kernel's configured edge_pred
-///     forward from Source, and Source itself is not a Target solution
-///     (reachableToRoot* walks reverse/category_child edges for demand
-///     pruning and includes the root).
+/// Contract: strict R+ (docs/design/WAM_TRANSITIVE_CLOSURE2_CONTRACT.md).
+/// A Target is emitted iff a path of ≥1 edges reaches it. Source is emitted
+/// only for a self-loop or a nonempty cycle back to Source — not merely
+/// because traversal starts there.
+///
+/// Organization: Mustache kept (non-trivial handler body; matches Haskell
+/// TC2 and F# category/bidirectional kernel templates). Lookup-function
+/// style matches nativeKernel_category_ancestor (ILookupSource / WcFfiFacts).
+/// HashSet visited tracks nodes discovered *via an edge* (Rust/Scala R+
+/// pattern) — do not seed with Source. This is intentionally distinct from
+/// reachableToRoot* (demand pruning; includes root; reverse/child edges).
 ///
 /// Returns interned Target atom ids; executeForeign streams them via
-/// the existing FFIStreamRetry choice-point machinery (stream-valued
-/// relation — not a deterministic Prolog interface).
+/// FFIStreamRetry (stream-valued relation at the Prolog interface).
 let nativeKernel_transitive_closure
     (edges: int -> int list)
     (source: int) : int list =
     let visited = System.Collections.Generic.HashSet<int>()
-    visited.Add(source) |> ignore
     let acc = System.Collections.Generic.List<int>()
     let mutable frontier = [source]
     while not (List.isEmpty frontier) do

--- a/templates/targets/haskell_wam/kernel_transitive_closure.hs.mustache
+++ b/templates/targets/haskell_wam/kernel_transitive_closure.hs.mustache
@@ -16,7 +16,14 @@ nativeKernel_transitive_closure edges source =
   where
     go [] _ acc = acc
     go (node:queue) visited acc =
-      let neighbors = edges node
-          newTargets = filter (\n -> not (IS.member n visited)) neighbors
-          visited' = foldr IS.insert visited newTargets
+      let (visited', newTargetsRev) =
+            foldl' discover (visited, []) (edges node)
+          newTargets = reverse newTargetsRev
       in go (queue ++ newTargets) visited' (acc ++ newTargets)
+
+    -- Update the seen set for each neighbor, rather than filtering the
+    -- whole adjacency list against the old set. This keeps only the first
+    -- occurrence of duplicate edges while preserving discovery order.
+    discover (seen, foundRev) target
+      | IS.member target seen = (seen, foundRev)
+      | otherwise = (IS.insert target seen, target : foundRev)

--- a/templates/targets/haskell_wam/kernel_transitive_closure.hs.mustache
+++ b/templates/targets/haskell_wam/kernel_transitive_closure.hs.mustache
@@ -1,17 +1,22 @@
--- | Native transitive closure for binary edge relations.
+-- | Native transitive closure for binary edge relations (strict R+).
 -- Auto-generated from kernel detection. Edge predicate: {{edge_pred}}.
--- Given a source node, returns all transitively reachable target nodes.
--- Atoms are interned at the FFI boundary so the traversal uses IntMap
--- and IntSet for O(log n) lookups without hashing.
+--
+-- Contract: docs/design/WAM_TRANSITIVE_CLOSURE2_CONTRACT.md
+-- Target is emitted iff a ≥1-edge path reaches it. Source is emitted only
+-- for a self-loop or nonempty cycle back to Source. Visited tracks nodes
+-- discovered via an outgoing edge (not seeded with Source) — same pattern
+-- as Rust/Scala/F#.
+--
+-- Organization: Mustache kept (non-trivial handler; F# TC2 mirrors this
+-- file). Atoms are interned at the FFI boundary so traversal uses IntMap
+-- / IntSet.
 nativeKernel_transitive_closure :: EdgeLookup -> Int -> [Int]
 nativeKernel_transitive_closure edges source =
   go [source] IS.empty []
   where
     go [] _ acc = acc
-    go (node:queue) visited acc
-      | IS.member node visited = go queue visited acc
-      | otherwise =
-          let visited' = IS.insert node visited
-              neighbors = edges node
-              newTargets = filter (\n -> not (IS.member n visited')) neighbors
-          in go (queue ++ newTargets) visited' (if node == source then acc else acc ++ [node])
+    go (node:queue) visited acc =
+      let neighbors = edges node
+          newTargets = filter (\n -> not (IS.member n visited)) neighbors
+          visited' = foldr IS.insert visited newTargets
+      in go (queue ++ newTargets) visited' (acc ++ newTargets)

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -4058,6 +4058,15 @@ tc_check_unbound:
 tc_run_bfs:
   %tc_start_id = call i64 @wam_get_reg_payload(%WamState* %vm, i32 0)
   %tc_target_id = call i64 @wam_get_reg_payload(%WamState* %vm, i32 1)
+  ; The per-kernel max is derived from edge-table endpoints, not every atom
+  ; interned by the module. Reject bound atoms outside that range before the
+  ; shared distance helper indexes visited[start].
+  %tc_start_in_range = icmp ule i64 %tc_start_id, %max_atom_id
+  %tc_target_in_range = icmp ule i64 %tc_target_id, %max_atom_id
+  %tc_ids_in_range = and i1 %tc_start_in_range, %tc_target_in_range
+  br i1 %tc_ids_in_range, label %tc_compare_ids, label %tc_bail
+
+tc_compare_ids:
   %tc_same = icmp eq i64 %tc_start_id, %tc_target_id
   br i1 %tc_same, label %tc_rplus_self, label %tc_dist
 
@@ -4100,7 +4109,10 @@ entry:
   call void @wam_arena_ensure()
   %arena_save = call i64 @wam_arena_mark()
   %vis_bytes = shl i64 %n, 2
-  %q_bytes = shl i64 %n, 3
+  ; One seed plus up to n edge-discovered atoms (including Source after a
+  ; cycle) can be resident over the traversal lifetime.
+  %q_slots = add i64 %n, 1
+  %q_bytes = shl i64 %q_slots, 3
   %vis_mem = call i8* @wam_arena_alloc(i64 %vis_bytes)
   %q_mem = call i8* @wam_arena_alloc(i64 %q_bytes)
   %visited = bitcast i8* %vis_mem to i32*
@@ -4197,7 +4209,8 @@ entry:
   call void @wam_arena_ensure()
   %arena_save = call i64 @wam_arena_mark()
   %vis_bytes = shl i64 %n, 2
-  %q_bytes = shl i64 %n, 3
+  %q_slots = add i64 %n, 1
+  %q_bytes = shl i64 %q_slots, 3
   %vis_mem = call i8* @wam_arena_alloc(i64 %vis_bytes)
   %q_mem = call i8* @wam_arena_alloc(i64 %q_bytes)
   %visited = bitcast i8* %vis_mem to i32*

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -4031,10 +4031,13 @@ define weak i1 @wam_ls2_kernel_impl(%WamState* %vm, i32 %instance) {
 }
 
 ; === M5.12: tc2 common runner helper ===
-; Boolean reachability: is there any path from start to target in the
-; %AtomFactPair graph? Calls @wam_bfs_atom_distance and discards the
-; distance — we only care about the success/failure return. No result
-; register is written (tc2 is arity 2: A1=start, A2=target).
+; Boolean reachability under strict R+ (docs/design/WAM_TRANSITIVE_CLOSURE2_CONTRACT.md):
+; succeed iff a path of ≥1 edges exists. When start != target, reuse
+; @wam_bfs_atom_distance (distance-0 fast-path is unreachable). When
+; start == target, that helper's R*-style self-hit would wrongly succeed
+; with zero edges — route through @wam_tc2_rplus_reaches instead.
+; Organization: kept inline in state.ll.mustache (matches surrounding
+; LLVM kernel helpers; not large enough to warrant a separate fragment).
 define i1 @wam_tc2_run(%WamState* %vm, %AtomFactPair* %table, i64 %len, i64 %max_atom_id) {
 entry:
   %tc_s_tag = call i32 @wam_get_reg_tag(%WamState* %vm, i32 0)
@@ -4055,6 +4058,17 @@ tc_check_unbound:
 tc_run_bfs:
   %tc_start_id = call i64 @wam_get_reg_payload(%WamState* %vm, i32 0)
   %tc_target_id = call i64 @wam_get_reg_payload(%WamState* %vm, i32 1)
+  %tc_same = icmp eq i64 %tc_start_id, %tc_target_id
+  br i1 %tc_same, label %tc_rplus_self, label %tc_dist
+
+tc_rplus_self:
+  ; Strict R+: Source==Target needs a self-loop or nonempty cycle.
+  %tc_self_ok = call i1 @wam_tc2_rplus_reaches(
+      i64 %tc_start_id, i64 %tc_target_id,
+      %AtomFactPair* %table, i64 %len, i64 %max_atom_id)
+  ret i1 %tc_self_ok
+
+tc_dist:
   %tc_dist_slot = alloca i64
   %tc_ok = call i1 @wam_bfs_atom_distance(
       i64 %tc_start_id, i64 %tc_target_id,
@@ -4075,10 +4089,99 @@ tc_bail:
   ret i1 false
 }
 
+; === M5.14b: Strict R+ reachability (no reflexive zero-edge hit) ===
+; BFS from %start; visited tracks nodes discovered via an outgoing edge
+; (not seeded with %start). Succeeds iff %target is discovered that way.
+define i1 @wam_tc2_rplus_reaches(
+    i64 %start, i64 %target,
+    %AtomFactPair* %table, i64 %len, i64 %max_atom_id) {
+entry:
+  %n = add i64 %max_atom_id, 1
+  call void @wam_arena_ensure()
+  %arena_save = call i64 @wam_arena_mark()
+  %vis_bytes = shl i64 %n, 2
+  %q_bytes = shl i64 %n, 3
+  %vis_mem = call i8* @wam_arena_alloc(i64 %vis_bytes)
+  %q_mem = call i8* @wam_arena_alloc(i64 %q_bytes)
+  %visited = bitcast i8* %vis_mem to i32*
+  %queue = bitcast i8* %q_mem to i64*
+  call void @llvm.memset.p0i8.i64(i8* %vis_mem, i8 0, i64 %vis_bytes, i1 false)
+  ; Queue starts at Source; do NOT mark Source visited (R+).
+  %q0 = getelementptr i64, i64* %queue, i64 0
+  store i64 %start, i64* %q0
+  br label %rp_loop
+
+rp_loop:
+  %head = phi i64 [0, %entry], [%head_next, %rp_scan_done]
+  %tail = phi i64 [1, %entry], [%tail_after, %rp_scan_done]
+  %more = icmp ult i64 %head, %tail
+  br i1 %more, label %rp_pop, label %rp_fail
+
+rp_pop:
+  %q_slot = getelementptr i64, i64* %queue, i64 %head
+  %node = load i64, i64* %q_slot
+  %head_next = add i64 %head, 1
+  br label %rp_scan
+
+rp_scan:
+  %si = phi i64 [0, %rp_pop], [%si_next, %rp_scan_cont]
+  %tail_cur = phi i64 [%tail, %rp_pop], [%tail_kept, %rp_scan_cont]
+  %si_cmp = icmp ult i64 %si, %len
+  br i1 %si_cmp, label %rp_scan_body, label %rp_scan_done
+
+rp_scan_body:
+  %pair_ptr = getelementptr %AtomFactPair, %AtomFactPair* %table, i64 %si
+  %from_ptr = getelementptr %AtomFactPair, %AtomFactPair* %pair_ptr, i32 0, i32 0
+  %to_ptr = getelementptr %AtomFactPair, %AtomFactPair* %pair_ptr, i32 0, i32 1
+  %from_id = load i64, i64* %from_ptr
+  %to_id = load i64, i64* %to_ptr
+  %from_match = icmp eq i64 %from_id, %node
+  br i1 %from_match, label %rp_check_to, label %rp_scan_cont
+
+rp_check_to:
+  %to_ok = icmp ult i64 %to_id, %n
+  br i1 %to_ok, label %rp_check_vis, label %rp_scan_cont
+
+rp_check_vis:
+  %vis_to_ptr = getelementptr i32, i32* %visited, i64 %to_id
+  %vis_to = load i32, i32* %vis_to_ptr
+  %already = icmp ne i32 %vis_to, 0
+  br i1 %already, label %rp_scan_cont, label %rp_hit_or_enq
+
+rp_hit_or_enq:
+  %is_tgt = icmp eq i64 %to_id, %target
+  br i1 %is_tgt, label %rp_success, label %rp_enqueue
+
+rp_enqueue:
+  store i32 1, i32* %vis_to_ptr
+  %q_push = getelementptr i64, i64* %queue, i64 %tail_cur
+  store i64 %to_id, i64* %q_push
+  %tail_inc = add i64 %tail_cur, 1
+  br label %rp_scan_cont
+
+rp_scan_cont:
+  %tail_kept = phi i64 [%tail_cur, %rp_scan_body], [%tail_cur, %rp_check_to], [%tail_cur, %rp_check_vis], [%tail_inc, %rp_enqueue]
+  %si_next = add i64 %si, 1
+  br label %rp_scan
+
+rp_scan_done:
+  %tail_after = phi i64 [%tail_cur, %rp_scan]
+  br label %rp_loop
+
+rp_success:
+  call void @wam_arena_rewind(i64 %arena_save)
+  ret i1 true
+
+rp_fail:
+  call void @wam_arena_rewind(i64 %arena_save)
+  ret i1 false
+}
+
 ; === M5.14: Stream-mode tc2 (enumerate all reachable nodes) ===
-; Runs BFS from A1, collects all reachable nodes (excluding start) into
-; a %Value array, pushes a foreign choice point, and yields the first
-; result. On backtrack, the iterator yields subsequent reachable nodes.
+; Strict R+ BFS from A1: collect every node discovered via an outgoing
+; edge (Source is included only for a self-loop or nonempty cycle).
+; Pushes a foreign choice point and yields the first result. On
+; backtrack, the iterator yields subsequent reachable nodes.
 ;
 ; Returns false if no reachable nodes exist (start is isolated).
 ; The result array is malloc'd (not arena) because it must outlive this
@@ -4109,9 +4212,8 @@ entry:
   ; Zero-init visited[].
   call void @llvm.memset.p0i8.i64(i8* %vis_mem, i8 0, i64 %vis_bytes, i1 false)
 
-  ; Seed BFS with start.
-  %vis_start = getelementptr i32, i32* %visited, i64 %start_id
-  store i32 1, i32* %vis_start
+  ; Seed queue with start; do NOT mark start visited (strict R+).
+  ; Nodes enter visited/results only when discovered via an edge.
   %q0 = getelementptr i64, i64* %queue, i64 0
   store i64 %start_id, i64* %q0
   br label %bfs_loop

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -2337,10 +2337,12 @@ WamRuntime$transitive_closure2 <- function(program, state, key, edge_pred,
   snap_build <- state$build_stack
 
   edge_atom_id <- WamRuntime$intern(table, edge_pred)
+  # Strict R+ (docs/design/WAM_TRANSITIVE_CLOSURE2_CONTRACT.md): visited
+  # tracks nodes discovered via an outgoing edge — do not seed with Source.
+  # Source appears in `reached` only for a self-loop or nonempty cycle.
   visited <- new.env(parent = emptyenv())
   queue   <- list(src_v)
   reached <- list()
-  assign(as.character(src_v$id), TRUE, envir = visited)
 
   while (length(queue) > 0L) {
     cur <- queue[[1L]]

--- a/tests/core/test_wam_fsharp_kernel_gate_tc.pl
+++ b/tests/core/test_wam_fsharp_kernel_gate_tc.pl
@@ -338,11 +338,12 @@ let main _argv =
     assertTrue \"non-tail foreign retry resumes its continuation\"
         (directCallRetryReturnsToCaller ctx)
 
+    // Graph a->b->c->d + c->a. Strict R+: Source is reachable via the cycle.
     let fromA = collectTargets ctx \"a\" None |> List.sort
-    assertTrue \"direct+multi-hop from a\" (fromA = [\"b\"; \"c\"; \"d\"])
+    assertTrue \"R+ from a includes cycle-back Source\" (fromA = [\"a\"; \"b\"; \"c\"; \"d\"])
 
     let fromC = collectTargets ctx \"c\" None |> List.sort
-    assertTrue \"cycle-safe from c\" (fromC = [\"a\"; \"b\"; \"d\"])
+    assertTrue \"R+ cycle-safe from c includes Source\" (fromC = [\"a\"; \"b\"; \"c\"; \"d\"])
 
     let fromD = collectTargets ctx \"d\" None
     assertTrue \"sink d has no targets\" (fromD = [])
@@ -351,6 +352,8 @@ let main _argv =
     assertTrue \"bound Target c succeeds\" (boundOk = [\"c\"])
     assertTrue \"bound Target preserves trail invariant\"
         (boundCallTrailIsConsistent ctx \"a\" \"c\")
+    let boundSrc = collectTargets ctx \"a\" (Some \"a\")
+    assertTrue \"bound Source succeeds via nonempty cycle\" (boundSrc = [\"a\"])
 
     let boundNo = collectTargets ctx \"a\" (Some \"z\")
     assertTrue \"bound unreachable z fails\" (boundNo = [])
@@ -458,7 +461,7 @@ test(native_tc2_codegen_and_build,
     run_dotnet_run(Dir, RunExit, RunOut),
     assertion(RunExit =:= 0),
     assertion(sub_string(RunOut, _, _, _, "RESULT ")),
-    (   sub_string(RunOut, _, _, _, "RESULT 10/10")
+    (   sub_string(RunOut, _, _, _, "RESULT 11/11")
     ->  true
     ;   format(user_error, 'native_tc2 run:~n~w~n', [RunOut]), fail
     ),

--- a/tests/core/test_wam_llvm_tc2_execution.pl
+++ b/tests/core/test_wam_llvm_tc2_execution.pl
@@ -8,6 +8,8 @@
 %   1. Reachable pair → exit 1 (true)
 %   2. Unreachable pair → exit 0 (false)
 %   3. Acyclic Source==Target → exit 0 (strict R+; no zero-edge hit)
+%   4. Self-loop Source==Target → exit 1 (strict R+)
+%   5. Nonempty cycle Source==Target → exit 1 (strict R+)
 
 :- use_module('../../src/unifyweaver/targets/wam_llvm_target',
     [write_wam_llvm_project/3,
@@ -20,6 +22,9 @@
 tc_edge(a, b).
 tc_edge(b, c).
 tc_edge(c, d).
+tc_edge(e, e).
+tc_edge(f, g).
+tc_edge(g, f).
 
 :- dynamic can_reach/2.
 can_reach(_, _) :- fail.
@@ -87,7 +92,7 @@ run_tc2_case(Label, StartAtom, TargetAtom, Expected) :-
         LLPath),
     read_file_to_string(LLPath, Src, []),
     extract_atom_id_for(Src, 'tc2_inst_can_reach_0_edges',
-        [a-b, b-c, c-d], AtomIds),
+        [a-b, b-c, c-d, e-e, f-g, g-f], AtomIds),
     get_dict(StartAtom, AtomIds, StartId),
     get_dict(TargetAtom, AtomIds, TargetId),
     extract_instr_count(Src, can_reach, IC),
@@ -149,7 +154,9 @@ test_tc2_executes :-
     ( process_which('clang'), process_which('llc')
     -> run_tc2_case('reachable a->d',    a, d, 1),
        run_tc2_case('direct edge a->b',  a, b, 1),
-       run_tc2_case('acyclic self a->a', a, a, 0)
+       run_tc2_case('acyclic self a->a', a, a, 0),
+       run_tc2_case('self-loop e->e',    e, e, 1),
+       run_tc2_case('cycle f->f',        f, f, 1)
     ;  format('  SKIP: clang or llc not found~n')
     ).
 
@@ -162,7 +169,10 @@ process_which(Tool) :-
         ), _, fail).
 
 test_all :-
-    catch(test_tc2_executes, E,
-        format('  ERROR: ~w~n', [E])).
+    ( catch(test_tc2_executes, E,
+          ( format(user_error, '  ERROR: ~w~n', [E]), fail ))
+    -> true
+    ;  halt(1)
+    ).
 
 :- initialization(test_all, main).

--- a/tests/core/test_wam_llvm_tc2_execution.pl
+++ b/tests/core/test_wam_llvm_tc2_execution.pl
@@ -7,7 +7,7 @@
 % Tests:
 %   1. Reachable pair → exit 1 (true)
 %   2. Unreachable pair → exit 0 (false)
-%   3. Self-reachability → exit 1 (start == target fast path)
+%   3. Acyclic Source==Target → exit 0 (strict R+; no zero-edge hit)
 
 :- use_module('../../src/unifyweaver/targets/wam_llvm_target',
     [write_wam_llvm_project/3,
@@ -149,7 +149,7 @@ test_tc2_executes :-
     ( process_which('clang'), process_which('llc')
     -> run_tc2_case('reachable a->d',    a, d, 1),
        run_tc2_case('direct edge a->b',  a, b, 1),
-       run_tc2_case('self a->a',         a, a, 1)
+       run_tc2_case('acyclic self a->a', a, a, 0)
     ;  format('  SKIP: clang or llc not found~n')
     ).
 

--- a/tests/core/test_wam_llvm_tc2_stream_execution.pl
+++ b/tests/core/test_wam_llvm_tc2_stream_execution.pl
@@ -5,12 +5,14 @@
 % via BFS and yields them one at a time through the multi-result
 % foreign dispatch iterator.
 %
-% Graph: a -> b -> c -> d
+% Graphs: a -> b -> c -> d, plus e -> f -> g -> e with an exit g -> h
+% and a duplicate e -> f edge.
 %
 % Tests:
 %   1. Stream from 'a' yields 3 reachable nodes (b, c, d).
 %   2. Stream from 'c' yields 1 reachable node (d).
 %   3. Stream from 'd' yields 0 (isolated sink → fail).
+%   4. Stream from cyclic 'e' yields f, g, e, h exactly once each.
 
 :- use_module('../../src/unifyweaver/targets/wam_llvm_target',
     [write_wam_llvm_project/3,
@@ -23,6 +25,11 @@
 tc_edge(a, b).
 tc_edge(b, c).
 tc_edge(c, d).
+tc_edge(e, f).
+tc_edge(e, f).
+tc_edge(f, g).
+tc_edge(g, e).
+tc_edge(g, h).
 
 :- dynamic can_reach/2.
 can_reach(_, _) :- fail.
@@ -95,7 +102,7 @@ run_stream_case(Label, StartAtom, Expected) :-
         LLPath),
     read_file_to_string(LLPath, Src, []),
     extract_atom_id_for(Src, 'tc2_inst_can_reach_0_edges',
-        [a-b, b-c, c-d], AtomIds),
+        [a-b, b-c, c-d, e-f, e-f, f-g, g-e, g-h], AtomIds),
     get_dict(StartAtom, AtomIds, StartId),
     extract_instr_count(Src, can_reach, IC),
     extract_label_count(Src, can_reach, LC),
@@ -175,7 +182,8 @@ test_tc2_stream :-
     ( process_which('clang'), process_which('llc')
     -> run_stream_case('all from a', a, 3),
        run_stream_case('one from c', c, 1),
-       run_stream_case('none from d', d, 0)
+       run_stream_case('none from d', d, 0),
+       run_stream_case('cycle from e includes source once', e, 4)
     ;  format('  SKIP: clang or llc not found~n')
     ).
 
@@ -188,7 +196,10 @@ process_which(Tool) :-
         ), _, fail).
 
 test_all :-
-    catch(test_tc2_stream, E,
-        format('  ERROR: ~w~n', [E])).
+    ( catch(test_tc2_stream, E,
+          ( format(user_error, '  ERROR: ~w~n', [E]), fail ))
+    -> true
+    ;  halt(1)
+    ).
 
 :- initialization(test_all, main).

--- a/tests/fixtures/tc2_contract_oracle.pl
+++ b/tests/fixtures/tc2_contract_oracle.pl
@@ -53,7 +53,7 @@ tc2_bfs(Edges, [Node|Queue], Seen, Acc0, Acc) :-
 
 %% tc2_fixture(?Name, -Edges, -QuerySources)
 tc2_fixture(chain, [a-b, b-c, c-d], [a, c, d, z]).
-tc2_fixture(branch, [a-b, a-c, b-d, c-d], [a, d]).
+tc2_fixture(branch, [a-b, a-c, b-d, c-e], [a, d, e]).
 tc2_fixture(diamond, [a-b, a-c, b-d, c-d], [a, d]).
 tc2_fixture(dup_edges, [a-b, a-b, b-c, b-c], [a, b]).
 tc2_fixture(sink_disconnected, [a-b, c-d], [a, b, c, z]).
@@ -62,6 +62,35 @@ tc2_fixture(two_cycle, [a-b, b-a], [a, b]).
 tc2_fixture(long_cycle_exit, [a-b, b-c, c-a, c-d], [a, c, d]).
 
 %% tc2_fixture_expected(+Name, +Source, -SortedTargets)
-tc2_fixture_expected(Name, Source, Sorted) :-
-    tc2_fixture(Name, Edges, _),
-    tc2_oracle_reachable(Edges, Source, Sorted).
+%  Independent expected results for every declared fixture query. Keep these
+%  literal rather than deriving them through tc2_oracle_reachable/3: the
+%  fixture matrix is intended to detect regressions in the oracle itself.
+tc2_fixture_expected(chain, a, [b, c, d]).
+tc2_fixture_expected(chain, c, [d]).
+tc2_fixture_expected(chain, d, []).
+tc2_fixture_expected(chain, z, []).
+
+tc2_fixture_expected(branch, a, [b, c, d, e]).
+tc2_fixture_expected(branch, d, []).
+tc2_fixture_expected(branch, e, []).
+
+tc2_fixture_expected(diamond, a, [b, c, d]).
+tc2_fixture_expected(diamond, d, []).
+
+tc2_fixture_expected(dup_edges, a, [b, c]).
+tc2_fixture_expected(dup_edges, b, [c]).
+
+tc2_fixture_expected(sink_disconnected, a, [b]).
+tc2_fixture_expected(sink_disconnected, b, []).
+tc2_fixture_expected(sink_disconnected, c, [d]).
+tc2_fixture_expected(sink_disconnected, z, []).
+
+tc2_fixture_expected(self_loop, a, [a, b]).
+tc2_fixture_expected(self_loop, b, []).
+
+tc2_fixture_expected(two_cycle, a, [a, b]).
+tc2_fixture_expected(two_cycle, b, [a, b]).
+
+tc2_fixture_expected(long_cycle_exit, a, [a, b, c, d]).
+tc2_fixture_expected(long_cycle_exit, c, [a, b, c, d]).
+tc2_fixture_expected(long_cycle_exit, d, []).

--- a/tests/fixtures/tc2_contract_oracle.pl
+++ b/tests/fixtures/tc2_contract_oracle.pl
@@ -1,0 +1,67 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% tc2_contract_oracle.pl — language-neutral finite oracle + fixture matrix
+% for the hybrid WAM transitive_closure2 contract (strict R+).
+%
+% See docs/design/WAM_TRANSITIVE_CLOSURE2_CONTRACT.md.
+%
+% The oracle is a finite BFS over an explicit edge list. It must NOT be
+% implemented by running cyclic Prolog recursion (path proofs / non-termination).
+
+:- module(tc2_contract_oracle, [
+    tc2_oracle_reachable/3,     % +Edges, +Source, -SortedTargets
+    tc2_oracle_reaches/3,       % +Edges, +Source, +Target
+    tc2_fixture/3,              % ?Name, -Edges, -Sources
+    tc2_fixture_expected/3      % +Name, +Source, -SortedTargets
+]).
+
+:- use_module(library(lists)).
+:- use_module(library(apply)).
+:- use_module(library(ordsets)).
+
+%% tc2_oracle_reachable(+Edges, +Source, -SortedTargets) is det.
+%  Edges: list of From-To. Strict R+: Target appears iff a ≥1-edge path
+%  exists. Source appears iff self-loop or nonempty cycle back.
+tc2_oracle_reachable(Edges, Source, Sorted) :-
+    tc2_bfs(Edges, [Source], [], [], Acc),
+    sort(Acc, Sorted).
+
+%% tc2_oracle_reaches(+Edges, +Source, +Target) is semidet.
+tc2_oracle_reaches(Edges, Source, Target) :-
+    tc2_oracle_reachable(Edges, Source, Sorted),
+    memberchk(Target, Sorted).
+
+%% BFS: queue starts at Source; Seen tracks nodes discovered *via an edge*.
+tc2_bfs(_, [], _Seen, Acc, Acc) :- !.
+tc2_bfs(Edges, [Node|Queue], Seen, Acc0, Acc) :-
+    findall(Next,
+            ( member(Node-Next, Edges),
+              \+ memberchk(Next, Seen)
+            ),
+            News0),
+    % Preserve first-discovery order for determinism; unique within layer.
+    list_to_set(News0, News),
+    append(Seen, News, Seen1),
+    append(Acc0, News, Acc1),
+    append(Queue, News, Queue1),
+    tc2_bfs(Edges, Queue1, Seen1, Acc1, Acc).
+
+% ============================================================
+% Fixture matrix
+% ============================================================
+
+%% tc2_fixture(?Name, -Edges, -QuerySources)
+tc2_fixture(chain, [a-b, b-c, c-d], [a, c, d, z]).
+tc2_fixture(branch, [a-b, a-c, b-d, c-d], [a, d]).
+tc2_fixture(diamond, [a-b, a-c, b-d, c-d], [a, d]).
+tc2_fixture(dup_edges, [a-b, a-b, b-c, b-c], [a, b]).
+tc2_fixture(sink_disconnected, [a-b, c-d], [a, b, c, z]).
+tc2_fixture(self_loop, [a-a, a-b], [a, b]).
+tc2_fixture(two_cycle, [a-b, b-a], [a, b]).
+tc2_fixture(long_cycle_exit, [a-b, b-c, c-a, c-d], [a, c, d]).
+
+%% tc2_fixture_expected(+Name, +Source, -SortedTargets)
+tc2_fixture_expected(Name, Source, Sorted) :-
+    tc2_fixture(Name, Edges, _),
+    tc2_oracle_reachable(Edges, Source, Sorted).

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -247,6 +247,20 @@ test_transitive_closure_kernel_function :-
     ;   fail_test(Test, 'transitive_closure2 template rendering failed')
     ).
 
+test_transitive_closure_dedupes_neighbor_batch :-
+    Test = 'WAM-Haskell: transitive_closure2 dedupes duplicate edges in discovery order',
+    Kernel = recursive_kernel(transitive_closure2, closure/2, [edge_pred(edge/2)]),
+    (   wam_haskell_target:render_kernel_function('closure/2'-Kernel, Code),
+        sub_string(Code, _, _, _, "foldl' discover (visited, []) (edges node)"),
+        sub_string(Code, _, _, _, "newTargets = reverse newTargetsRev"),
+        sub_string(Code, _, _, _, "IS.member target seen"),
+        sub_string(Code, _, _, _, "IS.insert target seen, target : foundRev"),
+        \+ sub_string(Code, _, _, _, "newTargets = filter")
+    ->  pass(Test)
+    ;   fail_test(Test,
+            'neighbor discoveries are not deduped incrementally in first-seen order')
+    ).
+
 test_transitive_closure_execute_foreign :-
     Test = 'WAM-Haskell: transitive_closure2 executeForeign generated',
     Kernel = recursive_kernel(transitive_closure2, closure/2, [edge_pred(edge/2)]),
@@ -2565,6 +2579,7 @@ run_tests :-
     test_parameterized_render_kernel_function,
     test_render_kernel_function_cwd_independent,
     test_transitive_closure_kernel_function,
+    test_transitive_closure_dedupes_neighbor_batch,
     test_transitive_closure_execute_foreign,
     test_multi_kernel_execute_foreign,
     test_call_foreign_in_types,

--- a/tests/test_wam_tc2_contract_parity.pl
+++ b/tests/test_wam_tc2_contract_parity.pl
@@ -1,0 +1,755 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_wam_tc2_contract_parity.pl — fleet-wide transitive_closure2
+% contract (strict R+) parity suite.
+%
+% Contract: docs/design/WAM_TRANSITIVE_CLOSURE2_CONTRACT.md
+% Oracle:   tests/fixtures/tc2_contract_oracle.pl
+%
+% Layers:
+%   1. Oracle self-tests + hardcoded fixture expectations
+%   2. Structural R+ pattern checks (handlers / templates)
+%   3. Native dispatch proof (emit contains foreign/native TC2)
+%   4. Executable smoke where toolchains exist (dotnet / gcc / cargo)
+%   5. Acyclic native vs oracle set-normalized compare (F#)
+%   6. Pin: cyclic generic WAM recursion is not the oracle
+%
+% Usage (from repo root):
+%   swipl -q -g run_tests -t halt tests/test_wam_tc2_contract_parity.pl
+%
+% F# e2e also covered by tests/core/test_wam_fsharp_kernel_gate_tc.pl.
+
+:- use_module(library(plunit)).
+:- use_module(library(lists)).
+:- use_module(library(filesex)).
+:- use_module(library(readutil)).
+:- use_module(library(process)).
+:- use_module(library(debug), [assertion/1]).
+
+:- use_module('fixtures/tc2_contract_oracle', [
+    tc2_oracle_reachable/3,
+    tc2_oracle_reaches/3,
+    tc2_fixture/3,
+    tc2_fixture_expected/3
+]).
+
+:- use_module('../src/unifyweaver/targets/wam_fsharp_target',
+              [write_wam_fsharp_project/3]).
+:- use_module('../src/unifyweaver/targets/wam_c_target',
+              [write_wam_c_project/3]).
+:- use_module('../src/unifyweaver/targets/wam_rust_target',
+              [write_wam_rust_project/3,
+               compile_wam_runtime_to_rust/2]).
+:- use_module('../src/unifyweaver/core/recursive_kernel_detection',
+              [detect_recursive_kernel/4]).
+
+:- dynamic user:tc_edge/2.
+:- dynamic user:tc/2.
+:- dynamic user:tc_parent/2.
+:- dynamic user:tc_ancestor/2.
+
+dotnet_available :-
+    catch(
+        ( process_create(path(dotnet), ['--version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, _) ),
+        _, fail).
+
+gcc_available :-
+    catch(
+        ( process_create(path(gcc), ['--version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, _) ),
+        _, fail).
+
+cargo_available :-
+    catch(
+        ( process_create(path(cargo), ['--version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, _) ),
+        _, fail).
+
+tmp_dir(Tag, Dir) :-
+    get_time(T),
+    Stamp is round(T * 1000000),
+    format(atom(Dir), '/tmp/uw_tc2_~w_~w', [Tag, Stamp]),
+    catch(delete_directory_and_contents(Dir), _, true),
+    make_directory_path(Dir).
+
+read_file_string(Path, String) :-
+    read_file_to_string(Path, String, []).
+
+assert_tc_cycle_program :-
+    retractall(user:tc_edge(_, _)),
+    retractall(user:tc(_, _)),
+    assertz(user:tc_edge(a, b)),
+    assertz(user:tc_edge(b, c)),
+    assertz(user:tc_edge(c, d)),
+    assertz(user:tc_edge(c, a)),
+    assertz((user:tc(X, Y) :- tc_edge(X, Y))),
+    assertz((user:tc(X, Y) :- tc_edge(X, Z), tc(Z, Y))).
+
+assert_tc_chain_program :-
+    retractall(user:tc_edge(_, _)),
+    retractall(user:tc(_, _)),
+    assertz(user:tc_edge(a, b)),
+    assertz(user:tc_edge(b, c)),
+    assertz(user:tc_edge(c, d)),
+    assertz((user:tc(X, Y) :- tc_edge(X, Y))),
+    assertz((user:tc(X, Y) :- tc_edge(X, Z), tc(Z, Y))).
+
+assert_c_tc_program :-
+    retractall(user:tc_parent(_, _)),
+    retractall(user:tc_ancestor(_, _)),
+    assertz(user:tc_parent(a, b)),
+    assertz(user:tc_parent(b, c)),
+    assertz(user:tc_parent(c, d)),
+    assertz(user:tc_parent(c, a)),
+    assertz((user:tc_ancestor(X, Y) :- tc_parent(X, Y))),
+    assertz((user:tc_ancestor(X, Y) :- tc_parent(X, Z), tc_ancestor(Z, Y))).
+
+% ============================================================
+% 1. Oracle
+% ============================================================
+
+:- begin_tests(tc2_oracle).
+
+test(hardcoded_fixture_expectations) :-
+    tc2_fixture_expected(chain, a, [b, c, d]),
+    tc2_fixture_expected(chain, c, [d]),
+    tc2_fixture_expected(chain, d, []),
+    tc2_fixture_expected(chain, z, []),
+    tc2_fixture_expected(self_loop, a, [a, b]),
+    tc2_fixture_expected(self_loop, b, []),
+    tc2_fixture_expected(two_cycle, a, [a, b]),
+    tc2_fixture_expected(two_cycle, b, [a, b]),
+    tc2_fixture_expected(long_cycle_exit, a, [a, b, c, d]),
+    tc2_fixture_expected(long_cycle_exit, c, [a, b, c, d]),
+    tc2_fixture_expected(long_cycle_exit, d, []),
+    tc2_fixture_expected(dup_edges, a, [b, c]),
+    tc2_fixture_expected(sink_disconnected, a, [b]),
+    tc2_fixture_expected(sink_disconnected, z, []).
+
+test(oracle_matches_all_fixture_sources) :-
+    forall(
+        ( tc2_fixture(Name, Edges, Sources),
+          member(Src, Sources)
+        ),
+        ( tc2_oracle_reachable(Edges, Src, Sorted),
+          tc2_fixture_expected(Name, Src, Sorted)
+        )
+    ).
+
+test(bound_mode_follows_set_membership) :-
+    tc2_oracle_reaches([a-b, b-a], a, a),
+    tc2_oracle_reaches([a-b, b-a], a, b),
+    \+ tc2_oracle_reaches([a-b, b-c], a, a),
+    \+ tc2_oracle_reaches([a-b], a, z).
+
+test(acyclic_source_not_reflexive) :-
+    tc2_oracle_reachable([a-b, b-c], a, Sorted),
+    \+ memberchk(a, Sorted).
+
+:- end_tests(tc2_oracle).
+
+% ============================================================
+% 2. Structural R+ pattern checks
+% ============================================================
+
+:- begin_tests(tc2_structural_rplus).
+
+test(rust_handler_does_not_seed_seen_with_source) :-
+    compile_wam_runtime_to_rust([], Code),
+    atom_string(Code, S),
+    assertion(sub_string(S, _, _, _, "collect_native_transitive_closure_nodes")),
+    assertion(sub_string(S, _, _, _, "let mut seen: HashSet<String> = HashSet::new();")),
+    assertion(sub_string(S, _, _, _, "let mut stack: Vec<String> = vec![start.to_string()];")),
+    assertion(sub_string(S, _, _, _, "if seen.insert(next.clone())")),
+    assertion(\+ sub_string(S, _, _, _, "seen.insert(start")).
+
+test(fsharp_mustache_rplus_visited) :-
+    read_file_string(
+        'templates/targets/fsharp_wam/kernel_transitive_closure.fs.mustache', S),
+    assertion(sub_string(S, _, _, _, "strict R+")),
+    assertion(sub_string(S, _, _, _, "let visited = System.Collections.Generic.HashSet<int>()")),
+    assertion(sub_string(S, _, _, _, "let mutable frontier = [source]")),
+    assertion(sub_string(S, _, _, _, "if visited.Add(n) then")),
+    assertion(\+ sub_string(S, _, _, _, "visited.Add(source)")).
+
+test(haskell_mustache_rplus_visited) :-
+    read_file_string(
+        'templates/targets/haskell_wam/kernel_transitive_closure.hs.mustache', S),
+    assertion(sub_string(S, _, _, _, "strict R+")),
+    assertion(sub_string(S, _, _, _, "go [source] IS.empty []")),
+    assertion(sub_string(S, _, _, _, "newTargets = filter")),
+    assertion(\+ sub_string(S, _, _, _, "IS.insert source")).
+
+test(c_handler_does_not_seed_visited_with_start) :-
+    read_file_string('src/unifyweaver/targets/wam_c_target.pl', S),
+    assertion(sub_string(S, _, _, _, "wam_transitive_closure_handler")),
+    assertion(sub_string(S, _, _, _, "Strict R+")),
+    assertion(sub_string(S, _, _, _, "do NOT seed visited with start")),
+    assertion(sub_string(S, _, _, _, "int visited_len = 0;")),
+    assertion(\+ sub_string(S, _, _, _, "visited[0] = start")).
+
+test(r_runtime_does_not_seed_visited_with_source) :-
+    read_file_string('templates/targets/r_wam/runtime.R.mustache', S),
+    assertion(sub_string(S, _, _, _, "WamRuntime$transitive_closure2")),
+    assertion(sub_string(S, _, _, _, "Strict R+")),
+    assertion(sub_string(S, _, _, _, "do not seed with Source")),
+    assertion(sub_string(S, _, _, _, "visited <- new.env(parent = emptyenv())")),
+    assertion(sub_string(S, _, _, _, "queue   <- list(src_v)")).
+
+test(scala_handler_rplus_visited) :-
+    read_file_string('src/unifyweaver/targets/wam_scala_target.pl', S),
+    assertion(sub_string(S, _, _, _, "recursive_kernel(transitive_closure2")),
+    assertion(sub_string(S, _, _, _,
+        "val visited = scala.collection.mutable.LinkedHashSet[WamTerm]()")),
+    assertion(sub_string(S, _, _, _,
+        "val queue = scala.collection.mutable.Queue[WamTerm](source)")),
+    assertion(sub_string(S, _, _, _, "visited += nb")),
+    assertion(\+ sub_string(S, _, _, _,
+        "LinkedHashSet[WamTerm](source)")).
+
+test(llvm_stream_and_bound_self_are_rplus) :-
+    read_file_string('templates/targets/llvm_wam/state.ll.mustache', S),
+    assertion(sub_string(S, _, _, _, "wam_tc2_stream_run")),
+    assertion(sub_string(S, _, _, _, "do NOT mark start visited")),
+    assertion(sub_string(S, _, _, _, "wam_tc2_rplus_reaches")),
+    assertion(sub_string(S, _, _, _, "tc_rplus_self")),
+    assertion(sub_string(S, _, _, _,
+        "Strict R+: Source==Target needs a self-loop")).
+
+test(go_handler_seeds_queue_from_neighbors) :-
+    read_file_string('src/unifyweaver/targets/wam_go_target.pl', S),
+    assertion(sub_string(S, _, _, _, "collectNativeTransitiveClosureResults")),
+    assertion(sub_string(S, _, _, _,
+        "queue := append([]string(nil), adjacency[source]...)")).
+
+:- end_tests(tc2_structural_rplus).
+
+% ============================================================
+% 3. Native dispatch proof
+% ============================================================
+
+:- begin_tests(tc2_native_dispatch).
+
+test(detector_fires_transitive_closure2) :-
+    assert_tc_cycle_program,
+    findall(tc(X, Y)-Body, clause(user:tc(X, Y), Body), Clauses),
+    detect_recursive_kernel(tc, 2, Clauses, Kernel),
+    assertion(Kernel = recursive_kernel(transitive_closure2, _, _)).
+
+test(fsharp_native_dispatch_emitted) :-
+    assert_tc_cycle_program,
+    tmp_dir(fs_dispatch, Dir),
+    write_wam_fsharp_project(
+        [user:tc/2, user:tc_edge/2],
+        [module_name('uw_tc2_dispatch')],
+        Dir),
+    directory_file_path(Dir, 'WamRuntime.fs', RT),
+    read_file_string(RT, RTS),
+    assertion(sub_string(RTS, _, _, _, "nativeKernel_transitive_closure")),
+    assertion(sub_string(RTS, _, _, _, "| \"tc/2\" ->")),
+    assertion(sub_string(RTS, _, _, _, "FFIStreamRetry")),
+    !.
+
+test(rust_foreign_kind_registered_for_tc2) :-
+    assert_tc_cycle_program,
+    tmp_dir(rs_dispatch, Dir),
+    write_wam_rust_project(
+        [user:tc/2, user:tc_edge/2],
+        [module_name('uw_tc2_rs_dispatch'), foreign_lowering(true)],
+        Dir),
+    directory_file_path(Dir, 'src/lib.rs', Lib),
+    read_file_string(Lib, S),
+    assertion(sub_string(S, _, _, _, "transitive_closure2")),
+    assertion(sub_string(S, _, _, _, "register_foreign_native_kind(\"tc/2\"")),
+    directory_file_path(Dir, 'src/state.rs', State),
+    read_file_string(State, SS),
+    assertion(sub_string(SS, _, _, _, "collect_native_transitive_closure_nodes")),
+    !.
+
+test(c_registers_transitive_closure_handler) :-
+    assert_c_tc_program,
+    tmp_dir(c_dispatch, Dir),
+    write_wam_c_project([user:tc_ancestor/2], [], Dir),
+    directory_file_path(Dir, 'lib.c', Lib),
+    read_file_string(Lib, LibS),
+    assertion(sub_string(LibS, _, _, _,
+        "wam_register_transitive_closure_kernel(state, \"tc_ancestor/2\")")),
+    directory_file_path(Dir, 'wam_runtime.c', RT),
+    read_file_string(RT, S),
+    assertion(sub_string(S, _, _, _, "wam_transitive_closure_handler")),
+    assertion(sub_string(S, _, _, _, "do NOT seed visited with start")),
+    !.
+
+:- end_tests(tc2_native_dispatch).
+
+% ============================================================
+% 4. Executable smokes
+% ============================================================
+
+:- begin_tests(tc2_executable).
+
+test(fsharp_cycle_rplus_e2e, [condition(dotnet_available)]) :-
+    assert_tc_cycle_program,
+    tmp_dir(fs_e2e, Dir),
+    write_wam_fsharp_project(
+        [user:tc/2, user:tc_edge/2],
+        [module_name('uw_tc2_e2e')],
+        Dir),
+    directory_file_path(Dir, 'Program.fs', Prog),
+    tc2_write_fsharp_rplus_driver(Prog),
+    run_dotnet_build(Dir, BuildExit, BuildOut),
+    assertion(BuildExit =:= 0),
+    ( BuildExit =:= 0 -> true
+    ; format(user_error, 'fsharp e2e build:~n~w~n', [BuildOut]), fail
+    ),
+    run_dotnet_run(Dir, RunExit, RunOut),
+    assertion(RunExit =:= 0),
+    assertion(sub_string(RunOut, _, _, _, "OK cycle_from_a")),
+    assertion(sub_string(RunOut, _, _, _, "OK bound_source")),
+    assertion(sub_string(RunOut, _, _, _, "OK sink_d")),
+    !.
+
+test(c_bound_source_via_cycle, [condition(gcc_available)]) :-
+    assert_c_tc_program,
+    tmp_dir(c_e2e, Dir),
+    write_wam_c_project([user:tc_ancestor/2], [], Dir),
+    directory_file_path(Dir, 'wam_runtime.c', RuntimePath),
+    directory_file_path(Dir, 'lib.c', LibPath),
+    directory_file_path(Dir, 'main.c', MainPath),
+    directory_file_path(Dir, 'tc2_c_smoke', ExePath),
+    tc2_c_cycle_main(MainCode),
+    setup_call_cleanup(
+        open(MainPath, write, Out, [encoding(utf8)]),
+        write(Out, MainCode),
+        close(Out)),
+    format(atom(Cmd),
+        'gcc -O0 -std=c11 -I~w ~w ~w ~w -o ~w 2>~w/gcc.err',
+        [Dir, RuntimePath, LibPath, MainPath, ExePath, Dir]),
+    shell(Cmd, GccExit),
+    ( GccExit =:= 0 -> true
+    ; directory_file_path(Dir, 'gcc.err', Err),
+      ( exists_file(Err) -> read_file_string(Err, E),
+        format(user_error, 'gcc failed:~n~w~n', [E]) ; true ),
+      fail
+    ),
+    shell(ExePath, RunExit),
+    assertion(RunExit =:= 0),
+    !.
+
+test(rust_collect_rplus_unit, [condition(cargo_available)]) :-
+    assert_tc_cycle_program,
+    tmp_dir(rs_e2e, Dir),
+    write_wam_rust_project(
+        [user:tc/2, user:tc_edge/2],
+        [module_name('uw_tc2_rs'), foreign_lowering(true)],
+        Dir),
+    tc2_append_rust_unit(Dir),
+    format(atom(Cmd),
+        'cd ~w && cargo test --quiet tc2_rplus_contract -- --nocapture >~w/cargo.out 2>~w/cargo.err',
+        [Dir, Dir, Dir]),
+    shell(Cmd, Exit),
+    ( Exit =:= 0 -> true
+    ; directory_file_path(Dir, 'cargo.err', ErrPath),
+      directory_file_path(Dir, 'cargo.out', OutPath),
+      ( exists_file(ErrPath) -> read_file_string(ErrPath, Err) ; Err = "" ),
+      ( exists_file(OutPath) -> read_file_string(OutPath, Out) ; Out = "" ),
+      format(user_error, 'rust tc2 unit failed:~n~w~n~w~n', [Out, Err]),
+      fail
+    ),
+    !.
+
+:- end_tests(tc2_executable).
+
+% ============================================================
+% 5. Acyclic native vs oracle + cyclic WAM note
+% ============================================================
+
+:- begin_tests(tc2_no_kernels_acyclic).
+
+test(fsharp_acyclic_native_matches_oracle_sorted,
+     [condition(dotnet_available)]) :-
+    assert_tc_chain_program,
+    tc2_oracle_reachable([a-b, b-c, c-d], a, Oracle),
+    tmp_dir(fs_chain, Dir),
+    write_wam_fsharp_project(
+        [user:tc/2, user:tc_edge/2],
+        [module_name('uw_tc2_chain')],
+        Dir),
+    directory_file_path(Dir, 'Program.fs', Prog),
+    tc2_write_fsharp_chain_driver(Prog, Oracle),
+    run_dotnet_build(Dir, BuildExit, BuildOut),
+    assertion(BuildExit =:= 0),
+    ( BuildExit =:= 0 -> true
+    ; format(user_error, 'fsharp chain build:~n~w~n', [BuildOut]), fail
+    ),
+    run_dotnet_run(Dir, RunExit, RunOut),
+    assertion(RunExit =:= 0),
+    assertion(sub_string(RunOut, _, _, _, "OK native_matches_oracle")),
+    !.
+
+test(cyclic_generic_wam_is_not_the_oracle) :-
+    % On cyclic graphs, no_kernels recursive WAM explores path proofs
+    % (may duplicate or not terminate). Finite oracle + native R+
+    % handlers are authoritative; do not cross-compare cyclic
+    % no_kernels streams against the oracle. Acyclic set-normalized
+    % compare is allowed (see fsharp_acyclic_native_matches_oracle_sorted).
+    assertion(true).
+
+:- end_tests(tc2_no_kernels_acyclic).
+
+% ============================================================
+% Helpers
+% ============================================================
+
+run_dotnet_build(Dir, Exit, Out) :-
+    setup_call_cleanup(
+        process_create(path(dotnet),
+            ['build', '--nologo', '-v', 'q', '-c', 'Release'],
+            [cwd(Dir), stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
+        ( read_string(SO, _, S1), read_string(SE, _, S2),
+          process_wait(Pid, exit(Exit)),
+          string_concat(S1, S2, Out) ),
+        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
+
+run_dotnet_run(Dir, Exit, Out) :-
+    setup_call_cleanup(
+        process_create(path(dotnet),
+            ['run', '--no-build', '-c', 'Release', '--no-launch-profile', '--'],
+            [cwd(Dir),
+             environment(['DOTNET_NOLOGO'='1', 'DOTNET_ROLL_FORWARD'='Major']),
+             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
+        ( read_string(SO, _, S1), read_string(SE, _, S2),
+          process_wait(Pid, exit(Exit)),
+          string_concat(S1, S2, Out) ),
+        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
+
+tc2_write_fsharp_rplus_driver(ProgPath) :-
+    Driver =
+"module Program
+
+open System
+open WamTypes
+open WamRuntime
+open Predicates
+
+let mutable passes = 0
+let mutable fails = 0
+
+let assertTrue (name: string) (cond: bool) =
+    if cond then
+        passes <- passes + 1
+        printfn \"OK %s\" name
+    else
+        fails <- fails + 1
+        printfn \"FAIL %s\" name
+
+let mkAtoms () =
+    let pairs = [(\"a\", 1); (\"b\", 2); (\"c\", 3); (\"d\", 4)]
+    Map.ofList pairs, Map.ofList (pairs |> List.map (fun (s, i) -> (i, s)))
+
+let mkEdgeFacts (intern: Map<string, int>) =
+    let edges = [(\"a\", \"b\"); (\"b\", \"c\"); (\"c\", \"d\"); (\"c\", \"a\")]
+    let grouped =
+        edges
+        |> List.map (fun (f, t) -> Map.find f intern, Map.find t intern)
+        |> List.groupBy fst
+        |> List.map (fun (k, vs) -> k, vs |> List.map snd)
+    Map.ofList [(\"tc_edge\", Map.ofList grouped)]
+
+let mkContext () =
+    let foreignPreds = [\"tc/2\"]
+    let resolvedCode =
+        resolveCallInstrs allLabels foreignPreds (Array.toList allCode)
+        |> List.toArray
+    let intern, deintern = mkAtoms ()
+    { WcCode              = resolvedCode
+      WcLabels            = allLabels
+      WcForeignFacts      = Map.empty
+      WcFfiFacts          = mkEdgeFacts intern
+      WcFfiWeightedFacts  = Map.empty
+      WcAtomIntern        = intern
+      WcAtomDeintern      = deintern
+      WcForeignConfig     = Map.empty
+      WcLoweredPredicates = Map.empty
+      WcLookupSources     = Map.empty
+      WcCancellationToken = None }
+
+let mkState (regs: Value array) : WamState =
+    { WsPC         = 0
+      WsRegs       = regs
+      WsStack      = []
+      WsHeap       = []
+      WsHeapLen    = 0
+      WsTrail      = []
+      WsTrailLen   = 0
+      WsCP         = 0
+      WsCPs        = []
+      WsCPsLen     = 0
+      WsBindings   = Map.empty
+      WsCutBar     = 0
+      WsVarCounter = 0
+      WsBuilder    = None
+      WsBuilderStack = []
+      WsAggAccum   = []
+      WsB0Stack    = []
+      WsCatchers   = [] }
+
+let collectTargets (ctx: WamContext) (source: string) (boundTarget: string option) : string list =
+    let regs = Array.create MaxRegs (Unbound -1)
+    regs.[1] <- Atom source
+    match boundTarget with
+    | Some t -> regs.[2] <- Atom t
+    | None   -> regs.[2] <- Unbound 100
+    match callForeign ctx \"tc/2\" (mkState regs) with
+    | None -> []
+    | Some s1 ->
+        let readTarget (s: WamState) =
+            match getReg 2 s with
+            | Some (Atom a) -> a
+            | _ -> \"?\"
+        let rec gather (s: WamState) (acc: string list) =
+            let tgt = readTarget s
+            match backtrack s with
+            | Some s2 -> gather s2 (tgt :: acc)
+            | None -> List.rev (tgt :: acc)
+        gather s1 []
+
+[<EntryPoint>]
+let main _argv =
+    let ctx = mkContext ()
+    let fromA = collectTargets ctx \"a\" None |> List.sort
+    assertTrue \"cycle_from_a\" (fromA = [\"a\"; \"b\"; \"c\"; \"d\"])
+    let boundSrc = collectTargets ctx \"a\" (Some \"a\")
+    assertTrue \"bound_source\" (boundSrc = [\"a\"])
+    let fromD = collectTargets ctx \"d\" None
+    assertTrue \"sink_d\" (fromD = [])
+    printfn \"RESULT %d/%d\" passes (passes + fails)
+    if fails > 0 then 1 else 0
+",
+    setup_call_cleanup(
+        open(ProgPath, write, Out, [encoding(utf8)]),
+        write(Out, Driver),
+        close(Out)).
+
+tc2_write_fsharp_chain_driver(ProgPath, Oracle) :-
+    maplist(tc2_atom_lit, Oracle, Lits),
+    atomic_list_concat(Lits, '; ', LitBody),
+    format(atom(ExpectedFs), '[~w]', [LitBody]),
+    format(atom(Driver),
+"module Program
+
+open System
+open WamTypes
+open WamRuntime
+open Predicates
+
+let mutable passes = 0
+let mutable fails = 0
+
+let assertTrue (name: string) (cond: bool) =
+    if cond then
+        passes <- passes + 1
+        printfn \"OK %s\" name
+    else
+        fails <- fails + 1
+        printfn \"FAIL %s\" name
+
+let mkAtoms () =
+    let pairs = [(\"a\", 1); (\"b\", 2); (\"c\", 3); (\"d\", 4)]
+    Map.ofList pairs, Map.ofList (pairs |> List.map (fun (s, i) -> (i, s)))
+
+let mkEdgeFacts (intern: Map<string, int>) =
+    let edges = [(\"a\", \"b\"); (\"b\", \"c\"); (\"c\", \"d\")]
+    let grouped =
+        edges
+        |> List.map (fun (f, t) -> Map.find f intern, Map.find t intern)
+        |> List.groupBy fst
+        |> List.map (fun (k, vs) -> k, vs |> List.map snd)
+    Map.ofList [(\"tc_edge\", Map.ofList grouped)]
+
+let mkContext () =
+    let foreignPreds = [\"tc/2\"]
+    let resolvedCode =
+        resolveCallInstrs allLabels foreignPreds (Array.toList allCode)
+        |> List.toArray
+    let intern, deintern = mkAtoms ()
+    { WcCode              = resolvedCode
+      WcLabels            = allLabels
+      WcForeignFacts      = Map.empty
+      WcFfiFacts          = mkEdgeFacts intern
+      WcFfiWeightedFacts  = Map.empty
+      WcAtomIntern        = intern
+      WcAtomDeintern      = deintern
+      WcForeignConfig     = Map.empty
+      WcLoweredPredicates = Map.empty
+      WcLookupSources     = Map.empty
+      WcCancellationToken = None }
+
+let mkState (regs: Value array) : WamState =
+    { WsPC         = 0
+      WsRegs       = regs
+      WsStack      = []
+      WsHeap       = []
+      WsHeapLen    = 0
+      WsTrail      = []
+      WsTrailLen   = 0
+      WsCP         = 0
+      WsCPs        = []
+      WsCPsLen     = 0
+      WsBindings   = Map.empty
+      WsCutBar     = 0
+      WsVarCounter = 0
+      WsBuilder    = None
+      WsBuilderStack = []
+      WsAggAccum   = []
+      WsB0Stack    = []
+      WsCatchers   = [] }
+
+let collectTargets (ctx: WamContext) (source: string) : string list =
+    let regs = Array.create MaxRegs (Unbound -1)
+    regs.[1] <- Atom source
+    regs.[2] <- Unbound 100
+    match callForeign ctx \"tc/2\" (mkState regs) with
+    | None -> []
+    | Some s1 ->
+        let readTarget (s: WamState) =
+            match getReg 2 s with
+            | Some (Atom a) -> a
+            | _ -> \"?\"
+        let rec gather (s: WamState) (acc: string list) =
+            let tgt = readTarget s
+            match backtrack s with
+            | Some s2 -> gather s2 (tgt :: acc)
+            | None -> List.rev (tgt :: acc)
+        gather s1 []
+
+[<EntryPoint>]
+let main _argv =
+    let ctx = mkContext ()
+    let got = collectTargets ctx \"a\" |> List.sort
+    let expected = ~w |> List.sort
+    assertTrue \"native_matches_oracle\" (got = expected)
+    printfn \"RESULT %d/%d\" passes (passes + fails)
+    if fails > 0 then 1 else 0
+",
+        [ExpectedFs]),
+    setup_call_cleanup(
+        open(ProgPath, write, Out, [encoding(utf8)]),
+        write(Out, Driver),
+        close(Out)).
+
+tc2_atom_lit(A, Lit) :-
+    format(atom(Lit), '"~w"', [A]).
+
+tc2_c_cycle_main(Code) :-
+    Code =
+'#include "wam_runtime.h"
+
+void setup_tc_ancestor_2(WamState* state);
+void setup_detected_wam_c_kernels(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_tc_ancestor_2(&state);
+    setup_detected_wam_c_kernels(&state);
+
+    wam_register_transitive_edge(&state, "a", "b");
+    wam_register_transitive_edge(&state, "b", "c");
+    wam_register_transitive_edge(&state, "c", "d");
+    wam_register_transitive_edge(&state, "c", "a");
+
+    /* Bound Source via nonempty cycle must succeed (strict R+). */
+    {
+        WamValue args[2] = { val_atom("a"), val_atom("a") };
+        int rc = wam_run_predicate(&state, "tc_ancestor/2", args, 2);
+        if (rc != 0 || state.P != WAM_HALT) {
+            wam_free_state(&state);
+            return 11;
+        }
+    }
+
+    wam_free_state(&state);
+    wam_state_init(&state);
+    setup_tc_ancestor_2(&state);
+    setup_detected_wam_c_kernels(&state);
+    wam_register_transitive_edge(&state, "a", "b");
+    wam_register_transitive_edge(&state, "b", "c");
+    wam_register_transitive_edge(&state, "c", "d");
+    wam_register_transitive_edge(&state, "c", "a");
+
+    /* Sink d has no outgoing edges — unbound Target must fail. */
+    {
+        WamValue args[2] = { val_atom("d"), val_unbound("T") };
+        int rc = wam_run_predicate(&state, "tc_ancestor/2", args, 2);
+        if (rc == 0 && state.P == WAM_HALT) {
+            wam_free_state(&state);
+            return 12;
+        }
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+'.
+
+tc2_append_rust_unit(Dir) :-
+    directory_file_path(Dir, 'src/lib.rs', Path),
+    read_file_string(Path, Existing),
+    Unit =
+"
+
+#[cfg(test)]
+mod tc2_rplus_contract {
+    use super::*;
+    use std::collections::HashMap;
+    use state::WamState;
+
+    #[test]
+    fn cycle_includes_source_under_rplus() {
+        let mut vm = WamState::new(Vec::new(), HashMap::new());
+        vm.register_indexed_atom_fact2_pairs(
+            \"tc_edge\",
+            &[(\"a\", \"b\"), (\"b\", \"c\"), (\"c\", \"d\"), (\"c\", \"a\")],
+        );
+        let mut nodes = Vec::new();
+        vm.collect_native_transitive_closure_nodes(\"a\", \"tc_edge\", &mut nodes);
+        nodes.sort();
+        assert_eq!(
+            nodes,
+            vec![
+                \"a\".to_string(),
+                \"b\".to_string(),
+                \"c\".to_string(),
+                \"d\".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn acyclic_excludes_source() {
+        let mut vm = WamState::new(Vec::new(), HashMap::new());
+        vm.register_indexed_atom_fact2_pairs(
+            \"tc_edge\",
+            &[(\"a\", \"b\"), (\"b\", \"c\"), (\"c\", \"d\")],
+        );
+        let mut nodes = Vec::new();
+        vm.collect_native_transitive_closure_nodes(\"a\", \"tc_edge\", &mut nodes);
+        nodes.sort();
+        assert_eq!(
+            nodes,
+            vec![\"b\".to_string(), \"c\".to_string(), \"d\".to_string()]
+        );
+        assert!(!nodes.iter().any(|n| n == \"a\"));
+    }
+}
+",
+    setup_call_cleanup(
+        open(Path, write, Out, [encoding(utf8)]),
+        ( write(Out, Existing), write(Out, Unit) ),
+        close(Out)).

--- a/tests/test_wam_tc2_contract_parity.pl
+++ b/tests/test_wam_tc2_contract_parity.pl
@@ -182,15 +182,18 @@ test(haskell_mustache_rplus_visited) :-
         'templates/targets/haskell_wam/kernel_transitive_closure.hs.mustache', S),
     assertion(sub_string(S, _, _, _, "strict R+")),
     assertion(sub_string(S, _, _, _, "go [source] IS.empty []")),
-    assertion(sub_string(S, _, _, _, "newTargets = filter")),
+    assertion(sub_string(S, _, _, _, "foldl' discover")),
+    assertion(sub_string(S, _, _, _, "IS.insert target seen")),
+    assertion(\+ sub_string(S, _, _, _, "newTargets = filter")),
     assertion(\+ sub_string(S, _, _, _, "IS.insert source")).
 
 test(c_handler_does_not_seed_visited_with_start) :-
     read_file_string('src/unifyweaver/targets/wam_c_target.pl', S),
     assertion(sub_string(S, _, _, _, "wam_transitive_closure_handler")),
     assertion(sub_string(S, _, _, _, "Strict R+")),
-    assertion(sub_string(S, _, _, _, "do NOT seed visited with start")),
+    assertion(sub_string(S, _, _, _, "wam_collect_transitive_closure")),
     assertion(sub_string(S, _, _, _, "int visited_len = 0;")),
+    assertion(sub_string(S, _, _, _, "WAM_FOREIGN_STREAM_NEXT")),
     assertion(\+ sub_string(S, _, _, _, "visited[0] = start")).
 
 test(r_runtime_does_not_seed_visited_with_source) :-
@@ -282,7 +285,8 @@ test(c_registers_transitive_closure_handler) :-
     directory_file_path(Dir, 'wam_runtime.c', RT),
     read_file_string(RT, S),
     assertion(sub_string(S, _, _, _, "wam_transitive_closure_handler")),
-    assertion(sub_string(S, _, _, _, "do NOT seed visited with start")),
+    assertion(sub_string(S, _, _, _, "wam_bind_foreign_atom_stream")),
+    assertion(sub_string(S, _, _, _, "WAM_FOREIGN_STREAM_NEXT")),
     !.
 
 :- end_tests(tc2_native_dispatch).
@@ -314,7 +318,7 @@ test(fsharp_cycle_rplus_e2e, [condition(dotnet_available)]) :-
     assertion(sub_string(RunOut, _, _, _, "OK sink_d")),
     !.
 
-test(c_bound_source_via_cycle, [condition(gcc_available)]) :-
+test(c_stream_and_bound_rplus, [condition(gcc_available)]) :-
     assert_c_tc_program,
     tmp_dir(c_e2e, Dir),
     write_wam_c_project([user:tc_ancestor/2], [], Dir),
@@ -661,9 +665,58 @@ int main(void) {
     setup_detected_wam_c_kernels(&state);
 
     wam_register_transitive_edge(&state, "a", "b");
+    wam_register_transitive_edge(&state, "a", "b");
+    wam_register_transitive_edge(&state, "a", "c");
     wam_register_transitive_edge(&state, "b", "c");
     wam_register_transitive_edge(&state, "c", "d");
     wam_register_transitive_edge(&state, "c", "a");
+
+    /* Drive the native foreign handler and then force ordinary WAM
+       backtracking through its foreign-stream choice point. Duplicate
+       edges and the second path to c must still yield one result each. */
+    {
+        int fail_pc = state.code_size;
+        state.code_size += 2;
+        state.code = realloc(state.code,
+                             sizeof(Instruction) * (size_t)state.code_size);
+        if (!state.code) return 20;
+        memset(&state.code[fail_pc], 0, sizeof(Instruction) * 2u);
+        state.code[fail_pc].tag = INSTR_BUILTIN_CALL;
+        state.code[fail_pc].as.pred.pred = "__tc2_retry_fail/0";
+        state.code[fail_pc].as.pred.arity = 0;
+        state.code[fail_pc + 1].tag = INSTR_PROCEED;
+
+        state.P = fail_pc;
+        state.CP = WAM_HALT;
+        state.A[0] = val_atom("a");
+        state.A[1] = val_unbound("T");
+        if (!wam_execute_foreign_predicate(&state, "tc_ancestor/2", 2)) {
+            wam_free_state(&state);
+            return 21;
+        }
+
+        const char *expected[4] = { "b", "c", "d", "a" };
+        for (int i = 0; i < 4; i++) {
+            if (i > 0) {
+                state.P = fail_pc;
+                if (wam_run(&state) != 0) {
+                    wam_free_state(&state);
+                    return 22 + i;
+                }
+            }
+            WamValue *cell = wam_deref_ptr(&state, &state.A[1]);
+            if (cell->tag != VAL_ATOM ||
+                strcmp(cell->data.atom, expected[i]) != 0) {
+                wam_free_state(&state);
+                return 30 + i;
+            }
+        }
+        state.P = fail_pc;
+        if (wam_run(&state) != WAM_HALT || state.B != 0) {
+            wam_free_state(&state);
+            return 40;
+        }
+    }
 
     /* Bound Source via nonempty cycle must succeed (strict R+). */
     {
@@ -674,15 +727,6 @@ int main(void) {
             return 11;
         }
     }
-
-    wam_free_state(&state);
-    wam_state_init(&state);
-    setup_tc_ancestor_2(&state);
-    setup_detected_wam_c_kernels(&state);
-    wam_register_transitive_edge(&state, "a", "b");
-    wam_register_transitive_edge(&state, "b", "c");
-    wam_register_transitive_edge(&state, "c", "d");
-    wam_register_transitive_edge(&state, "c", "a");
 
     /* Sink d has no outgoing edges — unbound Target must fail. */
     {

--- a/tests/test_wam_tc2_contract_parity.pl
+++ b/tests/test_wam_tc2_contract_parity.pl
@@ -327,9 +327,10 @@ test(c_bound_source_via_cycle, [condition(gcc_available)]) :-
         open(MainPath, write, Out, [encoding(utf8)]),
         write(Out, MainCode),
         close(Out)),
+    IncludeDir = 'src/unifyweaver/targets/wam_c_runtime',
     format(atom(Cmd),
         'gcc -O0 -std=c11 -I~w ~w ~w ~w -o ~w 2>~w/gcc.err',
-        [Dir, RuntimePath, LibPath, MainPath, ExePath, Dir]),
+        [IncludeDir, RuntimePath, LibPath, MainPath, ExePath, Dir]),
     shell(Cmd, GccExit),
     ( GccExit =:= 0 -> true
     ; directory_file_path(Dir, 'gcc.err', Err),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Defines and enforces fleet-wide `transitive_closure2` semantics as **strict R+** (path of ≥1 edges; Source only via self-loop or nonempty cycle).

## Contract

- Authored `docs/design/WAM_TRANSITIVE_CLOSURE2_CONTRACT.md`
- Finite BFS oracle + fixture matrix in `tests/fixtures/tc2_contract_oracle.pl`
- Cross-target compare uses normalized sorted sets; cyclic generic WAM recursion is not the oracle
- Template organization guidance: Mustache for non-trivial F#/Haskell TC2; inline elsewhere matching each target’s style

## Handler alignment

| Target | Change |
|---|---|
| F# / Haskell | Mustache TC2 kernels: do not seed visited with Source |
| C | Inline handler: empty visited (style kept inline) |
| R | `runtime.R.mustache`: do not seed visited with Source |
| LLVM | Stream BFS R+; bound `Source==Target` via `@wam_tc2_rplus_reaches` (not distance-0 R* hit) |
| Rust / Scala / Go / Elixir | Already R+ (structural checks only) |

## Tests

- `tests/test_wam_tc2_contract_parity.pl` — oracle, structural R+, native dispatch proof, executable F#/C/Rust smokes, acyclic native vs oracle
- Updates F# gate suite expectations (`RESULT 11/11`, cycle includes Source)
- LLVM bound self on acyclic chain now expects fail

## Measured

- `swipl -q -g run_tests -t halt tests/test_wam_tc2_contract_parity.pl` → exit 0
- `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_kernel_gate_tc.pl` → exit 0

## Out of scope

- Remaining five F# kernel kinds
- Changing shared detector to hide differences
- Mass-regenerating example `.ll` snapshots

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

