### PR TITLE
Add Rust WAM file content builtins

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1648,6 +1648,47 @@ compile_execute_io_builtin_to_rust(Code) :-
                 };
                 if result.is_ok() { self.pc += 1; true } else { false }
             }
+            "read_file_to_atom/2" => {
+                let path = match self.builtin_path_arg("A1") {
+                    Some(path) => path,
+                    None => return false,
+                };
+                let content = match std::fs::read_to_string(path) {
+                    Ok(content) => content,
+                    Err(_) => return false,
+                };
+                let output = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+                let mark = self.trail.len();
+                if self.unify(&output, &Value::Atom(content)) {
+                    self.pc += 1; true
+                } else {
+                    self.unwind_trail_to(mark);
+                    false
+                }
+            }
+            "write_atom_to_file/2" | "append_atom_to_file/2" => {
+                let path = match self.builtin_path_arg("A1") {
+                    Some(path) => path,
+                    None => return false,
+                };
+                let content = match self.get_reg_raw("A2")
+                    .map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::Atom(content)) => content,
+                    _ => return false,
+                };
+                let result = if op == "write_atom_to_file/2" {
+                    std::fs::write(path, content.as_bytes())
+                } else {
+                    std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(path)
+                        .and_then(|mut file| {
+                            std::io::Write::write_all(&mut file, content.as_bytes())
+                        })
+                };
+                if result.is_ok() { self.pc += 1; true } else { false }
+            }
             "exists_file/1" => {
                 let path = match self.builtin_path_arg("A1") {
                     Some(path) => path,

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -129,6 +129,13 @@ t_filesystem_mutation :-
     delete_file('mutation_compiled_fixture/renamed.toml'),
     delete_directory('mutation_compiled_fixture').
 
+:- dynamic t_file_content_io/1.
+t_file_content_io(Content) :-
+    write_atom_to_file('file_content_compiled_fixture.txt', alpha),
+    append_atom_to_file('file_content_compiled_fixture.txt', '-beta'),
+    read_file_to_atom('file_content_compiled_fixture.txt', Content),
+    delete_file('file_content_compiled_fixture.txt').
+
 :- dynamic t_pairs_project/2.
 t_pairs_project(Keys, Values) :-
     Pairs = [a-1, b-2],
@@ -270,6 +277,7 @@ test_builtin_parity_execution :-
              user:t_path_utilities/5,
              user:t_filesystem_identity/2,
              user:t_filesystem_mutation/0,
+             user:t_file_content_io/1,
              user:t_pairs_project/2, user:t_pairs_split/2, user:t_pairs_zip/1,
              user:t_thrower/0, user:t_deep/0, user:t_mid/0,
              user:t_catch_match/1, user:t_catch_deep/1,
@@ -303,6 +311,7 @@ use builtin_parity_test::{t_between_1, t_msort_1, t_sort_1, t_sort4_1, t_concat_
     t_path_utilities_5,
     t_filesystem_identity_2,
     t_filesystem_mutation_0,
+    t_file_content_io_1,
     t_pairs_project_2, t_pairs_split_2, t_pairs_zip_1,
     t_catch_match_1, t_catch_deep_1, t_catch_nomatch_0, t_catch_nothrow_1,
     t_catch_failgoal_0, t_catch_nested_1, t_succ_fwd_1, t_succ_rev_1,
@@ -607,6 +616,50 @@ fn test_filesystem_mutation_direct() {
     assert!(!call2("copy_file/2", a("missing-mutation-source"), a("unused")).0);
     assert!(!call2("copy_file/2", a("Cargo.toml"), ub("Destination")).0);
     assert!(!call2("rename_file/2", ub("Source"), a("unused")).0);
+}
+
+#[test]
+fn test_file_content_io_compiled() {
+    let fixture = std::path::Path::new("file_content_compiled_fixture.txt");
+    let _ = std::fs::remove_file(fixture);
+
+    let mut vm = vmnew();
+    assert!(t_file_content_io_1(&mut vm, ub("Content")));
+    assert_eq!(read_var(&vm, "Content"), a("alpha-beta"));
+    assert!(!fixture.exists());
+}
+
+#[test]
+fn test_file_content_io_direct() {
+    let path = "file_content_direct_fixture.txt";
+    let _ = std::fs::remove_file(path);
+
+    assert!(call2("write_atom_to_file/2", a(path), a("longer content")).0);
+    assert!(call2("write_atom_to_file/2", a(path), a("short")).0);
+    assert_eq!(std::fs::read(path).unwrap(), b"short");
+    assert!(call2("append_atom_to_file/2", a(path), a("-tail")).0);
+    assert_eq!(std::fs::read(path).unwrap(), b"short-tail");
+
+    let (read_ok, read_vm) = call2("read_file_to_atom/2", a(path), ub("Content"));
+    assert!(read_ok);
+    assert_eq!(read_var(&read_vm, "Content"), a("short-tail"));
+    assert!(call2("read_file_to_atom/2", a(path), a("short-tail")).0);
+    assert!(!call2("read_file_to_atom/2", a(path), a("wrong")).0);
+
+    std::fs::remove_file(path).unwrap();
+    assert!(call2("append_atom_to_file/2", a(path), a("created")).0,
+        "append_atom_to_file/2 creates a missing file");
+    assert_eq!(std::fs::read(path).unwrap(), b"created");
+
+    std::fs::write(path, [0xff]).unwrap();
+    assert!(!call2("read_file_to_atom/2", a(path), ub("Content")).0,
+        "Rust atoms require UTF-8 file content");
+    assert!(!call2("read_file_to_atom/2", a("missing-file-content"), ub("Content")).0);
+    assert!(!call2("read_file_to_atom/2", i(7), ub("Content")).0);
+    assert!(!call2("write_atom_to_file/2", a(path), i(7)).0);
+    assert!(!call2("append_atom_to_file/2", ub("Path"), a("content")).0);
+
+    std::fs::remove_file(path).unwrap();
 }
 
 #[test]

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -504,6 +504,8 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, 'MetadataExt'),
         sub_string(S, _, _, _, '"make_directory/1" | "delete_file/1" | "delete_directory/1"'),
         sub_string(S, _, _, _, '"copy_file/2" | "rename_file/2"'),
+        sub_string(S, _, _, _, '"read_file_to_atom/2"'),
+        sub_string(S, _, _, _, '"write_atom_to_file/2" | "append_atom_to_file/2"'),
         %% copy_term_walk helper (sharing-preserving recursive copy).
         sub_string(S, _, _, _, 'copy_term_walk'),
         %% Runtime-parser bridge support and the parser-required text/list builtins.


### PR DESCRIPTION
## Summary

- Add `read_file_to_atom/2`
- Add truncating `write_atom_to_file/2`
- Add creating and appending `append_atom_to_file/2`
- Treat non-UTF-8 input as failure because Rust WAM atoms use UTF-8 strings
- Add compiled-predicate and direct runtime coverage

## Testing

- Rust WAM target load check
- Full `test_wam_rust_target.pl` suite
- End-to-end `test_wam_rust_builtin_parity.pl` Cargo execution
- `git diff --check`