### PR TITLE
WAM/LLVM plawk: field assignment ($N = expr) rebuilds and re-emits $0

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -42,7 +42,7 @@ only (runtime pending) · ❌ missing.
 | `if` with a plain (non-accumulator) body | ✅ | `{ if (c) { print $1 } }` compiles and runs (fixed by the while-runtime body-print enablers); if/else with plain bodies too |
 | regex in `if` (`if ($0 ~ /re/)`) | ✅ | `if ($0 ~ /re/) { … }` and `!~` compile and run — guards a plain body |
 | brace-less `if`/loop body | ✅ | `if (c) print`, `while (c) x++`, `do stmt while (c)`, braceless else-if chains — a body is a braced block or one statement |
-| field assignment (`$2 = expr`) | ❌ | rebuilding `$0` from mutated fields not wired |
+| field assignment (`$2 = expr`) | ✅ | `Pattern { $N = expr; …; print $0 }` rebuilds `$0` from the mutated field (re-joined with OFS) via the `@wam_record_set_field` runtime primitive, re-interns, and re-emits. RHS is a string/integer literal or another field `$M`; chained assignments and a pattern guard work; setting a field past the end pads with empties. **v1 scope:** single-char explicit `FS`, a single rule with no `END`, and the print-the-record idiom. Follow-ons: default (space) `FS`, in-body field reads after assignment, `$0 = expr`, multi-rule/`END` programs, concat/arithmetic RHS |
 | C-style `for (;;)` | ❌ | |
 | `delete arr[k]` | ◐ | `delete arr[$k]` removes the entry keyed by a field (parity with `arr[$k]++`); backward-shift deletion in the runtime (later colliding keys stay reachable), missing key is a no-op. String-literal / var keys are a follow-on |
 | `exit [n]` | ✅ | stops the record loop, runs END, returns N (default 0); `exit` in a rule body, an `if`/`else` branch, or a loop (propagates past the loop) — scalar state at the exit point flows into END |

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -208,6 +208,154 @@ print_line:
             success, 'success:\n  ret i32 0'),
         DriverIR).
 
