### PR TITLE
WAM/LLVM plawk: split($N, arr, "sep") into a positional string array

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -55,7 +55,7 @@ only (runtime pending) · ❌ missing.
 |---|---|---|
 | user functions (`function f(a) { return … }`) | ✅ | compile to Prolog clauses; work in accumulator / typed-field (`BINFMT`) contexts **and text mode** — `print f($1)` auto-coerces the field (awk semantics). Optional numeric arg typing (`function f(num x)`) skips the coercion (typed-fast path). |
 | string: `length` `substr` `index` `tolower` `toupper` | ✅ | native, allocation-free |
-| string: `split` `sub` `gsub` `match` `sprintf` | ◐ | **`sprintf` landed** — `x = sprintf("fmt", args)` formats into a string scalar, reusing the printf format engine (same conversions/flags/width/precision) + `snprintf`→intern. Numeric convs need a numeric arg (`$1+0`/`NR`), as printf. `split`/`sub`/`gsub`/`match` still ❌ |
+| string: `split` `sub` `gsub` `match` `sprintf` | ◐ | **`sprintf` + `split` landed.** `sprintf`: `x = sprintf("fmt", args)` → string scalar (printf engine + `snprintf`→intern). `split`: `split($N, arr, "sep")` populates a positional string array `arr` (keys 1..n) via `@wam_str_split_into` (clears + repopulates; empty pieces kept), read via for-in (`for (k in arr) print k, arr[k]`). v1 split: single-char literal separator, for-in read (a return count, default-FS separator, and `arr[N]` constant-index read are follow-ons). `sub`/`gsub`/`match` still ❌ |
 | numeric: `int` | ✅ | `sin`/`cos`/`sqrt`/`rand`/… ❌ (f64 machinery exists) |
 | Prolog foreign calls (`pred($1)`, `float(pred(…))`) | ✅ | plawk-specific, beyond AWK |
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -4511,6 +4511,7 @@ plawk_passes_tables(Passes, Tables) :-
 
 plawk_action_table_name(inc_assoc(var(Name), _Key), Name).
 plawk_action_table_name(delete_assoc(var(Name), _Key), Name).
+plawk_action_table_name(split_into(_Src, var(Name), _Sep), Name).
 plawk_action_table_name(add_assoc(var(Name), _Key, _Delta), Name).
 plawk_action_table_name(set_row(var(Name), _Key), Name).
 plawk_action_table_name(set_row_cons(var(Name), _Key, _Fields), Name).
@@ -5256,6 +5257,7 @@ plawk_forin_assoc_plan(Rules, ArrayName, LookupArrays,
           ( member(RuleArrayName-_KeyIndex, ActionSpecs)
           ; member(dynassoc(RuleArrayName, _Call), ActionSpecs)
           ; member(assoc_delete(RuleArrayName, _KeyIndex), ActionSpecs)
+          ; member(assoc_split(RuleArrayName, _Ki, _Sep), ActionSpecs)
           ; plawk_assoc_spec_forin_array(ActionSpecs, RuleArrayName)
           )
         ),
@@ -5291,6 +5293,7 @@ plawk_assoc_specs_str_arrays(RuleSpecs, StrArrays) :-
           ; member(dynassoc(A, posarray_str(_Call)), ActionSpecs)
           ; member(assoc_set_row(A, _Key), ActionSpecs)   % row-valued (str)
           ; member(assoc_set_row_cons(A, _Key2, _Fs), ActionSpecs)  % row (str)
+          ; member(assoc_split(A, _Ski, _Ssep), ActionSpecs)   % split pieces (str)
           )
         ),
         As0),
@@ -5305,6 +5308,7 @@ plawk_assoc_specs_posarray_arrays(RuleSpecs, PosArrays) :-
         ( member(rule(_P, ActionSpecs, _C), RuleSpecs),
           ( member(dynassoc(A, posarray(_Call)), ActionSpecs)
           ; member(dynassoc(A, posarray_str(_Call)), ActionSpecs)
+          ; member(assoc_split(A, _Pki, _Psep), ActionSpecs)   % keys are 1..n positions
           )
         ),
         As0),
