### PR TITLE
mu_cosine: close Stage-A fail-closed and add grounded semantic diffusion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,8 +91,11 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: Install python lmdb (for F# LMDB cross-target conformance fixture)
-        run: pip3 install --user lmdb
+      - name: Install Python test dependencies (LMDB + grounded graph diffusion)
+        run: python3 -m pip install --user lmdb "numpy>=1.24" pytest
+
+      - name: Run grounded semantic diffusion tests
+        run: python3 -m pytest -q tests/test_leaky_diffusion.py
 
       - name: Run F# WAM target tests (codegen + dotnet smoke + LMDB conformance)
         env:

--- a/docs/design/COST_FUNCTION_PHILOSOPHY.md
+++ b/docs/design/COST_FUNCTION_PHILOSOPHY.md
@@ -247,6 +247,11 @@ In matrix form: `L V = b`, where `L = D − A` is the graph
 Laplacian (`D` = diagonal degree matrix, `A` = adjacency),
 and `b` is the boundary-condition / current-injection vector.
 
+The reusable variant with embedding-weighted edge conductance, finite shunt
+resistance to ground, equilibrium Green kernels, effective-resistance
+distance, and a direct inverse-covariance root is specified in
+[LEAKY_GRAPH_DIFFUSION.md](LEAKY_GRAPH_DIFFUSION.md).
+
 ### What the Green's function gives us
 
 `V_n = G(source, n)` is the **harmonic measure at `n`** given the

--- a/docs/design/LEAKY_GRAPH_DIFFUSION.md
+++ b/docs/design/LEAKY_GRAPH_DIFFUSION.md
@@ -1,0 +1,270 @@
+# Semantically weighted leaky graph diffusion
+
+## Status and scope
+
+This document specifies a reusable graph geometry and numerical primitive. It
+is not specific to mu-cosine training, a particular judge, or Pearltrees.
+Potential consumers include routing, smoothing, covariance construction,
+root-anchored metrics, and square-root Gaussian conditioning.
+
+The implementation in src/unifyweaver/graph/leaky_diffusion.py is a dense
+float64 correctness reference. It establishes the algebra and fail-closed API;
+it does not claim a CUDA crossover or authorize a learned cross-item
+covariance. The completed Stage-A repeated-judge source-power experiment
+failed closed and unlocked no candidate enumeration, Nomic use, judge calls,
+covariance deployment, independent batching, QR specialization, or CUDA
+claim. This primitive therefore remains outcome-blind infrastructure.
+
+## Separate topology, semantics, and grounding
+
+Let the fixed node universe be V and the undirected graph support be E.
+Topology decides whether a direct path exists. For an existing edge (i,j),
+semantic embeddings z_i and z_j modulate its conductance:
+
+    c_ij = c0_ij [
+        epsilon + (1-epsilon)
+        exp(-||z_i-z_j||^2 / (2 ell^2))
+    ].
+
+Here c0_ij is the base topological conductance, ell is the semantic length
+scale, and epsilon is an optional minimum conductance fraction. The reference
+implementation currently fixes c0_ij=1. A semantic model never creates an edge
+between graph non-neighbours. With epsilon=0, an RBF value below float64 range
+is represented as zero and the realized numerical graph loses that edge.
+Applications that must preserve every retained topological path therefore use
+a strictly positive, recorded epsilon.
+
+This division is intentional:
+
+- topology supplies domain-specific reachability and lineage;
+- semantics controls resistance along paths that the graph already permits;
+- grounding controls how far influence persists before leaking to a common
+  bath.
+
+For the current mu-cosine stack, a revision-pinned Nomic clustering embedding
+is the preferred semantic candidate because e5 is already an input to the
+deployed ranker. MiniLM is a sensitivity comparator. The general API accepts
+arbitrary finite embeddings and performs no model loading.
+
+## Electrical and thermal construction
+
+Let W be the symmetric conductance matrix and define the combinatorial
+Laplacian
+
+    L = diag(W 1) - W.
+
+Each node i may have a shunt conductance alpha_i to a common ground. Its
+leakage current is voltage dependent:
+
+    I_leak,i = alpha_i v_i,
+    R_leak,i = 1 / alpha_i.
+
+When alpha_i=0, the corresponding shunt resistance is infinite.
+
+The grounded precision is
+
+    J = L + diag(alpha).
+
+The API allows:
+
+- uniform weak leakage at every node;
+- heterogeneous leakage;
+- sparse boundary grounding, provided every connected component has a path to
+  at least one positive shunt.
+
+The last condition is checked on realized positive-conductance components
+before factorization. The spectrum and Cholesky factor then enforce numerical
+positive definiteness. An ungrounded component fails explicitly.
+
+The transient assumes unit heat capacity. Its electrical RC analogue assumes
+unit node capacitance C=I. For source q switched on at time zero,
+
+    du/dt = -J u + q,
+    u(0) = 0.
+
+The transient and equilibrium responses are
+
+    u(t) = J^-1 (I - exp(-tJ)) q,
+    u(infinity) = J^-1 q.
+
+For an initial impulse h rather than a maintained source,
+
+    u(t) = exp(-tJ) h.
+
+Without grounding, an ordinary connected Laplacian retains a constant mode
+and an isolated impulse converges to a uniform temperature. Grounding removes
+that mode: heat leaks to the bath and all impulse responses eventually decay.
+
+## Green kernel and distance
+
+The equilibrium Green kernel is
+
+    G = J^-1.
+
+For a unit current injected at source s, column s of G gives the equilibrium
+voltage field. This is a source-conditioned closeness score, not by itself a
+symmetric metric.
+
+A symmetric grounded effective-resistance distance is
+
+    d_R(i,j)^2 = G_ii + G_jj - 2 G_ij.
+
+It is the quadratic form of e_i-e_j under G and therefore a Euclidean distance
+whenever J is positive definite. If J=U^T U and X=U^-T, the same quantity is
+
+    d_R(i,j)^2 = ||X[:,i] - X[:,j]||^2.
+
+The reference computes distances in these factor coordinates, avoiding the
+subtraction of nearly equal Green-kernel entries. It materializes G only for
+small graphs. Large implementations should use selected linear solves or
+sparse factorization rather than form a dense inverse.
+
+With uniform leakage alpha,
+
+    J^-1 = (L + alpha I)^-1
+         = alpha^-1 (I + alpha^-1 L)^-1.
+
+Thus the equilibrium kernel is exactly a regularized-Laplacian/resolvent
+kernel up to a scalar. This explains the connection to the existing
+small-graph resolvent reference in prototypes/mu_cosine/graph_geometry.py.
+The new construction adds circuit units, semantic edge resistance,
+heterogeneous grounding, source response, effective resistance, and a direct
+precision root.
+
+## Square-root conditioning
+
+Because J is positive definite, Cholesky factorization gives
+
+    J = U^T U.
+
+Since G^-1=J, U is already an inverse-covariance square root for the physical
+Green kernel. Equilibrium solves use two triangular solves:
+
+    U^T y = q,
+    U u = y.
+
+No covariance inverse is needed.
+
+Some statistical consumers require a unit-diagonal correlation rather than
+the physical Green kernel. Let
+
+    D = diag(G),
+    C = D^-1/2 G D^-1/2.
+
+Then
+
+    C^-1 = D^1/2 J D^1/2
+         = (U D^1/2)^T (U D^1/2).
+
+Therefore scaling the columns of U by sqrt(diag(G)) produces the correlation
+precision root used by a square-root/QR conditioner. Correlation
+normalization is explicit because it discards physical voltage/temperature
+units.
+
+## Float64 numerical contract
+
+This module is a correctness reference, not a best-effort solver. Before
+Cholesky it requires:
+
+- every realized positive-conductance component to reach a positive shunt;
+- an equilibrium scale whose reciprocal is representable in float64; and
+- reciprocal spectral condition at least sqrt(machine epsilon), approximately
+  1.49e-8, corresponding to condition number at most about 6.71e7.
+
+The minimum reciprocal condition is an explicit argument and is recorded on
+the result. A caller may knowingly choose a weaker threshold for an experiment,
+but cannot obtain it through hidden jitter or an accidental near-singular
+factorization.
+
+Transient calculations also avoid unnecessary loss of precision. The maintained
+source response evaluates (1-exp(-t lambda))/lambda with expm1 rather than
+subtracting equilibrium-sized vectors. A normalized heat kernel shifts the
+spectrum separately within each disconnected component; the removed scalar
+decay cancels exactly during diagonal normalization. Matrix symmetry cleanup
+uses half-scaled operands, and every public result is checked for finiteness.
+Direct construction validates shapes, symmetry, the graph identities, and the
+stored precision factor.
+
+## Leakage is not numerical jitter
+
+Both leakage and diagonal jitter can improve a condition number, but they are
+different objects:
+
+- alpha is part of the graph model. It controls physical correlation range,
+  equilibrium amplitude, and relaxation time.
+- jitter is an implementation safeguard against floating-point failure after
+  the model is fixed.
+
+The reference applies no hidden jitter. A singular or insufficiently grounded
+model fails. A future sparse/GPU backend may expose bounded scale-relative
+jitter, but it must report it separately from alpha and may not use it to
+silently change the intended diffusion.
+
+For uniform alpha, increasing alpha raises the smallest precision eigenvalue
+and shortens the diffusion range. Taking alpha toward zero recovers global
+graph coupling and the Laplacian singular limit. Alpha and ell must be selected
+on training-only data for any learned application.
+
+## Directed graphs and principal lineage
+
+The resistor/heat operator requires a symmetric conductance network. The
+reference takes the undirected union of neighbor declarations on a fixed node
+universe. A directed lineage application must document whether that
+symmetrization is scientifically appropriate. Directional diffusion requires
+a separate reversible construction or directed-Laplacian theory; silently
+feeding an asymmetric transition matrix into this API is not allowed.
+
+For candidate-lineage work, principal path identity must come from the
+account-tagged materialized path, not the first parent in a sorted multi-parent
+union. This primitive does not choose a lineage source.
+
+## Rejected and deferred alternatives
+
+- Raw shortest-path Gaussian kernel: rejected as a general covariance because
+  an arbitrary graph shortest-path RBF is not guaranteed PSD.
+- Semantic completed graph: rejected for the first implementation because
+  embedding similarity would create shortcuts and erase the topology/semantic
+  separation. Weak semantic k-nearest-neighbor edges are a separate future
+  model.
+- Raw embedding distance as resistance: rejected because its units and zero
+  behavior are unsuitable. A nonnegative monotone conductance transform is
+  explicit and bounded; a positive epsilon is required when every retained
+  topological edge must remain numerically present.
+- Arbitrarily choosing distant nodes as ground: supported only when the
+  boundary is externally defined. Uniform weak leakage is the default because
+  defining distant by the metric being estimated would be circular.
+- Symmetric normalized Laplacian for the circuit: retained for spectral
+  references, but not used for physical KCL. The combinatorial Laplacian
+  preserves edge conductance units.
+- Explicit matrix inverse: rejected. The precision root and triangular solves
+  are primary; dense G is a reference output.
+- Immediate sparse/CUDA specialization: deferred until graph sizes and a
+  matched end-to-end benchmark justify it. Likely paths are sparse Cholesky or
+  preconditioned conjugate gradients for equilibrium, and
+  Lanczos/Chebyshev methods for heat action.
+- Treating G as learned measurement covariance without evidence: rejected.
+  Statistical promotion still requires train-only fitting and held,
+  dependence-aware predictive validation.
+
+## Reference verification
+
+tests/test_leaky_diffusion.py verifies:
+
+- semantic modulation only on existing edges, including extreme float64 scales;
+- the analytic two-node circuit and its Green kernel;
+- Kirchhoff residuals and superposition;
+- uniform-leakage resolvent equivalence;
+- failure of an ungrounded component and unknown sparse-mapping keys;
+- default and explicitly overridden reciprocal-condition gates;
+- failure of unrepresentable equilibrium scales;
+- heat semigroup and relaxation to equilibrium;
+- component-wise normalization after large-time heat underflow;
+- cancellation-stable tiny-time step response;
+- monotonic resistance under semantic separation;
+- factor-coordinate resistance parity with unit-current energy;
+- correlation precision-root parity;
+- direct-constructor invariants, immutable arrays, and fail-closed inputs;
+- absence of any explicit matrix inverse.
+
+The next engineering PR, if warranted, should add sparse operators and a
+matched CPU/GPU crossover benchmark without changing this statistical object.

--- a/docs/design/ROOT_ANCHORED_METRICS_PHILOSOPHY.md
+++ b/docs/design/ROOT_ANCHORED_METRICS_PHILOSOPHY.md
@@ -106,6 +106,10 @@ They differ only in the `(AGGREGATE, COMBINE)` pair — i.e. in the **semiring**
   `max_depth`, so each node carries a tiny fixed-width vector and the whole
   computation is one pass, `O(edges × max_depth)`.
 
+For the related symmetric circuit construction in which independent semantic
+embeddings modulate edge resistance and every node can leak to a common bath,
+see [LEAKY_GRAPH_DIFFUSION.md](LEAKY_GRAPH_DIFFUSION.md).
+
 Seeing all three as the same skeleton over different semirings is what lets a
 single recognition rule + a single lowering template cover them.
 

--- a/prototypes/mu_cosine/DECISIONS_graph_geometry.md
+++ b/prototypes/mu_cosine/DECISIONS_graph_geometry.md
@@ -250,3 +250,41 @@ Nomic values cannot trigger repacking or candidate optimization, and judge calls
 source/prompt inclusion-exclusion with an indefinite subtraction; inverse-variance component weights; observed
 power of exactly `.80` without an exact lower bound; automatic fallback after failed confirmation; and scalar
 ESS/row-sum certification of the realized design.
+
+## 2026-07-17 — general leaky semantic diffusion, without covariance promotion
+
+**Observed:** the exact immutable Stage-A source-power run completed all 18
+configurations. All 12 evaluable R=3 discovery designs failed their
+preregistered gates, the six R=4 diagnostics were non-evaluable by design, no
+confirmation design was selected, and every downstream authorization remained
+false.
+
+**Decision:** implement semantically weighted, shunt-grounded diffusion as a
+general graph/numerical primitive rather than as a promoted residual-covariance
+model. Topology defines the edge support. Frozen external embedding distance
+may modulate conductance only on those edges. Uniform or component-covering
+shunt conductance makes the combinatorial Laplacian positive definite and
+gives the regularized-Laplacian diagonal term a physical leakage-to-bath
+meaning.
+
+**Numerical consequence:** for grounded precision J=L+diag(alpha)=U.T U, U is
+directly the inverse-covariance root of the Green kernel. The model diagonal
+alpha is recorded separately from any future floating-point jitter. Dense
+equilibrium and heat kernels are correctness references; primary solves use
+the root and do not form an inverse.
+
+**Accepted:** analytic source response, Green correlation normalization,
+grounded effective-resistance distance, sparse boundary grounding when every
+component reaches a shunt, and Nomic as the preferred future semantic
+conductance candidate because it is not the deployed e5 input.
+
+**Rejected for this PR:** semantic shortcut edges, arbitrary shortest-path RBF
+covariance, asymmetric transition matrices, calling leakage numerical jitter,
+interpreting the resulting Green kernel as empirically validated judge
+covariance, lowering the failed Stage-A gates, or making a CUDA performance
+claim.
+
+**Reconsider:** sparse and CUDA specialization requires a matched full-cost
+crossover benchmark. Statistical use as cross-item measurement covariance
+still requires new prospective data or a separately authorized design with
+train-only fitting and dependence-aware held validation.

--- a/prototypes/mu_cosine/REPORT_repeated_judge_source_power.md
+++ b/prototypes/mu_cosine/REPORT_repeated_judge_source_power.md
@@ -2,20 +2,46 @@
 
 ## Bottom line
 
-This PR implements and preregisters the no-history Stage-A source-dependent power harness.  It does **not**
-report a power result: the immutable full discovery and confirmation runs have not been launched.  No attempted-
-input history, real Nomic embedding, candidate identity, label, judge response, or model output was read, and
-no judge/model call was made.  Every downstream authorization remains false.
+The exact immutable no-history Stage-A discovery finished on 2026-07-17. All 12 evaluable R=3 designs failed
+the complete preregistered gate family, so no provisional design was selected and the seed-disjoint confirmation
+was not run. The six R=4 configurations were diagnostic and non-evaluable by construction. The normal CLI
+therefore exited 2 with status **STAGE A FAIL-CLOSED; NO DOWNSTREAM AUTHORIZATION**.
+
+No attempted-input history, real Nomic embedding, candidate identity, label, judge response, or model output
+was read, and no judge/model call was made. Every authorization remains false: attempted identities, candidate
+enumeration, Nomic, judge calls, a live campaign, covariance deployment, independent batching, QR
+specialization, and CUDA are all still locked.
 
 The central correction is that source strength cannot be treated as one shared scalar or replaced by the
 largest value.  For every frozen design `G>K`, `H E H.T-I` is indefinite.  Therefore `.20` is not a universal
 Loewner upper envelope, and the exploratory and fresh corpora need not have the same strength.  The harness
 covers all 25 ordered pairs from `eta_source,c={0,.025,.05,.10,.20}`.
 
-The full run is intentionally deferred until this tooling and its cost are reviewed.  A representative
-`K=128,G=800` audit-only pilot completed the complete 5-by-5 source-strength grid with the full candidate and
-multiplier settings in 17.92 seconds for one null draw per null/pair cell and one planted evaluation replicate.
-That validates execution and resource shape, not power, type-I error, or a campaign size.
+This failure does not show that accurate graph/semantic covariance would be useless. It shows that this frozen
+procedure could not identify a campaign design satisfying all power and false-promotion requirements. General
+graph geometry may continue as non-deployment infrastructure, but the failed gate may not be bypassed by
+choosing a convenient configuration, lowering confidence, or treating a numerical kernel as empirical
+covariance evidence.
+
+## Immutable Stage-A outcome
+
+The run used detached source commit `d7e28a91b0f4efcc2d9b6f374463b8d26a5115fe` and frozen scientific
+fingerprint `989d274a032e814bad454e7a26bd4fa2ebed8e432139e3434ed43ad5cdce4fd7`. Its complete result artifact is
+29,154,632 bytes with SHA-256
+`4055c39e335464cc17261aa176bb508a6dd0b16804ff824eba59520b442d80a1`. The checkpoint manifest retained the
+same fingerprint and exact full-preregistration configuration. The CLI completion summary in `console.log`
+reports `wall_seconds=208218.401463738` from the final invocation's `perf_counter()` timer. Console timestamps
+span 197,364 seconds, 10,854.40 seconds less; these are runtime-provenance observations, not an accumulated
+checkpoint-history clock.
+
+| registered configurations | evaluable | passed | consequence |
+|---|---:|---:|---|
+| R=3 discovery | 12 | 0 | no provisional design |
+| R=4 diagnostics | 0 of 6 | n/a | diagnostic-only by preregistration |
+| seed-disjoint confirmation | 0 | n/a | not run because discovery selected nothing |
+
+The historical `K=128,G=800` audit-only pilot remains useful only as an execution/resource-shape check. Its
+one null draw and one planted replicate never supported power, type-I error, or campaign-size claims.
 
 ## Frozen statistical procedure
 
@@ -124,8 +150,8 @@ A selected-pair confirmation adds 67,980 corpus worlds, 99,950 null-pair combina
 combinations, for at most 1,291,620 expensive corpus worlds.  The runner submits 2,400 bounded chunks per
 discovery configuration and projects 241 checkpoint files per configuration; discovery plus confirmation is
 at most 45,600 chunk submissions and 4,580 checkpoint files.  The one-replicate pilot does not support a
-credible wall-time forecast for that heterogeneous workload.  Schedule the immutable run only after code
-review and report its observed resource use rather than extrapolating an ETA from this pilot.
+credible wall-time forecast for that heterogeneous workload. The completed immutable run is reported above
+using both the CLI timer and transcript span rather than an ETA extrapolated from this pilot.
 
 ## Verification
 
@@ -150,7 +176,8 @@ Only a complete exact discovery plus passing fixed-pair confirmation may set
 `R=4` runs cannot.  Candidate enumeration, real Nomic work, judge calls, live campaign, covariance deployment,
 independent batching, QR specialization, and CUDA remain false in every Stage-A outcome.
 
-If Stage A eventually confirms, Stage B is fixed-design: build the identity-only history inventory; enumerate
+Stage A did not confirm, so Stage B remains unauthorized. Under a future prospective design that legitimately
+clears the same authorization boundary, Stage B would be fixed-design: build the identity-only history inventory; enumerate
 and gate the topology-only universe; use a revision-pinned Nomic cache first only for agreement-cell quotas;
 freeze exact packing at the selected `(K,G,R=3)`; then compute the Nomic Gram on those immutable components and
 rerun the full null/evaluation/confirmation procedure on realized `H`, `E`, folds, and prompts.  Cross-corpus
@@ -178,7 +205,7 @@ python prototypes/mu_cosine/run_repeated_judge_source_power.py \
   --audit-only
 ```
 
-Eventual immutable run, only after review and with durable checkpoint storage:
+Command shape used for the exact immutable run with durable checkpoint storage:
 
 ```bash
 python prototypes/mu_cosine/run_repeated_judge_source_power.py \

--- a/src/unifyweaver/graph/__init__.py
+++ b/src/unifyweaver/graph/__init__.py
@@ -1,0 +1,15 @@
+"""Reusable graph geometry and diffusion primitives."""
+
+from .leaky_diffusion import (
+    GroundedSemanticDiffusion,
+    build_grounded_semantic_diffusion,
+    combinatorial_laplacian,
+    semantic_conductance_matrix,
+)
+
+__all__ = [
+    "GroundedSemanticDiffusion",
+    "build_grounded_semantic_diffusion",
+    "combinatorial_laplacian",
+    "semantic_conductance_matrix",
+]

--- a/src/unifyweaver/graph/leaky_diffusion.py
+++ b/src/unifyweaver/graph/leaky_diffusion.py
@@ -1,0 +1,636 @@
+"""Grounded graph diffusion with semantic edge resistance.
+
+This module is a dense, float64 reference for a general graph primitive.  It
+keeps topology and semantics in distinct roles:
+
+* graph edges define which direct electrical/thermal paths exist;
+* embedding distance modulates the conductance of those existing edges;
+* shunt conductance to a common ground makes the Laplacian precision positive
+  definite and gives long-range decay a physical interpretation.
+
+For conductance matrix ``W`` and combinatorial Laplacian ``L = D - W``, the
+grounded precision and equilibrium Green kernel are
+
+    J = L + diag(alpha),        G = J^-1.
+
+``alpha_i`` is the leakage conductance from node ``i`` to ground.  If
+``J = U.T @ U``, then ``U`` is already an inverse-covariance square root for
+``G``; no explicit inverse is required for equilibrium solves or whitening.
+
+The implementation deliberately does not add semantic k-nearest-neighbour
+edges.  That is a different graph model, not merely a different resistance.
+It also keeps physical leakage separate from any future floating-point jitter.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Mapping
+
+import numpy as np
+
+
+__all__ = [
+    "GroundedSemanticDiffusion",
+    "build_grounded_semantic_diffusion",
+    "combinatorial_laplacian",
+    "semantic_conductance_matrix",
+]
+
+
+_SYMMETRY_TOLERANCE = 1e-12
+_FLOAT64_EPSILON = np.finfo(float).eps
+_FLOAT64_MAXIMUM = np.finfo(float).max
+_DEFAULT_MINIMUM_RECIPROCAL_CONDITION = math.sqrt(_FLOAT64_EPSILON)
+
+
+def _symmetric_part(value):
+    """Return a symmetry cleanup without overflowing on representable values."""
+
+    value = np.asarray(value, dtype=float)
+    output = 0.5 * value + 0.5 * value.T
+    if not np.isfinite(output).all():
+        raise np.linalg.LinAlgError("symmetric matrix result is not finite")
+    return output
+
+
+def _normalize_psd_kernel(value):
+    """Normalize a symmetric positive-definite matrix to unit diagonal."""
+
+    value = np.asarray(value, dtype=float)
+    if value.ndim != 2 or value.shape[0] != value.shape[1] or not len(value):
+        raise ValueError("kernel must be a non-empty square matrix")
+    if not np.isfinite(value).all():
+        raise ValueError("kernel must be finite")
+    if not np.allclose(value, value.T, atol=_SYMMETRY_TOLERANCE, rtol=0.0):
+        raise ValueError("kernel must be symmetric")
+    value = _symmetric_part(value)
+    diagonal = np.diag(value)
+    if np.any(diagonal <= 0.0):
+        raise ValueError("a normalizable kernel must have positive diagonal")
+    scale = np.sqrt(diagonal)
+    output = value / scale[:, None] / scale[None, :]
+    output = _symmetric_part(output)
+    np.fill_diagonal(output, 1.0)
+    minimum = float(np.min(np.linalg.eigvalsh(output)))
+    if minimum < -1e-10:
+        raise ValueError(f"kernel is not positive semidefinite: {minimum:.3e}")
+    return output
+
+
+def _readonly(value):
+    output = np.array(value, dtype=float, copy=True)
+    output.setflags(write=False)
+    return output
+
+
+def _nodes(value):
+    nodes = tuple(value)
+    if not nodes:
+        raise ValueError("nodes must be non-empty")
+    if len(set(nodes)) != len(nodes):
+        raise ValueError("nodes must be unique")
+    return nodes
+
+
+def _positive_finite(name, value):
+    try:
+        value = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be positive and finite") from exc
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValueError(f"{name} must be positive and finite")
+    return value
+
+
+def _nonnegative_finite(name, value):
+    try:
+        value = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be nonnegative and finite") from exc
+    if not math.isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be nonnegative and finite")
+    return value
+
+
+def _unit_interval(name, value):
+    try:
+        value = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be finite and in [0, 1)") from exc
+    if not math.isfinite(value) or value < 0.0 or value >= 1.0:
+        raise ValueError(f"{name} must be finite and in [0, 1)")
+    return value
+
+
+def _positive_unit_interval(name, value):
+    value = _positive_finite(name, value)
+    if value > 1.0:
+        raise ValueError(f"{name} must be finite and in (0, 1]")
+    return value
+
+
+def _embedding_matrix(nodes, node_embeddings):
+    rows = []
+    width = None
+    for node in nodes:
+        try:
+            row = np.asarray(node_embeddings[node], dtype=float)
+        except KeyError as exc:
+            raise ValueError(f"node absent from embeddings: {exc.args[0]!r}") from exc
+        if row.ndim != 1 or not len(row):
+            raise ValueError("every node embedding must be a non-empty vector")
+        if width is None:
+            width = len(row)
+        if len(row) != width:
+            raise ValueError("every node embedding must have the same width")
+        if not np.isfinite(row).all():
+            raise ValueError("node embeddings must be finite")
+        rows.append(row)
+    return np.asarray(rows, dtype=float)
+
+
+def _stable_radial_factor(left, right, length_scale):
+    """Evaluate an RBF factor without overflow in differences or squares."""
+
+    cutoff = math.sqrt(-2.0 * math.log(np.nextafter(0.0, 1.0)))
+    log_cutoff = math.log(cutoff)
+    radius = 0.0
+    for left_value, right_value in zip(left, right):
+        left_value = float(left_value)
+        right_value = float(right_value)
+        if left_value == right_value:
+            continue
+        if math.copysign(1.0, left_value) == math.copysign(1.0, right_value):
+            difference = abs(left_value - right_value)
+            log_coordinate = math.log(difference) - math.log(length_scale)
+        else:
+            scale = max(abs(left_value), abs(right_value))
+            normalized = abs(left_value / scale - right_value / scale)
+            log_coordinate = (
+                math.log(normalized)
+                + math.log(scale)
+                - math.log(length_scale)
+            )
+        if log_coordinate >= log_cutoff:
+            return 0.0
+        coordinate = math.exp(log_coordinate)
+        radius = math.hypot(radius, coordinate)
+        if radius >= cutoff:
+            return 0.0
+    return math.exp(-0.5 * radius * radius)
+
+
+def semantic_conductance_matrix(
+    nodes,
+    neighbors,
+    node_embeddings=None,
+    *,
+    length_scale=None,
+    conductance_floor=0.0,
+):
+    """Return an undirected conductance matrix on one fixed node universe.
+
+    Each retained topological edge has unit base conductance.  With embeddings,
+
+    ``w_ij = floor + (1-floor) exp(-||z_i-z_j||^2 / (2 ell^2))``.
+
+    The floor applies only to existing edges; it never creates semantic
+    shortcuts between graph non-neighbours.  Neighbor references outside the
+    fixed ``nodes`` universe are ignored, matching an induced-subgraph view.
+    Directional neighbor declarations are combined by undirected union.
+    With a zero floor, a sufficiently distant retained edge may underflow to
+    zero conductance; use a positive floor when topology must be preserved.
+    """
+
+    nodes = _nodes(nodes)
+    floor = _unit_interval("conductance_floor", conductance_floor)
+    if node_embeddings is None:
+        if length_scale is not None:
+            raise ValueError("length_scale requires node_embeddings")
+        if floor != 0.0:
+            raise ValueError("conductance_floor requires node_embeddings")
+        embeddings = None
+    else:
+        length_scale = _positive_finite("length_scale", length_scale)
+        embeddings = _embedding_matrix(nodes, node_embeddings)
+
+    index = {node: row for row, node in enumerate(nodes)}
+    edges = set()
+    for left in nodes:
+        i = index[left]
+        for right in neighbors.get(left, ()):
+            j = index.get(right)
+            if j is not None and i != j:
+                edges.add((min(i, j), max(i, j)))
+
+    conductance = np.zeros((len(nodes), len(nodes)), dtype=float)
+    for i, j in edges:
+        value = 1.0
+        if embeddings is not None:
+            radial = _stable_radial_factor(
+                embeddings[i], embeddings[j], length_scale
+            )
+            value = floor + (1.0 - floor) * radial
+        conductance[i, j] = value
+        conductance[j, i] = value
+    if not np.isfinite(conductance).all():
+        raise ValueError("semantic conductance calculation was not finite")
+    return nodes, conductance
+
+
+def combinatorial_laplacian(conductance):
+    """Return ``diag(W 1) - W`` after validating resistor conductances."""
+
+    value = np.asarray(conductance, dtype=float)
+    if value.ndim != 2 or value.shape[0] != value.shape[1] or not len(value):
+        raise ValueError("conductance must be a non-empty square matrix")
+    if not np.isfinite(value).all():
+        raise ValueError("conductance must be finite")
+    if np.any(value < 0.0):
+        raise ValueError("conductance must be nonnegative")
+    if not np.allclose(value, value.T, atol=_SYMMETRY_TOLERANCE, rtol=0.0):
+        raise ValueError("conductance must be symmetric")
+    if not np.allclose(np.diag(value), 0.0, atol=_SYMMETRY_TOLERANCE, rtol=0.0):
+        raise ValueError("conductance diagonal must be zero")
+    value = _symmetric_part(value)
+    laplacian = np.diag(np.sum(value, axis=1)) - value
+    laplacian = _symmetric_part(laplacian)
+    scale = max(float(np.max(np.diag(laplacian), initial=0.0)), 1.0)
+    if float(np.min(np.linalg.eigvalsh(laplacian))) < -1e-12 * scale:
+        raise ValueError("conductance produced a non-PSD graph Laplacian")
+    return laplacian
+
+
+def _leakage_vector(nodes, leakage_conductance):
+    if isinstance(leakage_conductance, Mapping):
+        unknown = set(leakage_conductance).difference(nodes)
+        if unknown:
+            labels = ", ".join(sorted(repr(node) for node in unknown))
+            raise ValueError(f"leakage mapping contains unknown nodes: {labels}")
+        values = np.asarray(
+            [leakage_conductance.get(node, 0.0) for node in nodes], dtype=float
+        )
+    else:
+        values = np.asarray(leakage_conductance, dtype=float)
+        if values.ndim == 0:
+            values = np.full(len(nodes), float(values), dtype=float)
+    if values.shape != (len(nodes),):
+        raise ValueError("leakage_conductance must be scalar, node mapping, or node vector")
+    if not np.isfinite(values).all() or np.any(values < 0.0):
+        raise ValueError("leakage conductance must be finite and nonnegative")
+    if not np.any(values > 0.0):
+        raise ValueError("at least one node must have positive leakage conductance")
+    return values
+
+
+def _rhs(name, value, size):
+    output = np.asarray(value, dtype=float)
+    if output.ndim not in (1, 2) or output.shape[0] != size:
+        raise ValueError(f"{name} must have shape ({size},) or ({size}, k)")
+    if not np.isfinite(output).all():
+        raise ValueError(f"{name} must be finite")
+    return output
+
+
+def _positive_weight_components(conductance):
+    """Return connected components of the realized positive-weight graph."""
+
+    unseen = set(range(len(conductance)))
+    components = []
+    while unseen:
+        seed = unseen.pop()
+        component = [seed]
+        stack = [seed]
+        while stack:
+            row = stack.pop()
+            adjacent = set(np.flatnonzero(conductance[row] > 0.0)).intersection(
+                unseen
+            )
+            unseen.difference_update(adjacent)
+            stack.extend(adjacent)
+            component.extend(adjacent)
+        components.append(np.asarray(sorted(component), dtype=int))
+    return tuple(components)
+
+
+@dataclass(frozen=True)
+class GroundedSemanticDiffusion:
+    """A fixed grounded electrical/thermal graph and its precision root."""
+
+    nodes: tuple
+    conductance: np.ndarray
+    laplacian: np.ndarray
+    leakage_conductance: np.ndarray
+    precision: np.ndarray
+    precision_root: np.ndarray
+    minimum_precision_eigenvalue: float
+    maximum_precision_eigenvalue: float
+    condition_number: float
+    reciprocal_condition_number: float
+    minimum_reciprocal_condition: float
+    semantic_length_scale: float | None
+    conductance_floor: float
+
+    def __post_init__(self):
+        nodes = _nodes(self.nodes)
+        object.__setattr__(self, "nodes", nodes)
+        size = len(nodes)
+        arrays = {
+            "conductance": np.asarray(self.conductance, dtype=float),
+            "laplacian": np.asarray(self.laplacian, dtype=float),
+            "leakage_conductance": np.asarray(
+                self.leakage_conductance, dtype=float
+            ),
+            "precision": np.asarray(self.precision, dtype=float),
+            "precision_root": np.asarray(self.precision_root, dtype=float),
+        }
+        for name in ("conductance", "laplacian", "precision", "precision_root"):
+            if arrays[name].shape != (size, size):
+                raise ValueError(f"{name} must have shape ({size}, {size})")
+        if arrays["leakage_conductance"].shape != (size,):
+            raise ValueError(f"leakage_conductance must have shape ({size},)")
+        if any(not np.isfinite(value).all() for value in arrays.values()):
+            raise ValueError("model arrays must be finite")
+        if np.any(arrays["conductance"] < 0.0):
+            raise ValueError("conductance must be nonnegative")
+        if np.any(arrays["leakage_conductance"] < 0.0):
+            raise ValueError("leakage conductance must be nonnegative")
+        for name in ("conductance", "laplacian", "precision"):
+            if not np.allclose(
+                arrays[name],
+                arrays[name].T,
+                atol=_SYMMETRY_TOLERANCE,
+                rtol=0.0,
+            ):
+                raise ValueError(f"{name} must be symmetric")
+        expected_laplacian = (
+            np.diag(np.sum(arrays["conductance"], axis=1))
+            - arrays["conductance"]
+        )
+        if not np.allclose(
+            arrays["laplacian"], expected_laplacian, rtol=1e-12, atol=1e-12
+        ):
+            raise ValueError("laplacian does not match conductance")
+        expected_precision = arrays["laplacian"] + np.diag(
+            arrays["leakage_conductance"]
+        )
+        if not np.allclose(
+            arrays["precision"], expected_precision, rtol=1e-12, atol=1e-12
+        ):
+            raise ValueError("precision does not match laplacian plus leakage")
+        reconstructed = arrays["precision_root"].T @ arrays["precision_root"]
+        if not np.isfinite(reconstructed).all() or not np.allclose(
+            reconstructed, arrays["precision"], rtol=1e-11, atol=1e-12
+        ):
+            raise ValueError("precision_root does not factor precision")
+        eigenvalues = np.linalg.eigvalsh(arrays["precision"])
+        observed_minimum = _positive_finite(
+            "minimum_precision_eigenvalue", self.minimum_precision_eigenvalue
+        )
+        observed_maximum = _positive_finite(
+            "maximum_precision_eigenvalue", self.maximum_precision_eigenvalue
+        )
+        observed_condition = _positive_finite(
+            "condition_number", self.condition_number
+        )
+        observed_reciprocal = _positive_unit_interval(
+            "reciprocal_condition_number", self.reciprocal_condition_number
+        )
+        required_reciprocal = _positive_unit_interval(
+            "minimum_reciprocal_condition", self.minimum_reciprocal_condition
+        )
+        expected_minimum = float(eigenvalues[0])
+        expected_maximum = float(eigenvalues[-1])
+        if not math.isfinite(expected_minimum) or expected_minimum <= 0.0:
+            raise ValueError("precision must be positive definite")
+        if not math.isfinite(expected_maximum):
+            raise ValueError("precision spectrum must be finite")
+        expected_condition = expected_maximum / expected_minimum
+        expected_reciprocal = expected_minimum / expected_maximum
+        diagnostics = (
+            (observed_minimum, expected_minimum),
+            (observed_maximum, expected_maximum),
+            (observed_condition, expected_condition),
+            (observed_reciprocal, expected_reciprocal),
+        )
+        if any(
+            not math.isclose(left, right, rel_tol=1e-10, abs_tol=0.0)
+            for left, right in diagnostics
+        ):
+            raise ValueError("spectral diagnostics do not match precision")
+        if observed_reciprocal < required_reciprocal:
+            raise ValueError("reciprocal condition violates the recorded contract")
+        semantic_length_scale = self.semantic_length_scale
+        if semantic_length_scale is not None:
+            semantic_length_scale = _positive_finite(
+                "semantic_length_scale", semantic_length_scale
+            )
+        object.__setattr__(self, "semantic_length_scale", semantic_length_scale)
+        object.__setattr__(
+            self,
+            "conductance_floor",
+            _unit_interval("conductance_floor", self.conductance_floor),
+        )
+        for name, value in arrays.items():
+            object.__setattr__(self, name, _readonly(value))
+
+    def equilibrium_response(self, source):
+        """Solve ``J u = source`` through the stored triangular root."""
+
+        source = _rhs("source", source, len(self.nodes))
+        intermediate = np.linalg.solve(self.precision_root.T, source)
+        response = np.linalg.solve(self.precision_root, intermediate)
+        if not np.isfinite(response).all():
+            raise np.linalg.LinAlgError("equilibrium response is not finite")
+        return response
+
+    def green_kernel(self, *, normalize=False):
+        """Materialize ``J^-1`` for reference, optionally as a correlation."""
+
+        value = self.equilibrium_response(np.eye(len(self.nodes)))
+        value = _symmetric_part(value)
+        return _normalize_psd_kernel(value) if normalize else value
+
+    def correlation_precision_root(self):
+        """Return ``U_c`` with ``C^-1 = U_c.T U_c`` for normalized ``G``.
+
+        If ``D = diag(G)``, then ``C = D^-1/2 G D^-1/2`` and
+        ``C^-1 = D^1/2 J D^1/2``.  Consequently the desired root is obtained
+        by scaling columns of the already available grounded precision root.
+        """
+
+        diagonal = np.diag(self.green_kernel())
+        if np.any(diagonal <= 0.0):
+            raise np.linalg.LinAlgError("Green kernel must have positive diagonal")
+        root = np.asarray(self.precision_root) * np.sqrt(diagonal)[None, :]
+        if not np.isfinite(root).all():
+            raise np.linalg.LinAlgError("correlation precision root is not finite")
+        return root
+
+    def heat_kernel(self, time, *, normalize=False):
+        """Return the grounded impulse propagator ``exp(-time J)``."""
+
+        time = _nonnegative_finite("time", time)
+        value = np.zeros_like(self.precision)
+        for component in _positive_weight_components(self.conductance):
+            block = self.precision[np.ix_(component, component)]
+            eigenvalues, eigenvectors = np.linalg.eigh(block)
+            if normalize:
+                eigenvalues = np.maximum(eigenvalues - eigenvalues[0], 0.0)
+            with np.errstate(over="ignore", under="ignore"):
+                factors = np.exp(-time * eigenvalues)
+            heat = (eigenvectors * factors) @ eigenvectors.T
+            value[np.ix_(component, component)] = _symmetric_part(heat)
+        return _normalize_psd_kernel(value) if normalize else value
+
+    def impulse_response(self, source, *, time):
+        """Evolve an impulse with unit heat capacity (or unit capacitance)."""
+
+        source = _rhs("source", source, len(self.nodes))
+        return self.heat_kernel(time) @ source
+
+    def step_response(self, source, *, time):
+        """Response after a constant source is switched on at time zero."""
+
+        source = _rhs("source", source, len(self.nodes))
+        time = _nonnegative_finite("time", time)
+        eigenvalues, eigenvectors = np.linalg.eigh(self.precision)
+        with np.errstate(over="ignore", under="ignore"):
+            scaled = time * eigenvalues
+        factors = np.empty_like(eigenvalues)
+        finite = np.isfinite(scaled)
+        finite_scaled = scaled[finite]
+        phi = np.ones_like(finite_scaled)
+        nonzero = finite_scaled != 0.0
+        phi[nonzero] = (
+            -np.expm1(-finite_scaled[nonzero]) / finite_scaled[nonzero]
+        )
+        factors[finite] = time * phi
+        factors[~finite] = 1.0 / eigenvalues[~finite]
+        projected = eigenvectors.T @ source
+        if projected.ndim == 1:
+            response = eigenvectors @ (factors * projected)
+        else:
+            response = eigenvectors @ (factors[:, None] * projected)
+        if not np.isfinite(response).all():
+            raise np.linalg.LinAlgError("step response is not finite")
+        return response
+
+    def resistance_distance(self, *, squared=False):
+        """Pairwise grounded effective-resistance distance induced by ``G``."""
+
+        inverse_transpose = np.linalg.solve(
+            self.precision_root.T, np.eye(len(self.nodes))
+        )
+        distance_squared = np.zeros_like(self.precision)
+        for left in range(len(self.nodes)):
+            for right in range(left):
+                difference = inverse_transpose[:, left] - inverse_transpose[:, right]
+                norm = float(np.linalg.norm(difference))
+                value = norm * norm
+                if not math.isfinite(value):
+                    raise np.linalg.LinAlgError(
+                        "effective resistance is not representable in float64"
+                    )
+                distance_squared[left, right] = value
+                distance_squared[right, left] = value
+        return distance_squared if squared else np.sqrt(distance_squared)
+
+
+def build_grounded_semantic_diffusion(
+    nodes,
+    neighbors,
+    *,
+    leakage_conductance,
+    node_embeddings=None,
+    length_scale=None,
+    conductance_floor=0.0,
+    minimum_reciprocal_condition=_DEFAULT_MINIMUM_RECIPROCAL_CONDITION,
+):
+    """Build a grounded diffusion model without a covariance inversion.
+
+    Leakage may be uniform, a node-aligned vector, or a sparse node mapping.
+    Zero leakage at some nodes is allowed only when the resulting grounded
+    precision is positive definite (every connected component must reach
+    ground).  Failure is explicit; no numerical diagonal loading is hidden.
+    The default float64 contract also requires reciprocal spectral condition
+    at least sqrt(machine epsilon); a caller-supplied weaker threshold is
+    explicit and recorded on the returned model.
+    """
+
+    nodes, conductance = semantic_conductance_matrix(
+        nodes,
+        neighbors,
+        node_embeddings,
+        length_scale=length_scale,
+        conductance_floor=conductance_floor,
+    )
+    laplacian = combinatorial_laplacian(conductance)
+    leakage = _leakage_vector(nodes, leakage_conductance)
+    minimum_reciprocal_condition = _positive_unit_interval(
+        "minimum_reciprocal_condition", minimum_reciprocal_condition
+    )
+    precision = _symmetric_part(laplacian + np.diag(leakage))
+    components = _positive_weight_components(conductance)
+    for component in components:
+        if not np.any(leakage[component] > 0.0):
+            raise np.linalg.LinAlgError(
+                "grounded precision is not positive definite; every graph component "
+                "must have a path to positive leakage"
+            )
+        block_scale = float(
+            np.max(np.abs(precision[np.ix_(component, component)]))
+        )
+        if block_scale < 1.0 / _FLOAT64_MAXIMUM:
+            raise np.linalg.LinAlgError(
+                "grounded precision has an unrepresentable equilibrium scale"
+            )
+    eigenvalues = np.linalg.eigvalsh(precision)
+    minimum = float(np.min(eigenvalues))
+    maximum = float(np.max(eigenvalues))
+    if (
+        not math.isfinite(minimum)
+        or not math.isfinite(maximum)
+        or minimum <= 0.0
+        or maximum <= 0.0
+    ):
+        raise np.linalg.LinAlgError(
+            "grounded precision has no positive numerical spectral floor"
+        )
+    if minimum < 1.0 / _FLOAT64_MAXIMUM:
+        raise np.linalg.LinAlgError(
+            "grounded precision has an unrepresentable equilibrium scale"
+        )
+    reciprocal_condition = minimum / maximum
+    if reciprocal_condition < minimum_reciprocal_condition:
+        raise np.linalg.LinAlgError(
+            "grounded precision is too ill-conditioned for the requested "
+            "float64 contract: reciprocal condition "
+            f"{reciprocal_condition:.3e} < {minimum_reciprocal_condition:.3e}"
+        )
+    try:
+        lower_root = np.linalg.cholesky(precision)
+    except np.linalg.LinAlgError as exc:
+        raise np.linalg.LinAlgError(
+            "grounded precision is not positive definite; every graph component "
+            "must have a path to positive leakage"
+        ) from exc
+    return GroundedSemanticDiffusion(
+        nodes=nodes,
+        conductance=conductance,
+        laplacian=laplacian,
+        leakage_conductance=leakage,
+        precision=precision,
+        precision_root=lower_root.T,
+        minimum_precision_eigenvalue=minimum,
+        maximum_precision_eigenvalue=maximum,
+        condition_number=maximum / minimum,
+        reciprocal_condition_number=reciprocal_condition,
+        minimum_reciprocal_condition=minimum_reciprocal_condition,
+        semantic_length_scale=(
+            None if node_embeddings is None else float(length_scale)
+        ),
+        conductance_floor=float(conductance_floor),
+    )

--- a/tests/test_leaky_diffusion.py
+++ b/tests/test_leaky_diffusion.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Analytic tests for semantically weighted, grounded graph diffusion."""
+
+from dataclasses import replace
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from unifyweaver.graph.leaky_diffusion import (  # noqa: E402
+    build_grounded_semantic_diffusion,
+    combinatorial_laplacian,
+    semantic_conductance_matrix,
+)
+
+
+def _neighbors(edges, extra=()):
+    output = {node: set() for node in extra}
+    for left, right in edges:
+        output.setdefault(left, set()).add(right)
+        output.setdefault(right, set()).add(left)
+    return {node: frozenset(values) for node, values in output.items()}
+
+
+def _two_node(distance, *, leakage=0.2, length_scale=1.0):
+    return build_grounded_semantic_diffusion(
+        ("a", "b"),
+        _neighbors((("a", "b"),)),
+        leakage_conductance=leakage,
+        node_embeddings={
+            "a": np.array([0.0, 0.0]),
+            "b": np.array([distance, 0.0]),
+        },
+        length_scale=length_scale,
+    )
+
+
+def test_semantics_modulate_only_existing_graph_edges():
+    nodes = ("a", "b", "c")
+    embeddings = {
+        "a": np.array([0.0, 0.0]),
+        "b": np.array([0.1, 0.0]),
+        "c": np.array([3.0, 0.0]),
+    }
+    returned, conductance = semantic_conductance_matrix(
+        nodes,
+        _neighbors((("a", "b"), ("b", "c"))),
+        embeddings,
+        length_scale=1.0,
+    )
+    assert returned == nodes
+    assert conductance[0, 1] > conductance[1, 2] > 0.0
+    assert conductance[0, 2] == 0.0
+    assert np.allclose(conductance, conductance.T)
+    assert np.array_equal(np.diag(conductance), np.zeros(3))
+
+
+def test_semantic_floor_retains_distant_topological_edges_without_shortcuts():
+    _, conductance = semantic_conductance_matrix(
+        ("a", "b", "c"),
+        _neighbors((("a", "b"), ("b", "c"))),
+        {
+            "a": np.array([0.0]),
+            "b": np.array([100.0]),
+            "c": np.array([200.0]),
+        },
+        length_scale=1.0,
+        conductance_floor=0.05,
+    )
+    assert conductance[0, 1] == pytest.approx(0.05)
+    assert conductance[1, 2] == pytest.approx(0.05)
+    assert conductance[0, 2] == 0.0
+
+
+def test_topology_only_conductance_is_unit_weighted():
+    _, conductance = semantic_conductance_matrix(
+        ("a", "b", "c"),
+        _neighbors((("a", "b"),), extra=("c",)),
+    )
+    assert np.array_equal(
+        conductance,
+        np.array([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+    )
+
+
+def test_two_node_precision_green_and_root_match_analytic_circuit():
+    alpha = 0.2
+    model = _two_node(0.0, leakage=alpha)
+    expected_precision = np.array([[1.0 + alpha, -1.0], [-1.0, 1.0 + alpha]])
+    denominator = alpha * (alpha + 2.0)
+    expected_green = np.array(
+        [[alpha + 1.0, 1.0], [1.0, alpha + 1.0]]
+    ) / denominator
+
+    assert np.allclose(model.precision, expected_precision)
+    assert np.allclose(model.precision_root.T @ model.precision_root, expected_precision)
+    assert np.allclose(model.green_kernel(), expected_green)
+    assert np.allclose(model.precision @ model.green_kernel(), np.eye(2))
+    assert model.minimum_precision_eigenvalue == pytest.approx(alpha)
+    assert model.maximum_precision_eigenvalue == pytest.approx(alpha + 2.0)
+
+
+def test_uniform_grounding_is_the_regularized_laplacian_resolvent():
+    alpha = 0.4
+    model = build_grounded_semantic_diffusion(
+        ("a", "b", "c"),
+        _neighbors((("a", "b"), ("b", "c"))),
+        leakage_conductance=alpha,
+    )
+    reference = np.linalg.solve(
+        np.eye(3) + model.laplacian / alpha,
+        np.eye(3),
+    ) / alpha
+    assert np.allclose(model.green_kernel(), reference)
+
+
+def test_equilibrium_satisfies_kcl_and_superposition_for_multiple_sources():
+    model = build_grounded_semantic_diffusion(
+        ("a", "b", "c"),
+        _neighbors((("a", "b"), ("b", "c"))),
+        leakage_conductance=0.1,
+    )
+    first = np.array([1.0, 0.0, 0.0])
+    second = np.array([0.0, 0.0, 2.0])
+    both = np.column_stack((first, second))
+    response = model.equilibrium_response(both)
+
+    assert np.allclose(model.precision @ response, both)
+    assert np.allclose(response[:, 0], model.equilibrium_response(first))
+    assert np.allclose(response[:, 1], model.equilibrium_response(second))
+    assert np.all(response >= 0.0)
+
+
+def test_sparse_boundary_grounding_requires_every_component_to_reach_ground():
+    nodes = ("a", "b", "z")
+    neighbors = _neighbors((("a", "b"),), extra=("z",))
+    with pytest.raises(np.linalg.LinAlgError, match="every graph component"):
+        build_grounded_semantic_diffusion(
+            nodes,
+            neighbors,
+            leakage_conductance={"a": 0.1},
+        )
+
+    model = build_grounded_semantic_diffusion(
+        nodes,
+        neighbors,
+        leakage_conductance={"a": 0.1, "z": 0.2},
+    )
+    assert model.minimum_precision_eigenvalue > 0.0
+    assert np.allclose(model.leakage_conductance, [0.1, 0.0, 0.2])
+
+
+def test_correlation_precision_root_whitens_normalized_green_kernel():
+    model = build_grounded_semantic_diffusion(
+        ("a", "b", "c"),
+        _neighbors((("a", "b"), ("b", "c"))),
+        leakage_conductance={"a": 0.2, "b": 0.1, "c": 0.4},
+    )
+    correlation = model.green_kernel(normalize=True)
+    root = model.correlation_precision_root()
+    assert np.allclose(np.diag(correlation), 1.0)
+    assert np.min(np.linalg.eigvalsh(correlation)) > 0.0
+    assert np.allclose(root.T @ root @ correlation, np.eye(3), atol=1e-11)
+
+
+def test_heat_semigroup_and_step_relaxation_to_equilibrium():
+    model = build_grounded_semantic_diffusion(
+        ("a", "b", "c"),
+        _neighbors((("a", "b"), ("b", "c"))),
+        leakage_conductance=0.25,
+    )
+    source = np.array([1.0, 0.0, 0.0])
+    assert np.allclose(model.heat_kernel(0.0), np.eye(3))
+    assert np.allclose(model.step_response(source, time=0.0), np.zeros(3))
+    assert np.allclose(
+        model.heat_kernel(0.3) @ model.heat_kernel(0.7),
+        model.heat_kernel(1.0),
+        atol=1e-12,
+    )
+    early = model.step_response(source, time=1e-8)
+    late = model.step_response(source, time=1e4)
+    equilibrium = model.equilibrium_response(source)
+    assert np.linalg.norm(early) < 1e-7
+    assert np.allclose(late, equilibrium, atol=1e-12)
+    assert np.allclose(model.impulse_response(source, time=0.5), model.heat_kernel(0.5) @ source)
+
+
+def test_semantically_distant_edge_has_larger_effective_resistance():
+    near = _two_node(0.1, leakage=0.1)
+    far = _two_node(2.0, leakage=0.1)
+    assert near.conductance[0, 1] > far.conductance[0, 1]
+    assert near.resistance_distance()[0, 1] < far.resistance_distance()[0, 1]
+    for distance in (near.resistance_distance(), far.resistance_distance()):
+        assert np.allclose(distance, distance.T)
+        assert np.array_equal(np.diag(distance), np.zeros(2))
+
+
+def test_implementation_never_requires_explicit_matrix_inverse(monkeypatch):
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("explicit inverse is forbidden")
+
+    monkeypatch.setattr(np.linalg, "inv", forbidden)
+    model = _two_node(0.5)
+    source = np.array([1.0, 0.0])
+    assert np.all(np.isfinite(model.equilibrium_response(source)))
+    assert np.all(np.isfinite(model.green_kernel()))
+    assert np.all(np.isfinite(model.correlation_precision_root()))
+
+
+def test_model_arrays_are_read_only():
+    model = _two_node(0.0)
+    with pytest.raises(ValueError):
+        model.precision[0, 0] = 0.0
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"node_embeddings": {"a": [0.0], "b": [1.0]}}, "length_scale"),
+        ({"length_scale": 1.0}, "requires node_embeddings"),
+        ({"conductance_floor": 0.1}, "requires node_embeddings"),
+        (
+            {
+                "node_embeddings": {"a": [0.0], "b": [1.0]},
+                "length_scale": 1.0,
+                "conductance_floor": 1.0,
+            },
+            r"\[0, 1\)",
+        ),
+    ],
+)
+def test_invalid_semantic_conductance_contract_fails_closed(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        semantic_conductance_matrix(
+            ("a", "b"),
+            _neighbors((("a", "b"),)),
+            **kwargs,
+        )
+
+
+def test_invalid_conductance_and_ungrounded_network_fail_closed():
+    with pytest.raises(ValueError, match="symmetric"):
+        combinatorial_laplacian(np.array([[0.0, 1.0], [0.0, 0.0]]))
+    with pytest.raises(ValueError, match="nonnegative"):
+        combinatorial_laplacian(np.array([[0.0, -1.0], [-1.0, 0.0]]))
+    with pytest.raises(ValueError, match="at least one"):
+        build_grounded_semantic_diffusion(
+            ("a", "b"),
+            _neighbors((("a", "b"),)),
+            leakage_conductance=0.0,
+        )
+
+def test_semantic_rbf_is_stable_at_extreme_float64_scales():
+    edge = _neighbors((("a", "b"),))
+    _, opposite = semantic_conductance_matrix(
+        ("a", "b"),
+        edge,
+        {"a": [1e308], "b": [-1e308]},
+        length_scale=1e308,
+    )
+    assert opposite[0, 1] == pytest.approx(np.exp(-2.0))
+
+    _, small_coordinate = semantic_conductance_matrix(
+        ("a", "b"),
+        edge,
+        {"a": [1e308, 1.0], "b": [1e308, 0.0]},
+        length_scale=1.0,
+    )
+    assert small_coordinate[0, 1] == pytest.approx(np.exp(-0.5))
+
+    _, underflow = semantic_conductance_matrix(
+        ("a", "b"),
+        edge,
+        {"a": [0.0], "b": [1.0]},
+        length_scale=np.nextafter(0.0, 1.0),
+    )
+    assert np.isfinite(underflow).all()
+    assert underflow[0, 1] == 0.0
+
+
+def test_normalized_heat_is_stable_per_disconnected_component():
+    nodes = ("a", "b", "c", "d", "z")
+    model = build_grounded_semantic_diffusion(
+        nodes,
+        _neighbors((("a", "b"), ("c", "d")), extra=("z",)),
+        leakage_conductance={
+            "a": 1.0,
+            "b": 1.0,
+            "c": 1000.0,
+            "d": 1000.0,
+            "z": 10000.0,
+        },
+    )
+    raw = model.heat_kernel(1.0)
+    assert np.array_equal(raw[2:4, 2:4], np.zeros((2, 2)))
+
+    normalized = model.heat_kernel(1.0, normalize=True)
+    expected = np.eye(5)
+    expected[0, 1] = expected[1, 0] = np.tanh(1.0)
+    expected[2, 3] = expected[3, 2] = np.tanh(1.0)
+    assert np.isfinite(normalized).all()
+    assert np.allclose(normalized, expected, atol=1e-12)
+
+
+def test_step_response_uses_small_time_stable_phi_function():
+    singleton = build_grounded_semantic_diffusion(
+        ("a",),
+        _neighbors((), extra=("a",)),
+        leakage_conductance=1.0,
+    )
+    tiny = singleton.step_response(np.array([1.0]), time=1e-20)
+    assert tiny[0] > 0.0
+    assert tiny[0] == pytest.approx(1e-20)
+
+    weakly_grounded = build_grounded_semantic_diffusion(
+        ("a",),
+        _neighbors((), extra=("a",)),
+        leakage_conductance=1e-308,
+    )
+    weak_tiny = weakly_grounded.step_response(np.array([1.0]), time=1e-20)
+    assert weak_tiny[0] > 0.0
+    assert weak_tiny[0] == pytest.approx(1e-20)
+
+    model = build_grounded_semantic_diffusion(
+        ("a", "b"),
+        _neighbors((("a", "b"),)),
+        leakage_conductance=1e-4,
+    )
+    source = np.array([1.0, 0.0])
+    time = 1e-12
+    assert np.allclose(
+        model.step_response(source, time=time) / time,
+        source,
+        rtol=1e-10,
+        atol=1e-10,
+    )
+
+
+def test_float64_condition_contract_fails_closed_and_records_override():
+    with pytest.raises(np.linalg.LinAlgError, match="too ill-conditioned"):
+        build_grounded_semantic_diffusion(
+            ("a", "b"),
+            _neighbors((("a", "b"),)),
+            leakage_conductance=1e-9,
+        )
+
+    accepted = build_grounded_semantic_diffusion(
+        ("a", "b"),
+        _neighbors((("a", "b"),)),
+        leakage_conductance=1e-7,
+    )
+    assert accepted.reciprocal_condition_number >= np.sqrt(np.finfo(float).eps)
+    assert np.isfinite(accepted.green_kernel()).all()
+
+    explicit = build_grounded_semantic_diffusion(
+        ("a", "b"),
+        _neighbors((("a", "b"),)),
+        leakage_conductance=1e-9,
+        minimum_reciprocal_condition=1e-10,
+    )
+    assert explicit.reciprocal_condition_number >= 1e-10
+    assert explicit.minimum_reciprocal_condition == 1e-10
+
+
+def test_unrepresentable_equilibrium_scale_fails_but_large_finite_green_survives():
+    with pytest.raises(np.linalg.LinAlgError, match="unrepresentable"):
+        build_grounded_semantic_diffusion(
+            ("a",),
+            _neighbors((), extra=("a",)),
+            leakage_conductance=np.nextafter(0.0, 1.0),
+        )
+
+    model = build_grounded_semantic_diffusion(
+        ("a",),
+        _neighbors((), extra=("a",)),
+        leakage_conductance=1e-308,
+    )
+    assert np.isfinite(model.green_kernel()).all()
+    assert model.green_kernel()[0, 0] == pytest.approx(1e308)
+
+
+def test_sparse_leakage_mapping_rejects_unknown_node_keys():
+    with pytest.raises(ValueError, match="unknown nodes.*typo"):
+        build_grounded_semantic_diffusion(
+            ("a", "b"),
+            _neighbors((("a", "b"),)),
+            leakage_conductance={"a": 0.1, "typo": 0.2},
+        )
+
+
+def test_resistance_matches_unit_current_energy_without_green_cancellation():
+    model = build_grounded_semantic_diffusion(
+        ("a", "b", "c"),
+        _neighbors((("a", "b"), ("b", "c"))),
+        leakage_conductance={"a": 0.2, "b": 0.1, "c": 0.4},
+    )
+    squared = model.resistance_distance(squared=True)
+    for left in range(3):
+        for right in range(left):
+            current = np.zeros(3)
+            current[left] = 1.0
+            current[right] = -1.0
+            voltage = model.equilibrium_response(current)
+            assert squared[left, right] == pytest.approx(current @ voltage)
+
+
+def test_public_model_constructor_validates_precision_root_invariant():
+    model = _two_node(0.0)
+    with pytest.raises(ValueError, match="precision_root"):
+        replace(model, precision_root=np.eye(2))


### PR DESCRIPTION
## Summary

Closes the immutable Stage-A source-power study and adds a reusable grounded semantic-diffusion primitive without promoting it as empirical judge covariance.

- Records the exact Stage-A fail-closed outcome: all 12 evaluable R=3 discovery configurations failed, the six R=4 configurations were diagnostic/non-evaluable, no confirmation design was selected, and every downstream authorization remains false.
- Adds edge-only semantic conductance on an existing graph, shunt grounding, the grounded precision \(J=L+\operatorname{diag}(\alpha)\), and a Cholesky precision root.
- Exposes equilibrium, Green/correlation, impulse/heat, step-response, and grounded effective-resistance calculations.
- Documents the circuit/heat interpretation, numerical contract, alternatives rejected, and the separation between graph geometry and statistical covariance evidence.
- Adds a focused CI step and regression coverage for conditioning, disconnected components, extreme embedding scales, tiny leakage/time, stable heat normalization, root invariants, and solve/energy identities.

## Scientific outcome

The immutable run used source commit `d7e28a91b0f4efcc2d9b6f374463b8d26a5115fe` and frozen fingerprint `989d274a032e814bad454e7a26bd4fa2ebed8e432139e3434ed43ad5cdce4fd7`.

The complete result artifact is 29,154,632 bytes with SHA-256 `4055c39e335464cc17261aa176bb508a6dd0b16804ff824eba59520b442d80a1`. The result is a normal scientific fail-closed outcome, not an operational failure. It does not authorize covariance deployment, independent batching, QR specialization, or CUDA.

## Numerical contract

The default float64 path requires every realized component to reach a shunt, a representable equilibrium scale, and reciprocal condition number at least \(\sqrt{\epsilon}\). It records any explicit weaker threshold, uses triangular solves instead of forming an inverse, applies no hidden jitter, and keeps physical leakage separate from numerical regularization.

This is a dense CPU correctness/reference implementation. Sparse or CUDA specialization requires a later matched full-cost crossover benchmark.

## Validation

- `python3 -m pytest -q -s tests/test_leaky_diffusion.py prototypes/mu_cosine/test_graph_geometry.py prototypes/mu_cosine/test_joint_square_root_conditioner.py` — **51 passed**
- `python3 -m py_compile src/unifyweaver/graph/leaky_diffusion.py tests/test_leaky_diffusion.py`
- `git diff --check origin/main`
- Independent numerical and scope/provenance reviews completed; their final blockers were fixed before publication.
