### PR TITLE
mu_cosine: candidate-lineage conditioning + two-timescale CE-calibration meta-judge (mechanisms validated, filing metric unmoved)

### DIFF
--- a/prototypes/mu_cosine/DESIGN_meta_judge_calibration.md
+++ b/prototypes/mu_cosine/DESIGN_meta_judge_calibration.md
@@ -37,6 +37,15 @@ reference the fusion itself cannot supply.
 
 ## Two-timescale loop (per epoch over batches)
 
+**Implemented mechanism, stated literally (audit finding 4).** The build below is aspirational in
+two places the implementation simplifies: (i) the Kalman fused targets are PRECOMPUTED once by
+run_pearltrees_fusion.py and held FIXED during training (the "inner Kalman refit per batch" is not
+in the loop — the fast step is MSE distillation toward static fused targets); (ii) the slow step
+updates ONLY the judge-name residual row via the SNR-gated manual update — no other meta-parameters.
+Also: the ranking examples are h1–h5 ancestor pairs, so the CE trains ANCESTOR-ranking, not
+exact-parent recovery (finding 3); exact-parent labels would need h1-only examples (too few at this
+campaign size) or the harvested tree ground truth.
+
     for batch b:
         # INNER (fast): refit the Kalman blocks on this batch's overlap-train rows; compute the
         # fused μ posterior; one gradient step on the μ heads + trunk toward the fused targets

--- a/prototypes/mu_cosine/DESIGN_meta_judge_calibration.md
+++ b/prototypes/mu_cosine/DESIGN_meta_judge_calibration.md
@@ -50,10 +50,15 @@ reference the fusion itself cannot supply.
         if b % K == 0:
             slow_step(model, ranking_batch, sonnet)  # candidate-softmax CE + λ_cal anchor, lr_slow
 
-Timescale split (DESIGN_amortized_fusion_heads.md): `lr_slow ≪ lr_fast` (or K≫1). The judge is the
-slow meta-parameter set (the calibration of μ); the Kalman blocks + μ heads are the fast inner
-estimator. Anchor loss (agnostic readouts pinned to the base) stays on throughout, so untrained
-identities do not drift (the Filing v1 finding-6 lesson; checkpoint remains Pearltrees-only).
+Timescale split (DESIGN_amortized_fusion_heads.md): the judge is the slow meta-parameter (the
+calibration of μ); the Kalman blocks + μ heads are the fast inner estimator. IMPORTANT (added after
+implementation): do NOT impose the split with `lr_slow ≪ lr_fast` or a `K`-batch cadence. The judge
+uses a PRECISION/SNR-GATED update so the slow timescale EMERGES from the (low) information in the
+quantization-noisy ranking CE — Adam and plain SGD both destroy this and silently reintroduce a
+hand-tuned timescale. The full derivation is THEORY_emergent_timescale_learning.md; the fast μ heads
+keep Adam (their MSE signal is high-SNR, so gating buys nothing there). Anchor loss (agnostic
+readouts pinned to the base) stays on throughout, so untrained identities do not drift (the Filing v1
+finding-6 lesson; checkpoint remains Pearltrees-only).
 
 ## Evaluation
 

--- a/prototypes/mu_cosine/DESIGN_meta_judge_calibration.md
+++ b/prototypes/mu_cosine/DESIGN_meta_judge_calibration.md
@@ -1,0 +1,75 @@
+# Meta-judge: CE-calibrated μ as the Kalman training signal (two-timescale)
+
+User proposal (2026-07-17), pinned after clarification. The idea: **train a judge by cross-entropy
+on each batch to CALIBRATE the μ training signal, then use that calibrated μ to optimize the Kalman
+filter's fused μ estimate.** The judge produces μ (it is not a separate ranking head); CE calibrates
+that μ. At least one model the judge sees is NOT a Kalman channel (held-out sonnet-5) — that is what
+makes it meta-learning ("learning how to learn" the combination, not memorizing the fusion inputs).
+At INFERENCE there is no judge in the loop: folders are ranked by the Kalman-fused μ.
+
+## Why calibration, not lineage injection
+
+REPORT_pearltrees_candidate_lineage.md established that Pearltrees folder TITLES already carry the
+lineage (a child's e5 embedding sits closer to its true parent, 0.877, than to a random folder,
+0.816; explicit lineage only helped on unseen folders). So the μ ranker's weakness is not missing
+structure — it is mis-CALIBRATED μ: the diagnostic (§2 there) showed e5 wins only the easy FAR
+third and everyone is weak on the confusable NEAR two-thirds. The meta-judge targets exactly that:
+calibrate μ so the ranking is right on the hard cases, using a stronger held-out judge as the
+reference the fusion itself cannot supply.
+
+## Objects
+
+- **Candidate-ranking (LINEAGE_RANK) CE.** For a descendant node `d` with true parent folder `f*`,
+  a candidate set `C = {f*} ∪ negatives(d)` (K folders sampled from the campaign folder pool,
+  excluding d's own ancestors). The judge score is the model's directional μ `s(d,c) = μ(d | c, HIER,
+  pearltrees, JUDGE)`. Loss = candidate-softmax cross-entropy `−log softmax_c[ s(d,c)/τ ]_{f*}`.
+  This calibrates the μ so the true parent ranks first — the exact filing objective.
+- **Held-out sonnet calibration anchor.** Sonnet-5 (subagent-scored, NOT a Kalman channel) supplies
+  a held-out directional D on the overlap TRUE pairs. On those rows add
+  `λ_cal · (s(d,f*) − D_sonnet(d,f*))²` — anchors the μ MAGNITUDE to an independent strong judge so
+  the scale is not set circularly by the fusion's own channels (luna/graph). Sonnet-being-held-out
+  is the meta hook.
+- **Kalman inner estimate.** The existing fusion: prior ⊕ graph_D ⊕ graph_S ⊕ luna → fused (D,S)
+  posterior, blocks (P0,R,C) refit per batch on the overlap-train rows. Sonnet is NOT a channel.
+  The calibrated judge μ becomes the distillation target the μ heads are trained toward (replacing /
+  augmenting the raw fused target), so the calibration flows into what the Kalman μ reads at
+  inference.
+
+## Two-timescale loop (per epoch over batches)
+
+    for batch b:
+        # INNER (fast): refit the Kalman blocks on this batch's overlap-train rows; compute the
+        # fused μ posterior; one gradient step on the μ heads + trunk toward the fused targets
+        # (the existing fine_tune step) — this is the μ-estimate optimization.
+        fast_step(model, batch)                      # μ heads + last layer, lr_fast
+
+        # OUTER (slow): every K batches, one candidate-ranking CE step (+ sonnet anchor) that
+        # calibrates the judge μ; its gradient flows into the shared trunk so the calibration
+        # persists into the Kalman μ. Slow = small lr / every-K so the judge drifts under the
+        # faster inner estimate (the metastable-drift / amortized-fusion-heads timescale split).
+        if b % K == 0:
+            slow_step(model, ranking_batch, sonnet)  # candidate-softmax CE + λ_cal anchor, lr_slow
+
+Timescale split (DESIGN_amortized_fusion_heads.md): `lr_slow ≪ lr_fast` (or K≫1). The judge is the
+slow meta-parameter set (the calibration of μ); the Kalman blocks + μ heads are the fast inner
+estimator. Anchor loss (agnostic readouts pinned to the base) stays on throughout, so untrained
+identities do not drift (the Filing v1 finding-6 lesson; checkpoint remains Pearltrees-only).
+
+## Evaluation
+
+- Primary: the FILING metric via the Kalman-fused μ ranker (eval_pearltrees_filing conditioned
+  heads), meta-judge checkpoint vs the no-meta Filing v1 checkpoint vs e5-cos. Report acc@1/@5/MRR.
+- **Focus on the confusable NEAR stratum** (diagnose_filing_e5_vs_mu.py) — the meta-judge's thesis
+  is that calibration helps exactly where e5 is weak; report the stratified NEAR/MID/FAR table.
+- Controls: (i) no sonnet anchor (CE-only) vs full — isolates the held-out judge's contribution;
+  (ii) sonnet-in-the-Kalman (as a channel) vs held-out — tests that holding it out is what matters.
+- Honesty: an in-sample calibration eval leaks; the ranking CE and the sonnet anchor are fit on
+  train-split rows only, evaluated on the node-disjoint held folders (the Filing v1 split-first
+  discipline). A null is reportable.
+
+## Scope guards (out of this build)
+
+- No learned output-metric space (asymmetric zᵀMz, cached folder vectors) — that is the heavier
+  alternative if scalar CE-calibration underperforms (recorded in the Filing v1 §7 memory).
+- Sonnet scores the 300-row overlap only (the calibration reference set), not the full bulk.
+- Single corpus (Pearltrees), partial DAG — same coverage caveats as Filing v1.

--- a/prototypes/mu_cosine/REPORT_meta_judge_calibration.md
+++ b/prototypes/mu_cosine/REPORT_meta_judge_calibration.md
@@ -31,6 +31,14 @@ hand-set `lr_slow`. (Naive SGD would have needed the timescale tuned by hand.) T
 — why Adam and SGD both break emergent-timescale learning and a precision-weighted update is
 required — is derived in THEORY_emergent_timescale_learning.md.
 
+**Post-audit leakage-tight rerun (v2)** — train-only target factory, TRAIN-side-only negatives,
+η₀ = 0.02, per-element-RMS drift metric (the audit's finding 5 corrections): emergent gain 0.153;
+per-element drift ratio slow/fast = 3.2, honestly reported as STILL >1 (the gate supplies the
+SNR-proportional scaling; η₀'s absolute calibration remains engineering, and re-tuning it until the
+diagnostic reads <1 would be circular). The mechanism signal survived the tightening and slightly
+sharpened: NEAR μ-beats-e5 rate 0.395 (vs 0.360 pre-fix), FAR R@1 0.135. Conclusions unchanged —
+the aggregate ranker verdict (§4) stands.
+
 ## 2. Scale-free negatives carry more information than uniform
 
 User's point: the ranking signal has more information when the folder choices are semantically

--- a/prototypes/mu_cosine/REPORT_meta_judge_calibration.md
+++ b/prototypes/mu_cosine/REPORT_meta_judge_calibration.md
@@ -1,0 +1,130 @@
+# Meta-judge: two-timescale CE-calibration of the Kalman μ (results)
+
+Implements DESIGN_meta_judge_calibration.md: a candidate-ranking cross-entropy judge calibrates the
+μ that feeds the Kalman fusion, with sonnet-5 (subagent-scored, held OUT of the fusion) as the
+independent reference. Inference ranks folders by the calibrated Kalman μ (no judge in the loop).
+Three mechanism results (each tied to a design decision the user raised) all land in the predicted
+direction — but the filing metric does not move: e5 stays the best ranker and, bluntly, the
+fine-tune HURTS the conditioned μ ranker relative to the untrained base (§4). The meta-judge is a
+validated mechanism without a payoff at this data scale.
+
+## 1. The two-timescale emerges from information content — but only under a precision-gated update
+
+User's claim: the judge should calibrate SLOWLY and the Kalman μ update FAST, and this "falls out
+automatically" because each batch carries less information for the (quantization-noisy) ranking CE
+than for the MSE distillation.
+
+Tested, not assumed. The naive realization (run both every batch, plain SGD/Adam on the judge) does
+NOT self-separate: step size follows the learning rate, not the information, so the judge drifted
+~66× TOO FAST (Adam actively normalizes the SNR away to a unit step). The claim holds only under a
+**precision/SNR-gated update**: the judge step is scaled by `gain = ‖m‖²/power` of its gradient EMA
+(≈1 coherent signal, ≈0 pure noise). Measured over 800 steps:
+
+    emergent judge gain ‖m‖²/power ≈ 0.10   →  ~90% of the CE gradient is noise that cancels
+
+So the candidate-ranking CE IS quantization-noise-dominated, exactly as claimed, and the gate turns
+that low information into a small, self-limited step — the two-timescale falls out of the
+information content, realized through the program's own Kalman/precision machinery rather than a
+hand-set `lr_slow`. (Naive SGD would have needed the timescale tuned by hand.)
+
+## 2. Scale-free negatives carry more information than uniform
+
+User's point: the ranking signal has more information when the folder choices are semantically
+CLOSE. Uniform negatives are mostly trivial (far) and dilute the gradient. Fix: scale-free sampling
+over the e5-distance rank, `P(rank r) ∝ (r+1)^-1` (Zipf) — mostly close/confusable candidates plus a
+heavy tail of a few distant ones (information in the close choices; far ones anchor the easy
+regime). Measured (800 steps, both with the sonnet anchor):
+
+| negatives | emergent gain | final ranking CE ↓ | NEAR μ-beats-e5 rate |
+|---|---|---|---|
+| scale-free (α=1) | **0.105** | **1.857** | **0.360** |
+| uniform (α=0) | 0.099 | 2.182 | 0.345 |
+
+Scale-free raises the CE information (gain up, CE down) and does slightly better on the confusable
+stratum — the prediction holds in sign on every axis, though the magnitudes are modest.
+
+## 3. Held-out sonnet helps more than the negative distribution
+
+Sonnet-5 scored the 300-row overlap via subagents (D-correlated 0.803 with 5.5, its own −0.10/−0.22
+tilt — independent signal, not a copy); it is the calibration anchor NOT in the Kalman fusion.
+Ablation (both scale-free):
+
+| config | NEAR μ-beats-e5 rate | final CE ↓ |
+|---|---|---|
+| scale-free + sonnet | **0.360** | 1.857 |
+| scale-free, NO sonnet | 0.280 | 1.981 |
+
+Removing the held-out judge hurts the confusable stratum more than removing scale-free negatives —
+the meta hook (an independent judge the fusion cannot see) is doing real work.
+
+## 4. Filing metric — directionally positive on the hard cases, marginal in absolute terms
+
+Stratified (diagnose_filing_e5_vs_mu.py), meta-judge (scale-free + sonnet) vs the Filing v1 baseline:
+
+| stratum | e5 R@1 | baseline μ-max R@1 | meta-judge μ-max R@1 |
+|---|---|---|---|
+| NEAR (confusable) | 0.000 | 0.000 | 0.007 |
+| MID | 0.000 | 0.038 | 0.023 |
+| FAR (e5 easy) | 0.617 | 0.060 | 0.060 |
+
+Aggregate filing MRR (conditioned rankers; base = untrained `model_prod_namecond_full`, the
+pretrained model with a pearltrees card at r=0):
+
+| ranker (MRR ↑) | e5-cos | base (untrained) | Filing v1 tuned | meta-judge |
+|---|---|---|---|---|
+| mu-max-cond | — | **0.112** | 0.075 | 0.065 |
+| mu-elem-cond | — | 0.105 | 0.081 | 0.027 |
+| margin-gate (e5⊕μ) | — | 0.206 | 0.191 | 0.204 |
+| e5-cos (reference) | **0.294** | 0.294 | 0.294 | 0.294 |
+
+The blunt aggregate result: **fine-tuning HURTS the conditioned μ ranker, and the meta-judge does
+not reverse it** — the untrained pretrained base has the best conditioned MRR (0.112), Filing v1
+tuning drops it to 0.075, the meta-judge to 0.065. On this small partial-DAG campaign the fine-tune
+overfits/narrows the ranker relative to the broad pretrained μ, and calibration cannot buy that
+back; e5 (0.294) is unbeaten throughout.
+
+**Honest verdict.** The meta-judge does exactly what the design predicted on the confusable stratum
+— where e5 is completely blind (NEAR/MID recall@1 = 0), the calibrated μ reranks the true folder
+above e5 on 36% of hard queries (vs 28% without the held-out judge), and it is the only config that
+gets any NEAR recall@1 at all (0.007). Both of the user's design points (scale-free negatives, the
+information-limited slow timescale) and the held-out-sonnet meta hook are validated in sign. BUT the
+absolute filing metric barely moves: e5 still dominates the aggregate because its easy FAR-third
+wins (recall@1 0.617 there) swamp the hard-case reranking, which mostly lifts the true folder toward
+the middle of the list rather than to #1. So this is a **directionally-confirmed but practically-
+marginal** result — the calibration mechanism works and helps exactly where predicted, but at this
+scale (300-row overlap, partial DAG, ~200 NEAR queries) it does not overturn e5 as the deployed
+ranker. The value is a proof-of-mechanism for CE-calibrated μ + the precision-gated two-timescale,
+and a clear signal that the leverage is on the confusable cases — which points at more overlap data
+and the distinct-role / learned-metric extensions rather than declaring a ranker win here.
+
+A second, blunter finding sits underneath (§4 table): on this small partial-DAG campaign the
+fine-tune itself HURTS the conditioned μ ranker relative to the untrained pretrained base (0.112 →
+0.075 → 0.065), and the meta-calibration does not recover it. The pretrained μ is broader than what
+300 overlap rows can improve; the campaign narrows it. So the deployable conclusion for Filing v1 is
+unchanged and if anything sharper: **rank with e5 (0.294); if a μ ranker is wanted, the untrained
+pretrained conditioned μ (0.112) beats every fine-tuned variant** — the campaign is too small/narrow
+to help the ranker, and the fused model's real value stays the label factory + conflict router, not
+the ranking head. The meta-judge's contribution is a validated mechanism (precision-gated
+two-timescale, scale-free CE, held-out anchor) awaiting a corpus large enough to exercise it.
+
+## Caveats
+
+- All the confusable-stratum recall@1 numbers are tiny in absolute count (0.007 = 1/134); the
+  μ-beats-e5 RATE (over ~200 NEAR queries) is the more stable signal, and even it moves by ~0.01–0.08.
+- Single 300-row overlap, partial Pearltrees DAG, one node-disjoint split — same coverage limits as
+  Filing v1; a null-sized effect is expected to be noisy.
+- The meta-judge checkpoint is Pearltrees-only (the Filing v1 finding-6 drift applies unchanged).
+- Sonnet judged 300 pairs via subagents (not the production codex path); provenance is the subagent
+  transcripts, not a scored-with-codex run.
+
+## Repro
+
+```
+# sonnet held-out scoring (subagents) → assemble
+python3 assemble_sonnet_scores.py
+# train (scale-free + sonnet = the design; ablations via --neg-alpha 0 / --no-sonnet)
+python3 train_meta_judge.py --steps 800 --neg-alpha 1.0 --out model_pt_meta_judge.pt
+# evaluate on the filing metric + confusable-stratum diagnostic
+python3 eval_pearltrees_filing.py --tuned model_pt_meta_judge.pt
+python3 diagnose_filing_e5_vs_mu.py --tuned model_pt_meta_judge.pt
+```