@@ -5785,6 +5789,21 @@ plawk_forin_body_print_lines([var(LoopVar) | Rest], LoopVar, ArrayName,
         TableIndex, AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
     { plawk_descriptor_is_binary(Descriptor) },
     % Binary mode: keys are raw i64 field values, printed numerically.
+    plawk_forin_separator_lines(PrintIndex, OutputSeparator),
+    { format(atom(FmtVar), 'forin_key_fmt_~w', [PrintIndex]),
+      format(atom(PrintVar), 'forin_printed_key_~w', [PrintIndex]),
+      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar,
+          '%forin_key_id', [FmtPtr, PrintCall]),
+      NextPrintIndex is PrintIndex + 1
+    },
+    [FmtPtr, PrintCall],
+    plawk_forin_body_print_lines(Rest, LoopVar, ArrayName, TableIndex, AssocPlan,
+        Descriptor, OutputSeparator, NextPrintIndex).
+plawk_forin_body_print_lines([var(LoopVar) | Rest], LoopVar, ArrayName,
+        TableIndex, AssocPlan, Descriptor, OutputSeparator, PrintIndex) -->
+    { plawk_assoc_plan_posarray_array(AssocPlan, ArrayName) },
+    % Positional array (e.g. split): keys are integer positions, printed
+    % numerically rather than resolved as atom-registry ids.
     plawk_forin_separator_lines(PrintIndex, OutputSeparator),
     { format(atom(FmtVar), 'forin_key_fmt_~w', [PrintIndex]),
       format(atom(PrintVar), 'forin_printed_key_~w', [PrintIndex]),
@@ -6643,6 +6662,12 @@ plawk_assoc_body_action_spec(inc_assoc(var(ArrayName), Blob),
 plawk_assoc_body_action_spec(delete_assoc(var(ArrayName), field(KeyIndex)),
         assoc_delete(ArrayName, KeyIndex)) :-
     integer(KeyIndex), KeyIndex > 0.
+% `split($N, arr, "sep")`: populate arr (a str-valued positional table, keys
+% 1..n) by splitting field N on the single-char separator.
+plawk_assoc_body_action_spec(split_into(field(KeyIndex), var(ArrayName), string(Sep)),
+        assoc_split(ArrayName, KeyIndex, Sep)) :-
+    integer(KeyIndex), KeyIndex >= 0,
+    string(Sep), string_length(Sep, 1).
 % Associative add-assign `arr[$k] += DELTA`: fold DELTA (a field value or an
 % integer constant) into the table at the key interned from field k. The
 % general form of `arr[$k]++` and the pass-1 half of per-key normalise. v1
@@ -6952,6 +6977,13 @@ plawk_assoc_planned_actions([assoc_delete(ArrayName, KeyIndex) | Rest],
       NextIndex is Index + 1
     },
     [assoc_delete_action(Index, ArrayName, TableIndex, KeyIndex)],
+    plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
+plawk_assoc_planned_actions([assoc_split(ArrayName, KeyIndex, Sep) | Rest],
+        Tables, StrArrays, PosArrays, Index) -->
+    { nth0(TableIndex, Tables, ArrayName),
+      NextIndex is Index + 1
+    },
+    [assoc_split_action(Index, ArrayName, TableIndex, KeyIndex, Sep)],
     plawk_assoc_planned_actions(Rest, Tables, StrArrays, PosArrays, NextIndex).
 plawk_assoc_planned_actions([assoc_add(ArrayName, KeyIndex, Delta) | Rest],
         Tables, StrArrays, PosArrays, Index) -->
@@ -7801,6 +7833,47 @@ plawk_assoc_rule_action_blocks(RuleIndex, [assoc_delete_action(Index, _ArrayName
       format(atom(Next), '  br label %~w', [ActionNextLabel])
     },
     [Label, Slice, Ptr, Len, Missing, Branch, '', HaveLabel, KeyId, Del, Next, ''],
+    plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
+% `split($k, arr, "sep")`: resolve the source string, then call the split
+% primitive, which clears the table and repopulates it with the pieces keyed
+% 1..n (string values). $0 is the whole record (resolved directly, since the
+% field-slice helper is 1-based); a positive field uses its slice (missing field
+% -> empty array). The split byte is the separator literal's code.
+plawk_assoc_rule_action_blocks(RuleIndex, [assoc_split_action(Index, _ArrayName, TableIndex, KeyIndex, Sep) | Rest], NextLabel, FieldSeparator) -->
+    { ( Rest == []
+      -> ActionNextLabel = NextLabel
+      ;  NextIndex is Index + 1,
+         format(atom(ActionNextLabel), 'assoc_rule_~w_action_~w',
+             [RuleIndex, NextIndex])
+      ),
+      string_codes(Sep, [SepCode]),
+      format(atom(Base), 'assoc_rule_~w_action_~w', [RuleIndex, Index]),
+      format(atom(Label), '~w:', [Base]),
+      format(atom(Split),
+          '  %~w_n = call i64 @wam_str_split_into(%WamAssocI64Table* %plawk_assoc_table_~w, i8* %~w_src_ptr, i64 %~w_src_len, i8 ~w)',
+          [Base, TableIndex, Base, Base, SepCode]),
+      format(atom(Next), '  br label %~w', [ActionNextLabel]),
+      ( KeyIndex =:= 0
+      ->  % whole record: resolve %line's atom to its string
+          format(atom(Lp), '  %~w_lp = call i64 @value_payload(%Value %line)', [Base]),
+          format(atom(Sptr), '  %~w_src_ptr = call i8* @wam_atom_to_string(i64 %~w_lp)', [Base, Base]),
+          format(atom(Slen), '  %~w_src_len = call i64 @strlen(i8* %~w_src_ptr)', [Base, Base]),
+          Lines = [Label, Lp, Sptr, Slen, Split, Next, '']
+      ;   % positive field: project its slice, skip on a missing field
+          format(atom(HaveLabel), '~w_have_src:', [Base]),
+          format(atom(HaveLabelName), '~w_have_src', [Base]),
+          format(atom(Slice),
+              '  %~w_src_slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 ~w, i8 ~w)',
+              [Base, KeyIndex, FieldSeparator]),
+          format(atom(Ptr), '  %~w_src_ptr = extractvalue %WamSlice %~w_src_slice, 0', [Base, Base]),
+          format(atom(Len), '  %~w_src_len = extractvalue %WamSlice %~w_src_slice, 1', [Base, Base]),
+          format(atom(Missing), '  %~w_src_missing = icmp eq i8* %~w_src_ptr, null', [Base, Base]),
+          format(atom(Branch), '  br i1 %~w_src_missing, label %~w, label %~w',
+              [Base, ActionNextLabel, HaveLabelName]),
+          Lines = [Label, Slice, Ptr, Len, Missing, Branch, '', HaveLabel, Split, Next, '']
+      )
+    },
+    plawk_emit_lines(Lines),
     plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel, FieldSeparator).
 % Associative add-assign `arr[$k] += DELTA`: same key-intern + missing-key
 % skip as the counted inc, but the inc delta is the record's DELTA (a field
@@ -10190,6 +10263,11 @@ plawk_assoc_plan_str_array(assoc_plan(_Tables, Rules), ArrayName) :-
     member(str_arrays(StrArrays), Rules),
     memberchk(ArrayName, StrArrays),
     !.
+% split fills its array with string pieces (interned atom ids).
+plawk_assoc_plan_str_array(assoc_plan(_Tables, Rules), ArrayName) :-
+    member(assoc_rule(_RuleIndex, _Pattern, Actions, _Control), Rules),
+    member(assoc_split_action(_Index, ArrayName, _TableIndex, _Ki, _Sep), Actions),
+    !.
 
 %% plawk_assoc_plan_posarray_array(+AssocPlan, +ArrayName) is semidet.
 %  ArrayName''s table is a POSITIONAL array: some rule fills it through an
@@ -10203,6 +10281,11 @@ plawk_assoc_plan_posarray_array(assoc_plan(_Tables, Rules), ArrayName) :-
     ; member(assoc_dyn_action(_Index2, ArrayName, _TableIndex2,
         posarray_str(_Call2)), Actions)
     ),
+    !.
+% split keys its array by integer position (1..n).
+plawk_assoc_plan_posarray_array(assoc_plan(_Tables, Rules), ArrayName) :-
+    member(assoc_rule(_RuleIndex, _Pattern, Actions, _Control), Rules),
+    member(assoc_split_action(_Index, ArrayName, _TableIndex, _Ki, _Sep), Actions),
     !.
 
 % Binary record modes: assoc keys are raw i64 field values (no

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1593,8 +1593,37 @@ action(Action) -->
     delete_action(Action),
     !.
 action(Action) -->
+    split_action(Action),
+    !.
+action(Action) -->
     increment_action(Action),
     !.
+
+%% split_action(-Action)//
+%
+%  `split($N, arr, "sep")` -- split field $N on the single-char separator into
+%  positional array `arr` (keys 1..n, string values). Parses to
+%  split_into(field(N), var(Arr), string(Sep)). v1: field source, string-literal
+%  separator; the return count and a default (FS) separator are follow-ons.
+split_action(split_into(field(N), var(Arr), string(Sep))) -->
+    "split",
+    ws,
+    "(",
+    ws,
+    "$",
+    integer_codes(NCodes),
+    { NCodes \== [], number_codes(N, NCodes), N >= 0 },
+    ws,
+    ",",
+    ws,
+    identifier(Arr),
+    ws,
+    ",",
+    ws,
+    quoted_string(SepCodes),
+    { SepCodes \== [], string_codes(Sep, SepCodes) },
+    ws,
+    ")".
 
 %% delete_action(-Action)//
 %

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4752,6 +4752,83 @@ del.done:
   ret void
 }
 
+; Split %str[0..len) on the single byte %sep into %table, keyed by 1-based
+; position (values are interned atom ids). The table is cleared first (split
+; replaces the array). Returns the piece count. An empty input yields 0 pieces;
+; adjacent / trailing separators yield empty pieces, as awk does with an
+; explicit single-char separator.
+define i64 @wam_str_split_into(%WamAssocI64Table* %table, i8* %str, i64 %len, i8 %sep) {
+entry:
+  %table_null = icmp eq %WamAssocI64Table* %table, null
+  br i1 %table_null, label %sp.ret0, label %sp.clear_load
+
+sp.clear_load:
+  %cap_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 1
+  %cap = load i64, i64* %cap_slot
+  %entries_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 2
+  %entries = load %WamAssocI64Entry*, %WamAssocI64Entry** %entries_slot
+  br label %sp.clear_loop
+
+sp.clear_loop:
+  %ci = phi i64 [ 0, %sp.clear_load ], [ %ci.next, %sp.clear_body ]
+  %ci.done = icmp uge i64 %ci, %cap
+  br i1 %ci.done, label %sp.clear_done, label %sp.clear_body
+
+sp.clear_body:
+  %ce = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %entries, i64 %ci
+  %ce_occ = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %ce, i32 0, i32 2
+  store i1 false, i1* %ce_occ
+  %ci.next = add i64 %ci, 1
+  br label %sp.clear_loop
+
+sp.clear_done:
+  %count_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 0
+  store i64 0, i64* %count_slot
+  %len_zero = icmp eq i64 %len, 0
+  br i1 %len_zero, label %sp.ret0, label %sp.loop
+
+sp.loop:
+  %j = phi i64 [ 0, %sp.clear_done ], [ %jn, %sp.next ]
+  %fstart = phi i64 [ 0, %sp.clear_done ], [ %fstartn, %sp.next ]
+  %pos = phi i64 [ 1, %sp.clear_done ], [ %posn, %sp.next ]
+  %jdone = icmp uge i64 %j, %len
+  br i1 %jdone, label %sp.final, label %sp.body
+
+sp.body:
+  %cp = getelementptr i8, i8* %str, i64 %j
+  %c = load i8, i8* %cp
+  %sepc = icmp eq i8 %c, %sep
+  br i1 %sepc, label %sp.emit, label %sp.skip
+
+sp.emit:
+  %ep = getelementptr i8, i8* %str, i64 %fstart
+  %el = sub i64 %j, %fstart
+  %eid = call i64 @wam_intern_atom(i8* %ep, i64 %el)
+  %eset = call i64 @wam_assoc_i64_set(%WamAssocI64Table* %table, i64 %pos, i64 %eid)
+  %epos = add i64 %pos, 1
+  %efstart = add i64 %j, 1
+  br label %sp.next
+
+sp.skip:
+  br label %sp.next
+
+sp.next:
+  %posn = phi i64 [ %epos, %sp.emit ], [ %pos, %sp.skip ]
+  %fstartn = phi i64 [ %efstart, %sp.emit ], [ %fstart, %sp.skip ]
+  %jn = add i64 %j, 1
+  br label %sp.loop
+
+sp.final:
+  %lp = getelementptr i8, i8* %str, i64 %fstart
+  %ll = sub i64 %len, %fstart
+  %lid = call i64 @wam_intern_atom(i8* %lp, i64 %ll)
+  %lset = call i64 @wam_assoc_i64_set(%WamAssocI64Table* %table, i64 %pos, i64 %lid)
+  ret i64 %pos
+
+sp.ret0:
+  ret i64 0
+}
+
 define i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 %key, i64 %delta) {
 entry:
   %table_null = icmp eq %WamAssocI64Table* %table, null

--- a/tests/core/test_wam_llvm_assoc_i64_runtime.pl
+++ b/tests/core/test_wam_llvm_assoc_i64_runtime.pl
@@ -32,6 +32,10 @@ test(assoc_i64_delete_backward_shifts_probe_chain) :-
     assoc_i64_delete_driver_ir(DriverIR),
     run_assoc_i64_smoke('uw_wam_assoc_i64_delete', DriverIR).
 
+test(str_split_into_populates_positions) :-
+    str_split_driver_ir(DriverIR),
+    run_assoc_i64_smoke('uw_wam_str_split_into', DriverIR).
+
 run_assoc_i64_smoke(Name, DriverIR) :-
     tmp_root(Root),
     directory_file_path(Root, Name, Dir),
@@ -188,6 +192,50 @@ alloc_fail:
   ret i32 90
 
 bad_counts:
+  ret i32 91
+}
+').
+
+% Split "a,b,c" on ',' into a table keyed 1/2/3; the values are the interned ids
+% of "a"/"b"/"c" (interned up front for comparison; interning is canonical) and
+% the returned count is 3.
+str_split_driver_ir('
+@.uw_split_input = private constant [6 x i8] c"a,b,c\00"
+
+define i32 @main() {
+entry:
+  %table = call %WamAssocI64Table* @wam_assoc_i64_new(i64 8)
+  %tn = icmp eq %WamAssocI64Table* %table, null
+  br i1 %tn, label %alloc_fail, label %go
+
+go:
+  %sp = getelementptr [6 x i8], [6 x i8]* @.uw_split_input, i64 0, i64 0
+  %ida = call i64 @wam_intern_atom(i8* %sp, i64 1)
+  %bptr = getelementptr [6 x i8], [6 x i8]* @.uw_split_input, i64 0, i64 2
+  %idb = call i64 @wam_intern_atom(i8* %bptr, i64 1)
+  %cptr = getelementptr [6 x i8], [6 x i8]* @.uw_split_input, i64 0, i64 4
+  %idc = call i64 @wam_intern_atom(i8* %cptr, i64 1)
+  %n = call i64 @wam_str_split_into(%WamAssocI64Table* %table, i8* %sp, i64 5, i8 44)
+  %got1 = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 1)
+  %got2 = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 2)
+  %got3 = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 3)
+  %n_ok = icmp eq i64 %n, 3
+  %g1_ok = icmp eq i64 %got1, %ida
+  %g2_ok = icmp eq i64 %got2, %idb
+  %g3_ok = icmp eq i64 %got3, %idc
+  %a1 = and i1 %n_ok, %g1_ok
+  %a2 = and i1 %a1, %g2_ok
+  %a3 = and i1 %a2, %g3_ok
+  call void @wam_assoc_i64_free(%WamAssocI64Table* %table)
+  br i1 %a3, label %ok, label %bad
+
+ok:
+  ret i32 0
+
+alloc_fail:
+  ret i32 90
+
+bad:
   ret i32 91
 }
 ').