+% Field assignment: a single text-mode rule `Pattern { $N = expr; ...; print $0 }`.
+% Each `$N = expr` rebuilds the current record via @wam_record_set_field (fields
+% re-joined with OFS), folding a running interned-atom id; the trailing `print $0`
+% emits the rebuilt record. v1 scope: single-char explicit FS (so field splitting
+% matches how fields are read), a single rule with no END, and the print-the-record
+% idiom. RHS is a string literal, an integer literal, or another field `$M` (read
+% from the current record). In-body field reads after assignment, default (space)
+% FS, multi-rule/END programs, and `$0 = expr` are follow-ons.
+plawk_program_native_driver_ir(
+    program(BeginClauses, [rule(Pattern, Actions)], []),
+    InputPath,
+    DriverIR
+) :-
+    plawk_field_assign_body(Actions, SetFields, _PrintAction),
+    \+ plawk_begin_has_binfmt(BeginClauses),
+    plawk_record_descriptor(BeginClauses, FieldSeparator),
+    integer(FieldSeparator),
+    FieldSeparator =\= 32,
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_pattern_guard_ir(Pattern, FieldSeparator, GuardGlobalIR-GuardCallIR),
+    plawk_field_assign_actions_ir(SetFields, FieldSeparator, OutputSeparator,
+        AssignGlobalIR, AssignBodyIR, FinalIdVar),
+    format(atom(PrintIR),
+'  %fa_out = call i8* @wam_atom_to_string(i64 ~w)
+  %fa_out_fmt = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_line, i32 0, i32 0
+  %fa_out_pr = call i32 (i8*, ...) @printf(i8* %fa_out_fmt, i8* %fa_out)',
+        [FinalIdVar]),
+    format(atom(RecordIR),
+'~w
+  br i1 %is_match, label %print_line, label %continue_loop
+
+print_line:
+~w
+~w
+  br label %continue_loop',
+        [GuardCallIR, AssignBodyIR, PrintIR]),
+    format(atom(RuntimeGlobals),
+'@.plawk_surface_print_line = private constant [4 x i8] c"%s\\0A\\00"
+@.plawk_surface_print_slice = private constant [5 x i8] c"%.*s\\00"
+@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"
+@.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
+@.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"
+@.plawk_surface_print_f64 = private constant [3 x i8] c"%g\\00"
+~w
+~w
+~w
+',
+        [BeginGlobalIR, GuardGlobalIR, AssignGlobalIR]),
+    plawk_emit_record_driver_ir(FieldSeparator, InputPath,
+        driver_blocks(RuntimeGlobals, BeginIR, '', lowered_match, RecordIR, '',
+            success, 'success:\n  ret i32 0'),
+        DriverIR).
+
+%% plawk_field_assign_body(+Actions, -SetFields, -PrintAction)
+%
+%  A field-assignment rule body: one or more `set_field(N, Value)` actions
+%  followed by exactly `print $0` (`print([field(0)])`). This is the canonical
+%  "edit a field and re-emit the record" shape; anything else (a scalar update,
+%  a field read after the assignment, a non-`$0` print) does not match, so the
+%  program falls through to the general drivers.
+plawk_field_assign_body(Actions, SetFields, print([field(0)])) :-
+    append(SetFields, [print([field(0)])], Actions),
+    SetFields = [_ | _],
+    forall(member(A, SetFields), A = set_field(_, _)).
+
+%% plawk_field_assign_actions_ir(+SetFields, +FieldSeparator, +OutputSeparator,
+%%     -GlobalIR, -BodyIR, -FinalIdVar)
+%
+%  Fold the `set_field` list into IR that rebuilds the record once per
+%  assignment. The first rebuild reads the original line atom (%line_payload);
+%  each subsequent one reads the previous rebuild's atom id, so chained
+%  assignments (`$1="p"; $2="q"`) and field-copy RHS (`$1=$3`) see the running
+%  record. FinalIdVar is the atom id to print.
+plawk_field_assign_actions_ir(SetFields, FieldSeparator, OutputSeparator,
+        GlobalIR, BodyIR, FinalIdVar) :-
+    plawk_field_assign_fold(SetFields, FieldSeparator, OutputSeparator, 0,
+        '%line_payload', Parts, FinalIdVar),
+    pairs_keys_values(Parts, GlobalParts, BodyParts),
+    plawk_join_nonempty_ir(GlobalParts, GlobalIR),
+    atomic_list_concat(BodyParts, '\n', BodyIR).
+
+plawk_field_assign_fold([], _FieldSeparator, _OutputSeparator, _Index, CurId, [], CurId).
+plawk_field_assign_fold([set_field(N, Value) | Rest], FieldSeparator,
+        OutputSeparator, Index, CurId, [GlobalPart-BodyPart | Parts], FinalId) :-
+    plawk_field_assign_one(N, Value, FieldSeparator, OutputSeparator, Index,
+        CurId, GlobalPart, BodyPart, NextId),
+    NextIndex is Index + 1,
+    plawk_field_assign_fold(Rest, FieldSeparator, OutputSeparator, NextIndex,
+        NextId, Parts, FinalId).
+
+%% plawk_field_assign_one(+N, +Value, +FS, +OFS, +Index, +CurId,
+%%     -GlobalPart, -BodyPart, -NextId)
+%
+%  One `$N = Value` rebuild. Resolves the current record to text, materializes
+%  the new field value as a byte range, then calls @wam_record_set_field. The
+%  new atom id is NextId (threaded to the next assignment / the print).
+plawk_field_assign_one(N, Value, FieldSeparator, OutputSeparator, Index, CurId,
+        GlobalPart, BodyPart, NextId) :-
+    format(atom(RecVar), '%fa_~w_rec', [Index]),
+    format(atom(NextId), '%fa_~w_id', [Index]),
+    format(atom(RecLine), '  ~w = call i8* @wam_atom_to_string(i64 ~w)',
+        [RecVar, CurId]),
+    plawk_field_assign_value_ir(Value, FieldSeparator, Index, CurId,
+        GlobalPart, ValueLines, ValPtr, ValLen),
+    format(atom(CallLine),
+        '  ~w = call i64 @wam_record_set_field(i8* ~w, i64 ~w, i8* ~w, i64 ~w, i8 ~w, i8 ~w)',
+        [NextId, RecVar, N, ValPtr, ValLen, FieldSeparator, OutputSeparator]),
+    append([RecLine | ValueLines], [CallLine], Lines),
+    atomic_list_concat(Lines, '\n', BodyPart).
+
+%% plawk_field_assign_value_ir(+Value, +FS, +Index, +CurId,
+%%     -GlobalPart, -Lines, -ValPtr, -ValLen)
+%
+%  The new field value as (ValPtr, ValLen). A string / integer literal becomes a
+%  private C-string global; a field `$M` is projected from the current record
+%  (its slice ptr aliases the record text, which @wam_record_set_field copies out
+%  before interning). A missing field yields a {null,0} slice -> an empty field.
+plawk_field_assign_value_ir(string(S), _FieldSeparator, Index, _CurId,
+        GlobalPart, [PtrLine], ValPtr, ValLen) :-
+    format(atom(GlobalName), 'fa_val_~w', [Index]),
+    llvm_emit_c_string_global(GlobalName, S, GlobalPart, ValLen, BytesLen),
+    format(atom(ValPtr), '%fa_~w_vp', [Index]),
+    format(atom(PtrLine),
+        '  ~w = getelementptr [~w x i8], [~w x i8]* @.~w, i64 0, i64 0',
+        [ValPtr, BytesLen, BytesLen, GlobalName]).
+plawk_field_assign_value_ir(int(V), FieldSeparator, Index, CurId,
+        GlobalPart, Lines, ValPtr, ValLen) :-
+    format(atom(S), '~w', [V]),
+    plawk_field_assign_value_ir(string(S), FieldSeparator, Index, CurId,
+        GlobalPart, Lines, ValPtr, ValLen).
+plawk_field_assign_value_ir(field(M), FieldSeparator, Index, CurId,
+        '', Lines, ValPtr, ValLen) :-
+    format(atom(CvZero), '%fa_~w_cv0', [Index]),
+    format(atom(Cv), '%fa_~w_cv', [Index]),
+    format(atom(Slice), '%fa_~w_sl', [Index]),
+    format(atom(ValPtr), '%fa_~w_vp', [Index]),
+    format(atom(ValLen), '%fa_~w_vl', [Index]),
+    format(atom(L0), '  ~w = insertvalue %Value undef, i32 0, 0', [CvZero]),
+    format(atom(L1), '  ~w = insertvalue %Value ~w, i64 ~w, 1', [Cv, CvZero, CurId]),
+    format(atom(L2),
+        '  ~w = call %WamSlice @wam_atom_field_slice_value(%Value ~w, i64 ~w, i8 ~w)',
+        [Slice, Cv, M, FieldSeparator]),
+    format(atom(L3), '  ~w = extractvalue %WamSlice ~w, 0', [ValPtr, Slice]),
+    format(atom(L4), '  ~w = extractvalue %WamSlice ~w, 1', [ValLen, Slice]),
+    Lines = [L0, L1, L2, L3, L4].
+
 % A body-printing scalar rule chain with NO END block: all output comes from
 % the per-record body (e.g. `{ i = 0; while (i < 3) { print i; i++ } }`). Same
 % lowering as the scalar END-print chain but with an empty print list and NO

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -2044,6 +2044,35 @@ row_field(field(Index)) -->
     integer_codes(Codes),
     { Codes \== [], number_codes(Index, Codes), Index >= 0 }.
 
