### PR TITLE
WAM/LLVM plawk: strnum origin analysis + slot kind (step 2)

### DIFF
--- a/docs/design/PLAWK_STRNUM_DUALITY.md
+++ b/docs/design/PLAWK_STRNUM_DUALITY.md
@@ -5,17 +5,34 @@ Copyright (c) 2026 John William Creighton (@s243a)
 
 # plawk strnum: string/number scalar duality
 
-**Status**: **design note + step 1 landed.** The runtime primitives of §6 step 1
-(`@wam_looks_numeric` and `@wam_strnum_cmp`) are implemented in
-`src/unifyweaver/targets/wam_llvm_target.pl` and unit-tested standalone in
-`tests/core/test_wam_llvm_assoc_i64_runtime.pl` (the recogniser over
-numeric/non-numeric/blank-padded/empty inputs, and the comparison over the
-POSIX kind table incl. the `10 9` vs `10 9x` divergence). **No codegen calls
-them yet** — the `scalar_strnum` slot kind, origin analysis, and comparison
-dispatch (§6 steps 2–3) remain. §3–§5 describe the not-yet-built model. This
-document captures what POSIX "strnum" is, where plawk's current static type
-model diverges from it, why closing the gap is a *type-model* project rather
-than a single feature, and the phased plan.
+**Status**: **design note + steps 1–2 landed.**
+- **Step 1** (runtime): `@wam_looks_numeric` and `@wam_strnum_cmp` are
+  implemented in `src/unifyweaver/targets/wam_llvm_target.pl` and unit-tested in
+  `tests/core/test_wam_llvm_assoc_i64_runtime.pl` (the recogniser over
+  numeric/non-numeric/blank-padded/empty inputs, and the comparison over the
+  POSIX kind table incl. the `10 9` vs `10 9x` divergence).
+- **Step 2** (origin analysis): `plawk_scalar_strnum_names/2` in
+  `examples/plawk/codegen/plawk_native_codegen.pl` decides which names are
+  strnum by provenance (assigned only from a field copy, never from a literal /
+  arithmetic / concat / string builtin), unit-tested in
+  `tests/test_plawk_strnum.pl`. The `scalar_strnum` slot kind is registered as
+  infrastructure (symbol, i64 interned-id representation, zero init). This half
+  is **inert**: the type inferencer does not yet produce `scalar_strnum`, so
+  behaviour is unchanged.
+
+**Not yet built**: step 3 (retype strnum slots to the interned-id
+representation and route guard/`while` comparisons through `@wam_strnum_cmp`),
+step 4 (extend strnum sources beyond fields), step 5 (honest-scoping gate). §3–§5
+describe the not-yet-active model. This document captures what POSIX "strnum" is,
+where plawk's current static type model diverges from it, why closing the gap is
+a *type-model* project rather than a single feature, and the phased plan.
+
+**Representation note**: the shipped `scalar_strnum` slot uses the §4b
+interned-id representation (an i64 atom id, same width as a string scalar) rather
+than the §4a wide `%WamStrnum` cell. This keeps the SSA phi model unchanged — a
+strnum slot phis a single i64 like every other slot — and the looks-numeric
+decision is recomputed at each comparison in step 3. The §4a cell stays the
+documented option if per-comparison recomputation ever shows up in profiles.
 
 ## 1. What strnum is (POSIX awk)
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -6224,14 +6224,24 @@ plawk_slot_name(scalar_double(Name), Name).
 % A string scalar's slot holds an interned atom id (an i64); the id 0 is the
 % "unset" sentinel, printed as the empty string.
 plawk_slot_name(scalar_string(Name), Name).
+% A strnum scalar (POSIX numeric-string duality, PLAWK_STRNUM_DUALITY.md): a
+% value copied from a strnum source (a field for now) that compares numerically
+% or lexically by its runtime content. Its slot holds an interned atom id (an
+% i64) like a string scalar -- the string bytes are retained so a later
+% comparison can decide numeric vs lexical. This slot KIND is recognised
+% infrastructure (origin analysis, symbol, repr) but the type inferencer does
+% not yet produce it and no comparison dispatches on it -- that is step 3.
+plawk_slot_name(scalar_strnum(Name), Name).
 
 plawk_slot_llvm_type(scalar_counter(_Name), i64).
 plawk_slot_llvm_type(scalar_double(_Name), double).
 plawk_slot_llvm_type(scalar_string(_Name), i64).