--- a/tests/test_plawk_split.pl
+++ b/tests/test_plawk_split.pl
@@ -1,0 +1,114 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk `split($N, arr, "sep")` -- split a field on a single-char separator into
+% a positional array `arr` (keys 1..n, string values), read back via `arr[i]`
+% and for-in. Backed by the @wam_str_split_into runtime primitive (clears the
+% table and repopulates -- split replaces the array each call). $0 is the whole
+% record; a positive field uses its slice. Empty pieces are kept (explicit
+% single-char separator, as awk). v1: field source, string-literal single-char
+% separator; the return count and a default (FS) separator are follow-ons.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_split).
+
+% --- parsing ----------------------------------------------------------------
+
+test(split_parses) :-
+    plawk_parse_string("{ split($0, a, \",\") }\n",
+        program([], [rule(always, [split_into(field(0), var(a), string(","))])], [])),
+    !.
+
+test(split_field_parses) :-
+    plawk_parse_string("{ split($2, parts, \":\") }\n",
+        program([], [rule(always, [split_into(field(2), var(parts), string(":"))])], [])),
+    !.
+
+% --- runtime ----------------------------------------------------------------
+
+% split $0 into positions 1..n; for-in yields integer keys + string values.
+test(split_record_key_value, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'kv',
+        "{ split($0, a, \",\") }\nEND { for (k in a) print k, a[k] }\n",
+        "apple,banana,cherry\n", Out, St),
+    assertion(St == 0), assertion(Out == "1 apple\n2 banana\n3 cherry\n"), !.
+
+% value-only read.
+test(split_values, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'v', "{ split($0, a, \",\") }\nEND { for (k in a) print a[k] }\n",
+        "x,y,z\n", Out, St),
+    assertion(St == 0), assertion(Out == "x\ny\nz\n"), !.
+
+% split a positive field.
+test(split_field_source, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'fl', "{ split($2, a, \":\") }\nEND { for (k in a) print k, a[k] }\n",
+        "ignore x:y:z\n", Out, St),
+    assertion(St == 0), assertion(Out == "1 x\n2 y\n3 z\n"), !.
+
+% empty middle piece is kept.
+test(split_keeps_empty, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'em', "{ split($0, a, \",\") }\nEND { for (k in a) print k, a[k] }\n",
+        "a,,b\n", Out, St),
+    assertion(St == 0), assertion(Out == "1 a\n2 \n3 b\n"), !.
+
+% a source with no separator is one piece.
+test(split_single_piece, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'sg', "{ split($0, a, \",\") }\nEND { for (k in a) print k, a[k] }\n",
+        "solo\n", Out, St),
+    assertion(St == 0), assertion(Out == "1 solo\n"), !.
+
+% each record's split replaces the array (the table is cleared first).
+test(split_replaces_each_record, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'rp', "{ split($0, a, \",\") }\nEND { for (k in a) print a[k] }\n",
+        "p,q\nx,y,z\n", Out, St),
+    assertion(St == 0), assertion(Out == "x\ny\nz\n"), !.
+
+% a leading literal label prints alongside the for-in pair.
+test(split_labelled_forin, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'lb',
+        "{ split($0, a, \",\") }\nEND { for (k in a) print \"col\", k, a[k] }\n",
+        "x,y\n", Out, St),
+    assertion(St == 0), assertion(Out == "col 1 x\ncol 2 y\n"), !.
+
+:- end_tests(plawk_split).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_split', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
## Summary

