### PR TITLE
WAM/LLVM plawk: multi-char / regex field separator (FS)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -63,7 +63,7 @@ only (runtime pending) · ❌ missing.
 
 | Feature | Status | Notes |
 |---|---|---|
-| `$0` `$N` `NR` `NF` `FS` `OFS` | ✅ | |
+| `$0` `$N` `NR` `NF` `FS` `OFS` | ✅ | `FS` accepts a **multi-char / regex** value (a POSIX ERE, awk semantics): a length-≥2 `BEGIN { FS = "…" }` compiles to a reserved sentinel separator byte that the field runtime dispatches to `@wam_fs_regex_field_slice_value` / `_count_value` (lazily `regcomp`ed, one FS per program). Because the numeric / `length` / `eq` / `cmp` field projectors all delegate to the core slice, the regex FS reaches `$N` reads, `NF`, guards, and concat uniformly; `$0` and EOF are unaffected. A single-char `FS` stays a literal byte (awk treats a one-char FS literally). Field assignment with a regex FS, and `split()`'s own separator, remain single-char follow-ons. |
 | `FNR` `FILENAME` `ARGV` `ARGC` `RS` `ORS` `SUBSEP` `RSTART` `RLENGTH` | ❌ | single newline-delimited record model |
 | arithmetic `+ - * / % //` | ✅ | i64, awk precedence, safe div/mod |
 | comparison, `~`/`!~` | ✅ | |

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -227,6 +227,8 @@ plawk_program_native_driver_ir(
     \+ plawk_begin_has_binfmt(BeginClauses),
     plawk_record_descriptor(BeginClauses, FieldSeparator),
     integer(FieldSeparator),
+    % a real single-char FS: not whitespace (32), not the regex sentinel (0)
+    FieldSeparator > 0,
     FieldSeparator =\= 32,
     plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
@@ -8542,12 +8544,34 @@ plawk_binfmt_icmp_op(le, sle).
 plawk_binfmt_icmp_op(gt, sgt).
 plawk_binfmt_icmp_op(ge, sge).
 
+% Field separator code. A single character sets a literal byte separator (awk
+% treats a one-char FS literally, even a regex metachar like "."). A multi-char
+% FS is an ERE regex and yields the reserved sentinel 0 -- the field runtime
+% dispatches sentinel 0 to the FS-regex splitter, and the program stores the
+% pattern into @wam_fs_regex_pattern_ptr at startup (see plawk_fs_regex_pattern).
+% Default (no FS) and an empty FS fall back to 32 (whitespace).
 plawk_field_separator(BeginClauses, FieldSeparator) :-
     (   member(begin(Actions), BeginClauses),
         member(set(var('FS'), string(Value)), Actions)
-    ->  string_codes(Value, [FieldSeparator])
+    ->  (   string_codes(Value, [FieldSeparator])
+        ->  true
+        ;   string_length(Value, Len), Len >= 2
+        ->  FieldSeparator = 0
+        ;   FieldSeparator = 32
+        )
     ;   FieldSeparator = 32
     ).
+
+%% plawk_fs_regex_pattern(+BeginClauses, -Pattern)
+%
+%  The multi-char FS regex pattern (a `BEGIN { FS = "…" }` value of length >= 2),
+%  or fails when FS is a single char / unset. Multi-char FS is a POSIX ERE, so
+%  every field read splits the record on it (sentinel separator 0).
+plawk_fs_regex_pattern(BeginClauses, Pattern) :-
+    member(begin(Actions), BeginClauses),
+    member(set(var('FS'), string(Pattern)), Actions),
+    string_length(Pattern, Len),
+    Len >= 2.
 
 %% plawk_record_descriptor(+BeginClauses, -Descriptor)
 %
@@ -10137,8 +10161,20 @@ plawk_output_separator(BeginClauses, OutputSeparator) :-
 
 plawk_begin_print_string_globals(BeginClauses, GlobalIR) :-
     plawk_begin_print_fields(BeginClauses, Fields),
-    phrase(plawk_begin_print_string_global_lines(Fields, 0), Lines),
+    phrase(plawk_begin_print_string_global_lines(Fields, 0), Lines0),
+    plawk_fs_regex_global_lines(BeginClauses, RegexLines),
+    append(Lines0, RegexLines, Lines),
     atomic_list_concat(Lines, '\n', GlobalIR).
+
+%% plawk_fs_regex_global_lines(+BeginClauses, -Lines)
+%
+%  The private constant holding a multi-char FS regex pattern, or [] for a
+%  single-char / unset FS. Paired with the startup store in plawk_fs_regex_setup.
+plawk_fs_regex_global_lines(BeginClauses, [Line]) :-
+    plawk_fs_regex_pattern(BeginClauses, Pattern),
+    !,
+    llvm_emit_c_string_global(wam_fs_regex_pattern, Pattern, Line, _StringLen, _BytesLen).
+plawk_fs_regex_global_lines(_BeginClauses, []).
 
 plawk_begin_print_fields([], []).
 plawk_begin_print_fields([begin(Actions)], Fields) :-
@@ -10166,9 +10202,30 @@ plawk_begin_print_ir([begin(Actions)], OutputSeparator, IR) :-
     member(print(Fields), Actions),
     !,
     maplist(plawk_begin_print_field, Fields),
-    phrase(plawk_begin_print_lines(Fields, OutputSeparator, 0), Lines),
+    phrase(plawk_begin_print_lines(Fields, OutputSeparator, 0), PrintLines),
+    plawk_fs_regex_store_lines([begin(Actions)], StoreLines),
+    append(StoreLines, PrintLines, Lines),
     atomic_list_concat(Lines, '\n', IR).
-plawk_begin_print_ir([begin(_Actions)], _OutputSeparator, '').
+plawk_begin_print_ir([begin(Actions)], _OutputSeparator, IR) :-
+    plawk_fs_regex_store_lines([begin(Actions)], StoreLines),
+    (   StoreLines == []
+    ->  IR = ''
+    ;   atomic_list_concat(StoreLines, '\n', IR)
+    ).
+
+%% plawk_fs_regex_store_lines(+BeginClauses, -Lines)
+%
+%  The startup store that points @wam_fs_regex_pattern_ptr at the emitted FS
+%  regex pattern (so the field runtime can compile it on first use), or [] when
+%  FS is a single char / unset. Runs in the BEGIN block, before the record loop.
+plawk_fs_regex_store_lines(BeginClauses, [Line]) :-
+    plawk_fs_regex_pattern(BeginClauses, Pattern),
+    !,
+    llvm_emit_c_string_global(wam_fs_regex_pattern, Pattern, _GlobalIR, _StringLen, BytesLen),
+    format(atom(Line),
+        '  store i8* getelementptr inbounds ([~w x i8], [~w x i8]* @.wam_fs_regex_pattern, i64 0, i64 0), i8** @wam_fs_regex_pattern_ptr',
+        [BytesLen, BytesLen]).
+plawk_fs_regex_store_lines(_BeginClauses, []).
 
 plawk_begin_print_field(string(_)).
 

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -5816,6 +5816,262 @@ rgx.fail:
   ret i1 false
 }
 