+plawk_slot_llvm_type(scalar_strnum(_Name), i64).
 
 plawk_slot_zero_ir(scalar_counter(_Name), '0').
 plawk_slot_zero_ir(scalar_double(_Name), '0.0').
 plawk_slot_zero_ir(scalar_string(_Name), '0').
+plawk_slot_zero_ir(scalar_strnum(_Name), '0').
 
 plawk_state_slot_lookup(StatePlan, Name, Index, Slot) :-
     plawk_state_plan_slots(StatePlan, Slots),
@@ -6492,6 +6502,60 @@ plawk_scalar_string_names(Rules, Strings) :-
         ),
         Names0),
     sort(Names0, Strings).
+
+%% plawk_scalar_strnum_names(+Rules, -Strnums)
+%
+%  Origin/provenance analysis for POSIX strnum duality (PLAWK_STRNUM_DUALITY.md
+%  step 2). A name is a strnum when it is assigned **only** from strnum sources
+%  and never from a non-strnum one. A strnum source is a bare field copy
+%  (`x = $N`); a disqualifier is any other write to the name -- a literal,
+%  arithmetic, concat, a string builtin, a sprintf, a ternary, another var,
+%  etc. -- because those produce a plain number or string, destroying the
+%  duality (matching awk, where arithmetic yields a number and a literal yields
+%  a string). A name must have at least one strnum source and zero disqualifiers
+%  to qualify; a name written both ways cannot be tagged with one static slot
+%  kind, so it is conservatively excluded (step 5's honest-scoping gate governs
+%  those). v1 scope mirrors plawk_scalar_string_names/2: top-level rule-body
+%  assignments (nested if/loop-body writes and non-field sources such as
+%  split()/getline are follow-ons -- design doc step 4).
+plawk_scalar_strnum_names(Rules, Strnums) :-
+    findall(Name,
+        ( member(rule(_Pattern, Actions0), Rules),
+          plawk_trim_control_tails(Actions0, Actions),
+          member(Action, Actions),
+          plawk_scalar_strnum_source(Action, Name)
+        ),
+        Sources0),
+    sort(Sources0, Sources),
+    findall(Name,
+        ( member(rule(_Pattern, ActionsD0), Rules),
+          plawk_trim_control_tails(ActionsD0, ActionsD),
+          member(ActionD, ActionsD),
+          plawk_scalar_strnum_disqualify(ActionD, Name)
+        ),
+        Disq0),
+    sort(Disq0, Disq),
+    findall(Name,
+        ( member(Name, Sources),
+          \+ memberchk(Name, Disq)
+        ),
+        Strnums0),
+    sort(Strnums0, Strnums).
+
+% A strnum source: a bare field copy `x = $N`. Both surface shapes for a field
+% read (`field(N)` and `int(field(N))`) count.
+plawk_scalar_strnum_source(set(var(Name), field(FieldIndex)), Name) :-
+    integer(FieldIndex),
+    FieldIndex >= 0.
+plawk_scalar_strnum_source(set(var(Name), int(field(FieldIndex))), Name) :-
+    integer(FieldIndex),
+    FieldIndex >= 0.
+
+% Any write to Name that is not a strnum source disqualifies it from being a
+% pure strnum.
+plawk_scalar_strnum_disqualify(Action, Name) :-
+    plawk_scalar_action_update(Action, Name, _Operation),
+    \+ plawk_scalar_strnum_source(Action, Name).
 
 plawk_scalar_update_name_expr(Action, Name, Expr) :-
     plawk_scalar_action_update(Action, Name, Operation),

