### PR TITLE
WAM/LLVM plawk: strnum runtime primitives (step 1 of duality)

### DIFF
--- a/docs/design/PLAWK_STRNUM_DUALITY.md
+++ b/docs/design/PLAWK_STRNUM_DUALITY.md
@@ -5,11 +5,17 @@ Copyright (c) 2026 John William Creighton (@s243a)
 
 # plawk strnum: string/number scalar duality
 
-**Status**: **forward-looking design note.** None of §3–§5 is implemented.
-This captures what POSIX "strnum" is, where plawk's current static type model
-diverges from it, why closing the gap is a *type-model* project rather than a
-single feature, and a phased plan for getting there without destabilising the
-three-way slot model that ships today.
+**Status**: **design note + step 1 landed.** The runtime primitives of §6 step 1
+(`@wam_looks_numeric` and `@wam_strnum_cmp`) are implemented in
+`src/unifyweaver/targets/wam_llvm_target.pl` and unit-tested standalone in
+`tests/core/test_wam_llvm_assoc_i64_runtime.pl` (the recogniser over
+numeric/non-numeric/blank-padded/empty inputs, and the comparison over the
+POSIX kind table incl. the `10 9` vs `10 9x` divergence). **No codegen calls
+them yet** — the `scalar_strnum` slot kind, origin analysis, and comparison
+dispatch (§6 steps 2–3) remain. §3–§5 describe the not-yet-built model. This
+document captures what POSIX "strnum" is, where plawk's current static type
+model diverges from it, why closing the gap is a *type-model* project rather
+than a single feature, and the phased plan.
 
 ## 1. What strnum is (POSIX awk)
 

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -6662,6 +6662,133 @@ gs.fail:
   ret i64 0
 }
 