+% Field assignment `$N = expr` -- mutate field N of the current record, which
+% rebuilds `$0` (fields re-joined with OFS). Parses to set_field(N, Value). N>=1
+% (whole-record `$0 = ...` is a separate operation). RHS v1: a string literal,
+% a non-negative integer literal, or another field `$M` (M>=1, read from the
+% current record). Tried before the scalar `set` -- the leading `$` is
+% unambiguous. The codegen supports the canonical `{ $N = expr; ...; print }`
+% shape in single-char-FS text mode.
+assignment_action(set_field(N, Value)) -->
+    "$",
+    integer_codes(NCodes),
+    { NCodes \== [], number_codes(N, NCodes), N >= 1 },
+    ws,
+    "=",
+    ws,
+    field_assign_rhs(Value).
+
+field_assign_rhs(string(Value)) -->
+    quoted_string(Codes),
+    { string_codes(Value, Codes) },
+    !.
+field_assign_rhs(field(M)) -->
+    "$",
+    integer_codes(MCodes),
+    { MCodes \== [], number_codes(M, MCodes), M >= 1 },
+    !.
+field_assign_rhs(int(Value)) -->
+    integer_codes(VCodes),
+    { VCodes \== [], number_codes(Value, VCodes), Value >= 0 }.
+
 assignment_action(set(var(Name), Value)) -->
     identifier(Name),
     ws,

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4829,6 +4829,147 @@ sp.ret0:
   ret i64 0
 }
 