+; Multi-char / regex field separator (awk FS as a POSIX ERE). The program FS
+; pattern is stored (as a C string pointer) in @wam_fs_regex_pattern_ptr by the
+; generated program at startup; a null pointer means no regex FS is active.
+; @wam_fs_regex_cache holds the lazily regcomp()ed regex_t (shared: one FS per
+; program). regmatch_t is assumed { i32 rm_so, i32 rm_eo } (regoff_t = int on
+; glibc, musl, and bionic); a 32-byte scratch is used regardless.
+@wam_fs_regex_pattern_ptr = internal global i8* null
+@wam_fs_regex_cache = internal global i8* null
+
+; Project field %field_index (1-based) of the record by splitting its text on the
+; FS regex; the separators are the regex matches and the fields are the text
+; between them. Field 0 returns the whole record. A missing field, an unset FS
+; pattern, or a compile failure yields {null, 0}. The returned slice points into
+; the record atom text (no allocation).
+define %WamSlice @wam_fs_regex_field_slice_value(%Value %atom_value, i64 %field_index) {
+entry:
+  %fr.e0 = insertvalue %WamSlice undef, i8* null, 0
+  %fr.empty = insertvalue %WamSlice %fr.e0, i64 0, 1
+  %fr.t = call i32 @value_tag(%Value %atom_value)
+  %fr.isatom = icmp eq i32 %fr.t, 0
+  br i1 %fr.isatom, label %fr.resolve, label %fr.none
+
+fr.resolve:
+  %fr.aid = call i64 @value_payload(%Value %atom_value)
+  %fr.s = call i8* @wam_atom_to_string(i64 %fr.aid)
+  %fr.snull = icmp eq i8* %fr.s, null
+  br i1 %fr.snull, label %fr.none, label %fr.slen
+
+fr.slen:
+  %fr.li = phi i64 [ 0, %fr.resolve ], [ %fr.li1, %fr.slstep ]
+  %fr.lp = getelementptr i8, i8* %fr.s, i64 %fr.li
+  %fr.lc = load i8, i8* %fr.lp
+  %fr.lz = icmp eq i8 %fr.lc, 0
+  br i1 %fr.lz, label %fr.lendone, label %fr.slstep
+
+fr.slstep:
+  %fr.li1 = add i64 %fr.li, 1
+  br label %fr.slen
+
+fr.lendone:
+  ; %fr.li is the record length
+  %fr.iswhole = icmp eq i64 %field_index, 0
+  br i1 %fr.iswhole, label %fr.whole, label %fr.needidx
+
+fr.whole:
+  %fr.w0 = insertvalue %WamSlice undef, i8* %fr.s, 0
+  %fr.w = insertvalue %WamSlice %fr.w0, i64 %fr.li, 1
+  ret %WamSlice %fr.w
+
+fr.needidx:
+  %fr.idxbad = icmp slt i64 %field_index, 1
+  br i1 %fr.idxbad, label %fr.none, label %fr.getpat
+
+fr.getpat:
+  %fr.pat = load i8*, i8** @wam_fs_regex_pattern_ptr
+  %fr.patnull = icmp eq i8* %fr.pat, null
+  br i1 %fr.patnull, label %fr.none, label %fr.ensure
+
+fr.ensure:
+  %fr.cached = load i8*, i8** @wam_fs_regex_cache
+  %fr.havec = icmp ne i8* %fr.cached, null
+  br i1 %fr.havec, label %fr.ready, label %fr.compile
+
+fr.compile:
+  %fr.mem = call i8* @malloc(i64 512)
+  %fr.memnull = icmp eq i8* %fr.mem, null
+  br i1 %fr.memnull, label %fr.none, label %fr.docomp
+
+fr.docomp:
+  %fr.rc = call i32 @regcomp(i8* %fr.mem, i8* %fr.pat, i32 1)
+  %fr.ok = icmp eq i32 %fr.rc, 0
+  br i1 %fr.ok, label %fr.storec, label %fr.compfail
+
+fr.compfail:
+  call void @free(i8* %fr.mem)
+  br label %fr.none
+
+fr.storec:
+  store i8* %fr.mem, i8** @wam_fs_regex_cache
+  br label %fr.ready
+
+fr.ready:
+  %fr.preg = load i8*, i8** @wam_fs_regex_cache
+  %fr.pm = alloca [4 x i64], align 8
+  %fr.pmp = bitcast [4 x i64]* %fr.pm to i8*
+  br label %fr.walk
+
+; %fr.cur = current field number (1-based); %fr.fstart = its start offset
+fr.walk:
+  %fr.cur = phi i64 [ 1, %fr.ready ], [ %fr.curn, %fr.advance ]
+  %fr.fstart = phi i64 [ 0, %fr.ready ], [ %fr.fnext, %fr.advance ]
+  %fr.atcur = icmp eq i64 %fr.cur, %field_index
+  %fr.atend = icmp uge i64 %fr.fstart, %fr.li
+  br i1 %fr.atend, label %fr.nomatch, label %fr.exec
+
+fr.exec:
+  %fr.sp = getelementptr i8, i8* %fr.s, i64 %fr.fstart
+  %fr.isbol = icmp eq i64 %fr.fstart, 0
+  %fr.eflags = select i1 %fr.isbol, i32 0, i32 1
+  %fr.rc2 = call i32 @regexec(i8* %fr.preg, i8* %fr.sp, i64 1, i8* %fr.pmp, i32 %fr.eflags)
+  %fr.matched = icmp eq i32 %fr.rc2, 0
+  br i1 %fr.matched, label %fr.havematch, label %fr.nomatch
+
+fr.havematch:
+  %fr.so_p = bitcast i8* %fr.pmp to i32*
+  %fr.so = load i32, i32* %fr.so_p
+  %fr.eo_pp = getelementptr i8, i8* %fr.pmp, i64 4
+  %fr.eo_p = bitcast i8* %fr.eo_pp to i32*
+  %fr.eo = load i32, i32* %fr.eo_p
+  %fr.so64 = sext i32 %fr.so to i64
+  %fr.eo64 = sext i32 %fr.eo to i64
+  %fr.sep_start = add i64 %fr.fstart, %fr.so64
+  ; force progress on a zero-length match so the walk terminates
+  %fr.mlen = sub i32 %fr.eo, %fr.so
+  %fr.zero = icmp eq i32 %fr.mlen, 0
+  %fr.end_nz = add i64 %fr.fstart, %fr.eo64
+  %fr.end_z = add i64 %fr.sep_start, 1
+  %fr.sep_end = select i1 %fr.zero, i64 %fr.end_z, i64 %fr.end_nz
+  br i1 %fr.atcur, label %fr.retmatch, label %fr.advance
+
+fr.retmatch:
+  ; the current field is [%fr.fstart, %fr.sep_start)
+  %fr.fp = getelementptr i8, i8* %fr.s, i64 %fr.fstart
+  %fr.flen = sub i64 %fr.sep_start, %fr.fstart
+  %fr.r0 = insertvalue %WamSlice undef, i8* %fr.fp, 0
+  %fr.r = insertvalue %WamSlice %fr.r0, i64 %fr.flen, 1
+  ret %WamSlice %fr.r
+
+fr.advance:
+  %fr.curn = add i64 %fr.cur, 1
+  %fr.fnext = select i1 %fr.zero, i64 %fr.sep_end, i64 %fr.end_nz
+  br label %fr.walk
+
+fr.nomatch:
+  ; no further separator: the current field is the last one, [%fr.fstart, len)
+  br i1 %fr.atcur, label %fr.retlast, label %fr.none
+
+fr.retlast:
+  %fr.lp2 = getelementptr i8, i8* %fr.s, i64 %fr.fstart
+  %fr.llen = sub i64 %fr.li, %fr.fstart
+  %fr.rl0 = insertvalue %WamSlice undef, i8* %fr.lp2, 0
+  %fr.rl = insertvalue %WamSlice %fr.rl0, i64 %fr.llen, 1
+  ret %WamSlice %fr.rl
+
+fr.none:
+  ret %WamSlice %fr.empty
+}
+
+; Count fields (NF) by splitting the record text on the FS regex. An empty
+; record is 0 fields; an unset pattern or a compile failure counts 1 (the whole
+; record as a single field).
+define i64 @wam_fs_regex_field_count_value(%Value %atom_value) {
+entry:
+  %fc.t = call i32 @value_tag(%Value %atom_value)
+  %fc.isatom = icmp eq i32 %fc.t, 0
+  br i1 %fc.isatom, label %fc.resolve, label %fc.zero
+
+fc.resolve:
+  %fc.aid = call i64 @value_payload(%Value %atom_value)
+  %fc.s = call i8* @wam_atom_to_string(i64 %fc.aid)
+  %fc.snull = icmp eq i8* %fc.s, null
+  br i1 %fc.snull, label %fc.zero, label %fc.slen
+
+fc.slen:
+  %fc.li = phi i64 [ 0, %fc.resolve ], [ %fc.li1, %fc.slstep ]
+  %fc.lp = getelementptr i8, i8* %fc.s, i64 %fc.li
+  %fc.lc = load i8, i8* %fc.lp
+  %fc.lz = icmp eq i8 %fc.lc, 0
+  br i1 %fc.lz, label %fc.lendone, label %fc.slstep
+
+fc.slstep:
+  %fc.li1 = add i64 %fc.li, 1
+  br label %fc.slen
+
+fc.lendone:
+  %fc.emptyrec = icmp eq i64 %fc.li, 0
+  br i1 %fc.emptyrec, label %fc.zero, label %fc.getpat
+
+fc.getpat:
+  %fc.pat = load i8*, i8** @wam_fs_regex_pattern_ptr
+  %fc.patnull = icmp eq i8* %fc.pat, null
+  br i1 %fc.patnull, label %fc.one, label %fc.ensure
+
+fc.ensure:
+  %fc.cached = load i8*, i8** @wam_fs_regex_cache
+  %fc.havec = icmp ne i8* %fc.cached, null
+  br i1 %fc.havec, label %fc.ready, label %fc.compile
+
+fc.compile:
+  %fc.mem = call i8* @malloc(i64 512)
+  %fc.memnull = icmp eq i8* %fc.mem, null
+  br i1 %fc.memnull, label %fc.one, label %fc.docomp
+
+fc.docomp:
+  %fc.rc = call i32 @regcomp(i8* %fc.mem, i8* %fc.pat, i32 1)
+  %fc.ok = icmp eq i32 %fc.rc, 0
+  br i1 %fc.ok, label %fc.storec, label %fc.compfail
+
+fc.compfail:
+  call void @free(i8* %fc.mem)
+  br label %fc.one
+
+fc.storec:
+  store i8* %fc.mem, i8** @wam_fs_regex_cache
+  br label %fc.ready
+
+fc.ready:
+  %fc.preg = load i8*, i8** @wam_fs_regex_cache
+  %fc.pm = alloca [4 x i64], align 8
+  %fc.pmp = bitcast [4 x i64]* %fc.pm to i8*
+  br label %fc.walk
+
+fc.walk:
+  %fc.count = phi i64 [ 1, %fc.ready ], [ %fc.countn, %fc.advance ]
+  %fc.fstart = phi i64 [ 0, %fc.ready ], [ %fc.sep_end, %fc.advance ]
+  %fc.atend = icmp uge i64 %fc.fstart, %fc.li
+  br i1 %fc.atend, label %fc.done, label %fc.exec
+
+fc.exec:
+  %fc.sp = getelementptr i8, i8* %fc.s, i64 %fc.fstart
+  %fc.isbol = icmp eq i64 %fc.fstart, 0
+  %fc.eflags = select i1 %fc.isbol, i32 0, i32 1
+  %fc.rc2 = call i32 @regexec(i8* %fc.preg, i8* %fc.sp, i64 1, i8* %fc.pmp, i32 %fc.eflags)
+  %fc.matched = icmp eq i32 %fc.rc2, 0
+  br i1 %fc.matched, label %fc.havematch, label %fc.done
+
+fc.havematch:
+  %fc.so_p = bitcast i8* %fc.pmp to i32*
+  %fc.so = load i32, i32* %fc.so_p
+  %fc.eo_pp = getelementptr i8, i8* %fc.pmp, i64 4
+  %fc.eo_p = bitcast i8* %fc.eo_pp to i32*
+  %fc.eo = load i32, i32* %fc.eo_p
+  %fc.so64 = sext i32 %fc.so to i64
+  %fc.eo64 = sext i32 %fc.eo to i64
+  %fc.sep_start = add i64 %fc.fstart, %fc.so64
+  %fc.mlen = sub i32 %fc.eo, %fc.so
+  %fc.zlen = icmp eq i32 %fc.mlen, 0
+  %fc.end_nz = add i64 %fc.fstart, %fc.eo64
+  %fc.end_z = add i64 %fc.sep_start, 1
+  %fc.sep_end = select i1 %fc.zlen, i64 %fc.end_z, i64 %fc.end_nz
+  br label %fc.advance
+
+fc.advance:
+  %fc.countn = add i64 %fc.count, 1
+  br label %fc.walk
+
+fc.done:
+  ret i64 %fc.count
+
+fc.one:
+  ret i64 1
+
+fc.zero:
+  ret i64 0
+}
+
 ; awk-style numeric coercion of a record or projected field to double:
 ; strtod parses a leading number and ignores trailing text, so
 ; "3.14abc" reads as 3.14 and non-numeric text reads as 0.0. Field