Adds AWK's `split($N, arr, "sep")` to plawk: split a field on a single-character separator into a positional array `arr` (keys `1..n`, string values), then read the pieces back via `arr[i]` and for-in.

Example:

```awk
{ split($0, a, ",") }
END { for (k in a) print k, a[k] }
```

on `apple,banana,cherry` prints:

```
1 apple
2 banana
3 cherry
```

## What's in it

- **Runtime primitive `@wam_str_split_into`** (`src/unifyweaver/targets/wam_llvm_target.pl`): clears the target assoc table (occupied=false, count=0), scans the bytes splitting on the separator, interns each piece to an atom id, and `wam_assoc_i64_set(table, position, id)` for each 1-based position. Returns the piece count. Empty input → 0.
- **Parser** (`examples/plawk/parser/plawk_parser.pl`): `split_action` producing `split_into(field(N), var(Arr), string(Sep))`, wired into the action dispatch.
- **Codegen** (`examples/plawk/codegen/plawk_native_codegen.pl`): full integration through the assoc for-in driver — table discovery, str-valued + positional-array marking, `assoc_split` / `assoc_split_action` plan, and the emitter. `$0` is special-cased to resolve the whole record (a positive field uses its slice); positional keys print numerically and values resolve through the interned-atom path.

## Behaviour

- `$0` splits the whole record; a positive field `$N` splits that field's slice.
- Empty pieces are kept (explicit single-char separator, matching awk): `a,,b` → `1 a / 2 (empty) / 3 b`.
- Each record's split replaces the array (the table is cleared first).

## Scope / follow-ons

- v1 supports a **string-literal single-char separator** and the **for-in read path**.
- Deferred: returning the count into a scalar (`n = split(...)`), a default (FS) separator, `arr[N]` constant-index read (a distinct read path), and multi-char/regex separators.

## Tests

- `tests/core/test_wam_llvm_assoc_i64_runtime.pl`: `str_split_into_populates_positions` exercises the runtime primitive directly (splits `a,b,c`, checks keys 1/2/3 = interned ids, count 3).
- `tests/test_plawk_split.pl`: 9 tests covering parsing (`$0`/`$N`), record key+value, values-only, field source, kept empty piece, single piece, replace-per-record, and labelled for-in. All pass; assoc/for-in regressions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_