+; --- strnum support (PLAWK_STRNUM_DUALITY.md step 1) -------------------------
+; These primitives are the runtime half of POSIX numeric-string duality. They
+; are defined here and unit-tested standalone; no codegen calls them yet (the
+; scalar_strnum slot kind and comparison dispatch are later phases).
+
+; @wam_looks_numeric(s): does the NUL-terminated string %s look like a number
+; per POSIX (the whole string, after optional leading and trailing blanks, is a
+; valid numeric value)? strtod parses the leading number and reports where it
+; stopped; the string is numeric when a conversion happened and only blanks
+; (space or tab) remain after it. A null or empty string is not numeric.
+define i1 @wam_looks_numeric(i8* %s) {
+entry:
+  %ln.isnull = icmp eq i8* %s, null
+  br i1 %ln.isnull, label %ln.no, label %ln.check
+
+ln.check:
+  %ln.endp = alloca i8*, align 8
+  %ln.val = call double @strtod(i8* %s, i8** %ln.endp)
+  %ln.end = load i8*, i8** %ln.endp
+  %ln.consumed = icmp ne i8* %ln.end, %s
+  br i1 %ln.consumed, label %ln.wsloop, label %ln.no
+
+ln.wsloop:
+  %ln.p = phi i8* [ %ln.end, %ln.check ], [ %ln.pn, %ln.wsstep ]
+  %ln.c = load i8, i8* %ln.p
+  %ln.sp = icmp eq i8 %ln.c, 32
+  %ln.tab = icmp eq i8 %ln.c, 9
+  %ln.blank = or i1 %ln.sp, %ln.tab
+  br i1 %ln.blank, label %ln.wsstep, label %ln.wsdone
+
+ln.wsstep:
+  %ln.pn = getelementptr i8, i8* %ln.p, i64 1
+  br label %ln.wsloop
+
+ln.wsdone:
+  %ln.atnul = icmp eq i8 %ln.c, 0
+  br i1 %ln.atnul, label %ln.yes, label %ln.no
+
+ln.yes:
+  ret i1 1
+
+ln.no:
+  ret i1 0
+}
+
+; @wam_strnum_cmp(as, akind, bs, bkind): compare two operands given as their
+; NUL-terminated string forms plus a kind tag per operand -- 0 = number,
+; 1 = strnum (input-derived), 2 = string literal. The comparison is numeric iff
+; BOTH operands are numeric-typed, where number is always numeric-typed, a strnum
+; is numeric-typed only when its content looks numeric, and a string literal
+; never is (POSIX strnum table, see PLAWK_STRNUM_DUALITY.md). Numeric comparison
+; is over strtod values; otherwise it is a strcmp of the two strings. Returns the
+; sign of the comparison as an i32: -1, 0, or 1.
+define i32 @wam_strnum_cmp(i8* %as, i8 %akind, i8* %bs, i8 %bkind) {
+entry:
+  ; operand A numeric-typed?
+  %sc.a_isnum = icmp eq i8 %akind, 0
+  %sc.a_isstrnum = icmp eq i8 %akind, 1
+  br i1 %sc.a_isnum, label %sc.a_yes, label %sc.a_maybe
+
+sc.a_maybe:
+  br i1 %sc.a_isstrnum, label %sc.a_look, label %sc.a_no
+
+sc.a_look:
+  %sc.a_ln = call i1 @wam_looks_numeric(i8* %as)
+  br label %sc.a_done
+
+sc.a_yes:
+  br label %sc.a_done
+
+sc.a_no:
+  br label %sc.a_done
+
+sc.a_done:
+  %sc.a_num = phi i1 [ 1, %sc.a_yes ], [ %sc.a_ln, %sc.a_look ], [ 0, %sc.a_no ]
+  ; operand B numeric-typed?
+  %sc.b_isnum = icmp eq i8 %bkind, 0
+  %sc.b_isstrnum = icmp eq i8 %bkind, 1
+  br i1 %sc.b_isnum, label %sc.b_yes, label %sc.b_maybe
+
+sc.b_maybe:
+  br i1 %sc.b_isstrnum, label %sc.b_look, label %sc.b_no
+
+sc.b_look:
+  %sc.b_ln = call i1 @wam_looks_numeric(i8* %bs)
+  br label %sc.b_done
+
+sc.b_yes:
+  br label %sc.b_done
+
+sc.b_no:
+  br label %sc.b_done
+
+sc.b_done:
+  %sc.b_num = phi i1 [ 1, %sc.b_yes ], [ %sc.b_ln, %sc.b_look ], [ 0, %sc.b_no ]
+  %sc.both = and i1 %sc.a_num, %sc.b_num
+  br i1 %sc.both, label %sc.numeric, label %sc.lexical
+
+sc.numeric:
+  %sc.av = call double @strtod(i8* %as, i8** null)
+  %sc.bv = call double @strtod(i8* %bs, i8** null)
+  %sc.lt = fcmp olt double %sc.av, %sc.bv
+  br i1 %sc.lt, label %sc.neg, label %sc.numge
+
+sc.numge:
+  %sc.gt = fcmp ogt double %sc.av, %sc.bv
+  br i1 %sc.gt, label %sc.pos, label %sc.zero
+
+sc.lexical:
+  %sc.rc = call i32 @strcmp(i8* %as, i8* %bs)
+  %sc.slt = icmp slt i32 %sc.rc, 0
+  br i1 %sc.slt, label %sc.neg, label %sc.lexge
+
+sc.lexge:
+  %sc.sgt = icmp sgt i32 %sc.rc, 0
+  br i1 %sc.sgt, label %sc.pos, label %sc.zero
+
+sc.neg:
+  ret i32 -1
+
+sc.pos:
+  ret i32 1
+
+sc.zero:
+  ret i32 0
+}
+
 ; awk-style numeric coercion of a record or projected field to double:
 ; strtod parses a leading number and ignores trailing text, so
 ; "3.14abc" reads as 3.14 and non-numeric text reads as 0.0. Field

--- a/tests/core/test_wam_llvm_assoc_i64_runtime.pl
+++ b/tests/core/test_wam_llvm_assoc_i64_runtime.pl
@@ -48,6 +48,10 @@ test(regex_match_and_gsub) :-
     regex_match_gsub_driver_ir(DriverIR),
     run_assoc_i64_smoke('uw_wam_regex_match_gsub', DriverIR).
 
+test(strnum_looks_numeric_and_cmp) :-
+    strnum_driver_ir(DriverIR),
+    run_assoc_i64_smoke('uw_wam_strnum', DriverIR).
+
 run_assoc_i64_smoke(Name, DriverIR) :-
     tmp_root(Root),
     directory_file_path(Root, Name, Dir),
@@ -467,6 +471,109 @@ entry:
   %a7 = and i1 %a6, %aid_ok
   %a8 = and i1 %a7, %acnt_ok
   br i1 %a8, label %ok, label %bad