@@ -6513,8 +6769,12 @@ entry:
 
 define i1 @wam_atom_field_eq_value(%Value %atom_value, i64 %field_index, i8* %expected, i64 %expected_len, i8 %sep) {
 entry:
+  ; sep 0 (regex FS) and sep 32 (whitespace) both project via the slice path,
+  ; which dispatches to the regex splitter; only a literal single char inlines.
+  %fe.is_re = icmp eq i8 %sep, 0
   %fe.default_sep = icmp eq i8 %sep, 32
-  br i1 %fe.default_sep, label %fe.slice_compare, label %fe.literal_entry
+  %fe.via_slice = or i1 %fe.is_re, %fe.default_sep
+  br i1 %fe.via_slice, label %fe.slice_compare, label %fe.literal_entry
 
 fe.slice_compare:
   %fe.slice = call %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_index, i8 %sep)
@@ -6627,6 +6887,15 @@ define %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_inde
 entry:
   %fs.empty0 = insertvalue %WamSlice undef, i8* null, 0
   %fs.empty = insertvalue %WamSlice %fs.empty0, i64 0, 1
+  ; sep 0 is the reserved sentinel for a program-level regex FS
+  %fs.is_re = icmp eq i8 %sep, 0
+  br i1 %fs.is_re, label %fs.regex_dispatch, label %fs.sep_check
+
+fs.regex_dispatch:
+  %fs.rr = call %WamSlice @wam_fs_regex_field_slice_value(%Value %atom_value, i64 %field_index)
+  ret %WamSlice %fs.rr
+
+fs.sep_check:
   %fs.default_sep = icmp eq i8 %sep, 32
   br i1 %fs.default_sep, label %fs.ws_atom_check, label %fs.literal_entry
 