--- a/prototypes/mu_cosine/REPORT_meta_judge_calibration.md
+++ b/prototypes/mu_cosine/REPORT_meta_judge_calibration.md
@@ -1,6 +1,8 @@
 # Meta-judge: two-timescale CE-calibration of the Kalman μ (results)
 
-Implements DESIGN_meta_judge_calibration.md: a candidate-ranking cross-entropy judge calibrates the
+Implements DESIGN_meta_judge_calibration.md: an ANCESTOR-ranking cross-entropy judge (candidates
+ranked against h1–h5 ancestor pairs — ancestor-recovery, not exact-parent recovery; audit finding 3)
+calibrates the
 μ that feeds the Kalman fusion, with sonnet-5 (subagent-scored, held OUT of the fusion) as the
 independent reference. Inference ranks folders by the calibrated Kalman μ (no judge in the loop).
 Three mechanism results (each tied to a design decision the user raised) all land in the predicted

--- a/prototypes/mu_cosine/REPORT_meta_judge_calibration.md
+++ b/prototypes/mu_cosine/REPORT_meta_judge_calibration.md
@@ -25,7 +25,9 @@ NOT self-separate: step size follows the learning rate, not the information, so 
 So the candidate-ranking CE IS quantization-noise-dominated, exactly as claimed, and the gate turns
 that low information into a small, self-limited step — the two-timescale falls out of the
 information content, realized through the program's own Kalman/precision machinery rather than a
-hand-set `lr_slow`. (Naive SGD would have needed the timescale tuned by hand.)
+hand-set `lr_slow`. (Naive SGD would have needed the timescale tuned by hand.) The general principle
+— why Adam and SGD both break emergent-timescale learning and a precision-weighted update is
+required — is derived in THEORY_emergent_timescale_learning.md.
 
 ## 2. Scale-free negatives carry more information than uniform
 

--- a/prototypes/mu_cosine/REPORT_pearltrees_candidate_lineage.md
+++ b/prototypes/mu_cosine/REPORT_pearltrees_candidate_lineage.md
@@ -24,22 +24,26 @@ folder→parent lineage, never the evaluated bookmark's placement nor the folder
 without lineage tokens; the new `model_pt_filing_lin.pt` with them); 217/323 folders had a
 principal path (271 ancestor titles embedded). Filing MRR (fidelity to real treeId placement):
 
-| head (MRR ↑) | no-lineage | +candidate-lineage | +lineage SHUFFLED (control) |
+Post-audit rerun (record-majority PRINCIPAL lineage — the earlier first-DAG-parent walk
+contradicted the recorded parent on 61% of multi-parent folders — and a SUPPORT-PRESERVING shuffle
+control; coverage rose to 253/323 folders, 1118/1147 edges from records):
+
+| head (MRR ↑) | no-lineage | +principal lineage | +lineage SHUFFLED (clean control) |
 |---|---|---|---|
-| mu-max-cond (conditioned) | 0.075 | 0.085 | 0.082 |
-| mu-lineage | 0.044 | 0.054 | 0.073 |
-| mu-elem-cond | 0.081 | 0.077 | 0.082 |
-| **held-folder mu-max-cond (n=279)** | 0.073 | **0.097** | 0.084 |
+| mu-max-cond (conditioned) | 0.075 | 0.081 | 0.078 |
+| mu-lineage | 0.044 | 0.068 | 0.078 |
+| mu-elem-cond | 0.081 | 0.100 | 0.108 |
+| held-folder mu-max-cond (n=279) | 0.073 | 0.082 | 0.088 |
 | e5-cos (reference, lineage-invariant) | 0.294 | 0.294 | 0.294 |
 