--- a/tests/test_plawk_strnum.pl
+++ b/tests/test_plawk_strnum.pl
@@ -1,0 +1,68 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk strnum duality (PLAWK_STRNUM_DUALITY.md).
+%
+% Step 2: the origin/provenance analysis plawk_scalar_strnum_names/2. A scalar
+% is a strnum when it is assigned ONLY from strnum sources (a bare field copy
+% `x = $N`) and never from a non-strnum one (a literal, arithmetic, concat, a
+% string builtin, another var, ...). This locks down the analysis before the
+% codegen activation (slot representation + comparison dispatch) in step 3.
+% The runtime primitives (@wam_looks_numeric / @wam_strnum_cmp, step 1) are
+% exercised in tests/core/test_wam_llvm_assoc_i64_runtime.pl.
+
+:- use_module(library(plunit)).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- begin_tests(plawk_strnum).
+
+strnum_names(Src, Names) :-
+    plawk_parse_string(Src, program(_Begin, Rules, _End)),
+    plawk_native_codegen:plawk_scalar_strnum_names(Rules, Names).
+
+% a bare field copy is a strnum.
+test(field_copy_is_strnum) :-
+    strnum_names("{ x = $1 }\n", [x]), !.
+
+% two field copies -> two strnums (sorted).
+test(two_field_copies) :-
+    strnum_names("{ a = $1; b = $3 }\n", [a, b]), !.
+
+% reading the strnum (print) does not disqualify it.
+test(read_does_not_disqualify) :-
+    strnum_names("{ x = $1; print x }\n", [x]), !.
+
+% a string-literal assignment is not a strnum.
+test(literal_not_strnum) :-
+    strnum_names("{ y = \"text\" }\n", []), !.
+
+% an integer-literal assignment is not a strnum.
+test(int_literal_not_strnum) :-
+    strnum_names("{ x = 5 }\n", []), !.
+
+% a concat assignment (string-valued) is not a strnum.
+test(concat_not_strnum) :-
+    strnum_names("{ x = $1 $2 }\n", []), !.
+
+% a field copy later overwritten by arithmetic is disqualified (the arithmetic
+% write produces a number, destroying the duality).
+test(arith_overwrite_disqualifies) :-
+    strnum_names("{ x = $1; x = x + 1 }\n", []), !.
+
+% a field copy later overwritten by a literal is disqualified (mixed provenance
+% cannot be one static slot kind).
+test(literal_overwrite_disqualifies) :-
+    strnum_names("{ x = $1; x = \"lit\" }\n", []), !.
+
+% mixed program: the pure field-copy is a strnum, the arithmetic-written name
+% and the string name are not.
+test(mixed_program) :-
+    strnum_names("{ f = $2; c = c + 1; s = \"z\" }\n", [f]), !.
+
+% a strnum plus an unrelated string scalar: only the field copy qualifies.
+test(strnum_beside_string) :-
+    strnum_names("{ n = $1; s = $2 \"\" }\n", [n]), !.
+
+:- end_tests(plawk_strnum).


### PR DESCRIPTION
## Summary

Step 2 of `PLAWK_STRNUM_DUALITY.md`: the **origin/provenance analysis** — the hard, reusable core that decides which scalars are strnums — plus the `scalar_strnum` slot-kind symbol. This half is **inert**: the type inferencer does not yet produce `scalar_strnum` and nothing dispatches on it, so **behaviour is unchanged**. Codegen activation (representation switch + comparison dispatch) is step 3, where it can be tested end-to-end without a behaviour regression.

This mirrors the step-1 philosophy: land the analysis, prove it standalone, defer activation.

## What's here

- **`plawk_scalar_strnum_names/2`** — a name is a strnum when it is assigned **only** from a strnum source (a bare field copy `x = $N`) and **never** from a disqualifier (a literal, arithmetic, concat, a string builtin, a sprintf, a ternary, another var, …). At least one source and zero disqualifiers are required; a name written both ways can't be one static slot kind, so it's conservatively excluded (step 5's honest-scoping gate governs those). v1 scope mirrors `plawk_scalar_string_names/2` — top-level rule-body assignments; nested if/loop-body writes and non-field sources (`split()`/`getline`) are step-4 follow-ons.
- **`scalar_strnum(Name)`** registered in `plawk_slot_name` / `plawk_slot_llvm_type` / `plawk_slot_zero_ir` as an **i64 interned-id slot** — the §4b representation. This keeps the SSA phi model unchanged (a strnum slot phis a single i64 like every other slot); the looks-numeric decision is recomputed per comparison in step 3. The §4a wide `%WamStrnum` cell stays documented as the fallback if per-comparison recomputation ever shows up in profiles.

## Tests

`tests/test_plawk_strnum.pl` — **10 plunit cases** over the analysis: a field copy is a strnum; two field copies → two strnums; read/`print` does not disqualify; a string literal / int literal / concat is not a strnum; an arithmetic- or literal-overwrite disqualifies; mixed programs tag only the pure field copies. A smoke check confirms `{ x = $1; print x }` still compiles and prints unchanged (the slot kind is not yet produced).

## Next

Step 3 activates it: retype strnum names to the interned-id representation (so the string bytes survive), update print/arithmetic reads of those slots, and route `if`/`while` comparisons through `@wam_strnum_cmp` — the point where `10 9` vs `10 9x` starts comparing correctly. The design-doc status line is updated to mark steps 1–2 landed.

Based on the feature line `claude/plawk-llvm-wam-hybrid-p9ujut`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_