### PR TITLE
Add Rust WAM format builtin family

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1365,8 +1365,173 @@ compile_execute_io_builtin_to_rust(Code) :-
         }
     }
 
+    fn format_term_text(&self, value: &Value) -> String {
+        let derefed = self.deref_heap(&self.deref_var(value));
+        match derefed {
+            Value::Atom(text) => text,
+            Value::Integer(number) => number.to_string(),
+            Value::Float(number) => number.to_string(),
+            Value::Bool(boolean) => boolean.to_string(),
+            Value::Unbound(name) => {
+                if name.is_empty() { "_".to_string() } else { name }
+            }
+            Value::List(items) => {
+                let rendered: Vec<String> = items.iter()
+                    .map(|item| self.format_term_text(item))
+                    .collect();
+                format!("[{}]", rendered.join(", "))
+            }
+            Value::Str(functor, args) => {
+                let name = Self::display_functor_name(&functor, args.len());
+                let rendered: Vec<String> = args.iter()
+                    .map(|arg| self.format_term_text(arg))
+                    .collect();
+                format!("{}({})", name, rendered.join(", "))
+            }
+            value @ Value::Ref(_) => format!("{}", value),
+            Value::Uninit => "_".to_string(),
+        }
+    }
+
+    fn render_format(&self, format_raw: &Value, args_raw: Option<&Value>) -> Option<String> {
+        let format_value = self.deref_heap(&self.deref_var(format_raw));
+        let format_text = match format_value {
+            Value::Atom(text) => text,
+            Value::Integer(number) => number.to_string(),
+            Value::Bool(boolean) => boolean.to_string(),
+            Value::List(items) if items.is_empty() => "[]".to_string(),
+            _ => return None,
+        };
+        let args = match args_raw {
+            None => Vec::new(),
+            Some(raw) => match self.deref_heap(&self.deref_var(raw)) {
+                Value::List(items) => items,
+                Value::Atom(name) if name == "[]" => Vec::new(),
+                _ => return None,
+            },
+        };
+
+        let mut output = String::new();
+        let mut arg_index = 0usize;
+        let mut chars = format_text.chars();
+        while let Some(ch) = chars.next() {
+            if ch != ''~'' {
+                output.push(ch);
+                continue;
+            }
+            let directive = match chars.next() {
+                Some(directive) => directive,
+                None => {
+                    output.push(''~'');
+                    break;
+                }
+            };
+            match directive {
+                ''n'' => output.push(''\\n''),
+                ''t'' => output.push(''\\t''),
+                ''~'' => output.push(''~''),
+                ''w'' | ''p'' | ''a'' | ''d'' | ''s'' => {
+                    let value = self.deref_heap(&self.deref_var(args.get(arg_index)?));
+                    arg_index += 1;
+                    match directive {
+                        ''w'' | ''p'' => output.push_str(&self.format_term_text(&value)),
+                        ''a'' => match Self::value_atom_name(&value) {
+                            Some(atom) => output.push_str(&atom),
+                            None => output.push_str(&self.format_term_text(&value)),
+                        },
+                        ''d'' => match value {
+                            Value::Integer(number) => output.push_str(&number.to_string()),
+                            _ => output.push_str(&self.format_term_text(&value)),
+                        },
+                        ''s'' => match value {
+                            Value::List(items) => {
+                                output.push_str(&self.code_list_to_string(&items)?);
+                            }
+                            _ => match Self::value_atom_name(&value) {
+                                Some(atom) => output.push_str(&atom),
+                                None => output.push_str(&self.format_term_text(&value)),
+                            },
+                        },
+                        _ => unreachable!(),
+                    }
+                }
+                unknown => {
+                    output.push(''~'');
+                    output.push(unknown);
+                }
+            }
+        }
+        Some(output)
+    }
+
     fn execute_io_builtin(&mut self, op: &str, _arity: usize) -> bool {
         match op {
+            "format/1" | "format/2" | "format/3" => {
+                let is_format3 = op == "format/3";
+                let format_reg = if is_format3 { "A2" } else { "A1" };
+                let args_reg = if op == "format/2" {
+                    Some("A2")
+                } else if is_format3 {
+                    Some("A3")
+                } else {
+                    None
+                };
+                let format_raw = self.get_reg_raw(format_reg).unwrap_or(Value::Uninit);
+                let args_raw = args_reg
+                    .map(|reg| self.get_reg_raw(reg).unwrap_or(Value::Uninit));
+                let rendered = match self.render_format(&format_raw, args_raw.as_ref()) {
+                    Some(rendered) => rendered,
+                    None => return false,
+                };
+
+                if !is_format3 {
+                    let mut stdout = std::io::stdout().lock();
+                    if std::io::Write::write_all(&mut stdout, rendered.as_bytes()).is_err()
+                        || std::io::Write::flush(&mut stdout).is_err() {
+                        return false;
+                    }
+                    self.pc += 1;
+                    return true;
+                }
+
+                let destination = self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v)))
+                    .unwrap_or(Value::Uninit);
+                match destination {
+                    Value::Atom(name) if name == "user_output" => {
+                        let mut stdout = std::io::stdout().lock();
+                        if std::io::Write::write_all(&mut stdout, rendered.as_bytes()).is_err()
+                            || std::io::Write::flush(&mut stdout).is_err() {
+                            return false;
+                        }
+                        self.pc += 1; true
+                    }
+                    Value::Atom(name) if name == "user_error" => {
+                        let mut stderr = std::io::stderr().lock();
+                        if std::io::Write::write_all(&mut stderr, rendered.as_bytes()).is_err()
+                            || std::io::Write::flush(&mut stderr).is_err() {
+                            return false;
+                        }
+                        self.pc += 1; true
+                    }
+                    Value::Str(functor, args) if args.len() == 1 => {
+                        let name = Self::display_functor_name(&functor, 1);
+                        let output = match name.as_str() {
+                            "atom" | "string" => Value::Atom(rendered),
+                            "codes" => Self::string_to_codes_value(&rendered),
+                            _ => return false,
+                        };
+                        let mark = self.trail.len();
+                        if self.unify(&args[0], &output) {
+                            self.pc += 1; true
+                        } else {
+                            self.unwind_trail_to(mark);
+                            false
+                        }
+                    }
+                    _ => false,
+                }
+            }
             "write/1" | "display/1" | "print/1" => {
                 // These share Display rendering for now. Standard Prolog
                 // differentiates write/1, display/1, and print/1.

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -76,6 +76,18 @@ t_output_family :-
     write_canonical('two words'),
     write_canonical(node('has space', 7)).
 
+:- dynamic t_format_capture/3.
+t_format_capture(Atom, String, Codes) :-
+    format(atom(Atom), 'X=~w ~a ~d ~s~n~~',
+           [node(1), hello, 42, [111, 107]]),
+    format(string(String), '~p~t~a', [foo(bar), done]),
+    format(codes(Codes), ab, []).
+
+:- dynamic t_format_output/0.
+t_format_output :-
+    format('F1~~'),
+    format('|~w/~a/~d/~s~n', [node(1), hello, 42, [111, 107]]).
+
 :- dynamic t_filesystem_query/1.
 t_filesystem_query(Files) :-
     exists_file('Cargo.toml'),
@@ -275,12 +287,15 @@ write_output_probe(TmpDir) :-
     directory_file_path(BinDir, 'output_probe.rs', ProbePath),
     ProbeContent = '
 use builtin_parity_test::state::WamState;
-use builtin_parity_test::t_output_family_0;
+use builtin_parity_test::{t_format_output_0, t_output_family_0};
 use std::collections::HashMap;
 
 fn main() {
     let mut vm = WamState::new(vec![], HashMap::new());
     if !t_output_family_0(&mut vm) {
+        std::process::exit(1);
+    }
+    if !t_format_output_0(&mut vm) {
         std::process::exit(1);
     }
 }
@@ -313,6 +328,8 @@ test_builtin_parity_execution :-
              user:t_output_aliases/0,
              user:t_tab/0,
              user:t_output_family/0,
+             user:t_format_capture/3,
+             user:t_format_output/0,
              user:t_filesystem_query/1,
              user:t_file_metadata/2,
              user:t_system_queries/3,
@@ -351,6 +368,7 @@ use builtin_parity_test::{t_between_1, t_msort_1, t_sort_1, t_sort4_1, t_concat_
     t_output_aliases_0,
     t_tab_0,
     t_output_family_0,
+    t_format_capture_3,
     t_filesystem_query_1,
     t_file_metadata_2,
     t_system_queries_3,
@@ -520,6 +538,17 @@ fn test_output_aliases_compiled() {
 
     let mut output_vm = vmnew();
     assert!(t_output_family_0(&mut output_vm));
+}
+
+#[test]
+fn test_format_capture_compiled() {
+    let mut vm = vmnew();
+    assert!(t_format_capture_3(&mut vm, ub("Atom"), ub("String"), ub("Codes")));
+    assert_eq!(read_var(&vm, "Atom"),
+        a(&format!("X=node(1) hello 42 ok{}~", char::from(10))));
+    assert_eq!(read_var(&vm, "String"),
+        a(&format!("foo(bar){}done", char::from(9))));
+    assert_eq!(read_var(&vm, "Codes"), Value::List(vec![i(97), i(98)]));
 }
 
 #[test]
@@ -2115,6 +2144,45 @@ fn test_single_term_output_direct() {
 }
 
 #[test]
+fn test_format_direct() {
+    let args = Value::List(vec![
+        Value::Str("node".to_string(), vec![i(1)]),
+        a("hello"),
+        i(42),
+        Value::List(vec![i(111), i(107)]),
+    ]);
+    let destination = Value::Str("atom".to_string(), vec![ub("Out")]);
+    let (ok, vm) = call3("format/3", destination,
+        a("~w|~a|~d|~s|~t|~~"), args);
+    assert!(ok);
+    assert_eq!(read_var(&vm, "Out"),
+        a(&format!("node(1)|hello|42|ok|{}|~", char::from(9))));
+
+    let string_dest = Value::Str("string/1".to_string(), vec![ub("Out")]);
+    let (string_ok, string_vm) = call3("format/3", string_dest,
+        a("~p"), Value::List(vec![Value::List(vec![a("a"), i(2)])]));
+    assert!(string_ok);
+    assert_eq!(read_var(&string_vm, "Out"), a("[a, 2]"));
+
+    let codes_dest = Value::Str("codes".to_string(), vec![ub("Codes")]);
+    let (codes_ok, codes_vm) = call3("format/3", codes_dest,
+        a("ab"), Value::List(vec![]));
+    assert!(codes_ok);
+    assert_eq!(read_var(&codes_vm, "Codes"), Value::List(vec![i(97), i(98)]));
+
+    assert!(call3("format/3",
+        Value::Str("atom".to_string(), vec![a("ok")]),
+        a("ok"), Value::List(vec![])).0);
+    assert!(!call3("format/3",
+        Value::Str("atom".to_string(), vec![a("wrong")]),
+        a("ok"), Value::List(vec![])).0);
+    assert!(!call3("format/3", a("unknown"), a("ok"), Value::List(vec![])).0);
+    assert!(!call2("format/2", a("~w"), Value::List(vec![])).0);
+    assert!(!call2("format/2", a("ok"), i(7)).0);
+    assert!(!call2("format/2", Value::Float(2.5), Value::List(vec![])).0);
+}
+
+#[test]
 fn test_filesystem_query_direct() {
     assert!(call1("exists_file/1", a("Cargo.toml")).0);
     assert!(!call1("exists_file/1", a("src/bin")).0);
@@ -2253,7 +2321,7 @@ fn test_environment_mutation_direct() {
         (   ExitCode == 0,
             sub_string(Output, _, _, _, "test result: ok")
         ->  run_output_probe(TmpDir, ProbeExitCode, ProbeOutput),
-            ExpectedOutput = "xy'two words'node('has space', 7)",
+            ExpectedOutput = "xy'two words'node('has space', 7)F1~|node(1)/hello/42/ok\n",
             (   ProbeExitCode == 0,
                 ProbeOutput == ExpectedOutput
             ->  pass(Test)

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -500,6 +500,7 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, '"sub_atom/5"'),
         sub_string(S, _, _, _, '"code_type/2"'),
         sub_string(S, _, _, _, '"must_be/2"'),
+        sub_string(S, _, _, _, '"format/1" | "format/2" | "format/3"'),
         sub_string(S, _, _, _, '"file_base_name/2" | "file_directory_name/2"'),
         sub_string(S, _, _, _, '"file_name_extension/3"'),
         sub_string(S, _, _, _, '"is_absolute_file_name/1"'),


### PR DESCRIPTION
## Summary
- implement `format/1`, `format/2`, and `format/3`
- support `~w`, `~p`, `~a`, `~d`, `~s`, `~n`, `~t`, and `~~`
- support `user_output`, `user_error`, `atom/1`, `string/1`, and `codes/1` destinations
- render into a local buffer so malformed calls fail before producing partial output
- add compiled, direct, failure-case, and exact captured-output coverage
- add no runtime fields or dependencies

## Testing
- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `swipl -q -s tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_builtin_parity.pl`
- `git diff --check`