### PR TITLE
Add Rust WAM filesystem identity builtins

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1567,6 +1567,59 @@ compile_execute_io_builtin_to_rust(Code) :-
                     false
                 }
             }
+            "realpath/2" | "read_link/2" => {
+                let path = match self.builtin_path_arg("A1") {
+                    Some(path) => path,
+                    None => return false,
+                };
+                let resolved = if op == "realpath/2" {
+                    std::fs::canonicalize(path)
+                } else {
+                    std::fs::read_link(path)
+                };
+                let resolved = match resolved
+                    .ok()
+                    .and_then(|path| path.into_os_string().into_string().ok()) {
+                    Some(path) => path,
+                    None => return false,
+                };
+                let output = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+                let mark = self.trail.len();
+                if self.unify(&output, &Value::Atom(resolved)) {
+                    self.pc += 1; true
+                } else {
+                    self.unwind_trail_to(mark);
+                    false
+                }
+            }
+            "same_file/2" => {
+                let first = match self.builtin_path_arg("A1") {
+                    Some(path) => path,
+                    None => return false,
+                };
+                let second = match self.builtin_path_arg("A2") {
+                    Some(path) => path,
+                    None => return false,
+                };
+                let same = {
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::MetadataExt;
+                        match (std::fs::metadata(first), std::fs::metadata(second)) {
+                            (Ok(a), Ok(b)) => a.dev() == b.dev() && a.ino() == b.ino(),
+                            _ => false,
+                        }
+                    }
+                    #[cfg(not(unix))]
+                    {
+                        match (std::fs::canonicalize(first), std::fs::canonicalize(second)) {
+                            (Ok(a), Ok(b)) => a == b,
+                            _ => false,
+                        }
+                    }
+                };
+                if same { self.pc += 1; true } else { false }
+            }
             "exists_file/1" => {
                 let path = match self.builtin_path_arg("A1") {
                     Some(path) => path,

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -114,6 +114,12 @@ t_path_utilities(Base, Dir, Stem, Ext, Full) :-
     is_absolute_file_name('/tmp/archive.tar.gz'),
     path_join('/tmp/base', 'child.txt', Full).
 
+:- dynamic t_filesystem_identity/2.
+t_filesystem_identity(Real, Target) :-
+    realpath('identity_fixture/link.txt', Real),
+    read_link('identity_fixture/link.txt', Target),
+    same_file('identity_fixture/source.txt', 'identity_fixture/hard.txt').
+
 :- dynamic t_pairs_project/2.
 t_pairs_project(Keys, Values) :-
     Pairs = [a-1, b-2],
@@ -253,6 +259,7 @@ test_builtin_parity_execution :-
              user:t_system_queries/3,
              user:t_split_string/1, user:t_atom_split/1, user:t_atom_checks/0,
              user:t_path_utilities/5,
+             user:t_filesystem_identity/2,
              user:t_pairs_project/2, user:t_pairs_split/2, user:t_pairs_zip/1,
              user:t_thrower/0, user:t_deep/0, user:t_mid/0,
              user:t_catch_match/1, user:t_catch_deep/1,
@@ -284,6 +291,7 @@ use builtin_parity_test::{t_between_1, t_msort_1, t_sort_1, t_sort4_1, t_concat_
     t_system_queries_3,
     t_split_string_1, t_atom_split_1, t_atom_checks_0,
     t_path_utilities_5,
+    t_filesystem_identity_2,
     t_pairs_project_2, t_pairs_split_2, t_pairs_zip_1,
     t_catch_match_1, t_catch_deep_1, t_catch_nomatch_0, t_catch_nothrow_1,
     t_catch_failgoal_0, t_catch_nested_1, t_succ_fwd_1, t_succ_rev_1,
@@ -496,6 +504,53 @@ fn test_path_utility_family_compiled() {
     assert_eq!(read_var(&vm, "Stem"), a("/tmp/archive.tar"));
     assert_eq!(read_var(&vm, "Ext"), a("gz"));
     assert_eq!(read_var(&vm, "Full"), a("/tmp/base/child.txt"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_filesystem_identity_compiled_and_direct() {
+    let fixture = std::path::Path::new("identity_fixture");
+    let _ = std::fs::remove_dir_all(fixture);
+    std::fs::create_dir(fixture).unwrap();
+    std::fs::write(fixture.join("source.txt"), b"identity").unwrap();
+    std::fs::hard_link(fixture.join("source.txt"), fixture.join("hard.txt")).unwrap();
+    std::os::unix::fs::symlink("source.txt", fixture.join("link.txt")).unwrap();
+
+    let expected_real = std::fs::canonicalize(fixture.join("link.txt"))
+        .unwrap().into_os_string().into_string().unwrap();
+    let mut vm = vmnew();
+    assert!(t_filesystem_identity_2(&mut vm, ub("Real"), ub("Target")));
+    assert_eq!(read_var(&vm, "Real"), a(&expected_real));
+    assert_eq!(read_var(&vm, "Target"), a("source.txt"));
+
+    let source = fixture.join("source.txt").to_str().unwrap().to_string();
+    let hard = fixture.join("hard.txt").to_str().unwrap().to_string();
+    let link = fixture.join("link.txt").to_str().unwrap().to_string();
+    assert!(call2("same_file/2", a(&source), a(&hard)).0);
+    assert!(call2("same_file/2", a(&source), a(&link)).0,
+        "metadata follows symlinks");
+    std::fs::write(fixture.join("other.txt"), b"other").unwrap();
+    let other = fixture.join("other.txt").to_str().unwrap().to_string();
+    assert!(!call2("same_file/2", a(&source), a(&other)).0);
+
+    let (real_ok, real_vm) = call2("realpath/2", a(&link), ub("Real"));
+    assert!(real_ok);
+    assert_eq!(read_var(&real_vm, "Real"), a(&expected_real));
+    let (link_ok, link_vm) = call2("read_link/2", a(&link), ub("Target"));
+    assert!(link_ok);
+    assert_eq!(read_var(&link_vm, "Target"), a("source.txt"));
+
+    std::fs::remove_dir_all(fixture).unwrap();
+}
+
+#[test]
+fn test_filesystem_identity_validation() {
+    assert!(!call2("realpath/2", a("missing-identity-path"), ub("Real")).0);
+    assert!(!call2("read_link/2", a("missing-identity-link"), ub("Target")).0);
+    assert!(!call2("same_file/2", a("missing-a"), a("missing-b")).0);
+    assert!(!call2("realpath/2", i(1), ub("Real")).0);
+    assert!(!call2("read_link/2", ub("Path"), ub("Target")).0);
+    assert!(!call2("same_file/2", a("path"), i(2)).0);
 }
 
 #[test]

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -499,6 +499,9 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, '"file_name_extension/3"'),
         sub_string(S, _, _, _, '"is_absolute_file_name/1"'),
         sub_string(S, _, _, _, '"path_join/3"'),
+        sub_string(S, _, _, _, '"realpath/2" | "read_link/2"'),
+        sub_string(S, _, _, _, '"same_file/2"'),
+        sub_string(S, _, _, _, 'MetadataExt'),
         %% copy_term_walk helper (sharing-preserving recursive copy).
         sub_string(S, _, _, _, 'copy_term_walk'),
         %% Runtime-parser bridge support and the parser-required text/list builtins.


### PR DESCRIPTION
## Summary

- Implement `realpath/2` using canonical filesystem resolution
- Implement `read_link/2` while preserving the raw symlink target
- Implement `same_file/2`
- Compare device and inode on Unix for correct hard-link identity
- Follow symlinks when checking file identity
- Use canonical-path comparison as a dependency-free non-Unix fallback
- Avoid new runtime state, caches, and dependencies

## Testing

- Exercise compiled predicates through WAM fallback
- Verify symlink resolution and raw relative targets
- Verify hard-link and symlink identity
- Verify distinct, missing, and invalid paths fail
- `swipl -q -g run_tests -t halt tests/test_wam_rust_builtin_parity.pl`
- `swipl -q -s tests/test_wam_rust_target.pl`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `git diff --check`