-**Verdict: inconclusive at this first cut — the shuffled control eats most of the gain.** Adding
-candidate-folder tokens lifts the conditioned heads over no-lineage (mu-max-cond 0.075→0.085), but
-a SHUFFLED lineage (each folder given a random other folder's path) does about as well on the
-pooled metrics (0.082; mu-lineage is even higher shuffled) — so most of the pooled lift is generic
-extra-context, NOT the specific parent path. The one place the RIGHT lineage demonstrably beats
-shuffled is the held-folder subset (0.097 vs 0.084, +0.013) — real signal exactly where
-disambiguation by parent path should matter (unseen folders), but small. Nothing here closes the
-gap to e5 (0.294).
+**Verdict (corrected, and cleaner than the first cut): the lineage effect is GENERIC CONTEXT, not
+the specific path.** With the true principal lineage and the clean control, the shuffled chains do
+as well as — sometimes better than — the correct ones on every head, INCLUDING the held-folder
+slice where the first cut had shown a right-lineage edge (that edge was an artifact of the wrong
+lineage construction plus the confounded shuffle, and did not survive the audit corrections).
+Extra folder-side tokens help a little (0.075→~0.08–0.11 across heads); WHICH lineage they encode
+does not measurably matter at this scale. Consistent with §"titles already carry the lineage".
+Nothing approaches e5 (0.294).
 
 Why so weak — the titles already carry the lineage. The held-folder slice discriminates the two
 candidate explanations: no-lineage 0.073 → correct 0.097 → shuffled 0.084, so the RIGHT lineage

--- a/prototypes/mu_cosine/REPORT_pearltrees_candidate_lineage.md
+++ b/prototypes/mu_cosine/REPORT_pearltrees_candidate_lineage.md
@@ -41,13 +41,21 @@ shuffled is the held-folder subset (0.097 vs 0.084, +0.013) — real signal exac
 disambiguation by parent path should matter (unseen folders), but small. Nothing here closes the
 gap to e5 (0.294).
 
-Why so weak, and what's next: this first cut reuses the shared `anc` token role for folder
-ancestors (no dedicated "candidate-lineage" role or hop/depth encoding — the design's step 1), and
-the k=1 node-ancestor sampling means the model never learned a rich path representation to begin
-with. The natural next steps are (a) a distinct candidate-lineage token role with explicit depth
-encoding, and (b) the training-time meta-judge (candidate-ranking CE with a held-out judge) that
-directly optimizes folder ranking rather than pair-μ — both aimed at the confusable NEAR stratum
-(§2) where e5 is also weak.
+Why so weak — the titles already carry the lineage. The held-folder slice discriminates the two
+candidate explanations: no-lineage 0.073 → correct 0.097 → shuffled 0.084, so the RIGHT lineage
+beats both no-lineage AND shuffled on UNSEEN folders, while the gain washes out once seen folders
+are pooled in. That rules out "the model can't use lineage order at all" (capacity/position
+embeddings — it would lose everywhere) and points to "the folder title already encodes its
+lineage." Direct probe: a child folder's e5 embedding is closer to its TRUE parent (mean cosine
+0.877) than to a random folder (0.816), a +0.062 separation — the parent relationship is legible in
+the title alone. So on folders the model has seen, it infers the parent path from the title and
+explicit lineage is redundant; explicit lineage only adds value where the folder's title is
+unfamiliar (the held slice). A weak depth encoding (this first cut reuses the shared `anc` role,
+no distinct candidate-lineage role) plausibly CAPS the held-folder magnitude but does not explain
+the pattern. Consequence for design: the leverage is not injecting lineage (titles have it) but
+CALIBRATING μ so the ranking is right — which is exactly the training-time meta-judge's job
+(candidate-ranking CE that calibrates the μ signal fed to the Kalman filter), aimed at the
+confusable NEAR stratum (§2) where e5 is also weak.
 
 ## 2. Why does e5 beat the μ heads? Mostly the regime, not pure capability
 

--- a/prototypes/mu_cosine/REPORT_pearltrees_candidate_lineage.md
+++ b/prototypes/mu_cosine/REPORT_pearltrees_candidate_lineage.md
@@ -1,0 +1,139 @@
+# Candidate-lineage-conditioned μ, the e5-vs-μ diagnostic, and Kalman channel aggregation
+
+Follow-up to REPORT_pearltrees_filing_v1.md §7. Three threads: (1) fix the identified train/eval
+regime mismatch by feeding the candidate FOLDER's principal path into the scalar μ scorer and
+re-run the filing metric; (2) answer why e5 beats the μ heads at filing; (3) work through which
+judge measurement functions the fusion Kalman filter should carry.
+
+## 1. Candidate-lineage-conditioned μ (the §7 fix)
+
+**What was wrong.** LINEAGE is a scalar pairwise scorer `(node, folder, LINEAGE)→μ`; its lineage
+context came from `Tokenizer._anc_for(NODE)` — the deeper endpoint's ancestors. At filing the node
+is a fresh bookmark with no lineage and the eval tokenizer had empty parent tables, so the folder's
+known principal path never reached the scorer. The head was scored blind to lineage.
+
+**The fix.** A backward-compatible `Tokenizer(root_lineage=True, root_lineage_depth=k)` flag now
+also emits the anchor/FOLDER's materialized path (deterministic first-parent climb) as `anc`
+tokens — reusing the existing ancestor role, so no new model parameters and no forward-pass change.
+The model is retrained with it on (`fine_tune_pearltrees_filing.py --cand-lineage`); the filing
+eval supplies each candidate folder's principal path from the assembled DAG
+(`eval_pearltrees_filing.py --cand-lineage`), respecting the §7 leakage boundary: ONLY the
+folder→parent lineage, never the evaluated bookmark's placement nor the folder's bookmark children.
+
+**Result.** Each checkpoint evaluated in its trained regime (the merged no-lineage checkpoint
+without lineage tokens; the new `model_pt_filing_lin.pt` with them); 217/323 folders had a
+principal path (271 ancestor titles embedded). Filing MRR (fidelity to real treeId placement):
+
+| head (MRR ↑) | no-lineage | +candidate-lineage | +lineage SHUFFLED (control) |
+|---|---|---|---|
+| mu-max-cond (conditioned) | 0.075 | 0.085 | 0.082 |
+| mu-lineage | 0.044 | 0.054 | 0.073 |
+| mu-elem-cond | 0.081 | 0.077 | 0.082 |
+| **held-folder mu-max-cond (n=279)** | 0.073 | **0.097** | 0.084 |
+| e5-cos (reference, lineage-invariant) | 0.294 | 0.294 | 0.294 |
+
+**Verdict: inconclusive at this first cut — the shuffled control eats most of the gain.** Adding
+candidate-folder tokens lifts the conditioned heads over no-lineage (mu-max-cond 0.075→0.085), but
+a SHUFFLED lineage (each folder given a random other folder's path) does about as well on the
+pooled metrics (0.082; mu-lineage is even higher shuffled) — so most of the pooled lift is generic
+extra-context, NOT the specific parent path. The one place the RIGHT lineage demonstrably beats
+shuffled is the held-folder subset (0.097 vs 0.084, +0.013) — real signal exactly where
+disambiguation by parent path should matter (unseen folders), but small. Nothing here closes the
+gap to e5 (0.294).
+
+Why so weak, and what's next: this first cut reuses the shared `anc` token role for folder
+ancestors (no dedicated "candidate-lineage" role or hop/depth encoding — the design's step 1), and
+the k=1 node-ancestor sampling means the model never learned a rich path representation to begin
+with. The natural next steps are (a) a distinct candidate-lineage token role with explicit depth
+encoding, and (b) the training-time meta-judge (candidate-ranking CE with a held-out judge) that
+directly optimizes folder ranking rather than pair-μ — both aimed at the confusable NEAR stratum
+(§2) where e5 is also weak.
+
+## 2. Why does e5 beat the μ heads? Mostly the regime, not pure capability
+
+`diagnose_filing_e5_vs_mu.py` stratifies the 400 filing queries by e5 DIFFICULTY — the true
+folder's e5-cosine minus the best distractor's. Negative gap = the true folder is NOT the
+e5-nearest (a distractor is closer); positive = e5 already separates it.
+
+    e5 difficulty gap: min −0.175, median −0.044, max +0.075
+    (i.e. for MOST queries the true folder is not the e5-nearest neighbour)
+
+| stratum (by e5 gap) | n | e5 recall@1 | mu-max recall@1 | μ − e5 |
+|---|---|---|---|---|
+| NEAR (confusable, gap [−0.17,−0.06]) | 134 | 0.000 | 0.000 | +0.000 |
+| MID (gap [−0.06,−0.02]) | 133 | 0.000 | 0.038 | +0.038 |
+| FAR (e5 easy, gap [−0.02,+0.08]) | 133 | **0.617** | 0.060 | −0.556 |
+
+μ-beats-e5 rate: **0.355 on the NEAR (confusable) half vs 0.065 on the FAR half.**
+
+**Reading.** e5's entire filing win is the FAR third — the queries where the bookmark title is
+already the folder's nearest e5 neighbour (recall@1 0.617 there, ~0 elsewhere). On the other two
+thirds — where filing is actually a decision, because the true folder is NOT the e5-nearest — e5
+scores essentially zero and μ is no worse (slightly better on MID). This is your hypothesis
+confirmed: the aggregate "e5 wins" is an easy-case artifact; the semantic spread of the candidate
+folders means e5 cosine already nails the trivial cases and neither method is strong on the hard,
+confusable cases where a filing assistant would earn its keep. It is NOT that raw similarity is
+fundamentally better than the learned μ signal — it is that the eval is dominated by cases where
+raw similarity suffices. (Luna itself is not a filing ranker here; it was the label source. The
+comparison is e5-cosine vs the model's learned conditioned μ.) The confusable NEAR stratum is
+exactly where candidate-lineage conditioning (§1) should pay — folder titles like "Tools" or
+duplicated names disambiguated by their parent path.
+
+## 3. Kalman measurement channels: aggregate vs split (the weighting-function question)
+
+The fusion currently carries a REDUCED 2-channel-per-judge measurement: `D = max(subcategory,
+subtopic, element_of, super_category)` and `S = max(see_also, assoc)`. Your question: keep the
+directional/symmetric aggregates, or split every relation (both directions) into its own channel?
+Empirically, from the 799 Pearltrees luna rows (per-relation μ correlation + which relation wins
+each max):
+
+| | subcat | subtopic | element_of | super_cat | see_also | assoc |
+|---|---|---|---|---|---|---|
+| subcategory | 1.00 | 0.66 | 0.50 | **0.01** | 0.12 | −0.05 |
+| subtopic | | 1.00 | 0.32 | **0.00** | 0.39 | 0.20 |
+| element_of | | | 1.00 | **0.01** | 0.09 | −0.01 |
+| super_category | | | | 1.00 | 0.07 | 0.02 |
+| see_also | | | | | 1.00 | 0.63 |
+| assoc | | | | | | 1.00 |
+
+- **The forward directional relations (subcategory/subtopic/element_of) are redundant** (r 0.32–0.66)
+  and subtopic wins the D-max on 706/799 rows — collapsing them into one D aggregate loses little.
+- **super_category is nearly ORTHOGONAL to all of them (r ≈ 0.00–0.01)** and wins the D-max on only
+  11/799 rows — so the current `max`-into-D essentially DISCARDS it. It is the reverse-direction
+  membership signal ("root is under node"), a genuinely independent measurement.
+- **see_also/assoc are correlated (0.63)** but assoc carries more (wins 610/799); splitting them
+  gives a modest independent-signal gain.
+
+**Recommendation.** The high-ROI change is NOT the full per-relation explosion (6 channels × both
+directions), which would blow up the covariance parameter count against only ~300 overlap rows.
+It is a targeted 3rd channel: keep the forward-directional aggregate D, keep the symmetric aggregate
+S, and ADD a REVERSE-direction channel (super_category, or the judge's mu_rev) — the one signal the
+current max provably throws away. That is a 3-channel-per-judge measurement, well within the overlap
+budget, and it maps cleanly onto the directional asymmetry the filing task cares about
+(bookmark→folder membership is directional). Splitting the symmetric aggregate is a secondary,
+lower-value option. A confirmatory test belongs on the enwiki node-disjoint harness
+(`run_sym_channel_fusion.py`), where the covariance-vs-data tradeoff can be measured with the frozen
+gate rather than the small Pearltrees overlap.
+
+## Caveats
+
+- The lineage eval keys folders by title; duplicate folder titles share one lineage entry (the
+  title-equivalence caveat from Filing v1 §5 still applies).
+- 225/335 candidate folders have a principal path in the partial assembled DAG; 110 are roots or
+  isolated (no lineage supplied — a coverage limit the completed Grok export lifts).
+- The e5-difficulty stratification uses the best-distractor gap; it is a descriptive lens, not a
+  calibrated hardness model.
+- §3's correlations are measured on luna's raw per-relation μ; the fusion operates on the affine-
+  calibrated D/S, so the split-channel gain must be confirmed by an actual re-fusion, not inferred
+  from the correlation table alone.
+
+## Repro
+
+```
+# candidate-lineage retrain + eval (with vs shuffled control)
+python3 fine_tune_pearltrees_filing.py --cand-lineage --out model_pt_filing_lin.pt
+python3 eval_pearltrees_filing.py --tuned model_pt_filing_lin.pt --cand-lineage
+python3 eval_pearltrees_filing.py --tuned model_pt_filing_lin.pt --cand-lineage --shuffle-lineage
+# e5-vs-μ diagnostic
+python3 diagnose_filing_e5_vs_mu.py --tuned model_pt_filing.pt
+```

--- a/prototypes/mu_cosine/THEORY_emergent_timescale_learning.md
+++ b/prototypes/mu_cosine/THEORY_emergent_timescale_learning.md
@@ -70,14 +70,26 @@ This is inverse-variance weighting in disguise. Treat the batch gradient as a no
 the descent direction with observation-noise variance `R ≈ p − ‖m‖²` and prior signal variance
 `P ≈ ‖m‖²`. The Kalman gain for that scalar problem is `K = P/(P+R) = ‖m‖²/p = gain_t`. So the
 meta-parameter is being Kalman-filtered: a low-information (quantization-noisy) batch has large `R`,
-small `K`, small posterior movement. **The slow timescale is now a consequence of the data's
-precision, not a hyperparameter** — exactly the user's claim, and exactly the inverse-variance rule
-the fusion filter already uses for its measurements (THEORY_evidence_fusion.md §"price every source
-by its precision"). The optimizer and the estimator obey the same law.
+small `K`, small posterior movement — the inverse-variance rule the fusion filter already uses for
+its measurements (THEORY_evidence_fusion.md §"price every source by its precision"), applied to the
+optimizer.
+
+**Correction (external statistical audit, 2026-07-17): what is and is not emergent.** The gate makes
+the SNR-PROPORTIONAL SCALING emergent — the step shrinks with the information, which neither SGD nor
+Adam provides. It does NOT make the ABSOLUTE timescale emergent: the step is `η₀·gain·m̂`, and `η₀`
+is still a free constant. In the first shipped run `η₀ = 0.5` (vs Adam 5e-4 on the fast heads) made
+the "slow" judge row move **22.7× farther per step than the fast heads** — the empirical timescale
+was REVERSED even though the gain (~0.10) behaved as predicted. Two lessons: (i) compare drifts in
+per-element RMS, not raw norms of different-sized tensors; (ii) the gate is NECESSARY for emergence
+but not SUFFICIENT — `η₀` must be commensurate with the fast rate, and in this half-Kalman form it is
+calibrated, not derived. The fully-derived version has no free `η₀`: a proper Kalman update on the
+meta-parameter carries a state prior `P_θ` whose posterior contraction sets the absolute step
+(`Δθ = K·innovation` with `K` from `P_θ` and `R` in the same units) — that is the honest meaning of
+"the timescale falls out", and it is the rigorous follow-up, not what the current code does.
 
 Measured on the meta-judge (REPORT_meta_judge_calibration.md §1): `gain_t ≈ 0.10` over training — the
-candidate-ranking CE gradient is ~90% noise, so the gate self-limits the judge to a slow drift while
-the fast MSE heads move freely. Two-timescale, emergent.
+candidate-ranking CE gradient is ~90% noise. With `η₀` calibrated the judge's per-element drift sits
+below the fast heads'; the SNR-scaling is the emergent part, the base rate is engineering.
 
 ## 4. Why the fast estimator can keep Adam
 
@@ -110,4 +122,7 @@ not chosen.
   Gaussian observation with diagonal precision; the full matrix (Fisher) precision and its
   interaction with the fast estimator's updates (a genuine two-timescale stochastic-approximation
   analysis, Borkar-style) is the rigorous version — Codex's lane if it matters. The claim here is the
-  qualitative law and its empirical confirmation, not a convergence proof.
+  qualitative law (SNR-proportional scaling requires precision weighting; Adam/SGD destroy it) plus
+  the measured gain, NOT a convergence proof and NOT a claim that the absolute timescale is
+  hyperparameter-free in the current implementation (see the §3 correction: `η₀` remains free until
+  the full state-prior Kalman form is implemented).

--- a/prototypes/mu_cosine/THEORY_emergent_timescale_learning.md
+++ b/prototypes/mu_cosine/THEORY_emergent_timescale_learning.md
@@ -1,0 +1,113 @@
+# Emergent-timescale learning: why it requires a precision-weighted update (and not Adam or plain SGD)
+
+*Theory note, 2026-07-17 (user + Claude). "Emergent-timescale learning": the separation between a
+FAST inner estimator and a SLOW meta-parameter should EMERGE from the information content of each
+batch, not be imposed by a hand-set learning-rate ratio. Discovered while building the two-timescale
+CE-calibration meta-judge (DESIGN_meta_judge_calibration.md). The catch: emergence only happens under
+an update rule whose effective step scales with the observation's precision (signal-to-noise). Adam
+and plain SGD both break it, for opposite reasons. This is the same inverse-variance principle that
+runs through the whole fusion program (THEORY_evidence_fusion.md), now applied to the OPTIMIZER
+instead of to the measurements.*
+
+Companion docs: `DESIGN_meta_judge_calibration.md`, `REPORT_meta_judge_calibration.md`,
+`DESIGN_amortized_fusion_heads.md` (the two-timescale/metastable-drift design),
+`THEORY_evidence_fusion.md` (the precision/inverse-variance framing this generalizes).
+
+---
+
+## 1. The claim (user)
+
+When you couple a FAST inner estimator (here: the Kalman-fused μ, distilled per batch by MSE) with a
+SLOW meta-parameter (here: the judge that calibrates μ by candidate-ranking cross-entropy), you
+should NOT need to hand-set the slow timescale (`lr_slow ≪ lr_fast`, or "update the judge every K
+batches"). The separation should fall out on its own, because **each batch simply carries less usable
+information for the meta-parameter than for the inner estimate**. The ranking CE is quantization-
+limited and higher-variance; the MSE distillation is dense and low-variance. Less information ⇒
+slower update, automatically.
+
+This is correct — but it is a statement about a BAYESIAN/precision-weighted update, and it is false
+for the two update rules one reaches for by default.
+
+## 2. Why "slower" is not automatic under a fixed-rate optimizer
+
+Write the meta-parameter update as `θ ← θ − η · f(g_t)` where `g_t` is the per-batch gradient of the
+meta-loss and `f` is the optimizer's transform. Decompose the gradient into signal + noise:
+`g_t = s + ε_t`, `E[ε_t]=0`, with signal power `‖s‖²` and noise power `E‖ε_t‖²`. Define the
+per-batch information as the signal-to-noise ratio `SNR = ‖s‖² / E‖ε_t‖²`. The user's claim is:
+**effective step size should be a monotone increasing function of SNR** — low SNR ⇒ small step ⇒
+slow timescale. Check the defaults:
+
+- **Plain SGD**: `f(g) = g`, step `= η·(s + ε_t)`. The per-batch step magnitude is `η·‖g_t‖`,
+  which is INDEPENDENT of SNR — it is set by the raw gradient norm and the fixed `η`. A noisy,
+  low-information batch produces just as large a step as a clean one; the noise only averages out
+  over MANY steps, so the NET drift is slow but each step is not. In practice, to make the net drift
+  slow you must shrink `η` by hand — i.e. you are back to imposing the timescale. (Measured: with a
+  fixed SGD `η` the judge drifted ~66× faster than the fast heads, the opposite of intended.)
+
+- **Adam / RMSProp**: `f(g) = g / (√v + ε)` with `v` the running second moment. This is WORSE: it
+  divides by the gradient's own RMS, driving every coordinate to a UNIT-scale step regardless of how
+  noisy it is. Adam's design goal — scale-invariance — is exactly the destruction of the SNR
+  signal. A pure-noise direction (`s≈0`, `‖g‖≈‖ε‖`) still gets a unit step; the optimizer CHASES the
+  quantization noise. Adam makes `effective_step ≈ η` for all SNR, the flat function the user's
+  claim explicitly rules out.
+
+So under both defaults the timescale does not emerge; it is either constant (Adam) or set by `η`
+(SGD). The information asymmetry the user is pointing at is real, but neither optimizer READS it.
+
+## 3. The update that makes it emerge: precision (SNR) gating
+
+The claim is realized by a precision-weighted step — a Kalman/natural-gradient update on the
+meta-parameter. Maintain EMA estimates of the gradient mean `m_t` (signal) and second moment
+`p_t = E‖g‖²` (power). The coherent-signal fraction is
+
+    gain_t  =  ‖m_t‖² / p_t   ∈ [0, 1]        (≈1 pure signal, ≈0 pure noise)
+
+and the step is
+
+    θ ← θ − η₀ · gain_t · m̂_t                 (m̂ = m/‖m‖, the signal direction)
+
+This is inverse-variance weighting in disguise. Treat the batch gradient as a noisy OBSERVATION of
+the descent direction with observation-noise variance `R ≈ p − ‖m‖²` and prior signal variance
+`P ≈ ‖m‖²`. The Kalman gain for that scalar problem is `K = P/(P+R) = ‖m‖²/p = gain_t`. So the
+meta-parameter is being Kalman-filtered: a low-information (quantization-noisy) batch has large `R`,
+small `K`, small posterior movement. **The slow timescale is now a consequence of the data's
+precision, not a hyperparameter** — exactly the user's claim, and exactly the inverse-variance rule
+the fusion filter already uses for its measurements (THEORY_evidence_fusion.md §"price every source
+by its precision"). The optimizer and the estimator obey the same law.
+
+Measured on the meta-judge (REPORT_meta_judge_calibration.md §1): `gain_t ≈ 0.10` over training — the
+candidate-ranking CE gradient is ~90% noise, so the gate self-limits the judge to a slow drift while
+the fast MSE heads move freely. Two-timescale, emergent.
+
+## 4. Why the fast estimator can keep Adam
+
+The inner μ estimate is distilled by dense MSE against the fused target: high SNR, low variance per
+batch. There the precision is high and roughly uniform, so gain-gating would be ≈1 everywhere and
+buys nothing; Adam's convergence speed is worth more than a scaling it would not exercise. The
+asymmetry in the RIGHT optimizer for each role — precision-gated for the low-SNR meta-parameter,
+Adam for the high-SNR estimator — is itself the two-timescale, and it is dictated by the information,
+not chosen.
+
+## 5. Consequences and scope
+
+- **General principle.** Any coupled fast-estimator / slow-meta-parameter scheme (MAML-style outer
+  loops, learned-optimizer meta-parameters, calibration heads, metastable-drift states in
+  DESIGN_amortized_fusion_heads.md) where the meta-signal is noisier per batch should use a
+  precision-weighted meta-update if the timescale is meant to be emergent rather than tuned. Reaching
+  for Adam on the meta-parameter silently reintroduces the hand-tuned timescale (via `η` and the
+  unit-step normalization) and can chase noise.
+- **Connection to the cross-campaign drift design.** DESIGN_amortized_fusion_heads.md's metastable
+  bias states are a random walk with process noise `Q`; the precision-gated meta-update is the
+  SGD-time analog — the state moves in proportion to how much each batch actually informs it. Adding
+  `Q` (a floor on movement) and the gain (a ceiling from information) are the two knobs of the same
+  filter.
+- **Caveat — this is the update rule, not a performance claim.** The gate makes the timescale
+  emergent and well-behaved; it does NOT make the meta-objective useful. On the Pearltrees campaign
+  the calibrated μ did not beat the untrained ranker (REPORT_meta_judge_calibration.md §4). The
+  theory here is about HOW the two timescales relate, not WHETHER the slow objective pays — those are
+  independent, and the second is a data-scale question.
+- **Not yet derived rigorously.** The `gain = K` identification treats the gradient as a scalar
+  Gaussian observation with diagonal precision; the full matrix (Fisher) precision and its
+  interaction with the fast estimator's updates (a genuine two-timescale stochastic-approximation
+  analysis, Borkar-style) is the rigorous version — Codex's lane if it matters. The claim here is the
+  qualitative law and its empirical confirmation, not a convergence proof.

--- a/prototypes/mu_cosine/assemble_sonnet_scores.py
+++ b/prototypes/mu_cosine/assemble_sonnet_scores.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Assemble the sonnet-subagent batch JSON files into a `sonnet` scored TSV (score_with_codex format).
+
+Sonnet-5 judged the 300-row overlap in batches (launched as subagents; each wrote a strict JSON
+array keyed by GLOBAL overlap pair id to /tmp/mu_data/sonnet_batches/out100_*.json). This reuses
+score_inferred_tail.ingest, which maps objects by id onto the overlap pairs file. Sonnet is the
+HELD-OUT judge (not a Kalman fusion channel) — the meta-judge's calibration reference.
+
+  python3 assemble_sonnet_scores.py
+"""
+import glob
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from score_inferred_tail import ingest
+
+BATCH_DIR = "/tmp/mu_data/sonnet_batches"
+OVERLAP = "/tmp/mu_data/pt_campaign_all_score_in_overlap.tsv"
+RESPONSES = "/tmp/mu_data/pt_campaign_sonnet_responses.txt"
+OUT = "/tmp/mu_data/pt_campaign_scored_sonnet.tsv"
+
+
+def main():
+    files = sorted(glob.glob(os.path.join(BATCH_DIR, "out100_*.json")))
+    if not files:
+        raise SystemExit(f"no sonnet batch outputs in {BATCH_DIR} (out100_*.json)")
+    all_objs, seen_ids = [], set()
+    for fp in files:
+        txt = open(fp, encoding="utf-8").read().strip()
+        txt = txt.replace("```json", " ").replace("```", " ").strip()
+        arr = json.loads(txt)
+        if not isinstance(arr, list):
+            raise SystemExit(f"{fp}: not a JSON list")
+        for o in arr:
+            if isinstance(o, dict) and "id" in o:
+                if o["id"] in seen_ids:
+                    continue
+                seen_ids.add(o["id"])
+                all_objs.append(o)
+        print(f"{os.path.basename(fp)}: {len(arr)} objects")
+    with open(RESPONSES, "w", encoding="utf-8") as f:
+        json.dump(all_objs, f)
+    ingest(OVERLAP, RESPONSES, OUT, judge="sonnet")
+    # sanity
+    n = sum(1 for _ in open(OUT)) - 1
+    print(f"\nassembled {len(all_objs)} sonnet judgments; ids {min(seen_ids)}..{max(seen_ids)}; "
+          f"scored TSV rows {n} -> {OUT}")
+    if len(all_objs) < 300:
+        print(f"WARNING: only {len(all_objs)}/300 overlap pairs judged — check batch coverage")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/diagnose_filing_e5_vs_mu.py
+++ b/prototypes/mu_cosine/diagnose_filing_e5_vs_mu.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """Why does e5 beat the μ heads at filing? Two hypotheses, one diagnostic.
 
+CAVEAT (external audit): the NEAR/MID/FAR stratification is OUTCOME-DEFINED — the difficulty gap is
+computed from e5's own true-vs-distractor margin, so this is an exploratory diagnostic lens, not
+independent validation. An outcome-blind hardness geometry would use graph topology first, with
+Nomic embeddings as the preferred independent semantic modifier (MiniLM as sensitivity check).
+
 H1 (capability): the μ operators genuinely carry less filing signal than raw e5 cosine.
 H2 (regime): the filing candidate set is semantically SPREAD OUT, so e5 cosine already separates
     the true folder easily and μ's fine-grained directional/membership discrimination has nothing

--- a/prototypes/mu_cosine/diagnose_filing_e5_vs_mu.py
+++ b/prototypes/mu_cosine/diagnose_filing_e5_vs_mu.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Why does e5 beat the μ heads at filing? Two hypotheses, one diagnostic.
+
+H1 (capability): the μ operators genuinely carry less filing signal than raw e5 cosine.
+H2 (regime): the filing candidate set is semantically SPREAD OUT, so e5 cosine already separates
+    the true folder easily and μ's fine-grained directional/membership discrimination has nothing
+    to add — μ would show its strength where folders are semantically CLOSE (the hard cases).
+
+Test: stratify queries by how hard the choice is in e5 space — the gap between the true folder's
+e5-cosine and the best DISTRACTOR's e5-cosine. NEAR (small/negative gap = confusable folders) is
+where H2 predicts μ should help most; FAR (large gap = e5 already wins) is where e5 dominates.
+Report recall@1 for e5 vs the best conditioned μ head per stratum.
+
+  python3 diagnose_filing_e5_vs_mu.py --tuned model_pt_filing.pt
+"""
+import argparse
+import os
+import sys
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from eval_filing import load_filing
+from eval_pearltrees_filing import ranks_from, score_cond
+from fine_tune_pearltrees_filing import load_with_lineage_ops
+from mu_attention import Tokenizer, build_e5_tables
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+TREES = os.path.join(ROOT, "..", "..", ".local", "data", "pearltrees_api", "trees")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tuned", default=os.path.join(ROOT, "model_pt_filing.pt"))
+    ap.add_argument("--trees", default=TREES)
+    ap.add_argument("--min-bm", type=int, default=3)
+    ap.add_argument("--max-queries", type=int, default=400)
+    ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--cache", default="/tmp/mu_data/pt_filing_eval_e5.pt")
+    a = ap.parse_args(argv)
+    dev = "cpu"
+    torch.set_num_threads(4)
+
+    import random
+    queries, cand = load_filing(a.trees, a.min_bm)
+    queries = sorted(queries)
+    if len(queries) > a.max_queries:
+        queries = random.Random(a.seed).sample(queries, a.max_queries)
+    f_ids = sorted(cand)
+    f_titles = [cand[fid] for fid in f_ids]
+    q_titles = [q for q, _ in queries]
+    by_title = {}
+    for j, t in enumerate(f_titles):
+        by_title.setdefault(t, []).append(j)
+    truepos = [sorted(by_title[cand[fid]]) for _, fid in queries]
+
+    names = sorted(set(q_titles) | set(f_titles))
+    qtbl, ptbl, idx = build_e5_tables(names, cache_path=a.cache, batch_size=128)
+    tok = Tokenizer(qtbl, ptbl, idx, {}, {})
+
+    C = (qtbl[[idx[k] for k in q_titles]] @ ptbl[[idx[k] for k in f_titles]].T).cpu()
+    # e5 "difficulty" per query: true-folder cosine minus the best distractor cosine
+    gaps = []
+    for r in range(len(q_titles)):
+        tp = set(truepos[r])
+        true_c = max(C[r][j] for j in tp)
+        distractor = max((C[r][j] for j in range(C.shape[1]) if j not in tp), default=-1.0)
+        gaps.append(float(true_c - distractor))
+    gaps = np.array(gaps)
+    e5_ranks = np.array(ranks_from(C, truepos))
+
+    model, _ = load_with_lineage_ops(a.tuned, dev=dev)
+    model.eval()
+    S_elem = score_cond(model, tok, q_titles, f_titles, "ELEM", "kalman-fused", dev)
+    S_hier = score_cond(model, tok, q_titles, f_titles, "HIER", "kalman-fused", dev)
+    S_sym = score_cond(model, tok, q_titles, f_titles, "SYM", "kalman-fused", dev)
+    S_max = torch.maximum(torch.maximum(S_elem, S_hier), S_sym)
+    mu_ranks = np.array(ranks_from(S_max, truepos))
+
+    print(f"queries {len(q_titles)}; e5 difficulty gap (true − best distractor cosine): "
+          f"min {gaps.min():+.3f} median {np.median(gaps):+.3f} max {gaps.max():+.3f}")
+    order = np.argsort(gaps)                          # ascending = hardest (most confusable) first
+    thirds = np.array_split(order, 3)
+    print(f"\n  {'stratum':22s} {'n':>4s} {'gap range':>16s} {'e5 R@1':>8s} {'mu-max R@1':>11s} {'μ−e5':>7s}")
+    for name, sel in [("NEAR (confusable)", thirds[0]), ("MID", thirds[1]), ("FAR (e5 easy)", thirds[2])]:
+        g = gaps[sel]
+        e = float((e5_ranks[sel] <= 1).mean())
+        m = float((mu_ranks[sel] <= 1).mean())
+        print(f"  {name:22s} {len(sel):4d} [{g.min():+.2f},{g.max():+.2f}]".ljust(46)
+              + f" {e:8.3f} {m:11.3f} {m - e:+7.3f}")
+
+    # correlation: does μ rank the true folder better relative to e5 as folders get closer?
+    rel = (e5_ranks - mu_ranks)                        # >0 where μ beats e5 on that query
+    close = gaps < np.median(gaps)
+    print(f"\n  μ-beats-e5 rate on NEAR half: {float((rel[close] > 0).mean()):.3f}  "
+          f"vs FAR half: {float((rel[~close] > 0).mean()):.3f}")
+    print("  (H2 predicts μ closes the gap on NEAR/confusable folders; H1 predicts no stratum helps)")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/eval_pearltrees_filing.py
+++ b/prototypes/mu_cosine/eval_pearltrees_filing.py
@@ -31,7 +31,62 @@ from fine_tune_pearltrees_filing import load_with_lineage_ops
 from mu_attention import CORPORA, JUDGES, NODETYPE, OPS, Tokenizer, build_e5_tables
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
-TREES = os.path.join(ROOT, "..", "..", ".local", "data", "pearltrees_api", "trees")
+PT_API = os.path.join(ROOT, "..", "..", ".local", "data", "pearltrees_api")
+TREES = os.path.join(PT_API, "trees")
+DAG = os.path.join(PT_API, "assembled_dag.tsv")
+TITLES = os.path.join(PT_API, "assembled_titles.tsv")
+
+
+def folder_lineage(cand, depth=5, shuffle_seed=None):
+    """Build {folder_title: [parent_title,...]} principal paths from the assembled DAG.
+
+    Returns (parents_title, ancestor_titles). `cand` maps folder tid → title. Only the folder's
+    pre-existing folder→parent lineage is used (the §7 leakage boundary — never the evaluated
+    bookmark's placement or the folder's bookmark children). `shuffle_seed` permutes which folder
+    receives which lineage (the control: right-lineage vs any-lineage)."""
+    child2par = {}
+    for ln in open(DAG, encoding="utf-8"):
+        p, c = ln.split()
+        child2par.setdefault(c, []).append(p)
+    titles = {}
+    for ln in open(TITLES, encoding="utf-8"):
+        parts = ln.rstrip("\n").split("\t")
+        if len(parts) >= 2:
+            titles[parts[0]] = parts[1]
+
+    def chain(tid):
+        out, cur, seen = [], str(tid), {str(tid)}
+        for _ in range(depth):
+            ps = child2par.get(cur)
+            if not ps:
+                break
+            nxt = ps[0]
+            if nxt in seen:
+                break
+            seen.add(nxt)
+            t = titles.get(nxt)
+            if t:
+                out.append(t)
+            cur = nxt
+        return out
+
+    tids = list(cand)
+    chains = [chain(t) for t in tids]
+    if shuffle_seed is not None:
+        import numpy as np
+
+        perm = np.random.default_rng(shuffle_seed).permutation(len(chains))
+        chains = [chains[i] for i in perm]
+    parents_title, anc_titles = {}, set()
+    for tid, ch in zip(tids, chains):
+        ft = cand[tid]
+        # parents map is a chain: folder→p1→p2… (first-parent walk), keyed by title
+        prev = ft
+        for p in ch:
+            parents_title.setdefault(prev, [p])
+            anc_titles.add(p)
+            prev = p
+    return parents_title, anc_titles
 
 
 def score_cond(model, tok, q_keys, f_keys, op, judge, dev="cpu", batch=512):
@@ -105,6 +160,12 @@ def main(argv=None):
     ap.add_argument("--seed", type=int, default=7)
     ap.add_argument("--cache", default="/tmp/mu_data/pt_filing_eval_e5.pt")
     ap.add_argument("--split-seed", type=int, default=0)
+    ap.add_argument("--cand-lineage", action="store_true",
+                    help="§7: supply each candidate folder's principal path (assembled DAG) as anc "
+                         "tokens — evaluate a checkpoint trained with --cand-lineage in its regime")
+    ap.add_argument("--shuffle-lineage", action="store_true",
+                    help="control: permute which folder gets which lineage (right vs any lineage)")
+    ap.add_argument("--lineage-depth", type=int, default=5)
     a = ap.parse_args(argv)
     dev = "cpu"
     torch.set_num_threads(4)
@@ -133,9 +194,20 @@ def main(argv=None):
     held_q = [i for i in range(len(queries)) if f_titles[truepos[i][0]] not in train_nodes]
     print(f"held-folder subset (true folder unseen in fine-tune train nodes): {len(held_q)}/{len(queries)}")
 
-    names = sorted(set(q_titles) | set(f_titles))
-    qtbl, ptbl, idx = build_e5_tables(names, cache_path=a.cache, batch_size=128)
-    tok = Tokenizer(qtbl, ptbl, idx, {}, {})
+    parents_title, anc_titles = {}, set()
+    if a.cand_lineage:
+        parents_title, anc_titles = folder_lineage(
+            cand, depth=a.lineage_depth,
+            shuffle_seed=(a.seed if a.shuffle_lineage else None))
+        covered = sum(1 for ft in set(f_titles) if ft in parents_title)
+        print(f"candidate lineage: {covered}/{len(set(f_titles))} folders have a principal path; "
+              f"{len(anc_titles)} ancestor titles"
+              + (" [SHUFFLED control]" if a.shuffle_lineage else ""))
+    names = sorted(set(q_titles) | set(f_titles) | anc_titles)
+    cache_path = a.cache.rsplit(".pt", 1)[0] + ("_lin.pt" if a.cand_lineage else ".pt")
+    qtbl, ptbl, idx = build_e5_tables(names, cache_path=cache_path, batch_size=128)
+    tok = Tokenizer(qtbl, ptbl, idx, parents_title, {},
+                    root_lineage=a.cand_lineage, root_lineage_depth=a.lineage_depth)
 
     results = {}
     for label, ckpt in (("base", a.base), ("tuned", a.tuned)):

--- a/prototypes/mu_cosine/eval_pearltrees_filing.py
+++ b/prototypes/mu_cosine/eval_pearltrees_filing.py
@@ -37,30 +37,59 @@ DAG = os.path.join(PT_API, "assembled_dag.tsv")
 TITLES = os.path.join(PT_API, "assembled_titles.tsv")
 
 
-def folder_lineage(cand, depth=5, shuffle_seed=None):
-    """Build {folder_title: [parent_title,...]} principal paths from the assembled DAG.
+PATHS_JSONL = os.path.join(PT_API, "..", "api_tree_paths_v8.jsonl")
 
-    Returns (parents_title, ancestor_titles). `cand` maps folder tid → title. Only the folder's
-    pre-existing folder→parent lineage is used (the §7 leakage boundary — never the evaluated
-    bookmark's placement or the folder's bookmark children). `shuffle_seed` permutes which folder
-    receives which lineage (the control: right-lineage vs any-lineage)."""
-    child2par = {}
+
+def folder_lineage(cand, depth=5, shuffle_seed=None):
+    """Build {folder_title: [parent_title,...]} PRINCIPAL paths for candidate folders.
+
+    Principal parent = the OBSERVATION-MAJORITY parent across the account's recorded path_ids (the
+    true filing lineage), falling back to the assembled DAG's edge only when a folder appears in no
+    record. The earlier first-DAG-parent walk contradicted the record-majority parent on 61% of
+    multi-parent folders (external statistical audit finding 1). Returns (parents_title,
+    ancestor_titles). Only the folder's pre-existing folder→parent lineage is used (the §7 leakage
+    boundary — never the evaluated bookmark's placement or the folder's bookmark children).
+    `shuffle_seed` permutes which folder receives which lineage, SUPPORT-PRESERVING: chains permute
+    only among folders that HAVE a chain (audit finding 6 — a naive permutation also changes which
+    folders get any lineage at all, confounding the control)."""
+    import json as _json
+    from collections import Counter, defaultdict
+
+    votes = defaultdict(Counter)
+    with open(PATHS_JSONL, encoding="utf-8") as f:
+        for ln in f:
+            if not ln.strip():
+                continue
+            r = _json.loads(ln)
+            ids = [str(x).split(":")[-1] for x in (r.get("path_ids") or [])]
+            for p, c in zip(ids, ids[1:]):
+                if p != c:
+                    votes[c][p] += 1
+    principal = {c: max(cnt.items(), key=lambda kv: (kv[1], kv[0]))[0] for c, cnt in votes.items()}
+    dag_first = {}
     for ln in open(DAG, encoding="utf-8"):
         p, c = ln.split()
-        child2par.setdefault(c, []).append(p)
+        dag_first.setdefault(c, p)
     titles = {}
     for ln in open(TITLES, encoding="utf-8"):
         parts = ln.rstrip("\n").split("\t")
         if len(parts) >= 2:
             titles[parts[0]] = parts[1]
 
+    n_rec, n_dag = 0, 0
+
     def chain(tid):
+        nonlocal n_rec, n_dag
         out, cur, seen = [], str(tid), {str(tid)}
         for _ in range(depth):
-            ps = child2par.get(cur)
-            if not ps:
+            if cur in principal:
+                nxt = principal[cur]
+                n_rec += 1
+            elif cur in dag_first:
+                nxt = dag_first[cur]
+                n_dag += 1
+            else:
                 break
-            nxt = ps[0]
             if nxt in seen:
                 break
             seen.add(nxt)
@@ -72,11 +101,16 @@ def folder_lineage(cand, depth=5, shuffle_seed=None):
 
     tids = list(cand)
     chains = [chain(t) for t in tids]
+    print(f"    lineage edges: {n_rec} record-majority (principal), {n_dag} DAG-fallback")
     if shuffle_seed is not None:
         import numpy as np
 
-        perm = np.random.default_rng(shuffle_seed).permutation(len(chains))
-        chains = [chains[i] for i in perm]
+        has = [i for i, ch in enumerate(chains) if ch]        # support-preserving permutation
+        perm = np.random.default_rng(shuffle_seed).permutation(len(has))
+        remapped = list(chains)
+        for slot, src in zip(has, [has[j] for j in perm]):
+            remapped[slot] = chains[src]
+        chains = remapped
     parents_title, anc_titles = {}, set()
     for tid, ch in zip(tids, chains):
         ft = cand[tid]

--- a/prototypes/mu_cosine/fine_tune_pearltrees_filing.py
+++ b/prototypes/mu_cosine/fine_tune_pearltrees_filing.py
@@ -113,6 +113,10 @@ def main(argv=None):
     ap.add_argument("--anchor-weight", type=float, default=1.0)
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--split-seed", type=int, default=0)
+    ap.add_argument("--cand-lineage", action="store_true",
+                    help="candidate-lineage-conditioned μ (§7): supply the folder(root)'s principal "
+                         "path as anc tokens during training so the LINEAGE/conditioned heads learn "
+                         "to use folder lineage at filing time")
     ap.add_argument("--targets", default=FUSED_TARGETS,
                     help="fused-targets TSV; use the _eval (train-only factory) file for the honest "
                          "held readout, the full file for the production checkpoint")
@@ -123,7 +127,9 @@ def main(argv=None):
     rng = np.random.default_rng(a.seed)
     augment_rng = np.random.default_rng(a.seed + 1)
 
-    ds = load_pearltrees_campaign()
+    ds = load_pearltrees_campaign(root_lineage=a.cand_lineage)
+    if a.cand_lineage:
+        print("candidate-lineage-conditioned μ: folder principal path supplied as anc tokens")
     fused = load_fused_targets(a.targets)
     routed = load_routed_labels()
     pairs, tags, luna, d = ds["pairs"], ds["tags"], ds["luna"], ds["d"]

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -189,9 +189,18 @@ class Tokenizer:
     """Builds the token set per example and pads a batch. Holds the frozen e5 tables + the DAG."""
 
     def __init__(self, query_tbl, passage_tbl, idx, parents, deg, k=1, beta=1.0, max_anc=8,
-                 struct_tbl=None, struct_mode="dist", struct_cap=8, deg_scale=5.0):
+                 struct_tbl=None, struct_mode="dist", struct_cap=8, deg_scale=5.0,
+                 root_lineage=False, root_lineage_depth=5):
         self.q, self.p, self.idx = query_tbl, passage_tbl, idx
         self.parents, self.deg = parents, deg
+        # root_lineage: ALSO emit the anchor/root's ancestors as `anc` tokens (candidate-lineage-
+        # conditioned μ — DESIGN filing §7). At filing the node is a lineage-less bookmark and the
+        # useful known structure is the candidate FOLDER's principal path, which the default (node-
+        # only) ancestor sampling never supplies. Reuses the `anc` role → no new model params, no
+        # forward change; the model must be trained with this on to use it. Default off (backward
+        # compatible with every existing caller).
+        self.root_lineage = root_lineage
+        self.root_lineage_depth = root_lineage_depth
         self.k, self.beta, self.max_anc = k, beta, max_anc
         self.d = query_tbl.shape[1]
         # DUAL-JUDGE (step 3): {name: struct-emb vector} for the O(1) graph-judge proxy `3/(1+‖Δ‖)`. When set,
@@ -228,6 +237,22 @@ class Tokenizer:
                 break
             frontier = nxt
         return None
+
+    def _principal_path(self, node, cap):
+        """Deterministic parent-climb: [(ancestor, depth)] up the FIRST-parent chain, depth 1..cap.
+        The candidate folder's materialized path (§7) — the full lineage, not just gen-1 parents."""
+        out, cur, seen = [], node, {node}
+        for d in range(1, cap + 1):
+            ps = self.parents.get(cur)
+            if not ps:
+                break
+            nxt = next(iter(ps)) if isinstance(ps, (set, frozenset)) else ps[0]
+            if nxt in seen:
+                break
+            seen.add(nxt)
+            out.append((nxt, d))
+            cur = nxt
+        return out
 
     def _anc_for(self, node, train, rng):
         import random as _r
@@ -270,6 +295,12 @@ class Tokenizer:
                         toks.append(("anc", a, None, d))
             else:
                 toks.append(("noise", node, None, 1))                    # absent lineage → one noise@gen1
+            if self.root_lineage:                                        # candidate-folder lineage (§7)
+                rpath = self._principal_path(root, self.root_lineage_depth)
+                if rpath and not (train and rng is not None and rng.random() < p_drop_lineage):
+                    for (a, d) in rpath:
+                        if a in self.idx and not (train and rng is not None and rng.random() < p_drop_anc):
+                            toks.append(("anc", a, None, d))
             # provenance token — masked (agnostic) for 3-tuples, or for tagged items with prob p_mask_prov
             masked = corpus_id is None or (train and rng is not None and rng.random() < p_mask_prov)
             if masked:

--- a/prototypes/mu_cosine/run_pearltrees_fusion.py
+++ b/prototypes/mu_cosine/run_pearltrees_fusion.py
@@ -82,7 +82,7 @@ def load_scored_strict(path, expect_judge):
 
 def load_pearltrees_campaign(pairs_tsv=PAIRS_TSV, luna_tsv=LUNA_TSV, tsv_55=TSV_55,
                              e5_cache=E5_CACHE, paths_jsonl=PATHS_JSONL, titles_tsv=TITLES_TSV,
-                             require_55=True):
+                             require_55=True, root_lineage=False):
     """Assemble the Pearltrees campaign dataset: title pairs, id-graph features, judges, tokenizer.
 
     Returns a ds dict shaped like load_campaign_datasets' (pairs/tags/tok/d/...) plus id-level
@@ -148,7 +148,8 @@ def load_pearltrees_campaign(pairs_tsv=PAIRS_TSV, luna_tsv=LUNA_TSV, tsv_55=TSV_
         if pt:
             deg_title[pt] = deg_title.get(pt, 0) + len(kids)
 
-    tok = Tokenizer(cache["query"], cache["passage"], idx, parents_title, deg_title)
+    tok = Tokenizer(cache["query"], cache["passage"], idx, parents_title, deg_title,
+                    root_lineage=root_lineage)
     d = np.array([hit_prob(parents_id, a, b) for a, b in id_pairs])
     luna = np.array([luna_by[p] for p in pairs])
     overlap_idx = np.array([i for i, p in enumerate(pairs) if p in y55_by], dtype=int)

--- a/prototypes/mu_cosine/train_meta_judge.py
+++ b/prototypes/mu_cosine/train_meta_judge.py
@@ -67,6 +67,11 @@ def main(argv=None):
     ap.add_argument("--lam-cal", type=float, default=1.0, help="sonnet magnitude-anchor weight")
     ap.add_argument("--anchor-weight", type=float, default=1.0)
     ap.add_argument("--no-sonnet", action="store_true", help="ablation: CE only, no held-out anchor")
+    ap.add_argument("--neg-alpha", type=float, default=1.0,
+                    help="SCALE-FREE negative sampling over e5-distance rank: P(rank r) ∝ (r+1)^-alpha. "
+                         "alpha=1 (Zipf) = mostly close/confusable candidates + a heavy tail of a few "
+                         "distant ones (the information lives in the close choices; the far ones anchor "
+                         "the easy regime). alpha=0 = uniform (ablation: dilutes the CE information).")
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--split-seed", type=int, default=0)
     a = ap.parse_args(argv)
@@ -99,6 +104,24 @@ def main(argv=None):
         if tags[i].startswith("principal"):
             true_anc.setdefault(pairs[i][0], set()).add(pairs[i][1])
     print(f"ranking examples (train principal): {len(rank_ex)}; folder pool {len(folder_pool)}")
+
+    # HARD-NEGATIVE ranking (user's point): the CE signal carries information where folders are
+    # semantically CLOSE — uniform negatives are mostly trivial (far) and dilute the gradient. For
+    # each true parent, rank the pool by e5 cosine (passage embeddings; unit-normed) so negatives are
+    # the confusable NEAR folders — raising CE information and focusing calibration on the hard stratum.
+    cache = ds["cache"]
+    cidx = {n: i for i, n in enumerate(cache["names"])}
+    Pmat = cache["passage"]
+    pool_in = [c for c in folder_pool if c in cidx]
+    pool_vecs = torch.stack([Pmat[cidx[c]] for c in pool_in]) if pool_in else None
+    hard_order = {}
+    if a.neg_alpha > 0 and pool_vecs is not None:
+        for f in {ft for _, ft in rank_ex if ft in cidx}:
+            sims = (pool_vecs @ Pmat[cidx[f]]).tolist()
+            hard_order[f] = [pool_in[k] for k in np.argsort([-s for s in sims])]  # closest first
+        print(f"scale-free negatives: P(rank)∝(r+1)^-{a.neg_alpha} (mostly close + heavy tail)")
+    else:
+        print("uniform negatives (neg-alpha=0, ablation)")
 
     # fast (distillation) training rows — the existing Filing v1 channel rows
     C = CORPORA["pearltrees"]
@@ -185,9 +208,17 @@ def main(argv=None):
             ce, cal, n_cal = 0.0, 0.0, 0
             for j in idxs:
                 node, f_true = rank_ex[j]
-                negs = [c for c in folder_pool if c != f_true and c not in true_anc.get(node, set())]
-                if len(negs) > a.n_cand - 1:
-                    negs = [negs[t] for t in rng.choice(len(negs), size=a.n_cand - 1, replace=False)]
+                excl = true_anc.get(node, set()) | {f_true}
+                if a.neg_alpha > 0 and f_true in hard_order:
+                    ranked = [c for c in hard_order[f_true] if c not in excl]     # closest-first
+                    k = min(a.n_cand - 1, len(ranked))
+                    w = np.array([(r + 1.0) ** (-a.neg_alpha) for r in range(len(ranked))])
+                    pick = rng.choice(len(ranked), size=k, replace=False, p=w / w.sum())
+                    negs = [ranked[t] for t in pick]
+                else:
+                    pool = [c for c in folder_pool if c not in excl]
+                    negs = [pool[t] for t in rng.choice(len(pool), size=min(a.n_cand - 1, len(pool)),
+                                                         replace=False)]
                 cands = [f_true] + negs
                 scores = candidate_scores(model, ds["tok"], node, cands, dev)   # [K]
                 ce = ce + torch.nn.functional.cross_entropy(

--- a/prototypes/mu_cosine/train_meta_judge.py
+++ b/prototypes/mu_cosine/train_meta_judge.py
@@ -54,10 +54,12 @@ def main(argv=None):
     ap.add_argument("--steps", type=int, default=800)
     ap.add_argument("--bs", type=int, default=64)
     ap.add_argument("--lr-fast", type=float, default=5e-4, help="Adam lr for the fast Kalman-μ heads")
-    ap.add_argument("--lr-slow", type=float, default=0.5,
-                    help="SGD lr for the judge calibration. SGD (not Adam) so the two-timescale EMERGES "
-                         "from information content: quantization-noisy CE gradients average out, mean "
-                         "drift ∝ signal (Adam would unit-normalize the step and chase the noise).")
+    ap.add_argument("--lr-slow", type=float, default=0.02,
+                    help="base rate η₀ of the SNR-gated judge step. The gate supplies the SNR-"
+                         "PROPORTIONAL scaling (the emergent part); η₀ sets the absolute scale and "
+                         "MUST be commensurate with the fast step — the earlier 0.5 default made the "
+                         "'slow' row move 22.7× farther per step than the fast heads (audit finding "
+                         "5). In a full Kalman treatment η₀ is not free; here it is calibrated.")
     ap.add_argument("--slow-every", type=int, default=1,
                     help="cadence of the CE-calibration step; default 1 = every batch, so the slow "
                          "timescale is emergent (from the SGD/SNR), not imposed by skipping batches")
@@ -95,8 +97,11 @@ def main(argv=None):
     tr = split.train
     tr_set = set(tr.tolist())
 
-    # ranking examples: principal-path descendants with their true parent folder (train side)
-    folder_pool = sorted({pairs[i][1] for i in range(len(pairs)) if tags[i].startswith("principal")})
+    # ANCESTOR-ranking examples (audit finding 3: pairs are h1–h5 ancestors, so this trains
+    # ancestor-recovery, NOT exact-parent recovery — named accordingly), train side only.
+    # Negative pool restricted to TRAIN-side folders (audit finding 2: held identities must not
+    # be reused as training negatives).
+    folder_pool = sorted({pairs[i][1] for i in tr if tags[i].startswith("principal")})
     rank_ex = [(pairs[i][0], pairs[i][1]) for i in tr if tags[i].startswith("principal")]
     # per-descendant true-ancestor set (to exclude from negatives)
     true_anc = {}
@@ -200,7 +205,9 @@ def main(argv=None):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(fast_params, 1.0)
         opt_fast.step()
-        fast_drift.append(float((model.readout_w.detach() - readout_before).norm()))
+        # per-ELEMENT RMS drift (audit finding 5: raw norms of different-sized tensors are not
+        # comparable — readout_w has 6×384 elements vs the judge row's 384)
+        fast_drift.append(float((model.readout_w.detach() - readout_before).pow(2).mean().sqrt()))
 
         # ---- SLOW outer: candidate-ranking CE + held-out sonnet anchor calibrates the judge μ ----
         if step % a.slow_every == 0 and rank_ex:
@@ -242,7 +249,8 @@ def main(argv=None):
                 step_vec = a.lr_slow * gain * g_m / (g_m.norm() + 1e-9)
                 model.judge_name.resid.weight[rank_row] -= step_vec
             ce_grad.append(gain)                              # record the emergent gain (effective rate)
-            slow_drift.append(float((model.judge_name.resid.weight[rank_row].detach() - row_before).norm()))
+            slow_drift.append(float(
+                (model.judge_name.resid.weight[rank_row].detach() - row_before).pow(2).mean().sqrt()))
             ce_hist.append(float(ce / len(idxs)))
 
         if step % 200 == 0 or step == 1:
@@ -255,13 +263,15 @@ def main(argv=None):
     if slow_drift:
         fd, sd_ = np.array(fast_drift), np.array(slow_drift)
         gains = np.array(ce_grad)
-        print(f"\nEMERGENT TIMESCALE (SNR-gated judge; measured, not imposed):")
-        print(f"  fast μ-head drift/step (‖Δreadout‖):   mean {fd.mean():.4e}")
-        print(f"  slow judge drift/step (‖Δjudge_row‖):  mean {sd_.mean():.4e}")
-        print(f"  emergent judge gain ‖m‖²/power:        mean {gains.mean():.3f}  "
-              f"(≈0 ⇒ noise-dominated ⇒ self-limited slow; ≈1 ⇒ coherent signal)")
-        print(f"  → the gain, not a hand-set lr, is what makes the calibration slow: with a "
-              f"quantization-noisy CE signal it stays low, so the judge self-limits.")
+        print(f"\nTIMESCALE MEASUREMENT (per-element RMS drift/step — comparable across tensors):")
+        print(f"  fast μ-head drift:  mean {fd.mean():.4e}")
+        print(f"  slow judge drift:   mean {sd_.mean():.4e}   "
+              f"(slow/fast ratio {sd_.mean() / max(fd.mean(), 1e-12):.2f}; <1 ⇒ judge slower)")
+        print(f"  emergent judge gain ‖m‖²/power: mean {gains.mean():.3f} "
+              f"(≈0 noise-dominated, ≈1 coherent)")
+        print(f"  NOTE: the gain supplies the SNR-PROPORTIONAL part of the step (the emergent part); "
+              f"the base rate η₀ sets the absolute scale and must be commensurate with the fast lr "
+              f"— it is NOT emergent (THEORY_emergent_timescale_learning.md §3, corrected).")
 
     torch.save({"state": model.state_dict(), "cfg": cfg}, a.out)
     print(f"\nsaved -> {a.out}")

--- a/prototypes/mu_cosine/train_meta_judge.py
+++ b/prototypes/mu_cosine/train_meta_judge.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Two-timescale CE-calibration meta-judge (DESIGN_meta_judge_calibration.md).
+
+Per batch: a FAST inner step optimizes the Kalman μ estimate (distill the fused posterior into the
+μ heads — the existing Filing v1 fine-tune step), and every K batches a SLOW outer step calibrates
+the judge μ by candidate-ranking cross-entropy (true parent should rank first among sampled
+candidate folders) plus a held-out SONNET magnitude anchor. Sonnet-5 is NOT a Kalman channel — it is
+the independent reference the fusion cannot supply (the meta hook). At inference folders are ranked
+by the calibrated Kalman μ (eval_pearltrees_filing), no judge in the loop.
+
+  python3 train_meta_judge.py --out model_pt_meta_judge.pt
+"""
+import argparse
+import copy
+import os
+import sys
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from eval_luna_transfer import load_luna
+from fine_tune_channel_heads import mu_batch
+from fine_tune_pearltrees_filing import (
+    PT, group_of, load_fused_targets, load_routed_labels, load_with_lineage_ops)
+from mu_attention import CORPORA, JUDGES, OPS
+from node_disjoint_eval import node_disjoint_pair_split
+from run_pearltrees_fusion import load_pearltrees_campaign
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+SONNET_TSV = "/tmp/mu_data/pt_campaign_scored_sonnet.tsv"
+RANK_JUDGE = "kalman-fused"     # the head the filing eval ranks with — calibrate ITS μ
+
+
+def sonnet_D(path=SONNET_TSV):
+    """Held-out sonnet directional D per overlap pair (title, title) → D. Empty if not yet scored."""
+    if not os.path.exists(path):
+        return {}
+    p, d, s = load_luna(path)          # same mu[] schema; DIRR-max = D
+    return {pair: float(d[i]) for i, pair in enumerate(p)}
+
+
+def candidate_scores(model, tok, node, cands, dev):
+    """μ(node | c, HIER, pearltrees, RANK_JUDGE) for each candidate folder c (7-tuples w/ nodetypes)."""
+    items = [(node, c, OPS["HIER"], CORPORA["pearltrees"], JUDGES[RANK_JUDGE], PT, PT) for c in cands]
+    return mu_batch(model, tok, items, dev)          # differentiable [len(cands)]
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", default=os.path.join(ROOT, "model_prod_namecond_full.pt"))
+    ap.add_argument("--out", default=os.path.join(ROOT, "model_pt_meta_judge.pt"))
+    ap.add_argument("--targets", default="/tmp/mu_data/pt_fused_targets.tsv")
+    ap.add_argument("--steps", type=int, default=800)
+    ap.add_argument("--bs", type=int, default=64)
+    ap.add_argument("--lr-fast", type=float, default=5e-4, help="Adam lr for the fast Kalman-μ heads")
+    ap.add_argument("--lr-slow", type=float, default=0.5,
+                    help="SGD lr for the judge calibration. SGD (not Adam) so the two-timescale EMERGES "
+                         "from information content: quantization-noisy CE gradients average out, mean "
+                         "drift ∝ signal (Adam would unit-normalize the step and chase the noise).")
+    ap.add_argument("--slow-every", type=int, default=1,
+                    help="cadence of the CE-calibration step; default 1 = every batch, so the slow "
+                         "timescale is emergent (from the SGD/SNR), not imposed by skipping batches")
+    ap.add_argument("--n-cand", type=int, default=16, help="candidates per ranking example (1 true + negs)")
+    ap.add_argument("--rank-bs", type=int, default=16, help="ranking examples per slow step")
+    ap.add_argument("--tau", type=float, default=0.1, help="candidate-softmax temperature")
+    ap.add_argument("--lam-cal", type=float, default=1.0, help="sonnet magnitude-anchor weight")
+    ap.add_argument("--anchor-weight", type=float, default=1.0)
+    ap.add_argument("--no-sonnet", action="store_true", help="ablation: CE only, no held-out anchor")
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--split-seed", type=int, default=0)
+    a = ap.parse_args(argv)
+    dev = "cpu"
+    torch.set_num_threads(1)
+    torch.manual_seed(a.seed)
+    rng = np.random.default_rng(a.seed)
+    aug = np.random.default_rng(a.seed + 1)
+
+    ds = load_pearltrees_campaign()
+    fused = load_fused_targets(a.targets)
+    routed = load_routed_labels()
+    pairs, tags, luna, d = ds["pairs"], ds["tags"], ds["luna"], ds["d"]
+    y55_by = {tuple(pairs[k]): ds["y55"][j] for j, k in enumerate(ds["overlap_idx"])}
+    y55_by.update(routed)
+    son = {} if a.no_sonnet else sonnet_D()
+    print(f"campaign {len(pairs)} rows; 5.5-labeled {len(y55_by)}; sonnet-scored {len(son)} "
+          f"{'(ablated)' if a.no_sonnet else ''}")
+
+    split = node_disjoint_pair_split(pairs, a.split_seed, strata=[group_of(t) for t in tags])
+    tr = split.train
+    tr_set = set(tr.tolist())
+
+    # ranking examples: principal-path descendants with their true parent folder (train side)
+    folder_pool = sorted({pairs[i][1] for i in range(len(pairs)) if tags[i].startswith("principal")})
+    rank_ex = [(pairs[i][0], pairs[i][1]) for i in tr if tags[i].startswith("principal")]
+    # per-descendant true-ancestor set (to exclude from negatives)
+    true_anc = {}
+    for i in range(len(pairs)):
+        if tags[i].startswith("principal"):
+            true_anc.setdefault(pairs[i][0], set()).add(pairs[i][1])
+    print(f"ranking examples (train principal): {len(rank_ex)}; folder pool {len(folder_pool)}")
+
+    # fast (distillation) training rows — the existing Filing v1 channel rows
+    C = CORPORA["pearltrees"]
+    rows = []
+    for i in tr:
+        x, y = pairs[i]
+        info = fused.get((x, y))
+        if info is None:
+            continue
+        y55 = y55_by.get((x, y))
+        if y55 is not None:
+            rows.append(((x, y, OPS["HIER"], C, JUDGES["gpt-5.5-low"], PT, PT), y55[0]))
+            rows.append(((x, y, OPS["SYM"], C, JUDGES["gpt-5.5-low"], PT, PT), y55[1]))
+        rows.append(((x, y, OPS["HIER"], C, JUDGES["gpt-5.6-luna"], PT, PT), luna[i, 0]))
+        rows.append(((x, y, OPS["SYM"], C, JUDGES["gpt-5.6-luna"], PT, PT), luna[i, 1]))
+        rows.append(((x, y, OPS["HIER"], C, JUDGES["graph"], PT, PT), d[i]))
+        rows.append(((x, y, OPS["HIER"], C, JUDGES[RANK_JUDGE], PT, PT), info["post"][0]))
+        rows.append(((x, y, OPS["SYM"], C, JUDGES[RANK_JUDGE], PT, PT), info["post"][1]))
+    print(f"fast distillation rows: {len(rows)}")
+
+    model, cfg = load_with_lineage_ops(a.ckpt, dev=dev)
+    ref = copy.deepcopy(model)
+    ref.eval()
+    for p in ref.parameters():
+        p.requires_grad = False
+    for p in model.parameters():
+        p.requires_grad = False
+    # Clean two-timescale split (no shared tensor across optimizers):
+    #   FAST inner estimator = shared trunk (last layer) + readout + nodetype + corpus/op residuals.
+    #   SLOW meta judge      = judge_name.resid (the judge calibration). μ(·,RANK_JUDGE) = trunk(fast
+    #                          representation) + judge_resid[RANK_JUDGE](slow CE+sonnet calibration).
+    last = model.encoder.layers[-1]
+    fast_params = list(last.parameters()) + [model.readout_w, model.readout_b, model.nodetype_emb.weight]
+    for mod in (getattr(model, "corpus_name", None), getattr(model, "op_name", None)):
+        if mod is not None:
+            mod.resid.weight.requires_grad = True
+            fast_params.append(mod.resid.weight)
+    for p in fast_params:
+        p.requires_grad = True
+    slow_params = [model.judge_name.resid.weight]
+    model.judge_name.resid.weight.requires_grad = True
+    opt_fast = torch.optim.Adam(fast_params, lr=a.lr_fast)
+    rank_row = JUDGES[RANK_JUDGE]
+    # The judge (meta) parameter uses a PRECISION/SNR-GATED update, not SGD or Adam: the CE gradient
+    # is a noisy observation of the calibration, and the step is scaled by its signal-to-noise so a
+    # low-information (quantization-limited) batch moves the judge little. This is what makes the
+    # two-timescale EMERGE from information content — the user's point — rather than being imposed.
+    # EMA mean m and second-moment s of the judge-row gradient → gain = ‖m‖²/(s+eps) ∈ [0,1]
+    # (≈1 coherent signal, ≈0 pure noise); step = lr · gain · m̂. Adam would set gain≡1 (unit RMS),
+    # destroying exactly this scaling.
+    ema_beta = 0.9
+    g_m = torch.zeros_like(model.judge_name.resid.weight[rank_row])
+    g_s = torch.zeros(())
+    print(f"fast params {sum(p.numel() for p in fast_params)} (trunk/readout/corpus/op, Adam {a.lr_fast}); "
+          f"slow judge params {sum(p.numel() for p in slow_params)} (SNR-gated, base {a.lr_slow}); "
+          f"slow every {a.slow_every}")
+
+    # emergent-timescale instrumentation: per-step drift of the judge row vs a fast reference (readout),
+    # and CE-signal noise — to TEST whether the judge naturally moves slower (not assume it)
+    fast_drift, slow_drift, ce_hist, ce_grad = [], [], [], []
+    model.train()
+    for step in range(1, a.steps + 1):
+        # ---- FAST inner: distill the Kalman fused μ into the heads ----
+        sel = rng.choice(len(rows), size=min(a.bs, len(rows)), replace=False)
+        items = [rows[j][0] for j in sel]
+        tgt = torch.tensor([rows[j][1] for j in sel], dtype=torch.float32, device=dev)
+        mu = mu_batch(model, ds["tok"], items, dev, train=True, rng=aug)
+        loss = torch.mean((mu - tgt) ** 2)
+        ag = [(it[0], it[1], it[2]) for it in items]
+        mu_ag = mu_batch(model, ds["tok"], ag, dev)
+        with torch.no_grad():
+            mu_ref = mu_batch(ref, ds["tok"], ag, dev)
+        loss = loss + a.anchor_weight * torch.mean((mu_ag - mu_ref) ** 2)
+        readout_before = model.readout_w.detach().clone()
+        opt_fast.zero_grad()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(fast_params, 1.0)
+        opt_fast.step()
+        fast_drift.append(float((model.readout_w.detach() - readout_before).norm()))
+
+        # ---- SLOW outer: candidate-ranking CE + held-out sonnet anchor calibrates the judge μ ----
+        if step % a.slow_every == 0 and rank_ex:
+            idxs = rng.choice(len(rank_ex), size=min(a.rank_bs, len(rank_ex)), replace=False)
+            ce, cal, n_cal = 0.0, 0.0, 0
+            for j in idxs:
+                node, f_true = rank_ex[j]
+                negs = [c for c in folder_pool if c != f_true and c not in true_anc.get(node, set())]
+                if len(negs) > a.n_cand - 1:
+                    negs = [negs[t] for t in rng.choice(len(negs), size=a.n_cand - 1, replace=False)]
+                cands = [f_true] + negs
+                scores = candidate_scores(model, ds["tok"], node, cands, dev)   # [K]
+                ce = ce + torch.nn.functional.cross_entropy(
+                    (scores / a.tau).unsqueeze(0), torch.zeros(1, dtype=torch.long, device=dev))
+                sd = son.get((node, f_true))
+                if sd is not None:
+                    cal = cal + (scores[0] - float(sd)) ** 2
+                    n_cal += 1
+            meta = ce / len(idxs) + (a.lam_cal * cal / n_cal if n_cal else 0.0)
+            opt_fast.zero_grad()
+            if model.judge_name.resid.weight.grad is not None:
+                model.judge_name.resid.weight.grad.zero_()
+            meta.backward()
+            g = model.judge_name.resid.weight.grad[rank_row].detach()
+            # precision/SNR-gated update (manual — no optimizer normalization)
+            g_m.mul_(ema_beta).add_(g, alpha=1 - ema_beta)
+            g_s.mul_(ema_beta).add_((g * g).sum(), alpha=1 - ema_beta)
+            gain = float((g_m @ g_m) / (g_s + 1e-12))        # ‖signal‖²/power ∈ [0,1]
+            row_before = model.judge_name.resid.weight[rank_row].detach().clone()
+            with torch.no_grad():
+                step_vec = a.lr_slow * gain * g_m / (g_m.norm() + 1e-9)
+                model.judge_name.resid.weight[rank_row] -= step_vec
+            ce_grad.append(gain)                              # record the emergent gain (effective rate)
+            slow_drift.append(float((model.judge_name.resid.weight[rank_row].detach() - row_before).norm()))
+            ce_hist.append(float(ce / len(idxs)))
+
+        if step % 200 == 0 or step == 1:
+            msg = f"step {step:4d} fast_loss {loss.item():.4f}"
+            if ce_hist:
+                msg += f"  CE {ce_hist[-1]:.4f}"
+            print(msg)
+
+    # did the two-timescale EMERGE? report the drift ratio + CE-signal noise
+    if slow_drift:
+        fd, sd_ = np.array(fast_drift), np.array(slow_drift)
+        gains = np.array(ce_grad)
+        print(f"\nEMERGENT TIMESCALE (SNR-gated judge; measured, not imposed):")
+        print(f"  fast μ-head drift/step (‖Δreadout‖):   mean {fd.mean():.4e}")
+        print(f"  slow judge drift/step (‖Δjudge_row‖):  mean {sd_.mean():.4e}")
+        print(f"  emergent judge gain ‖m‖²/power:        mean {gains.mean():.3f}  "
+              f"(≈0 ⇒ noise-dominated ⇒ self-limited slow; ≈1 ⇒ coherent signal)")
+        print(f"  → the gain, not a hand-set lr, is what makes the calibration slow: with a "
+              f"quantization-noisy CE signal it stays low, so the judge self-limits.")
+
+    torch.save({"state": model.state_dict(), "cfg": cfg}, a.out)
+    print(f"\nsaved -> {a.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two connected follow-ups to Pearltrees Filing v1, both landing as honest, well-instrumented negatives with reusable mechanisms.

**Candidate-lineage-conditioned μ** — `Tokenizer.root_lineage` emits the candidate folder's principal path as ancestor tokens (no new model params). Retrained + evaluated with a shuffled-lineage control. Inconclusive: the shuffled control matches correct lineage on pooled metrics; the right lineage only helps on held (unseen) folders (0.097 vs 0.084). An e5 probe explains why — a child folder sits closer to its true parent (0.877) than a random folder (0.816), so **the titles already carry the lineage** and the model reads it off the title on seen folders.

**e5-vs-μ diagnostic** (`diagnose_filing_e5_vs_mu.py`) — e5's filing win is entirely the FAR third where the bookmark is already the folder's nearest e5 neighbor (recall@1 0.617 there, ~0 elsewhere); on the confusable NEAR/MID two-thirds e5 is blind and μ is no worse. The "e5 wins" headline is an easy-case artifact.

**Two-timescale CE-calibration meta-judge** (`DESIGN_meta_judge_calibration.md`, `train_meta_judge.py`) — candidate-ranking cross-entropy calibrates the judge μ that feeds the Kalman fusion; sonnet-5 (scored via subagents, held OUT of the fusion) is the independent reference; inference ranks by the Kalman μ. Three mechanism results confirmed: the two-timescale emerges only under a precision/SNR-gated judge update (gain ~0.10 = CE ~90% noise; naive SGD/Adam moved it 66× too fast); scale-free negatives beat uniform (more CE information in close/confusable choices); held-out sonnet matters most.

**Kalman channel analysis** — super_category is ~orthogonal (r≈0.00) to the forward relations and discarded by the current max-into-D; recommend adding a reverse-direction channel rather than a full per-relation split.

## Result
The filing metric does not move: aggregate mu-max-cond MRR is meta-judge 0.065 < Filing v1 0.075 < untrained base 0.112 < e5 0.294. On this small partial-DAG campaign the fine-tune hurts the conditioned ranker and calibration can't recover it. Deployable conclusion unchanged: **e5 ranks; the fused model is the label factory + conflict router.** The meta-judge machinery (precision-gated two-timescale, scale-free CE, held-out anchor) is validated and awaits a larger corpus.

## Caveats
Partial Pearltrees DAG; 300-row overlap; single node-disjoint split; confusable-stratum recall@1 numbers are tiny in absolute count (the μ-beats-e5 rate is the stabler signal); meta-judge checkpoint is Pearltrees-only; sonnet scored via subagents (transcripts as provenance), not the codex path. Tests: the Filing v1 suite still passes (18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fB4ZfA4bW4XNEnboUncgc