+
+ok:
+  ret i32 0
+
+bad:
+  ret i32 91
+}
+').
+
+% Exercise the strnum primitives (PLAWK_STRNUM_DUALITY.md step 1). First the
+% recogniser @wam_looks_numeric over numeric / non-numeric / blank-padded /
+% empty inputs, then @wam_strnum_cmp over the POSIX kind table (0=number,
+% 1=strnum, 2=string literal) -- including the classic "10 9" (numeric) vs
+% "10 9x" (lexical) divergence and the "2" vs "10" case where numeric and
+% lexical disagree in sign.
+strnum_driver_ir('
+@.uw_sn_10 = private constant [3 x i8] c"10\00"
+@.uw_sn_314 = private constant [5 x i8] c"3.14\00"
+@.uw_sn_pad = private constant [7 x i8] c"  42  \00"
+@.uw_sn_neg = private constant [3 x i8] c"-5\00"
+@.uw_sn_exp = private constant [4 x i8] c"1e3\00"
+@.uw_sn_10x = private constant [4 x i8] c"10x\00"
+@.uw_sn_abc = private constant [4 x i8] c"abc\00"
+@.uw_sn_empty = private constant [1 x i8] c"\00"
+@.uw_sn_blanks = private constant [3 x i8] c"  \00"
+@.uw_sn_9 = private constant [2 x i8] c"9\00"
+@.uw_sn_9x = private constant [3 x i8] c"9x\00"
+@.uw_sn_2 = private constant [2 x i8] c"2\00"
+
+define i32 @main() {
+entry:
+  %p10 = getelementptr [3 x i8], [3 x i8]* @.uw_sn_10, i64 0, i64 0
+  %p314 = getelementptr [5 x i8], [5 x i8]* @.uw_sn_314, i64 0, i64 0
+  %ppad = getelementptr [7 x i8], [7 x i8]* @.uw_sn_pad, i64 0, i64 0
+  %pneg = getelementptr [3 x i8], [3 x i8]* @.uw_sn_neg, i64 0, i64 0
+  %pexp = getelementptr [4 x i8], [4 x i8]* @.uw_sn_exp, i64 0, i64 0
+  %p10x = getelementptr [4 x i8], [4 x i8]* @.uw_sn_10x, i64 0, i64 0
+  %pabc = getelementptr [4 x i8], [4 x i8]* @.uw_sn_abc, i64 0, i64 0
+  %pempty = getelementptr [1 x i8], [1 x i8]* @.uw_sn_empty, i64 0, i64 0
+  %pblanks = getelementptr [3 x i8], [3 x i8]* @.uw_sn_blanks, i64 0, i64 0
+  %p9 = getelementptr [2 x i8], [2 x i8]* @.uw_sn_9, i64 0, i64 0
+  %p9x = getelementptr [3 x i8], [3 x i8]* @.uw_sn_9x, i64 0, i64 0
+  %p2 = getelementptr [2 x i8], [2 x i8]* @.uw_sn_2, i64 0, i64 0
+
+  ; --- @wam_looks_numeric ---
+  %ln_10 = call i1 @wam_looks_numeric(i8* %p10)
+  %ln_10_ok = icmp eq i1 %ln_10, 1
+  %ln_314 = call i1 @wam_looks_numeric(i8* %p314)
+  %ln_314_ok = icmp eq i1 %ln_314, 1
+  %ln_pad = call i1 @wam_looks_numeric(i8* %ppad)
+  %ln_pad_ok = icmp eq i1 %ln_pad, 1
+  %ln_neg = call i1 @wam_looks_numeric(i8* %pneg)
+  %ln_neg_ok = icmp eq i1 %ln_neg, 1
+  %ln_exp = call i1 @wam_looks_numeric(i8* %pexp)
+  %ln_exp_ok = icmp eq i1 %ln_exp, 1
+  %ln_10x = call i1 @wam_looks_numeric(i8* %p10x)
+  %ln_10x_ok = icmp eq i1 %ln_10x, 0
+  %ln_abc = call i1 @wam_looks_numeric(i8* %pabc)
+  %ln_abc_ok = icmp eq i1 %ln_abc, 0
+  %ln_empty = call i1 @wam_looks_numeric(i8* %pempty)
+  %ln_empty_ok = icmp eq i1 %ln_empty, 0
+  %ln_blanks = call i1 @wam_looks_numeric(i8* %pblanks)
+  %ln_blanks_ok = icmp eq i1 %ln_blanks, 0
+
+  ; --- @wam_strnum_cmp (kinds 0=number 1=strnum 2=string) ---
+  ; "10" strnum vs "9" strnum -> both numeric -> 10 > 9 -> +1
+  %c1 = call i32 @wam_strnum_cmp(i8* %p10, i8 1, i8* %p9, i8 1)
+  %c1_ok = icmp eq i32 %c1, 1
+  ; "10" strnum vs "9x" strnum -> 9x not numeric -> lexical -> "10" < "9x" -> -1
+  %c2 = call i32 @wam_strnum_cmp(i8* %p10, i8 1, i8* %p9x, i8 1)
+  %c2_ok = icmp eq i32 %c2, -1
+  ; "10" strnum vs "10" string literal -> literal never numeric -> lexical eq -> 0
+  %c3 = call i32 @wam_strnum_cmp(i8* %p10, i8 1, i8* %p10, i8 2)
+  %c3_ok = icmp eq i32 %c3, 0
+  ; "10" number vs "9" number -> numeric -> +1
+  %c4 = call i32 @wam_strnum_cmp(i8* %p10, i8 0, i8* %p9, i8 0)
+  %c4_ok = icmp eq i32 %c4, 1
+  ; "abc" strnum vs "abc" strnum -> both non-numeric -> lexical eq -> 0
+  %c5 = call i32 @wam_strnum_cmp(i8* %pabc, i8 1, i8* %pabc, i8 1)
+  %c5_ok = icmp eq i32 %c5, 0
+  ; "2" strnum vs "10" strnum -> numeric -> 2 < 10 -> -1 (lexical would be +1)
+  %c6 = call i32 @wam_strnum_cmp(i8* %p2, i8 1, i8* %p10, i8 1)
+  %c6_ok = icmp eq i32 %c6, -1
+  ; "10" number vs "9x" strnum -> 9x not numeric -> lexical -> "10" < "9x" -> -1
+  %c7 = call i32 @wam_strnum_cmp(i8* %p10, i8 0, i8* %p9x, i8 1)
+  %c7_ok = icmp eq i32 %c7, -1
+
+  %a1 = and i1 %ln_10_ok, %ln_314_ok
+  %a2 = and i1 %a1, %ln_pad_ok
+  %a3 = and i1 %a2, %ln_neg_ok
+  %a4 = and i1 %a3, %ln_exp_ok
+  %a5 = and i1 %a4, %ln_10x_ok
+  %a6 = and i1 %a5, %ln_abc_ok
+  %a7 = and i1 %a6, %ln_empty_ok
+  %a8 = and i1 %a7, %ln_blanks_ok
+  %a9 = and i1 %a8, %c1_ok
+  %a10 = and i1 %a9, %c2_ok
+  %a11 = and i1 %a10, %c3_ok
+  %a12 = and i1 %a11, %c4_ok
+  %a13 = and i1 %a12, %c5_ok
+  %a14 = and i1 %a13, %c6_ok
+  %a15 = and i1 %a14, %c7_ok
+  br i1 %a15, label %ok, label %bad
 
 ok:
   ret i32 0


### PR DESCRIPTION
## Summary

First step of the strnum implementation plan from `PLAWK_STRNUM_DUALITY.md`: the **runtime half** of POSIX numeric-string duality, defined and **unit-tested standalone with no codegen wiring**. Nothing calls these yet, so this can't destabilize the shipping three-slot scalar model — it front-loads the hard-to-get-right recogniser and comparison logic where it's cheapest to test exhaustively.

Two primitives added to `src/unifyweaver/targets/wam_llvm_target.pl`:

- **`@wam_looks_numeric(i8* s) -> i1`** — the POSIX "looks like a number" test: the whole string, after optional leading/trailing blanks, is a valid numeric value. Implemented with `strtod` + an end-position check (conversion happened, and only blanks remain after it). Null / empty / all-blank → not numeric.
- **`@wam_strnum_cmp(i8* as, i8 akind, i8* bs, i8 bkind) -> i32`** — compares two operands given as string form plus a **kind tag** (`0`=number, `1`=strnum, `2`=string literal). The comparison is **numeric iff both operands are numeric-typed** — a number always is, a strnum only when its content looks numeric, a string literal never is — otherwise it's a `strcmp`. Returns the sign `-1/0/1`, implementing the POSIX comparison table from the design doc.

## Tests

One runtime driver added to `tests/core/test_wam_llvm_assoc_i64_runtime.pl` (**8 total pass**), compiled and run by clang like the other runtime primitives:

- `looks_numeric` over `10`, `3.14`, `  42  ` (blank-padded), `-5`, `1e3` (→ numeric) and `10x`, `abc`, `""`, `"  "` (→ not).
- `strnum_cmp` over the kind table, including:
  - the classic **`10` vs `9`** as strnums → numeric → `+1`, versus **`10` vs `9x`** → `9x` isn't numeric → lexical → `-1`;
  - **`2` vs `10`** as strnums → numeric `-1` where lexical would give `+1` (proves numeric dispatch);
  - strnum vs **string literal** → forced lexical;
  - number vs non-numeric strnum → lexical.

## Scope

Runtime + unit tests only. The next phases (per the design doc): §6 step 2 — the `scalar_strnum` slot kind + origin/provenance analysis; step 3 — route guard/`while` comparisons through `@wam_strnum_cmp`; step 4 — extend value sources; step 5 — the honest-scoping gate. The design doc's status line is updated to mark step 1 landed.

Based on the feature line `claude/plawk-llvm-wam-hybrid-p9ujut`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_