+; Rebuild a text record with field %idx (1-based) set to %val[0..vlen). The
+; record %rec is a NUL-terminated string split on the single byte %sep; the
+; fields are re-joined with %ofs. Fields past the current count are padded with
+; empties up to %idx. Returns the interned atom id of the rebuilt record (0 on
+; a malloc failure). Mirrors awk: assigning a field rebuilds $0 using OFS.
+define i64 @wam_record_set_field(i8* %rec, i64 %idx, i8* %val, i64 %vlen, i8 %sep, i8 %ofs) {
+entry:
+  br label %rsf.sl
+
+; reclen = index of the terminating NUL
+rsf.sl:
+  %rsf.si = phi i64 [ 0, %entry ], [ %rsf.si1, %rsf.ss ]
+  %rsf.sp = getelementptr i8, i8* %rec, i64 %rsf.si
+  %rsf.sc = load i8, i8* %rsf.sp
+  %rsf.sz = icmp eq i8 %rsf.sc, 0
+  br i1 %rsf.sz, label %rsf.cs, label %rsf.ss
+
+rsf.ss:
+  %rsf.si1 = add i64 %rsf.si, 1
+  br label %rsf.sl
+
+; count separators to derive the field count
+rsf.cs:
+  br label %rsf.cl
+
+rsf.cl:
+  %rsf.ci = phi i64 [ 0, %rsf.cs ], [ %rsf.ci1, %rsf.cst ]
+  %rsf.cnt = phi i64 [ 0, %rsf.cs ], [ %rsf.cnt1, %rsf.cst ]
+  %rsf.cd = icmp uge i64 %rsf.ci, %rsf.si
+  br i1 %rsf.cd, label %rsf.cf, label %rsf.cb
+
+rsf.cb:
+  %rsf.cp = getelementptr i8, i8* %rec, i64 %rsf.ci
+  %rsf.cc = load i8, i8* %rsf.cp
+  %rsf.cissep = icmp eq i8 %rsf.cc, %sep
+  %rsf.cinc = zext i1 %rsf.cissep to i64
+  br label %rsf.cst
+
+rsf.cst:
+  %rsf.cnt1 = add i64 %rsf.cnt, %rsf.cinc
+  %rsf.ci1 = add i64 %rsf.ci, 1
+  br label %rsf.cl
+
+rsf.cf:
+  %rsf.empty = icmp eq i64 %rsf.si, 0
+  %rsf.nf1 = add i64 %rsf.cnt, 1
+  %rsf.nf = select i1 %rsf.empty, i64 0, i64 %rsf.nf1
+  %rsf.idxgt = icmp ugt i64 %idx, %rsf.nf
+  %rsf.outcount = select i1 %rsf.idxgt, i64 %idx, i64 %rsf.nf
+  ; cap bound: original bytes + new field + one sep per field + NUL slack
+  %rsf.cap0 = add i64 %rsf.si, %vlen
+  %rsf.cap1 = add i64 %rsf.cap0, %rsf.outcount
+  %rsf.cap = add i64 %rsf.cap1, 2
+  %rsf.buf = call i8* @malloc(i64 %rsf.cap)
+  %rsf.bufnull = icmp eq i8* %rsf.buf, null
+  br i1 %rsf.bufnull, label %rsf.fail, label %rsf.floop
+
+; emit fields 1..outcount into %rsf.buf, joined by %ofs
+rsf.floop:
+  %rsf.f = phi i64 [ 1, %rsf.cf ], [ %rsf.fn, %rsf.fcont ]
+  %rsf.outpos = phi i64 [ 0, %rsf.cf ], [ %rsf.outposn, %rsf.fcont ]
+  %rsf.spos = phi i64 [ 0, %rsf.cf ], [ %rsf.sposn, %rsf.fcont ]
+  %rsf.fdone = icmp ugt i64 %rsf.f, %rsf.outcount
+  br i1 %rsf.fdone, label %rsf.finish, label %rsf.fbody
+
+rsf.fbody:
+  %rsf.fgt1 = icmp ugt i64 %rsf.f, 1
+  br i1 %rsf.fgt1, label %rsf.emitsep, label %rsf.aftersep
+
+rsf.emitsep:
+  %rsf.sepdst = getelementptr i8, i8* %rsf.buf, i64 %rsf.outpos
+  store i8 %ofs, i8* %rsf.sepdst
+  %rsf.outpos_sep = add i64 %rsf.outpos, 1
+  br label %rsf.aftersep
+
+rsf.aftersep:
+  %rsf.outposa = phi i64 [ %rsf.outpos_sep, %rsf.emitsep ], [ %rsf.outpos, %rsf.fbody ]
+  br label %rsf.feloop
+
+; find the end of the source field starting at %rsf.spos
+rsf.feloop:
+  %rsf.fei = phi i64 [ %rsf.spos, %rsf.aftersep ], [ %rsf.fei1, %rsf.fest ]
+  %rsf.feend = icmp uge i64 %rsf.fei, %rsf.si
+  br i1 %rsf.feend, label %rsf.fedone, label %rsf.fechk
+
+rsf.fechk:
+  %rsf.fep = getelementptr i8, i8* %rec, i64 %rsf.fei
+  %rsf.fec = load i8, i8* %rsf.fep
+  %rsf.feissep = icmp eq i8 %rsf.fec, %sep
+  br i1 %rsf.feissep, label %rsf.fedone, label %rsf.fest
+
+rsf.fest:
+  %rsf.fei1 = add i64 %rsf.fei, 1
+  br label %rsf.feloop
+
+rsf.fedone:
+  ; source field is [%rsf.spos, %rsf.fei); pick the value to append
+  %rsf.isidx = icmp eq i64 %rsf.f, %idx
+  %rsf.lenf = icmp ule i64 %rsf.f, %rsf.nf
+  %rsf.srcptr = getelementptr i8, i8* %rec, i64 %rsf.spos
+  %rsf.srclen = sub i64 %rsf.fei, %rsf.spos
+  %rsf.srcorpad = select i1 %rsf.lenf, i64 %rsf.srclen, i64 0
+  %rsf.applen = select i1 %rsf.isidx, i64 %vlen, i64 %rsf.srcorpad
+  %rsf.apptr = select i1 %rsf.isidx, i8* %val, i8* %rsf.srcptr
+  %rsf.fei_1 = add i64 %rsf.fei, 1
+  %rsf.sposn = select i1 %rsf.lenf, i64 %rsf.fei_1, i64 %rsf.spos
+  br label %rsf.aploop
+
+rsf.aploop:
+  %rsf.api = phi i64 [ 0, %rsf.fedone ], [ %rsf.api1, %rsf.apst ]
+  %rsf.apdone = icmp uge i64 %rsf.api, %rsf.applen
+  br i1 %rsf.apdone, label %rsf.apfin, label %rsf.apst
+
+rsf.apst:
+  %rsf.apsp = getelementptr i8, i8* %rsf.apptr, i64 %rsf.api
+  %rsf.apc = load i8, i8* %rsf.apsp
+  %rsf.apdpos = add i64 %rsf.outposa, %rsf.api
+  %rsf.apdp = getelementptr i8, i8* %rsf.buf, i64 %rsf.apdpos
+  store i8 %rsf.apc, i8* %rsf.apdp
+  %rsf.api1 = add i64 %rsf.api, 1
+  br label %rsf.aploop
+
+rsf.apfin:
+  %rsf.outposn = add i64 %rsf.outposa, %rsf.applen
+  %rsf.fn = add i64 %rsf.f, 1
+  br label %rsf.fcont
+
+rsf.fcont:
+  br label %rsf.floop
+
+rsf.finish:
+  %rsf.nuldst = getelementptr i8, i8* %rsf.buf, i64 %rsf.outpos
+  store i8 0, i8* %rsf.nuldst
+  %rsf.id = call i64 @wam_intern_atom(i8* %rsf.buf, i64 %rsf.outpos)
+  call void @free(i8* %rsf.buf)
+  ret i64 %rsf.id
+
+rsf.fail:
+  ret i64 0
+}
+
 define i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 %key, i64 %delta) {
 entry:
   %table_null = icmp eq %WamAssocI64Table* %table, null

--- a/tests/core/test_wam_llvm_assoc_i64_runtime.pl
+++ b/tests/core/test_wam_llvm_assoc_i64_runtime.pl
@@ -36,6 +36,10 @@ test(str_split_into_populates_positions) :-
     str_split_driver_ir(DriverIR),
     run_assoc_i64_smoke('uw_wam_str_split_into', DriverIR).
 
+test(record_set_field_rebuilds_record) :-
+    record_set_field_driver_ir(DriverIR),
+    run_assoc_i64_smoke('uw_wam_record_set_field', DriverIR).
+
 run_assoc_i64_smoke(Name, DriverIR) :-
     tmp_root(Root),
     directory_file_path(Root, Name, Dir),
@@ -234,6 +238,54 @@ ok:
 
 alloc_fail:
   ret i32 90
+
+bad:
+  ret i32 91
+}
+').
+
+% Rebuild records via @wam_record_set_field and compare against the interned id
+% of the expected result (interning is canonical). Three cases: replace a middle
+% field keeping the separator (FS=OFS=','); replace with a different OFS (FS=',',
+% OFS=' '); and set a field past the end, which pads with empty fields.
+record_set_field_driver_ir('
+@.uw_rsf_abc = private constant [6 x i8] c"a,b,c\00"
+@.uw_rsf_X = private constant [2 x i8] c"X\00"
+@.uw_rsf_aXc = private constant [6 x i8] c"a,X,c\00"
+@.uw_rsf_aspXspc = private constant [6 x i8] c"a X c\00"
+@.uw_rsf_a = private constant [2 x i8] c"a\00"
+@.uw_rsf_Z = private constant [2 x i8] c"Z\00"
+@.uw_rsf_a__Z = private constant [6 x i8] c"a,,,Z\00"
+
+define i32 @main() {
+entry:
+  %abc = getelementptr [6 x i8], [6 x i8]* @.uw_rsf_abc, i64 0, i64 0
+  %vX = getelementptr [2 x i8], [2 x i8]* @.uw_rsf_X, i64 0, i64 0
+  %eaXc_p = getelementptr [6 x i8], [6 x i8]* @.uw_rsf_aXc, i64 0, i64 0
+  %eaXc = call i64 @wam_intern_atom(i8* %eaXc_p, i64 5)
+  %easc_p = getelementptr [6 x i8], [6 x i8]* @.uw_rsf_aspXspc, i64 0, i64 0
+  %easc = call i64 @wam_intern_atom(i8* %easc_p, i64 5)
+  %aa = getelementptr [2 x i8], [2 x i8]* @.uw_rsf_a, i64 0, i64 0
+  %vZ = getelementptr [2 x i8], [2 x i8]* @.uw_rsf_Z, i64 0, i64 0
+  %epad_p = getelementptr [6 x i8], [6 x i8]* @.uw_rsf_a__Z, i64 0, i64 0
+  %epad = call i64 @wam_intern_atom(i8* %epad_p, i64 5)
+
+  ; abc with field 2 = X, sep comma ofs comma -> a,X,c
+  %r1 = call i64 @wam_record_set_field(i8* %abc, i64 2, i8* %vX, i64 1, i8 44, i8 44)
+  %r1_ok = icmp eq i64 %r1, %eaXc
+  ; abc with field 2 = X, sep comma ofs space -> a X c
+  %r2 = call i64 @wam_record_set_field(i8* %abc, i64 2, i8* %vX, i64 1, i8 44, i8 32)
+  %r2_ok = icmp eq i64 %r2, %easc
+  ; a with field 4 = Z, sep comma ofs comma -> a,,,Z (pad empties)
+  %r3 = call i64 @wam_record_set_field(i8* %aa, i64 4, i8* %vZ, i64 1, i8 44, i8 44)
+  %r3_ok = icmp eq i64 %r3, %epad
+
+  %a1 = and i1 %r1_ok, %r2_ok
+  %a2 = and i1 %a1, %r3_ok
+  br i1 %a2, label %ok, label %bad
+
+ok:
+  ret i32 0
 
 bad:
   ret i32 91

--- a/tests/test_plawk_fieldassign.pl
+++ b/tests/test_plawk_fieldassign.pl
@@ -1,0 +1,147 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk field assignment `$N = expr` -- mutate field N of the current record,
+% which rebuilds `$0` (fields re-joined with OFS) and re-emits it via `print $0`.
+% Backed by the @wam_record_set_field runtime primitive (split on FS, replace the
+% field, join on OFS, re-intern). RHS is a string literal, an integer literal, or
+% another field `$M` read from the current record; chained assignments and a
+% pattern guard are supported. v1: single-char explicit FS, a single rule with no
+% END, and the print-the-record idiom. Default (space) FS, in-body field reads
+% after assignment, and `$0 = expr` are follow-ons.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_fieldassign).
+
+% --- parsing ----------------------------------------------------------------
+
+test(fieldassign_string_parses) :-
+    plawk_parse_string("{ $2 = \"X\"; print $0 }\n",
+        program([], [rule(always, [set_field(2, string("X")), print([field(0)])])], [])),
+    !.
+
+test(fieldassign_field_rhs_parses) :-
+    plawk_parse_string("{ $1 = $3; print $0 }\n",
+        program([], [rule(always, [set_field(1, field(3)), print([field(0)])])], [])),
+    !.
+
+test(fieldassign_int_rhs_parses) :-
+    plawk_parse_string("{ $2 = 9; print $0 }\n",
+        program([], [rule(always, [set_field(2, int(9)), print([field(0)])])], [])),
+    !.
+
+% $0 = ... is not a field assignment (whole-record assign is a separate op).
+test(fieldassign_rejects_zero, [fail]) :-
+    plawk_parse_string("{ $0 = \"x\"; print $0 }\n",
+        program([], [rule(always, [set_field(0, _) | _])], [])).
+
+% --- runtime ----------------------------------------------------------------
+
+% replace a middle field, keeping the separator (OFS = FS).
+test(fieldassign_replace, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'rep',
+        "BEGIN { FS = \",\"; OFS = \",\" }\n{ $2 = \"X\"; print $0 }\n",
+        "a,b,c\nd,e,f\n", Out, St),
+    assertion(St == 0), assertion(Out == "a,X,c\nd,X,f\n"), !.
+
+% an integer RHS renders as text.
+test(fieldassign_int, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'int',
+        "BEGIN { FS = \",\"; OFS = \",\" }\n{ $2 = 9; print $0 }\n",
+        "a,b,c\n", Out, St),
+    assertion(St == 0), assertion(Out == "a,9,c\n"), !.
+
+% a field-copy RHS reads the current record.
+test(fieldassign_field_copy, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'cp',
+        "BEGIN { FS = \",\"; OFS = \",\" }\n{ $1 = $3; print $0 }\n",
+        "a,b,c\n", Out, St),
+    assertion(St == 0), assertion(Out == "c,b,c\n"), !.
+
+% setting a field past the end pads with empty fields.
+test(fieldassign_pads, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'pad',
+        "BEGIN { FS = \",\"; OFS = \",\" }\n{ $5 = \"Z\"; print $0 }\n",
+        "a,b\n", Out, St),
+    assertion(St == 0), assertion(Out == "a,b,,,Z\n"), !.
+
+% the rebuild uses OFS: a comma FS with the default (space) OFS re-joins on space.
+test(fieldassign_ofs_rebuild, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ofs',
+        "BEGIN { FS = \",\" }\n{ $2 = \"X\"; print $0 }\n",
+        "a,b,c\n", Out, St),
+    assertion(St == 0), assertion(Out == "a X c\n"), !.
+
+% chained assignments fold onto the running record.
+test(fieldassign_chained, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ch',
+        "BEGIN { FS = \",\"; OFS = \",\" }\n{ $1 = \"p\"; $2 = \"q\"; print $0 }\n",
+        "a,b,c\n", Out, St),
+    assertion(St == 0), assertion(Out == "p,q,c\n"), !.
+
+% a pattern guard gates the assignment+print; non-matching records are dropped.
+test(fieldassign_guarded, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'gd',
+        "BEGIN { FS = \",\"; OFS = \",\" }\n$1 == \"err\" { $2 = \"X\"; print $0 }\n",
+        "err,b,c\nok,y,z\n", Out, St),
+    assertion(St == 0), assertion(Out == "err,X,c\n"), !.
+
+% default (space) FS field assignment is out of the v1 surface: it must fail the
+% build cleanly (exit 3) rather than miscompile.
+test(fieldassign_default_fs_rejected, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_status(Dir, 'df', "{ $2 = \"X\"; print $0 }\n", BuildStatus),
+    assertion(BuildStatus == exit(3)), !.
+
+:- end_tests(plawk_fieldassign).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_fieldassign', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).
+
+build_status(Dir, Name, Src, BuildStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, BuildStatus).


### PR DESCRIPTION
## Summary

Adds AWK field assignment `$N = expr` to plawk. A text-mode rule of the shape `Pattern { $N = expr; …; print $0 }` mutates field N of the current record, which rebuilds `$0` (fields re-joined with OFS) and re-emits it.

Example:

```awk
BEGIN { FS = ","; OFS = "," }
{ $2 = "X"; print $0 }
```

on `a,b,c` prints `a,X,c`.

## Why this shape

The record is an immutable SSA value (`%line`, an interned atom) that field reads re-project on demand — there is no mutable "current $0". Rather than thread a mutable record through the whole general scalar machinery (30+ field-read sites), this lands the canonical *edit-a-field-and-re-emit* idiom as its own self-contained text-mode driver, the same way the single-action print / assoc / query paths are their own modes.

## What's in it

- **Runtime primitive `@wam_record_set_field`** (`src/unifyweaver/targets/wam_llvm_target.pl`): splits the record on the single-byte FS, replaces the 1-based field with the new value (padding with empty fields when the index is past the current count), re-joins with OFS, and interns the result — returning the new atom id (0 on malloc failure). Mirrors awk: assigning a field rebuilds `$0` using OFS.
- **Parser** (`examples/plawk/parser/plawk_parser.pl`): `set_field(N, Value)` action (N ≥ 1). RHS is a string literal, a non-negative integer literal, or another field `$M`.
- **Codegen** (`examples/plawk/codegen/plawk_native_codegen.pl`): a dedicated driver clause that folds each `$N = expr` through the primitive — threading a running atom id so chained assignments (`$1="p"; $2="q"`) and field-copy RHS (`$1=$3`) see the running record — then prints the rebuilt record. Guarded to text mode with an explicit single-char FS.

## Behaviour

- `$2 = "X"` on `a,b,c` (FS=OFS=`,`) → `a,X,c`.
- Integer RHS renders as text: `$2 = 9` → `a,9,c`.
- Field-copy reads the current record: `$1 = $3` on `a,b,c` → `c,b,c`.
- Setting past the end pads with empties: `$5 = "Z"` on `a,b` → `a,b,,,Z`.
- The rebuild uses OFS: FS=`,` with default (space) OFS re-joins on space — `$2="X"` on `a,b,c` → `a X c`.
- Chained assignments fold onto the running record; a pattern guard gates the assignment+print.

## Scope / follow-ons

- **v1:** single-char explicit `FS` (so splitting matches how fields are read), a single rule with no `END`, and the print-the-record idiom.
- Default (space) `FS` field assignment is **rejected cleanly (exit 3)** rather than miscompiled.
- Deferred: default-`FS` (whitespace-run) splitting, in-body field reads after assignment, `$0 = expr` (whole-record assign), multi-rule / `END` programs, and concat / arithmetic RHS.

## Tests

- `tests/core/test_wam_llvm_assoc_i64_runtime.pl`: `record_set_field_rebuilds_record` exercises the primitive directly (replace-middle, differing OFS, pad-empties).
- `tests/test_plawk_fieldassign.pl`: 12 tests — parsing (`$N`, field/int RHS, `$0` rejected), replace, integer RHS, field-copy, padding, OFS rebuild, chained, guarded, and the clean rejection of default-FS. All pass; surface/print/guard regressions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_