@@ -6780,6 +7049,15 @@ fs.no:
 
 define i64 @wam_atom_field_count_value(%Value %atom_value, i8 %sep) {
 entry:
+  ; sep 0 is the reserved sentinel for a program-level regex FS
+  %fc.is_re = icmp eq i8 %sep, 0
+  br i1 %fc.is_re, label %fc.regex_dispatch, label %fc.sep_check
+
+fc.regex_dispatch:
+  %fc.rr = call i64 @wam_fs_regex_field_count_value(%Value %atom_value)
+  ret i64 %fc.rr
+
+fc.sep_check:
   %fc.default_sep = icmp eq i8 %sep, 32
   br i1 %fc.default_sep, label %fc.ws_atom_check, label %fc.literal_entry
 

--- a/tests/core/test_wam_llvm_assoc_i64_runtime.pl
+++ b/tests/core/test_wam_llvm_assoc_i64_runtime.pl
@@ -40,6 +40,10 @@ test(fields_buffer_split_edit_join) :-
     fields_buffer_driver_ir(DriverIR),
     run_assoc_i64_smoke('uw_wam_fields_buffer', DriverIR).
 
+test(regex_fs_field_slice_and_count) :-
+    regex_fs_driver_ir(DriverIR),
+    run_assoc_i64_smoke('uw_wam_regex_fs', DriverIR).
+
 run_assoc_i64_smoke(Name, DriverIR) :-
     tmp_root(Root),
     directory_file_path(Root, Name, Dir),
@@ -293,6 +297,92 @@ entry:
   %a1 = and i1 %c1_ok, %c2_ok
   %a2 = and i1 %a1, %c3_ok
   br i1 %a2, label %ok, label %bad
+
+ok:
+  ret i32 0
+
+bad:
+  ret i32 91
+}
+').
+
+% Exercise the regex/multi-char FS field splitter through the public field
+% functions with the sentinel separator (i8 0). Two patterns: a multi-char
+% literal "::" over "a::b::c", and a regex ", *" over "a, b,c" (comma then
+% optional spaces). Checks NF and per-field bytes; the cache is reset between
+% patterns since one FS regex is compiled per program.
+regex_fs_driver_ir('
+@.uw_rfs_colons = private constant [3 x i8] c"::\00"
+@.uw_rfs_rec1 = private constant [8 x i8] c"a::b::c\00"
+@.uw_rfs_comma = private constant [4 x i8] c", *\00"
+@.uw_rfs_rec2 = private constant [7 x i8] c"a, b,c\00"
+
+define i32 @main() {
+entry:
+  ; --- multi-char literal FS "::" over "a::b::c" ---
+  %p1 = getelementptr [3 x i8], [3 x i8]* @.uw_rfs_colons, i64 0, i64 0
+  store i8* %p1, i8** @wam_fs_regex_pattern_ptr
+  store i8* null, i8** @wam_fs_regex_cache
+  %r1p = getelementptr [8 x i8], [8 x i8]* @.uw_rfs_rec1, i64 0, i64 0
+  %id1 = call i64 @wam_intern_atom(i8* %r1p, i64 7)
+  %v1a = insertvalue %Value undef, i32 0, 0
+  %v1 = insertvalue %Value %v1a, i64 %id1, 1
+
+  %n1 = call i64 @wam_atom_field_count_value(%Value %v1, i8 0)
+  %n1_ok = icmp eq i64 %n1, 3
+
+  %f1 = call %WamSlice @wam_atom_field_slice_value(%Value %v1, i64 1, i8 0)
+  %f1p = extractvalue %WamSlice %f1, 0
+  %f1l = extractvalue %WamSlice %f1, 1
+  %f1l_ok = icmp eq i64 %f1l, 1
+  %f1c = load i8, i8* %f1p
+  %f1c_ok = icmp eq i8 %f1c, 97
+
+  %f2 = call %WamSlice @wam_atom_field_slice_value(%Value %v1, i64 2, i8 0)
+  %f2p = extractvalue %WamSlice %f2, 0
+  %f2l = extractvalue %WamSlice %f2, 1
+  %f2l_ok = icmp eq i64 %f2l, 1
+  %f2c = load i8, i8* %f2p
+  %f2c_ok = icmp eq i8 %f2c, 98
+
+  %f3 = call %WamSlice @wam_atom_field_slice_value(%Value %v1, i64 3, i8 0)
+  %f3p = extractvalue %WamSlice %f3, 0
+  %f3c = load i8, i8* %f3p
+  %f3c_ok = icmp eq i8 %f3c, 99
+
+  %f4 = call %WamSlice @wam_atom_field_slice_value(%Value %v1, i64 4, i8 0)
+  %f4p = extractvalue %WamSlice %f4, 0
+  %f4_missing = icmp eq i8* %f4p, null
+
+  ; --- regex FS ", *" over "a, b,c" ---
+  %p2 = getelementptr [4 x i8], [4 x i8]* @.uw_rfs_comma, i64 0, i64 0
+  store i8* %p2, i8** @wam_fs_regex_pattern_ptr
+  store i8* null, i8** @wam_fs_regex_cache
+  %r2p = getelementptr [7 x i8], [7 x i8]* @.uw_rfs_rec2, i64 0, i64 0
+  %id2 = call i64 @wam_intern_atom(i8* %r2p, i64 6)
+  %v2a = insertvalue %Value undef, i32 0, 0
+  %v2 = insertvalue %Value %v2a, i64 %id2, 1
+
+  %n2 = call i64 @wam_atom_field_count_value(%Value %v2, i8 0)
+  %n2_ok = icmp eq i64 %n2, 3
+
+  %g2 = call %WamSlice @wam_atom_field_slice_value(%Value %v2, i64 2, i8 0)
+  %g2p = extractvalue %WamSlice %g2, 0
+  %g2l = extractvalue %WamSlice %g2, 1
+  %g2l_ok = icmp eq i64 %g2l, 1
+  %g2c = load i8, i8* %g2p
+  %g2c_ok = icmp eq i8 %g2c, 98
+
+  %a1 = and i1 %n1_ok, %f1l_ok
+  %a2 = and i1 %a1, %f1c_ok
+  %a3 = and i1 %a2, %f2l_ok
+  %a4 = and i1 %a3, %f2c_ok
+  %a5 = and i1 %a4, %f3c_ok
+  %a6 = and i1 %a5, %f4_missing
+  %a7 = and i1 %a6, %n2_ok
+  %a8 = and i1 %a7, %g2l_ok
+  %a9 = and i1 %a8, %g2c_ok
+  br i1 %a9, label %ok, label %bad
 
 ok:
   ret i32 0

--- a/tests/test_plawk_regex_fs.pl
+++ b/tests/test_plawk_regex_fs.pl
@@ -1,0 +1,139 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk multi-char / regex field separator: `BEGIN { FS = "…" }` with a value of
+% two or more characters is a POSIX ERE, and every field read splits the record
+% on it. Implemented with a reserved sentinel separator byte (0) that the field
+% runtime dispatches to @wam_fs_regex_field_slice_value / _count_value; the
+% program stores the pattern into @wam_fs_regex_pattern_ptr at startup. Because
+% the numeric/length/eq/cmp field projectors all delegate to the core slice, the
+% regex FS reaches $N reads, NF, guards, and concat uniformly. A single-char FS
+% is still a literal byte (awk treats a one-char FS literally). Field assignment
+% with a regex FS is a documented follow-on (rejected cleanly).
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_regex_fs).
+
+% multi-char literal separator (an ERE where no char is special).
+test(regex_fs_multichar_literal, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ml', "BEGIN { FS = \"::\" }\n{ print $2 }\n",
+        "a::b::c\n", Out, St),
+    assertion(St == 0), assertion(Out == "b\n"), !.
+
+% a genuine regex: comma then optional spaces, joined on the default OFS (space).
+test(regex_fs_comma_spaces, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'cs', "BEGIN { FS = \", *\" }\n{ print $1, $3 }\n",
+        "a, b,c\n", Out, St),
+    assertion(St == 0), assertion(Out == "a c\n"), !.
+
+% a character-class regex separator.
+test(regex_fs_char_class, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'cc', "BEGIN { FS = \"[0-9]+\" }\n{ print $2 }\n",
+        "a12b34c\n", Out, St),
+    assertion(St == 0), assertion(Out == "b\n"), !.
+
+% NF reflects the regex split.
+test(regex_fs_nf, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'nf', "BEGIN { FS = \"::\" }\n{ print NF }\n",
+        "a::b::c\n", Out, St),
+    assertion(St == 0), assertion(Out == "3\n"), !.
+
+% a string field-equality guard splits with the regex FS.
+test(regex_fs_field_guard, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'fg', "BEGIN { FS = \"::\" }\n$1 == \"a\" { print $2 }\n",
+        "a::b\nx::y\n", Out, St),
+    assertion(St == 0), assertion(Out == "b\n"), !.
+
+% numeric field arithmetic reads regex-split fields.
+test(regex_fs_numeric_add, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'na', "BEGIN { FS = \"::\" }\n{ print $1 + $2 }\n",
+        "3::4::5\n", Out, St),
+    assertion(St == 0), assertion(Out == "7\n"), !.
+
+% a numeric field comparison guard.
+test(regex_fs_numeric_guard, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ng', "BEGIN { FS = \"::\" }\n$2 > 5 { print $1 }\n",
+        "a::9\nb::3\n", Out, St),
+    assertion(St == 0), assertion(Out == "a\n"), !.
+
+% length() of a regex-split field.
+test(regex_fs_length, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ln', "BEGIN { FS = \"::\" }\n{ print length($2) }\n",
+        "a::bcd\n", Out, St),
+    assertion(St == 0), assertion(Out == "3\n"), !.
+
+% concatenation of regex-split fields.
+test(regex_fs_concat, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ct', "BEGIN { FS = \"::\" }\n{ x = $1 $2; print x }\n",
+        "a::b\n", Out, St),
+    assertion(St == 0), assertion(Out == "ab\n"), !.
+
+% a single-char FS stays literal (a metachar is not a regex).
+test(regex_fs_single_char_literal, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'sc', "BEGIN { FS = \".\" }\n{ print $2 }\n",
+        "a.b.c\n", Out, St),
+    assertion(St == 0), assertion(Out == "b\n"), !.
+
+% field assignment with a regex FS is out of the v1 surface: it must fail the
+% build cleanly (exit 3) rather than split on the sentinel byte.
+test(regex_fs_field_assign_rejected, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_status(Dir, 'fa', "BEGIN { FS = \"::\" }\n{ $2 = \"X\"; print $0 }\n",
+        BuildStatus),
+    assertion(BuildStatus == exit(3)), !.
+
+:- end_tests(plawk_regex_fs).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_regex_fs', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).
+
+build_status(Dir, Name, Src, BuildStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, BuildStatus).


### PR DESCRIPTION
## Summary

`BEGIN { FS = "…" }` with a value of **two or more characters** is now a POSIX ERE, and every field read splits the record on it — real awk semantics. Previously a multi-char `FS` **silently fell back to whitespace splitting** (a latent miscompile); this fixes that and makes it correct.

```awk
BEGIN { FS = ", *" }      # comma then optional spaces
{ print $1, $3 }
```
on `a, b,c` → `a c`. Character classes (`FS = "[0-9]+"`), multi-char literals (`FS = "::"`), etc. all work.

## Design — one sentinel byte, one chokepoint

The field separator threads through ~20 codegen sites and a dozen runtime projectors as a single `i8`. Rather than widen all of that, this reserves the **sentinel byte `0`** to mean "use the program's FS regex":

- **`plawk_field_separator`** yields `0` for a multi-char FS (a single char stays its literal byte — awk treats a one-char FS literally, even a metachar like `.`).
- The runtime **chokepoint** `@wam_atom_field_slice_value` (and `@wam_atom_field_count_value` for `NF`, and the `_eq` fast-path) gets a `sep == 0` branch that dispatches to two new helpers — `@wam_fs_regex_field_slice_value` / `@wam_fs_regex_field_count_value` — which split the record via a lazily `regcomp`ed regex (one FS per program, cached).
- Because the numeric / `length` / `index` / `subslice` / `i64_cmp` projectors **all delegate to the core slice**, they pick up regex FS for free — so `$N` reads, `NF`, string/numeric guards, and concat are covered with **no codegen field-site changes**. `$0` and the EOF check use the whole record / `%line_s` and are untouched.
- The pattern is emitted as a private constant and stored into `@wam_fs_regex_pattern_ptr` at `BEGIN`, injected uniformly through the shared BEGIN helpers (so every text driver gets it).

`regmatch_t` is read as `{ i32 rm_so, i32 rm_eo }` (regoff_t = int on glibc/musl/bionic), matching the existing regex helper's platform assumptions.

## Scope / follow-ons

- Covers the text field-reading surface: `$N`, `NF`, field guards (string + numeric), `length`/`substr`/`index`, concat.
- **Rejected cleanly (exit 3), not silently mishandled:** field assignment `$N = expr` with a regex FS (the field-assign driver requires a real single-char FS). `split()`'s own separator and regex FS inside the assoc/multipass drivers remain single-char follow-ons.
- Single-char FS behaviour is unchanged.

## Tests

- `tests/test_plawk_regex_fs.pl` (11): multi-char literal, comma-spaces regex, char-class, `NF`, string + numeric field guards, numeric add, `length`, concat, single-char-literal regression, and the clean rejection of field-assign + regex FS.
- `tests/core/test_wam_llvm_assoc_i64_runtime.pl`: a runtime unit test drives `@wam_atom_field_slice_value`/`_count_value` with the sentinel over `::` and `, *`.
- Regressions green: `surface_prefix_print` (221), `print_literals` (11), `split` (9), `fieldassign` (12), `guard_string` (6), `scalar_if` (8); BEGIN-print + single-char FS spot-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_