### PR TITLE
mu_cosine: local grounded diffusion — exact Dirichlet cuts + leakage calibration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,10 @@ jobs:
         run: python3 -m pip install --user lmdb "numpy>=1.24" pytest
 
       - name: Run grounded semantic diffusion tests
-        run: python3 -m pytest -q tests/test_leaky_diffusion.py
+        run: |
+          python3 -m pytest -q tests/test_leaky_diffusion.py \
+            tests/test_local_grounded_diffusion.py
+          python3 prototypes/mu_cosine/benchmark_local_grounded_diffusion.py --smoke
 
       - name: Run F# WAM target tests (codegen + dotnet smoke + LMDB conformance)
         env:

--- a/docs/design/COST_FUNCTION_PHILOSOPHY.md
+++ b/docs/design/COST_FUNCTION_PHILOSOPHY.md
@@ -299,6 +299,13 @@ Three practical consequences:
    push-based PPR (Andersen-Chung-Lang) does — it bounds the
    work to a local region while remaining mathematically faithful
    to the global Green's function within that region.
+   [LOCAL_GROUNDED_DIFFUSION.md](LOCAL_GROUNDED_DIFFUSION.md) makes the
+   corresponding bath boundary explicit for anchored Green solves: select a
+   frozen hop or semantic-resistance neighborhood, aggregate cut-edge
+   conductance on the diagonal, and retain distributed leakage to set the
+   screening length. This is a reusable numerical operator rather than a new
+   cache-ranking default.
+
 
 3. **Connection to effective resistance**. `V_source − V_sink`
    divided by injected current is the effective resistance
@@ -420,6 +427,8 @@ pluggable; the math is what the new variant brings.
   + hop_distance), P3+ (warm-build + flux)
 - `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` — Phase L / Phase M
   measurements that inform the decision guide
+- `docs/design/LOCAL_GROUNDED_DIFFUSION.md` — bounded Dirichlet Green solves,
+  screening calibration, and boundary diagnostics for massive graphs
 - `src/unifyweaver/core/cost_function.pl` — the registry
 - `templates/targets/haskell_wam/cost_function.hs.mustache` —
   Haskell-side concrete constructors

--- a/docs/design/LEAKY_GRAPH_DIFFUSION.md
+++ b/docs/design/LEAKY_GRAPH_DIFFUSION.md
@@ -14,6 +14,12 @@ covariance. The completed Stage-A repeated-judge source-power experiment
 failed closed and unlocked no candidate enumeration, Nomic use, judge calls,
 covariance deployment, independent batching, QR specialization, or CUDA
 claim. This primitive therefore remains outcome-blind infrastructure.
+For million-node graphs, the bounded Dirichlet construction in
+[LOCAL_GROUNDED_DIFFUSION.md](LOCAL_GROUNDED_DIFFUSION.md) selects an
+outcome-blind topological neighborhood, aggregates every cut edge into an
+explicit bath shunt, and reuses the same operator and precision-root algebra
+on the retained domain.
+
 
 ## Separate topology, semantics, and grounding
 
@@ -230,9 +236,12 @@ union. This primitive does not choose a lineage source.
   behavior are unsuitable. A nonnegative monotone conductance transform is
   explicit and bounded; a positive epsilon is required when every retained
   topological edge must remain numerically present.
-- Arbitrarily choosing distant nodes as ground: supported only when the
-  boundary is externally defined. Uniform weak leakage is the default because
-  defining distant by the metric being estimated would be circular.
+- Arbitrarily choosing distant nodes as ground: rejected. A scalable local
+  model may ground the complete exterior of a frozen hop-distance or
+  Nomic-resistance neighborhood, provided every severed conductance is retained
+  in the Dirichlet cut term. Selecting the boundary with fitted Green distance
+  or outcomes would be circular. Uniform weak leakage remains part of the
+  model inside the local domain.
 - Symmetric normalized Laplacian for the circuit: retained for spectral
   references, but not used for physical KCL. The combinatorial Laplacian
   preserves edge conductance units.
@@ -266,5 +275,7 @@ tests/test_leaky_diffusion.py verifies:
 - direct-constructor invariants, immutable arrays, and fail-closed inputs;
 - absence of any explicit matrix inverse.
 
-The next engineering PR, if warranted, should add sparse operators and a
-matched CPU/GPU crossover benchmark without changing this statistical object.
+The bounded local extension is specified in
+[LOCAL_GROUNDED_DIFFUSION.md](LOCAL_GROUNDED_DIFFUSION.md). Sparse operators
+and any CPU/GPU crossover claim still require a matched full-cost benchmark
+without changing this statistical object.

--- a/docs/design/LOCAL_GROUNDED_DIFFUSION.md
+++ b/docs/design/LOCAL_GROUNDED_DIFFUSION.md
@@ -1,0 +1,364 @@
+# Local grounded diffusion on massive graphs
+
+## Status and scope
+
+This document extends
+[LEAKY_GRAPH_DIFFUSION.md](LEAKY_GRAPH_DIFFUSION.md) from a dense,
+whole-graph correctness reference to a bounded local problem. It specifies the
+neighborhood, boundary condition, screening calibration, and diagnostics that
+must remain invariant across dense, sparse, CPU, and possible future GPU
+backends.
+
+The construction is general graph infrastructure. It does not promote a
+Green kernel to learned measurement covariance, relax the failed Stage-A
+source-power gates, or make a CUDA performance claim.
+
+## Why locality is necessary
+
+A Wikipedia-scale graph can have millions of nodes. A dense float64 matrix on
+one million nodes would require about 8 TB before factorization, and dense
+Cholesky would require cubic work. More accelerator memory does not make that
+whole-graph dense representation a viable default.
+
+Most uses in this project are anchored queries or batches: only the response
+near one or more source nodes is decision relevant. We therefore choose an
+outcome-blind local node set `S`, impose an explicit zero-temperature/grounded
+bath outside it, and solve one positive-definite system on `S`. Locality is a
+modelled boundary condition, not an excuse to silently delete edges.
+
+## Choosing the local domain
+
+Let `A` be the set of query, source, or measurement anchors. Rank nodes by a
+distance `D(A,i)` and retain a deterministic prefix `S_K` containing every
+anchor.
+
+### Primary: graph hop distance
+
+The default is ordinary multi-source shortest hop distance on the fixed graph
+support, with every anchor explicitly assigned distance zero. A truncated BFS
+can stop after the requested budget rather than scanning the whole corpus.
+For non-anchor nodes, this is the same minimum edge-count geometry documented
+by [WAM_TRANSITIVE_DISTANCE3_CONTRACT.md](WAM_TRANSITIVE_DISTANCE3_CONTRACT.md);
+that relation itself intentionally exposes positive distances rather than the
+selector's seeded zero.
+
+Equal-distance nodes need a revision-stable tie rule. If memory permits, keep
+the complete final hop shell; this avoids an arbitrary directional cut around
+a high-degree anchor. A strict `K` cap may split the shell, but must record the
+tie rule and realized boundary. Nested convergence runs must use prefixes of
+one frozen ordering so that
+
+    S_K subset S_2K subset S_4K.
+
+The reference tie key assumes value-like node identifiers with revision-stable
+representations, such as strings and integers. Custom objects must first be
+mapped to stable string or scalar identifiers.
+
+### Secondary: Nomic-resistance weighted shortest path
+
+When a hop shell is too large or heterogeneous, use a weighted shortest-path
+ordering on the same topological edges. For the conductance `c_ij` defined in
+the global diffusion design, set a positive dimensionless edge length such as
+
+    r_ij = c_ref / c_ij
+
+and define `D` by the minimum sum of `r_ij` along a path. The reference scale
+`c_ref` changes units, not ordering. This makes a semantically discordant
+existing edge more resistant; it never creates an embedding-only shortcut.
+Truncated Dijkstra supplies the top prefix. The repository's weighted
+shortest-path machinery is illustrated by
+`examples/benchmark/min_semantic_distance.pl`, although this design uses the
+strictly positive resistance derived from the diffusion conductance rather
+than a raw cosine-distance edge weight.
+
+A revision-pinned Nomic embedding is the preferred secondary geometry because
+e5 is already used by the filing ranker. MiniLM remains a sensitivity check.
+The embedding model, revision, conductance transform, length scale, floor, and
+tie rule are provenance, not tuning details.
+
+The dense reference in `src/unifyweaver/graph/local_diffusion.py` currently
+implements the primary hop selector. The Nomic-resistance Dijkstra ordering is
+a specified adapter/follow-up, not an implemented performance claim in this
+change.
+
+The selector is outcome blind. Effective resistance and the fitted Green
+kernel are not allowed to choose their own local domain: that would require
+solving the object being approximated and would make the approximation
+circular.
+
+## The exact Dirichlet cut
+
+Let `W_SS` contain conductances whose endpoints are both retained, and let
+
+    L_ind = diag(W_SS 1) - W_SS
+
+be the Laplacian of the induced subgraph. For every retained node, aggregate
+all severed conductance into
+
+    beta_i = sum over j not in S of c_ij.
+
+Fixing every exterior node at bath potential zero makes the local Kirchhoff
+equation exactly
+
+    J_S = L_ind + diag(alpha + beta),
+    J_S u_S = q_S.
+
+Equivalently, `J_S` is the principal block of the full grounded precision.
+The `beta` term is the conductance of the cut to the common bath. It is not
+optional bookkeeping: dropping it turns the cut into an insulating Neumann
+boundary, traps flux inside `S`, and generally exaggerates long-range
+influence.
+The optional `bath_temperature` API is a coordinate shift for one common
+bath connected through both `alpha` and `beta`. In absolute coordinates,
+
+    J_S T_S = q_S + (alpha + beta) T_b,
+    T_S = T_b 1 + J_S^-1 q_S.
+
+It does not represent an exterior-only nonzero bath with intrinsic leakage
+held at a different ground; that model would require a separate boundary
+right-hand side.
+
+
+This is exact for the stated Dirichlet boundary, not an exact marginalization
+of unknown exterior values. A Schur complement of the exterior would instead
+create additional, usually dense, couplings among boundary nodes.
+
+The implementation need not enumerate the entire exterior. It only needs the
+incident edges of retained nodes. If total weighted degree
+
+    d_i^c = sum over all j of c_ij
+
+is precomputed, then `beta_i = d_i^c - sum_{j in S} c_ij`; otherwise a boundary
+pass reads the outside endpoints of cut edges. Semantic conductance on a cut
+edge may require the outside endpoint's embedding, but that endpoint does not
+enter the factorization.
+
+### Nonzero grounding remains mandatory
+
+Every positive-conductance component of the induced graph must reach a
+positive entry of `alpha + beta`. A completely retained connected component
+has `beta=0`, so it still needs model leakage `alpha>0`. An ungrounded
+component fails closed; numerical jitter may not substitute for a bath.
+
+## Screening and leakage calibration
+
+For source `s`, let
+
+    G_alpha = J_S(alpha)^-1,
+    h_s(i; alpha) = G_alpha(i,s) / G_alpha(s,s).
+
+The normalized column `h_s` has `h_s(s)=1`. On nodes other than `s` it solves
+the killed harmonic equation. Probabilistically, it is the chance that a
+continuous-time graph walk reaches `s` before distributed leakage or the
+Dirichlet cut absorbs it. Electrically, it is the voltage relative to the
+source voltage. This gives an attenuation target without correlation scaling.
+
+With a uniform `alpha`, increasing `alpha` couples the walk to an earlier
+killing clock. Consequently `h_s(i;alpha)` is nonincreasing for every
+`i != s`, and so is its maximum on any frozen calibration shell. Bracketed
+bisection can therefore choose the smallest `alpha` satisfying
+
+    max over s in A, i in F_e(s) of h_s(i;alpha) <= exp(-1),
+
+where `F_e` is the preregistered e-fold shell and lies strictly inside the
+truncation boundary. Since `R_leak=1/alpha`, this selects the largest leakage
+resistance that still meets the attenuation target, avoiding unnecessary
+over-grounding. If the upper bracket violates the float64 conditioning or
+physical-scale contract, calibration fails rather than adding hidden jitter.
+Calibration uses the raw Green response ratio; unit-diagonal correlation
+normalization does not have the required monotone interpretation.
+
+### Chain initializer
+
+On an infinite regular chain with edge conductance `c`, uniform leakage
+`alpha`, and hop radius `R_e`, the response has form `exp(-kappa r)` with
+
+    cosh(kappa) = 1 + alpha/(2c).
+
+Setting `kappa=1/R_e` gives the exact one-dimensional initializer
+
+    alpha_0 = 2c [cosh(1/R_e) - 1]
+            approximately c/R_e^2.
+
+Using a robust typical internal conductance for `c` supplies a bracket seed,
+not a final calibration on an irregular graph.
+
+### Screening radius is not truncation radius
+
+`R_e` is the distance at which influence falls to `exp(-1)`, about 0.368. A
+hard zero bath at that same distance can still be a substantial perturbation.
+When accuracy rather than only a fixed memory cap determines the boundary,
+put the hard bath farther away:
+
+- `3 R_e` leaves the chain envelope at `exp(-3)`, about 0.050;
+- `4.6 R_e` leaves it near one percent.
+
+Thus use the e-fold shell to calibrate leakage and a farther shell or larger
+`K` to control truncation. A strict resource budget may force a nearer bath;
+the diagnostics below then quantify, rather than conceal, its influence.
+
+## Boundary-error diagnostics
+
+Diagnostics are evaluated per anchor and jointly over a batch. They are part
+of the result provenance.
+
+### Maximum-principle envelope
+
+For nonnegative sources, the Dirichlet local solution is a lower bound on the
+restriction of the full positive solution. If all omitted boundary voltages
+are at most `M`, the error `e` satisfies
+
+    0 <= e <= M p,
+    p = J_S^-1 beta.
+
+Here `p_i` is the killed-walk harmonic measure of the artificial cut: the
+probability of reaching the cut before model leakage, under the local
+continuous-time interpretation. Because `J_S` is a grounded M-matrix,
+`0 <= p_i <= 1`. Report `p` at every anchor and its maximum on the scored
+region. It is an outcome-independent sensitivity envelope even when `M` is
+not known tightly.
+
+### Cut current
+
+For a maintained nonnegative source and zero exterior bath, report
+
+    I_cut = sum_i beta_i u_i,
+    I_leak = sum_i alpha_i u_i.
+
+Kirchhoff balance gives `sum_i q_i = I_cut + I_leak`, up to numerical error.
+The fraction `I_cut / sum(q)` says how much injected flux is absorbed by the
+artificial hard boundary rather than the intended distributed leakage. Large
+cut fraction requests a larger domain; it is not repaired by relabelling the
+boundary as harmless.
+
+### Nested-domain convergence
+
+Calibrate `alpha` once on the frozen largest reference domain, then hold it
+fixed while solving the nested domains `K`, `2K`, and `4K` with the same
+conductance model. For nonnegative sources, raw Dirichlet voltages
+on common nodes obey domain monotonicity:
+
+    u_K <= u_2K <= u_4K <= u_full.
+
+Report relative changes on anchors and the scored inner region. The ordering
+is a useful implementation invariant. It need not hold after dividing each
+column by its changing diagonal, so normalized Green correlations and
+effective resistances receive separate convergence summaries rather than a
+false monotonicity claim.
+
+## Multiple anchors and positive semidefiniteness
+
+For a batch of anchors, form one shared domain from the union of their frozen
+neighborhoods, or use one multi-source top-`K` ordering. Build one `J_S`, one
+factor, and one Green kernel on that domain. This preserves symmetry and
+positive definiteness for all cross-anchor entries.
+
+Factoring a different local system for each anchor and splicing the resulting
+columns together does not, in general, produce a symmetric or PSD matrix. A
+per-anchor solve may be used for independent routing scores, but not to claim
+one joint covariance or precision root.
+
+Record requested `K`, realized union size, per-anchor coverage, cut size, and
+whether a complete distance shell was retained. Batch construction must be
+independent of downstream labels.
+
+## Computational contract and scale path
+
+For a retained domain with `K` nodes and `E_S` internal edges:
+
+- truncated multi-source BFS costs `O(K + E_touched)`;
+- weighted selection uses truncated Dijkstra and a priority queue;
+- boundary aggregation touches incident cut edges, or uses precomputed
+  weighted degrees;
+- sparse assembly stores `O(K + E_S)` entries;
+- the current dense factor remains a small-`K` correctness oracle.
+
+A strict node cap bounds the dense algebra, not necessarily
+`E_touched`. The current correctness selector materializes the complete
+incident list of each retained node, so a million-neighbor hub can still
+require universe-scale preprocessing. Likewise, requesting a complete final
+shell can realize far more than `K` nodes. Production use on such graphs
+requires an indexed/streaming top-`K` neighbor adapter and precomputed
+weighted-degree or cut-conductance aggregation. Until that path exists, report
+maximum touched degree and do not call preprocessing `O(K)`.
+
+The included CPU microbenchmark intentionally uses a constant-degree implicit
+million-node universe; it proves absence of a global node scan in that regime,
+not a hub-safe or deployment-latency result.
+
+Sparse Cholesky is the first direct-solver candidate, but its cost depends on
+fill-in and elimination order rather than only `K`. Selected equilibrium
+columns can instead use preconditioned conjugate gradients; heat action can
+use Lanczos or Chebyshev methods. Hierarchical domains, graph partitions,
+multigrid, and spectral sparsifiers are later options if one local domain is
+still too large.
+
+A GPU is not automatically faster. Truncated graph traversal is irregular,
+sparse factorization can be fill-bound, and host/device transfer matters. Any
+CUDA specialization requires a matched full-cost benchmark including
+neighborhood selection, embedding access, boundary aggregation, assembly,
+factorization or iteration, diagnostics, and transfers. Until then the API
+records backend facts and makes no CUDA crossover claim.
+
+## Implementation invariants
+
+An implementation of local grounded diffusion must:
+
+1. accept an explicit, deterministic retained node ordering or domain;
+2. compute and expose nonnegative `beta` rather than discard cut edges;
+3. build `J_S = L_ind + diag(alpha + beta)` and verify the grounded-component
+   and reciprocal-condition contracts from the global design;
+4. retain the Cholesky/solve-first interface and never require an explicit
+   inverse for primary computation;
+5. expose killed-response, harmonic-measure, cut-current, and nested-domain
+   diagnostics with finite-value and Kirchhoff-residual checks;
+6. keep model leakage, Dirichlet cut conductance, and any future numerical
+   jitter as three separately named quantities;
+7. preserve the node map, selector provenance, requested and realized `K`,
+   and boundary statistics; and
+8. compare small local systems against the whole-graph dense reference.
+
+## Rejected and deferred alternatives
+
+- **Delete cut edges:** rejected because it creates an insulating boundary and
+  overstates retained influence. Aggregate them into `beta`.
+- **Use the whole graph densely:** rejected by quadratic memory and cubic
+  factorization before any million-node experiment begins.
+- **Embedding-only nearest neighbors:** rejected as the default domain because
+  they can jump across graph topology. Semantics may weight existing paths.
+- **Let Green distance choose `S`:** rejected as circular and expensive. Use a
+  cheaper frozen `D` before solving.
+- **Hard-boundary calibration at `exp(-1)` alone:** acceptable only as an
+  explicit resource compromise. Prefer a farther `exp(-3)` or one-percent
+  truncation boundary and verify nested convergence.
+- **Drop distributed leakage after adding the cut bath:** rejected. `beta`
+  represents truncation; `alpha` represents the intended finite correlation
+  range and also grounds a fully retained component.
+- **Correlation-normalized calibration:** rejected because its changing
+  diagonal obscures the killed-walk monotonicity used by bisection.
+- **One local matrix per anchor for joint inference:** rejected because the
+  assembled cross-anchor object need not be symmetric or PSD.
+- **Exact exterior Schur complement by default:** deferred because it destroys
+  strict locality through fill and models an integrated exterior, not the
+  requested fixed-temperature bath.
+- **Tune `D`, `K`, or `alpha` against held outcomes:** rejected. Geometry and
+  numerical accuracy are selected outcome blind; any later statistical use
+  still requires train-only fitting and held, dependence-aware validation.
+- **Immediate sparse/GPU or covariance promotion:** deferred pending separate
+  correctness, full-cost crossover, and statistical gates.
+
+## Cross-references
+
+- [LEAKY_GRAPH_DIFFUSION.md](LEAKY_GRAPH_DIFFUSION.md) — whole-graph physical
+  operator, Green kernel, effective resistance, and precision-root algebra.
+- [COST_FUNCTION_PHILOSOPHY.md](COST_FUNCTION_PHILOSOPHY.md) — hop, semantic,
+  and local-exact graph scoring in the broader cost-function design space.
+- [WAM_TRANSITIVE_DISTANCE3_CONTRACT.md](WAM_TRANSITIVE_DISTANCE3_CONTRACT.md)
+  — fleet-wide shortest positive hop-distance semantics.
+- `examples/benchmark/min_semantic_distance.pl` — existing weighted
+  shortest-path/Dijkstra specification surface.
+- `prototypes/mu_cosine/benchmark_local_grounded_diffusion.py` —
+  compute-only CPU scaling and memory estimates on an implicit million-node
+  universe.
+- `prototypes/mu_cosine/DECISIONS_graph_geometry.md` — experiment-specific
+  authorization boundaries and geometry decisions.

--- a/prototypes/mu_cosine/DECISIONS_graph_geometry.md
+++ b/prototypes/mu_cosine/DECISIONS_graph_geometry.md
@@ -288,3 +288,50 @@ claim.
 crossover benchmark. Statistical use as cross-item measurement covariance
 still requires new prospective data or a separately authorized design with
 train-only fitting and dependence-aware held validation.
+
+## 2026-07-17 — local Dirichlet grounding for million-node graphs
+
+**Decision:** bound anchored diffusion with an outcome-blind top-`K` graph
+domain. Use multi-source hop distance as the primary ordering and a
+revision-pinned Nomic-resistance weighted shortest path as the secondary
+ordering. For retained set `S`, preserve every severed edge through
+`beta_i=sum_{j not in S} c_ij` and solve
+`J_S=L_ind+diag(alpha+beta)`. The exterior is one fixed zero-temperature bath;
+it is not silently deleted.
+
+**Calibration:** choose uniform model leakage from the killed-response ratio
+`G_alpha(i,s)/G_alpha(s,s)`, targeting at most `exp(-1)` on a frozen e-fold
+shell. Treat that as a screening length, not automatically an accurate hard
+truncation: prefer a boundary near `exp(-3)` or one-percent attenuation when
+the memory budget permits. Verify `K`, `2K`, and `4K` nested-domain
+stability, harmonic measure of the artificial cut, and the fraction of
+injected current absorbed by the cut.
+
+**Batch consequence:** construct one shared union or multi-source domain and
+one grounded operator for all anchors whose cross-relations are used jointly.
+Splicing columns from separate anchor-specific operators is not guaranteed
+symmetric or PSD.
+
+**Reason:** a million-node dense float64 matrix is already about 8 TB before
+factorization. The local Dirichlet system preserves the physical meaning of
+the omitted adjacency while making work depend on the touched neighborhood.
+It also supplies monotone, outcome-blind diagnostics for deciding whether the
+boundary is far enough away.
+
+**Rejected:** dropping cut edges and thereby imposing an insulating boundary;
+embedding-only nearest neighbors that create topological shortcuts; selecting
+`S` with the fitted Green distance; using correlation-normalized response to
+calibrate leakage; setting `alpha=0` merely because a cut bath exists;
+per-anchor matrices presented as one joint kernel; or tuning `D`, `K`, or
+`alpha` against held residual outcomes.
+
+**Implementation status:** this change ships the strict-`K` multi-source hop
+selector, exact cut-shunt assembly, common-bath dense factor, leakage
+calibration, and nested-domain diagnostics. It also ships a constant-degree
+CPU microbenchmark. Nomic-resistance Dijkstra, hub-streaming adjacency,
+precomputed weighted cut degrees, sparse solvers, and CUDA remain follow-ups.
+
+**Not authorized:** learned judge covariance, relaxed source-power gates,
+sparse/CUDA performance claims, or hidden numerical jitter. Sparse direct and
+iterative backends remain engineering candidates only after parity with the
+dense local reference and a matched end-to-end crossover benchmark.

--- a/prototypes/mu_cosine/benchmark_local_grounded_diffusion.py
+++ b/prototypes/mu_cosine/benchmark_local_grounded_diffusion.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Deterministic CPU scaling benchmark for query-local grounded diffusion.
+
+The benchmark deliberately represents a potentially million-node graph through
+an O(1) incident-neighbor provider.  Query-local BFS therefore touches only K
+retained nodes and their fixed-degree adjacency.  The omitted exterior is not
+discarded: every cut edge becomes a Dirichlet shunt to the common bath, exactly
+as in :mod:`unifyweaver.graph.local_diffusion`.
+
+The measured phases are kept distinct:
+
+``domain_ms``
+    deterministic multi-source BFS and local-domain validation;
+``assembly_ms``
+    unit-conductance dense precision assembly, including cut-edge shunts;
+``cholesky_ms``
+    raw dense Cholesky factorization of that precision;
+``pipeline_build_ms``
+    the complete validated reference builder (useful for measuring current
+    implementation overhead beyond the raw phases); and
+``solve_ms``
+    one equilibrium solve through the stored reference precision root.
+
+The implicit provider makes traversal independent of the total node universe
+apart from integer identifier arithmetic.  Dense local algebra is still
+quadratic in memory and cubic in K for factorization.  Locality consequently
+makes a million-node *universe* feasible; it does not make a million-node dense
+retained domain feasible.  For one million float64 nodes, one dense matrix is
+about 7.28 TiB, while the current four-matrix reference model needs at least
+about 29.1 TiB before temporaries.
+
+This is a compute-only microbenchmark, not a deployment latency claim.  The
+synthetic graph has constant degree, unit edge conductance, one anchor, and no
+embedding lookup or storage cost.  Timings are median/MAD across independent
+trials.  The current reference solve calls ``numpy.linalg.solve`` on triangular
+roots; an optimized triangular BLAS path should have O(K^2) work, but the
+reported solve time intentionally measures the implementation that exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import math
+import os
+from pathlib import Path
+import statistics
+import sys
+import time
+from typing import Callable
+
+import numpy as np
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from unifyweaver.graph.local_diffusion import (  # noqa: E402
+    build_local_grounded_semantic_diffusion,
+    select_hop_local_domain,
+)
+
+
+_FLOAT64_BYTES = np.dtype(np.float64).itemsize
+_MIB = 1024.0**2
+_TIB = 1024.0**4
+
+
+@dataclass(frozen=True)
+class Timing:
+    median_ms: float
+    mad_ms: float
+
+
+class ImplicitCirculantGraph:
+    """A fixed-degree undirected graph with no O(N) materialized state."""
+
+    def __init__(self, node_count: int, degree: int):
+        if node_count < 3:
+            raise ValueError("node_count must be at least 3")
+        if degree < 2 or degree % 2:
+            raise ValueError("degree must be a positive even integer")
+        if degree >= node_count:
+            raise ValueError("degree must be smaller than node_count")
+        self.node_count = node_count
+        self.degree = degree
+        self.calls = 0
+
+    def __call__(self, node: int) -> tuple[int, ...]:
+        if not 0 <= node < self.node_count:
+            raise KeyError(node)
+        self.calls += 1
+        half = self.degree // 2
+        neighbors = {
+            (node + offset) % self.node_count
+            for offset in range(1, half + 1)
+        }
+        neighbors.update(
+            (node - offset) % self.node_count
+            for offset in range(1, half + 1)
+        )
+        return tuple(sorted(neighbors))
+
+
+def _csv_positive_ints(value: str) -> list[int]:
+    try:
+        values = [int(part.strip()) for part in value.split(",") if part.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "expected comma-separated positive integers"
+        ) from exc
+    if not values or any(item <= 0 for item in values):
+        raise argparse.ArgumentTypeError(
+            "expected comma-separated positive integers"
+        )
+    return values
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected a positive integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("expected a positive integer")
+    return parsed
+
+
+def _nonnegative_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected a nonnegative integer") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("expected a nonnegative integer")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "expected a positive finite number"
+        ) from exc
+    if not math.isfinite(parsed) or parsed <= 0.0:
+        raise argparse.ArgumentTypeError("expected a positive finite number")
+    return parsed
+
+
+def _median_mad(values: list[float]) -> Timing:
+    median = statistics.median(values)
+    mad = statistics.median(abs(value - median) for value in values)
+    return Timing(median_ms=median, mad_ms=mad)
+
+
+def _time_callable(
+    function: Callable[[], object],
+    *,
+    warmups: int,
+    trials: int,
+    inner_repeats: int = 1,
+) -> Timing:
+    for _ in range(warmups):
+        output = function()
+        del output
+
+    elapsed_ms: list[float] = []
+    for _ in range(trials):
+        start = time.perf_counter()
+        for _ in range(inner_repeats):
+            output = function()
+            del output
+        elapsed_ms.append(
+            1000.0 * (time.perf_counter() - start) / inner_repeats
+        )
+    return _median_mad(elapsed_ms)
+
+
+def _select_domain(universe_nodes: int, degree: int, retained_nodes: int):
+    graph = ImplicitCirculantGraph(universe_nodes, degree)
+    domain = select_hop_local_domain(
+        (0,),
+        graph,
+        maximum_nodes=retained_nodes,
+    )
+    return domain, graph.calls
+
+
+def _assemble_unit_precision(domain, intrinsic_leakage: float) -> np.ndarray:
+    """Assemble the unit-edge Dirichlet precision without factorization.
+
+    This is the no-embedding branch of the production local builder, split out
+    here solely so assembly and factorization can be timed independently.
+    """
+
+    nodes = domain.nodes
+    index = {node: row for row, node in enumerate(nodes)}
+    conductance = np.zeros((len(nodes), len(nodes)), dtype=np.float64)
+    cut_conductance = np.zeros(len(nodes), dtype=np.float64)
+    for left, incident in zip(nodes, domain.neighbors):
+        left_row = index[left]
+        for right in incident:
+            right_row = index.get(right)
+            if right_row is None:
+                cut_conductance[left_row] += 1.0
+            else:
+                conductance[left_row, right_row] = 1.0
+                conductance[right_row, left_row] = 1.0
+
+    precision = np.diag(np.sum(conductance, axis=1)) - conductance
+    diagonal = np.diag_indices_from(precision)
+    precision[diagonal] += intrinsic_leakage + cut_conductance
+    return precision
+
+
+def _environment_identity() -> str:
+    keys = (
+        "OPENBLAS_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "OMP_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+    )
+    values = [f"{key}={os.environ[key]}" for key in keys if key in os.environ]
+    return ";".join(values) if values else "not_pinned"
+
+
+def _run_size(
+    *,
+    retained_nodes: int,
+    universe_nodes: int,
+    degree: int,
+    intrinsic_leakage: float,
+    warmups: int,
+    trials: int,
+    solve_repeats: int,
+) -> str:
+    domain_timing = _time_callable(
+        lambda: _select_domain(universe_nodes, degree, retained_nodes),
+        warmups=warmups,
+        trials=trials,
+    )
+    domain, provider_calls = _select_domain(
+        universe_nodes, degree, retained_nodes
+    )
+    if len(domain.nodes) != retained_nodes:
+        raise RuntimeError(
+            f"implicit graph selected {len(domain.nodes)} nodes instead of K="
+            f"{retained_nodes}"
+        )
+
+    assembly_timing = _time_callable(
+        lambda: _assemble_unit_precision(domain, intrinsic_leakage),
+        warmups=warmups,
+        trials=trials,
+    )
+    precision = _assemble_unit_precision(domain, intrinsic_leakage)
+    cholesky_timing = _time_callable(
+        lambda: np.linalg.cholesky(precision),
+        warmups=warmups,
+        trials=trials,
+    )
+
+    pipeline_timing = _time_callable(
+        lambda: build_local_grounded_semantic_diffusion(
+            domain,
+            intrinsic_leakage_conductance=intrinsic_leakage,
+        ),
+        warmups=warmups,
+        trials=trials,
+    )
+    model = build_local_grounded_semantic_diffusion(
+        domain,
+        intrinsic_leakage_conductance=intrinsic_leakage,
+    )
+    if not np.array_equal(precision, model.precision):
+        maximum_error = float(np.max(np.abs(precision - model.precision)))
+        raise RuntimeError(
+            "split assembly does not match the production local precision; "
+            f"maximum absolute error={maximum_error:.3e}"
+        )
+
+    source = np.zeros(retained_nodes, dtype=np.float64)
+    source[0] = 1.0
+    solve_timing = _time_callable(
+        lambda: model.equilibrium_response(source),
+        warmups=warmups,
+        trials=trials,
+        inner_repeats=solve_repeats,
+    )
+    response = model.equilibrium_response(source)
+    residual = float(np.linalg.norm(model.precision @ response - source, ord=np.inf))
+
+    one_dense_mib = _FLOAT64_BYTES * retained_nodes**2 / _MIB
+    reference_persistent_mib = 4.0 * one_dense_mib
+    assembly_working_mib = 3.0 * one_dense_mib
+    full_one_dense_tib = _FLOAT64_BYTES * universe_nodes**2 / _TIB
+    full_reference_tib = 4.0 * full_one_dense_tib
+    retained_fraction_ppm = 1.0e6 * retained_nodes / universe_nodes
+    cholesky_flops = retained_nodes**3 / 3.0
+
+    return (
+        f"{retained_nodes},{universe_nodes},{degree},{provider_calls},"
+        f"{retained_fraction_ppm:.6f},"
+        f"{domain_timing.median_ms:.6f},{domain_timing.mad_ms:.6f},"
+        f"{assembly_timing.median_ms:.6f},{assembly_timing.mad_ms:.6f},"
+        f"{cholesky_timing.median_ms:.6f},{cholesky_timing.mad_ms:.6f},"
+        f"{pipeline_timing.median_ms:.6f},{pipeline_timing.mad_ms:.6f},"
+        f"{solve_timing.median_ms:.6f},{solve_timing.mad_ms:.6f},"
+        f"{one_dense_mib:.6f},{assembly_working_mib:.6f},"
+        f"{reference_persistent_mib:.6f},{full_one_dense_tib:.6f},"
+        f"{full_reference_tib:.6f},{cholesky_flops:.3f},{residual:.9e}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--k-values",
+        type=_csv_positive_ints,
+        default=_csv_positive_ints("16,32,64,128"),
+        help="comma-separated retained-domain sizes",
+    )
+    parser.add_argument(
+        "--universe-nodes",
+        type=_positive_int,
+        default=1_000_000,
+        help="implicit graph size; no O(N) graph is allocated",
+    )
+    parser.add_argument(
+        "--degree",
+        type=_positive_int,
+        default=6,
+        help="even degree of the implicit circulant graph",
+    )
+    parser.add_argument(
+        "--intrinsic-leakage",
+        type=_positive_float,
+        default=0.1,
+        help="uniform intrinsic conductance to the common ground",
+    )
+    parser.add_argument("--warmups", type=_nonnegative_int, default=1)
+    parser.add_argument("--trials", type=_positive_int, default=5)
+    parser.add_argument(
+        "--solve-repeats",
+        type=_positive_int,
+        default=3,
+        help="inner repeats per solve timing trial",
+    )
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="override sizes/repeats with a quick 8,16,32-node validation run",
+    )
+    args = parser.parse_args()
+
+    if args.smoke:
+        args.k_values = [8, 16, 32]
+        args.warmups = 0
+        args.trials = 2
+        args.solve_repeats = 1
+    if args.degree < 2 or args.degree % 2:
+        parser.error("--degree must be an even integer of at least 2")
+    if args.degree >= args.universe_nodes:
+        parser.error("--degree must be smaller than --universe-nodes")
+    if max(args.k_values) >= args.universe_nodes:
+        parser.error("every K must be smaller than --universe-nodes")
+
+    print("# Query-local grounded diffusion CPU scaling benchmark")
+    print("# compute-only synthetic microbenchmark; not deployment latency")
+    print(
+        "# implicit fixed-degree universe: traversal touches only retained nodes; "
+        "the global graph is not materialized"
+    )
+    print(
+        "# dense local factorization remains O(K^3) time and O(K^2) memory; "
+        "million-node dense domains remain infeasible"
+    )
+    print(
+        "# reference_persistent_mib counts conductance, Laplacian, precision, "
+        "and precision-root arrays; temporaries are excluded"
+    )
+    print(
+        "# assembly_working_mib is a three-dense-array estimate, not measured "
+        "peak RSS"
+    )
+    print(
+        "# solve_ms measures the current numpy.linalg.solve-based stored-root path; "
+        "ideal triangular solves are O(K^2)"
+    )
+    print(f"# numpy={np.__version__}; blas_threads={_environment_identity()}")
+    print(
+        "k,universe_nodes,degree,provider_calls,retained_fraction_ppm,"
+        "domain_median_ms,domain_mad_ms,assembly_median_ms,assembly_mad_ms,"
+        "cholesky_median_ms,cholesky_mad_ms,pipeline_build_median_ms,"
+        "pipeline_build_mad_ms,solve_median_ms,solve_mad_ms,one_dense_mib,"
+        "assembly_working_mib,reference_persistent_mib,full_one_dense_tib,"
+        "full_reference_tib,cholesky_flop_estimate,residual_inf"
+    )
+    for retained_nodes in args.k_values:
+        print(
+            _run_size(
+                retained_nodes=retained_nodes,
+                universe_nodes=args.universe_nodes,
+                degree=args.degree,
+                intrinsic_leakage=args.intrinsic_leakage,
+                warmups=args.warmups,
+                trials=args.trials,
+                solve_repeats=args.solve_repeats,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/unifyweaver/graph/__init__.py
+++ b/src/unifyweaver/graph/__init__.py
@@ -6,10 +6,28 @@ from .leaky_diffusion import (
     combinatorial_laplacian,
     semantic_conductance_matrix,
 )
+from .local_diffusion import (
+    LeakageCalibrationResult,
+    LocalDiffusionDomain,
+    LocalGroundedSemanticDiffusion,
+    NestedDomainDiagnostics,
+    build_local_grounded_semantic_diffusion,
+    calibrate_uniform_leakage,
+    compare_nested_domains,
+    select_hop_local_domain,
+)
 
 __all__ = [
     "GroundedSemanticDiffusion",
     "build_grounded_semantic_diffusion",
+    "LeakageCalibrationResult",
+    "LocalDiffusionDomain",
+    "LocalGroundedSemanticDiffusion",
+    "NestedDomainDiagnostics",
+    "build_local_grounded_semantic_diffusion",
+    "calibrate_uniform_leakage",
+    "compare_nested_domains",
+    "select_hop_local_domain",
     "combinatorial_laplacian",
     "semantic_conductance_matrix",
 ]

--- a/src/unifyweaver/graph/leaky_diffusion.py
+++ b/src/unifyweaver/graph/leaky_diffusion.py
@@ -539,35 +539,21 @@ class GroundedSemanticDiffusion:
         return distance_squared if squared else np.sqrt(distance_squared)
 
 
-def build_grounded_semantic_diffusion(
+def _build_grounded_semantic_diffusion_from_components(
     nodes,
-    neighbors,
+    conductance,
+    laplacian,
     *,
     leakage_conductance,
-    node_embeddings=None,
-    length_scale=None,
-    conductance_floor=0.0,
+    semantic_length_scale,
+    conductance_floor,
     minimum_reciprocal_condition=_DEFAULT_MINIMUM_RECIPROCAL_CONDITION,
 ):
-    """Build a grounded diffusion model without a covariance inversion.
+    """Build one model from a single validated component snapshot."""
 
-    Leakage may be uniform, a node-aligned vector, or a sparse node mapping.
-    Zero leakage at some nodes is allowed only when the resulting grounded
-    precision is positive definite (every connected component must reach
-    ground).  Failure is explicit; no numerical diagonal loading is hidden.
-    The default float64 contract also requires reciprocal spectral condition
-    at least sqrt(machine epsilon); a caller-supplied weaker threshold is
-    explicit and recorded on the returned model.
-    """
-
-    nodes, conductance = semantic_conductance_matrix(
-        nodes,
-        neighbors,
-        node_embeddings,
-        length_scale=length_scale,
-        conductance_floor=conductance_floor,
-    )
-    laplacian = combinatorial_laplacian(conductance)
+    nodes = _nodes(nodes)
+    conductance = np.asarray(conductance, dtype=float)
+    laplacian = np.asarray(laplacian, dtype=float)
     leakage = _leakage_vector(nodes, leakage_conductance)
     minimum_reciprocal_condition = _positive_unit_interval(
         "minimum_reciprocal_condition", minimum_reciprocal_condition
@@ -629,8 +615,48 @@ def build_grounded_semantic_diffusion(
         condition_number=maximum / minimum,
         reciprocal_condition_number=reciprocal_condition,
         minimum_reciprocal_condition=minimum_reciprocal_condition,
+        semantic_length_scale=semantic_length_scale,
+        conductance_floor=float(conductance_floor),
+    )
+
+
+def build_grounded_semantic_diffusion(
+    nodes,
+    neighbors,
+    *,
+    leakage_conductance,
+    node_embeddings=None,
+    length_scale=None,
+    conductance_floor=0.0,
+    minimum_reciprocal_condition=_DEFAULT_MINIMUM_RECIPROCAL_CONDITION,
+):
+    """Build a grounded diffusion model without a covariance inversion.
+
+    Leakage may be uniform, a node-aligned vector, or a sparse node mapping.
+    Zero leakage at some nodes is allowed only when the resulting grounded
+    precision is positive definite (every connected component must reach
+    ground). Failure is explicit; no numerical diagonal loading is hidden.
+    The default float64 contract also requires reciprocal spectral condition
+    at least sqrt(machine epsilon); a caller-supplied weaker threshold is
+    explicit and recorded on the returned model.
+    """
+
+    nodes, conductance = semantic_conductance_matrix(
+        nodes,
+        neighbors,
+        node_embeddings,
+        length_scale=length_scale,
+        conductance_floor=conductance_floor,
+    )
+    laplacian = combinatorial_laplacian(conductance)
+    return _build_grounded_semantic_diffusion_from_components(
+        nodes,
+        conductance,
+        laplacian,
+        leakage_conductance=leakage_conductance,
         semantic_length_scale=(
             None if node_embeddings is None else float(length_scale)
         ),
         conductance_floor=float(conductance_floor),
+        minimum_reciprocal_condition=minimum_reciprocal_condition,
     )

--- a/src/unifyweaver/graph/local_diffusion.py
+++ b/src/unifyweaver/graph/local_diffusion.py
@@ -1,0 +1,1106 @@
+"""Query-local Dirichlet domains for grounded semantic diffusion.
+
+The global graph may be arbitrarily large.  This module retains a bounded,
+topology-connected node set, clamps the omitted exterior to a common bath, and
+reuses the dense grounded-diffusion implementation as a small-domain
+correctness backend.
+
+For retained nodes S, every omitted edge contributes its conductance to a
+boundary shunt,
+
+    beta_i = sum_{j outside S} c_ij,
+
+so the local precision is the exact Dirichlet principal block
+
+    J_S = L(W_SS) + diag(alpha + beta).
+
+The inverse of this operator is a conditional/bath-clamped Green kernel.  It
+is not the marginal principal block of the full Green kernel, which would
+require a Schur complement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Mapping
+
+import numpy as np
+
+from .leaky_diffusion import (
+    GroundedSemanticDiffusion,
+    _DEFAULT_MINIMUM_RECIPROCAL_CONDITION,
+    _embedding_matrix,
+    _positive_finite,
+    _positive_unit_interval,
+    _stable_radial_factor,
+    _unit_interval,
+    _build_grounded_semantic_diffusion_from_components,
+    combinatorial_laplacian,
+    semantic_conductance_matrix,
+)
+
+
+__all__ = [
+    "LeakageCalibrationResult",
+    "LocalDiffusionDomain",
+    "LocalGroundedSemanticDiffusion",
+    "NestedDomainDiagnostics",
+    "build_local_grounded_semantic_diffusion",
+    "calibrate_uniform_leakage",
+    "compare_nested_domains",
+    "select_hop_local_domain",
+]
+
+
+def _stable_key(value):
+    return (type(value).__module__, type(value).__qualname__, repr(value))
+
+
+def _positive_integer(name, value):
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer")
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+    if result != value or result <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return result
+
+
+def _finite_scalar(name, value):
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be finite") from exc
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _readonly(value, *, dtype=float):
+    output = np.array(value, dtype=dtype, copy=True)
+    output.setflags(write=False)
+    return output
+
+
+def _canonical_unique(values, *, name):
+    raw = tuple(values)
+    if not raw:
+        raise ValueError(f"{name} must be non-empty")
+    try:
+        result = tuple(sorted(set(raw), key=_stable_key))
+    except TypeError as exc:
+        raise ValueError(f"{name} must contain hashable nodes") from exc
+    return result
+
+
+def _read_incident_neighbors(provider, node):
+    try:
+        if callable(provider):
+            values = provider(node)
+        elif isinstance(provider, Mapping):
+            # An explicit empty value denotes a genuine isolate.  A missing
+            # key is incomplete adjacency and must not silently delete edges.
+            values = provider[node]
+        else:
+            raise TypeError(
+                "incident-neighbor provider must be callable or a mapping"
+            )
+    except (KeyError, TypeError) as exc:
+        raise ValueError(f"unable to read incident neighbors for {node!r}") from exc
+    if values is None:
+        values = ()
+    try:
+        result = tuple(
+            sorted({value for value in values if value != node}, key=_stable_key)
+        )
+    except TypeError as exc:
+        raise ValueError("incident neighbor identifiers must be hashable") from exc
+    return result
+
+
+@dataclass(frozen=True)
+class LocalDiffusionDomain:
+    """A deterministic hop-local domain with complete incident adjacency."""
+
+    nodes: tuple
+    anchors: tuple
+    hop_distance: np.ndarray
+    neighbors: tuple
+    maximum_nodes: int
+    complete_distance_shell: bool
+    truncated_tie_count: int
+    selection_metric: str = "hop_distance"
+
+    def __post_init__(self):
+        nodes = tuple(self.nodes)
+        anchors = tuple(self.anchors)
+        if not nodes:
+            raise ValueError("nodes must be non-empty and unique")
+        if not anchors:
+            raise ValueError("anchors must be non-empty and unique")
+        try:
+            node_index = {node: row for row, node in enumerate(nodes)}
+            anchor_set = set(anchors)
+        except TypeError as exc:
+            raise ValueError("nodes and anchors must be hashable") from exc
+        if len(node_index) != len(nodes):
+            raise ValueError("nodes must be non-empty and unique")
+        if len(anchor_set) != len(anchors):
+            raise ValueError("anchors must be non-empty and unique")
+        if not anchor_set.issubset(node_index):
+            raise ValueError("every anchor must be retained")
+        maximum_nodes = _positive_integer("maximum_nodes", self.maximum_nodes)
+        if len(anchors) > maximum_nodes:
+            raise ValueError("maximum_nodes must retain every anchor")
+        complete = bool(self.complete_distance_shell)
+        if len(nodes) > maximum_nodes and not complete:
+            raise ValueError("a hard-K domain cannot exceed maximum_nodes")
+        try:
+            truncated = int(self.truncated_tie_count)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "truncated_tie_count must be a nonnegative integer"
+            ) from exc
+        if truncated != self.truncated_tie_count or truncated < 0:
+            raise ValueError("truncated_tie_count must be a nonnegative integer")
+        if complete and truncated:
+            raise ValueError("a complete distance shell cannot report truncated ties")
+
+        raw_distance = np.asarray(self.hop_distance)
+        if raw_distance.shape != (len(nodes),):
+            raise ValueError("hop_distance must align with nodes")
+        if not np.issubdtype(raw_distance.dtype, np.integer):
+            if not np.isfinite(raw_distance).all() or not np.equal(
+                raw_distance, np.floor(raw_distance)
+            ).all():
+                raise ValueError("hop_distance must contain nonnegative integers")
+        distance = np.asarray(raw_distance, dtype=np.int64)
+        if np.any(distance < 0):
+            raise ValueError("hop_distance must contain nonnegative integers")
+        if any(distance[node_index[anchor]] != 0 for anchor in anchors):
+            raise ValueError("anchors must have hop distance zero")
+        if np.any(distance[:-1] > distance[1:]):
+            raise ValueError("nodes must be ordered by nondecreasing hop distance")
+        if (
+            len(nodes) > maximum_nodes
+            and distance[maximum_nodes - 1] != distance[-1]
+        ):
+            raise ValueError("nodes beyond maximum_nodes must complete one shell")
+
+        raw_neighbors = tuple(tuple(values) for values in self.neighbors)
+        if len(raw_neighbors) != len(nodes):
+            raise ValueError("neighbors must align with nodes")
+        canonical_neighbors = []
+        neighbor_sets = {}
+        for node, values in zip(nodes, raw_neighbors):
+            try:
+                value_set = set(values)
+            except TypeError as exc:
+                raise ValueError(
+                    "incident neighbor identifiers must be hashable"
+                ) from exc
+            if node in value_set:
+                raise ValueError("incident neighbor lists must omit self loops")
+            if len(value_set) != len(values):
+                raise ValueError("incident neighbor lists must be unique")
+            canonical_neighbors.append(tuple(sorted(value_set, key=_stable_key)))
+            neighbor_sets[node] = value_set
+        mapping = dict(zip(nodes, canonical_neighbors))
+        for row, (node, values) in enumerate(mapping.items()):
+            for neighbor in values:
+                if neighbor in node_index:
+                    neighbor_row = node_index[neighbor]
+                    if abs(int(distance[row]) - int(distance[neighbor_row])) > 1:
+                        raise ValueError("retained edges cannot skip a hop shell")
+                    if node not in neighbor_sets[neighbor]:
+                        raise ValueError(
+                            "incident neighbors must provide reciprocal "
+                            "undirected adjacency"
+                        )
+            if node not in anchor_set:
+                parent_distance = distance[row] - 1
+                if not any(
+                    neighbor in node_index
+                    and distance[node_index[neighbor]] == parent_distance
+                    for neighbor in values
+                ):
+                    raise ValueError(
+                        "every retained non-anchor must have a predecessor "
+                        "one hop nearer"
+                    )
+
+        metric = str(self.selection_metric)
+        if not metric:
+            raise ValueError("selection_metric must be non-empty")
+        object.__setattr__(self, "nodes", nodes)
+        object.__setattr__(self, "anchors", anchors)
+        object.__setattr__(self, "hop_distance", _readonly(distance, dtype=np.int64))
+        object.__setattr__(self, "neighbors", tuple(canonical_neighbors))
+        object.__setattr__(self, "maximum_nodes", maximum_nodes)
+        object.__setattr__(self, "complete_distance_shell", complete)
+        object.__setattr__(self, "truncated_tie_count", truncated)
+        object.__setattr__(self, "selection_metric", metric)
+
+    @property
+    def cutoff_distance(self):
+        return int(np.max(self.hop_distance))
+
+    @property
+    def frontier_nodes(self):
+        cutoff = self.cutoff_distance
+        return tuple(
+            node
+            for node, distance in zip(self.nodes, self.hop_distance)
+            if distance == cutoff
+        )
+
+    @property
+    def distance_by_node(self):
+        return {
+            node: int(distance)
+            for node, distance in zip(self.nodes, self.hop_distance)
+        }
+
+    @property
+    def neighbor_mapping(self):
+        return dict(zip(self.nodes, self.neighbors))
+
+
+def select_hop_local_domain(
+    anchors,
+    incident_neighbors,
+    *,
+    maximum_nodes,
+    complete_distance_shell=False,
+):
+    """Select a deterministic multi-source BFS domain without scanning all nodes.
+
+    The neighbor provider must return the complete undirected incident
+    adjacency for a requested node.  It may be a mapping, callable, CSR/LMDB
+    adapter, or any object exposing get(node, default).
+
+    With complete_distance_shell false, the result contains at most K nodes
+    and breaks a tied final shell by a stable node key.  With it true, the
+    entire first shell that reaches K is retained, so realized size may exceed
+    K.  Either construction is connected to at least one anchor.
+    """
+
+    anchors = _canonical_unique(anchors, name="anchors")
+    maximum_nodes = _positive_integer("maximum_nodes", maximum_nodes)
+    if len(anchors) > maximum_nodes:
+        raise ValueError("maximum_nodes must be at least the number of anchors")
+
+    cache = {}
+
+    def neighbors_for(node):
+        if node not in cache:
+            cache[node] = _read_incident_neighbors(incident_neighbors, node)
+        return cache[node]
+
+    selected = list(anchors)
+    distance_by_node = {node: 0 for node in anchors}
+    seen = set(anchors)
+    layer = list(anchors)
+    truncated = 0
+
+    while layer and len(selected) < maximum_nodes:
+        candidates = set()
+        for node in layer:
+            for neighbor in neighbors_for(node):
+                if neighbor not in seen:
+                    candidates.add(neighbor)
+        ordered = tuple(sorted(candidates, key=_stable_key))
+        if not ordered:
+            break
+        next_distance = distance_by_node[layer[0]] + 1
+        remaining = maximum_nodes - len(selected)
+        if len(ordered) > remaining:
+            if complete_distance_shell:
+                chosen = ordered
+            else:
+                chosen = ordered[:remaining]
+                truncated = len(ordered) - remaining
+            selected.extend(chosen)
+            for node in chosen:
+                distance_by_node[node] = next_distance
+            seen.update(chosen)
+            layer = list(chosen)
+            break
+        selected.extend(ordered)
+        for node in ordered:
+            distance_by_node[node] = next_distance
+        seen.update(ordered)
+        layer = list(ordered)
+
+    for node in selected:
+        neighbors_for(node)
+    distances = np.asarray(
+        [distance_by_node[node] for node in selected],
+        dtype=np.int64,
+    )
+    return LocalDiffusionDomain(
+        nodes=tuple(selected),
+        anchors=anchors,
+        hop_distance=distances,
+        neighbors=tuple(cache[node] for node in selected),
+        maximum_nodes=maximum_nodes,
+        complete_distance_shell=(truncated == 0),
+        truncated_tie_count=truncated,
+    )
+
+
+def _nonnegative_node_vector(name, nodes, value):
+    if isinstance(value, Mapping):
+        unknown = set(value).difference(nodes)
+        if unknown:
+            labels = ", ".join(sorted(repr(node) for node in unknown))
+            raise ValueError(f"{name} contains unknown nodes: {labels}")
+        result = np.asarray([value.get(node, 0.0) for node in nodes], dtype=float)
+    else:
+        result = np.asarray(value, dtype=float)
+        if result.ndim == 0:
+            result = np.full(len(nodes), float(result), dtype=float)
+    if result.shape != (len(nodes),):
+        raise ValueError(f"{name} must be scalar, node mapping, or aligned vector")
+    if not np.isfinite(result).all() or np.any(result < 0.0):
+        raise ValueError(f"{name} must be finite and nonnegative")
+    return result
+
+
+def _embedding_row(node_embeddings, node, width):
+    try:
+        row = np.asarray(node_embeddings[node], dtype=float)
+    except KeyError as exc:
+        raise ValueError(
+            f"exterior cut neighbor absent from embeddings: {exc.args[0]!r}"
+        ) from exc
+    if row.shape != (width,) or not np.isfinite(row).all():
+        raise ValueError(
+            "every retained and one-hop exterior embedding must have one finite width"
+        )
+    return row
+
+
+def _assemble_local_components(
+    domain,
+    *,
+    intrinsic_leakage_conductance,
+    node_embeddings,
+    length_scale,
+    conductance_floor,
+):
+    if not isinstance(domain, LocalDiffusionDomain):
+        raise TypeError("domain must be a LocalDiffusionDomain")
+    nodes = domain.nodes
+    intrinsic = _nonnegative_node_vector(
+        "intrinsic_leakage_conductance",
+        nodes,
+        intrinsic_leakage_conductance,
+    )
+    cut = np.zeros(len(nodes), dtype=float)
+    retained = set(nodes)
+    exterior_embeddings = {}
+
+    if node_embeddings is None:
+        embeddings = None
+        embedding_snapshot = None
+        floor = 0.0
+        scale = None
+    else:
+        scale = _positive_finite("length_scale", length_scale)
+        floor = _unit_interval("conductance_floor", conductance_floor)
+        embeddings = _embedding_matrix(nodes, node_embeddings)
+        embedding_snapshot = {
+            node: embeddings[row].copy()
+            for row, node in enumerate(nodes)
+        }
+        width = embeddings.shape[1]
+
+
+    _, conductance = semantic_conductance_matrix(
+        nodes,
+        domain.neighbor_mapping,
+        embedding_snapshot,
+        length_scale=length_scale,
+        conductance_floor=conductance_floor,
+    )
+    laplacian = combinatorial_laplacian(conductance)
+    for row, (node, incident) in enumerate(zip(nodes, domain.neighbors)):
+        for neighbor in incident:
+            if neighbor in retained:
+                continue
+            value = 1.0
+            if embeddings is not None:
+                exterior = exterior_embeddings.get(neighbor)
+                if exterior is None:
+                    exterior = _embedding_row(
+                        node_embeddings, neighbor, width
+                    ).copy()
+                    exterior_embeddings[neighbor] = exterior
+                radial = _stable_radial_factor(embeddings[row], exterior, scale)
+                value = floor + (1.0 - floor) * radial
+            cut[row] += value
+        if not math.isfinite(float(cut[row])):
+            raise ValueError(f"cut conductance is not finite at node {node!r}")
+
+    return conductance, laplacian, intrinsic, cut
+
+
+@dataclass(frozen=True)
+class LocalGroundedSemanticDiffusion:
+    """A bath-clamped local operator with shunt provenance kept separate."""
+
+    domain: LocalDiffusionDomain
+    model: GroundedSemanticDiffusion
+    intrinsic_leakage_conductance: np.ndarray
+    cut_conductance: np.ndarray
+    bath_temperature: float = 0.0
+
+    def __post_init__(self):
+        if not isinstance(self.domain, LocalDiffusionDomain):
+            raise TypeError("domain must be a LocalDiffusionDomain")
+        if not isinstance(self.model, GroundedSemanticDiffusion):
+            raise TypeError("model must be a GroundedSemanticDiffusion")
+        if self.model.nodes != self.domain.nodes:
+            raise ValueError("model and local domain node order must match")
+        intrinsic = np.asarray(self.intrinsic_leakage_conductance, dtype=float)
+        cut = np.asarray(self.cut_conductance, dtype=float)
+        expected_shape = (len(self.domain.nodes),)
+        if intrinsic.shape != expected_shape or cut.shape != expected_shape:
+            raise ValueError("intrinsic and cut conductance must align with nodes")
+        if (
+            not np.isfinite(intrinsic).all()
+            or not np.isfinite(cut).all()
+            or np.any(intrinsic < 0.0)
+            or np.any(cut < 0.0)
+        ):
+            raise ValueError("intrinsic and cut conductance must be nonnegative")
+        expected_leakage = intrinsic + cut
+        leakage_scale = max(
+            float(np.max(np.abs(expected_leakage), initial=0.0)),
+            float(np.max(np.abs(self.model.leakage_conductance), initial=0.0)),
+            np.finfo(float).tiny,
+        )
+        if not np.allclose(
+            self.model.leakage_conductance,
+            expected_leakage,
+            rtol=1e-12,
+            atol=64.0 * np.finfo(float).eps * leakage_scale,
+        ):
+            raise ValueError("model leakage must equal intrinsic plus cut conductance")
+        object.__setattr__(
+            self,
+            "intrinsic_leakage_conductance",
+            _readonly(intrinsic),
+        )
+        object.__setattr__(self, "cut_conductance", _readonly(cut))
+        object.__setattr__(
+            self,
+            "bath_temperature",
+            _finite_scalar("bath_temperature", self.bath_temperature),
+        )
+
+    @property
+    def nodes(self):
+        return self.domain.nodes
+
+    @property
+    def precision(self):
+        return self.model.precision
+
+    def equilibrium_response(self, source, *, absolute=False):
+        """Return deviation from the bath, or absolute common-bath state."""
+
+        response = self.model.equilibrium_response(source)
+        if absolute:
+            with np.errstate(over="ignore", invalid="ignore"):
+                response = response + self.bath_temperature
+            if not np.isfinite(response).all():
+                raise np.linalg.LinAlgError(
+                    "absolute common-bath response is not finite"
+                )
+        return response
+
+    def boundary_harmonic_measure(self):
+        """Return A^-1 beta, the influence of an artificial unit bath boundary."""
+
+        if not np.any(self.cut_conductance):
+            return np.zeros(len(self.nodes), dtype=float)
+        value = self.model.equilibrium_response(self.cut_conductance)
+        scale = max(float(np.max(np.abs(value), initial=0.0)), 1.0)
+        if np.min(value) < -1e-12 * scale or np.max(value) > 1.0 + 1e-10:
+            raise np.linalg.LinAlgError("boundary harmonic measure left [0, 1]")
+        return np.clip(value, 0.0, 1.0)
+
+    def cut_current_fraction(self, source):
+        """Fraction of a nonnegative maintained source drained by the cut."""
+
+        source = np.asarray(source, dtype=float)
+        if source.shape != (len(self.nodes),):
+            raise ValueError("source must be one node-aligned vector")
+        if not np.isfinite(source).all() or np.any(source < 0.0):
+            raise ValueError("source must be finite and nonnegative")
+        total = float(np.sum(source))
+        if total <= 0.0:
+            raise ValueError("source must inject positive total current")
+        response = self.model.equilibrium_response(source)
+        cut_current = float(self.cut_conductance @ response)
+        leakage_current = float(self.intrinsic_leakage_conductance @ response)
+        balance = cut_current + leakage_current
+        scale = max(total, abs(cut_current), abs(leakage_current), 1.0)
+        if not math.isfinite(balance) or abs(balance - total) > 1e-10 * scale:
+            raise np.linalg.LinAlgError(
+                "cut and intrinsic leakage currents do not balance the source"
+            )
+        fraction = cut_current / total
+        if not math.isfinite(fraction) or fraction < -1e-12 or fraction > 1.0 + 1e-10:
+            raise np.linalg.LinAlgError("cut current fraction left [0, 1]")
+        return min(max(fraction, 0.0), 1.0)
+
+    def frontier_attenuation(self, source_nodes=None, shell_nodes=None):
+        """Maximum raw Green voltage ratio from sources to a fixed shell."""
+
+        sources = _selected_nodes(
+            self.nodes,
+            self.domain.anchors if source_nodes is None else source_nodes,
+            name="source_nodes",
+        )
+        shell = _selected_nodes(
+            self.nodes,
+            self.domain.frontier_nodes if shell_nodes is None else shell_nodes,
+            name="shell_nodes",
+        )
+        index = {node: row for row, node in enumerate(self.nodes)}
+        maximum = None
+        for source_node in sources:
+            source_row = index[source_node]
+            rhs = np.zeros(len(self.nodes))
+            rhs[source_row] = 1.0
+            response = self.model.equilibrium_response(rhs)
+            scale = max(float(np.max(np.abs(response), initial=0.0)), 1.0)
+            if np.min(response) < -1e-11 * scale or response[source_row] <= 0.0:
+                raise np.linalg.LinAlgError("Green response is not nonnegative")
+            for shell_node in shell:
+                if shell_node == source_node:
+                    continue
+                ratio = max(float(response[index[shell_node]]), 0.0) / float(
+                    response[source_row]
+                )
+                maximum = ratio if maximum is None else max(maximum, ratio)
+        if maximum is None:
+            raise ValueError("attenuation shell must include a non-source node")
+        return float(maximum)
+
+
+def _selected_nodes(nodes, values, *, name):
+    try:
+        result = tuple(values)
+    except TypeError as exc:
+        raise ValueError(f"{name} must be an iterable of retained nodes") from exc
+    if not result:
+        raise ValueError(f"{name} must be non-empty")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicates")
+    unknown = set(result).difference(nodes)
+    if unknown:
+        labels = ", ".join(sorted(repr(node) for node in unknown))
+        raise ValueError(f"{name} contains unretained nodes: {labels}")
+    return tuple(sorted(result, key=_stable_key))
+
+
+def _build_local_from_components(
+    domain,
+    conductance,
+    laplacian,
+    intrinsic,
+    cut,
+    *,
+    semantic_length_scale,
+    conductance_floor,
+    bath_temperature,
+    minimum_reciprocal_condition,
+):
+    """Finish one local model without rereading graph or embedding providers."""
+
+    arguments = {}
+    if minimum_reciprocal_condition is not None:
+        arguments["minimum_reciprocal_condition"] = minimum_reciprocal_condition
+    model = _build_grounded_semantic_diffusion_from_components(
+        domain.nodes,
+        conductance,
+        laplacian,
+        leakage_conductance=intrinsic + cut,
+        semantic_length_scale=semantic_length_scale,
+        conductance_floor=float(conductance_floor),
+        **arguments,
+    )
+    return LocalGroundedSemanticDiffusion(
+        domain=domain,
+        model=model,
+        intrinsic_leakage_conductance=intrinsic,
+        cut_conductance=cut,
+        bath_temperature=bath_temperature,
+    )
+
+
+def build_local_grounded_semantic_diffusion(
+    domain,
+    *,
+    intrinsic_leakage_conductance=0.0,
+    node_embeddings=None,
+    length_scale=None,
+    conductance_floor=0.0,
+    bath_temperature=0.0,
+    minimum_reciprocal_condition=None,
+):
+    """Build the exact dense Dirichlet principal block on one local domain."""
+
+    conductance, laplacian, intrinsic, cut = _assemble_local_components(
+        domain,
+        intrinsic_leakage_conductance=intrinsic_leakage_conductance,
+        node_embeddings=node_embeddings,
+        length_scale=length_scale,
+        conductance_floor=conductance_floor,
+    )
+    return _build_local_from_components(
+        domain,
+        conductance,
+        laplacian,
+        intrinsic,
+        cut,
+        semantic_length_scale=(
+            None if node_embeddings is None else float(length_scale)
+        ),
+        conductance_floor=float(conductance_floor),
+        bath_temperature=bath_temperature,
+        minimum_reciprocal_condition=minimum_reciprocal_condition,
+    )
+
+
+@dataclass(frozen=True)
+class LeakageCalibrationResult:
+    model: LocalGroundedSemanticDiffusion
+    leakage_conductance: float
+    leakage_resistance: float
+    target_attenuation: float
+    achieved_attenuation: float
+    shell_nodes: tuple
+    iterations: int
+    numerical_minimum_leakage: float
+
+    def __post_init__(self):
+        if not isinstance(self.model, LocalGroundedSemanticDiffusion):
+            raise TypeError("model must be a LocalGroundedSemanticDiffusion")
+        shell = _selected_nodes(
+            self.model.nodes,
+            self.shell_nodes,
+            name="shell_nodes",
+        )
+        leakage = _finite_scalar("leakage_conductance", self.leakage_conductance)
+        if leakage < 0.0:
+            raise ValueError("leakage_conductance must be nonnegative")
+        resistance = float(self.leakage_resistance)
+        expected = math.inf if leakage == 0.0 else 1.0 / leakage
+        if leakage == 0.0 and resistance != math.inf:
+            raise ValueError("leakage_resistance must be reciprocal conductance")
+        if leakage > 0.0 and (
+            not math.isfinite(resistance)
+            or not math.isclose(resistance, expected, rel_tol=1e-12)
+        ):
+            raise ValueError("leakage_resistance must be reciprocal conductance")
+        target = _positive_unit_interval(
+            "target_attenuation", self.target_attenuation
+        )
+        achieved = _finite_scalar("achieved_attenuation", self.achieved_attenuation)
+        if achieved < 0.0 or achieved > target * (1.0 + 1e-8):
+            raise ValueError("calibrated attenuation does not meet its target")
+        if int(self.iterations) != self.iterations or self.iterations < 0:
+            raise ValueError("iterations must be a nonnegative integer")
+        numeric = _finite_scalar(
+            "numerical_minimum_leakage", self.numerical_minimum_leakage
+        )
+        numeric_scale = max(
+            abs(leakage),
+            abs(numeric),
+            np.finfo(float).tiny,
+        )
+        if (
+            numeric < 0.0
+            or leakage + 64.0 * np.finfo(float).eps * numeric_scale < numeric
+        ):
+            raise ValueError("selected leakage is below the numerical minimum")
+        object.__setattr__(self, "shell_nodes", shell)
+
+
+def _attenuation_from_eigendecomposition(
+    eigenvalues,
+    eigenvectors,
+    *,
+    leakage,
+    source_rows,
+    shell_rows,
+):
+    denominators = eigenvalues + leakage
+    if np.any(denominators <= 0.0) or not np.isfinite(denominators).all():
+        return math.inf
+    maximum = None
+    for source_row in source_rows:
+        response = eigenvectors @ (eigenvectors[source_row, :] / denominators)
+        source_value = float(response[source_row])
+        if source_value <= 0.0 or not np.isfinite(response).all():
+            return math.inf
+        scale = max(float(np.max(np.abs(response), initial=0.0)), 1.0)
+        if np.min(response) < -1e-10 * scale:
+            raise np.linalg.LinAlgError("spectral Green response is negative")
+        for shell_row in shell_rows:
+            if shell_row == source_row:
+                continue
+            ratio = max(float(response[shell_row]), 0.0) / source_value
+            maximum = ratio if maximum is None else max(maximum, ratio)
+    if maximum is None:
+        raise ValueError("attenuation shell must include a non-source node")
+    return float(maximum)
+
+
+def calibrate_uniform_leakage(
+    domain,
+    *,
+    anchors=None,
+    shell_nodes,
+    target_attenuation=math.exp(-1.0),
+    intrinsic_leakage_conductance=0.0,
+    node_embeddings=None,
+    length_scale=None,
+    conductance_floor=0.0,
+    bath_temperature=0.0,
+    minimum_reciprocal_condition=None,
+    maximum_leakage_conductance=None,
+    relative_tolerance=1e-8,
+    maximum_iterations=80,
+):
+    """Choose the smallest added uniform leakage meeting a shell attenuation.
+    The calibration shell is required explicitly so callers must name an
+    intended interior e-fold shell instead of silently defaulting to the hard
+    boundary.  Interiority is a caller-owned design choice, not inferred here.
+
+
+    Calibration uses G(i,s)/G(s,s), the killed-walk hitting probability.  It
+    deliberately does not use correlation-normalized Green entries, whose
+    dependence on leakage need not be monotone.
+    """
+
+    target = _positive_unit_interval("target_attenuation", target_attenuation)
+    tolerance = _positive_finite("relative_tolerance", relative_tolerance)
+    maximum_iterations = _positive_integer("maximum_iterations", maximum_iterations)
+    source_nodes = _selected_nodes(
+        domain.nodes,
+        domain.anchors if anchors is None else anchors,
+        name="anchors",
+    )
+    shell = _selected_nodes(
+        domain.nodes,
+        shell_nodes,
+        name="shell_nodes",
+    )
+    index = {node: row for row, node in enumerate(domain.nodes)}
+    source_rows = tuple(index[node] for node in source_nodes)
+    shell_rows = tuple(index[node] for node in shell)
+
+    conductance, laplacian, intrinsic, cut = _assemble_local_components(
+        domain,
+        intrinsic_leakage_conductance=intrinsic_leakage_conductance,
+        node_embeddings=node_embeddings,
+        length_scale=length_scale,
+        conductance_floor=conductance_floor,
+    )
+    base_precision = laplacian + np.diag(intrinsic + cut)
+    eigenvalues, eigenvectors = np.linalg.eigh(base_precision)
+    spectral_scale = max(float(np.max(np.abs(eigenvalues), initial=0.0)), 1.0)
+    if float(eigenvalues[0]) < -1e-12 * spectral_scale:
+        raise np.linalg.LinAlgError("local base precision is not positive semidefinite")
+    eigenvalues = np.maximum(eigenvalues, 0.0)
+    minimum = float(eigenvalues[0])
+    maximum = float(eigenvalues[-1])
+
+    required_rcond = (
+        _DEFAULT_MINIMUM_RECIPROCAL_CONDITION
+        if minimum_reciprocal_condition is None
+        else _positive_unit_interval(
+            "minimum_reciprocal_condition",
+            minimum_reciprocal_condition,
+        )
+    )
+    if required_rcond == 1.0 and maximum > minimum:
+        raise ValueError(
+            "finite uniform leakage cannot make a nonscalar spectrum exact"
+        )
+    if required_rcond == 1.0:
+        numerical_minimum = 0.0
+    else:
+        numerical_minimum = max(
+            0.0,
+            (required_rcond * maximum - minimum) / (1.0 - required_rcond),
+        )
+        if numerical_minimum > 0.0:
+            numerical_minimum += (
+                64.0 * np.finfo(float).eps * max(maximum, np.finfo(float).tiny)
+            )
+    representable = np.nextafter(1.0 / np.finfo(float).max, math.inf)
+    numerical_minimum = max(numerical_minimum, representable - minimum, 0.0)
+    if numerical_minimum > 0.0:
+        numerical_minimum = float(np.nextafter(numerical_minimum, math.inf))
+
+    if maximum_leakage_conductance is None:
+        maximum_allowed = math.inf
+    else:
+        maximum_allowed = _finite_scalar(
+            "maximum_leakage_conductance",
+            maximum_leakage_conductance,
+        )
+        if maximum_allowed < 0.0:
+            raise ValueError("maximum_leakage_conductance must be nonnegative")
+    if numerical_minimum > maximum_allowed:
+        raise np.linalg.LinAlgError(
+            "numerical conditioning requires leakage above the allowed maximum"
+        )
+
+    evaluations = 0
+
+    def evaluate(leakage):
+        nonlocal evaluations
+        evaluations += 1
+        return _attenuation_from_eigendecomposition(
+            eigenvalues,
+            eigenvectors,
+            leakage=leakage,
+            source_rows=source_rows,
+            shell_rows=shell_rows,
+        )
+
+    lower = numerical_minimum
+    lower_value = evaluate(lower)
+    if lower_value <= target:
+        selected = lower
+        achieved = lower_value
+    else:
+        positive_edges = conductance[conductance > 0.0]
+        typical_conductance = (
+            float(np.median(positive_edges)) if len(positive_edges) else 1.0
+        )
+        radius = max(domain.cutoff_distance, 1)
+        gamma = math.log(1.0 / target) / radius
+        try:
+            chain_seed = 2.0 * typical_conductance * (math.cosh(gamma) - 1.0)
+        except OverflowError:
+            chain_seed = math.inf
+        upper = max(
+            float(np.nextafter(lower, math.inf)) * 2.0,
+            chain_seed,
+            np.finfo(float).tiny,
+        )
+        upper = min(upper, maximum_allowed)
+        upper_value = evaluate(upper)
+        while upper_value > target and evaluations < maximum_iterations:
+            if upper >= maximum_allowed or not math.isfinite(upper):
+                break
+            candidate = min(upper * 2.0, maximum_allowed)
+            if candidate <= upper:
+                break
+            upper = candidate
+            upper_value = evaluate(upper)
+        if upper_value > target:
+            if evaluations >= maximum_iterations:
+                raise np.linalg.LinAlgError(
+                    "leakage calibration exhausted evaluations before "
+                    "bracketing"
+                )
+            raise np.linalg.LinAlgError(
+                "no allowed uniform leakage meets the attenuation target"
+            )
+
+        while evaluations < maximum_iterations:
+            scale = max(abs(upper), np.finfo(float).tiny)
+            if upper - lower <= tolerance * scale:
+                break
+            if lower > 0.0 and upper / lower > 4.0:
+                middle = math.sqrt(lower * upper)
+            else:
+                middle = lower + 0.5 * (upper - lower)
+            middle_value = evaluate(middle)
+            if middle_value <= target:
+                upper = middle
+                upper_value = middle_value
+            else:
+                lower = middle
+        selected = upper
+        scale = max(abs(upper), np.finfo(float).tiny)
+        if upper - lower > tolerance * scale:
+            raise np.linalg.LinAlgError(
+                "leakage calibration did not converge within maximum_iterations"
+            )
+        achieved = upper_value
+
+    final_intrinsic = intrinsic + selected
+    local = _build_local_from_components(
+        domain,
+        conductance,
+        laplacian,
+        final_intrinsic,
+        cut,
+        semantic_length_scale=(
+            None if node_embeddings is None else float(length_scale)
+        ),
+        conductance_floor=float(conductance_floor),
+        bath_temperature=bath_temperature,
+        minimum_reciprocal_condition=required_rcond,
+    )
+    observed = local.frontier_attenuation(source_nodes, shell)
+    if observed > target * (1.0 + max(tolerance, 1e-10)):
+        raise np.linalg.LinAlgError("final model missed the attenuation target")
+    return LeakageCalibrationResult(
+        model=local,
+        leakage_conductance=selected,
+        leakage_resistance=(math.inf if selected == 0.0 else 1.0 / selected),
+        target_attenuation=target,
+        achieved_attenuation=observed,
+        shell_nodes=shell,
+        iterations=evaluations,
+        numerical_minimum_leakage=numerical_minimum,
+    )
+
+
+@dataclass(frozen=True)
+class NestedDomainDiagnostics:
+    source_nodes: tuple
+    protected_nodes: tuple
+    maximum_protected_absolute_error: float
+    maximum_protected_relative_error: float
+    minimum_monotone_increment: float
+    monotonic: bool
+    inner_boundary_harmonic_max: float
+    outer_boundary_harmonic_max: float
+
+
+def compare_nested_domains(
+    inner,
+    outer,
+    *,
+    source_nodes=None,
+    protected_nodes=None,
+):
+    """Compare raw responses on a common core of two exact nested domains."""
+
+    if not isinstance(inner, LocalGroundedSemanticDiffusion) or not isinstance(
+        outer, LocalGroundedSemanticDiffusion
+    ):
+        raise TypeError("inner and outer must be local grounded models")
+    if not set(inner.nodes).issubset(outer.nodes):
+        raise ValueError("inner nodes must be a subset of outer nodes")
+    sources = _selected_nodes(
+        inner.nodes,
+        inner.domain.anchors if source_nodes is None else source_nodes,
+        name="source_nodes",
+    )
+    protected = _selected_nodes(
+        inner.nodes,
+        inner.nodes if protected_nodes is None else protected_nodes,
+        name="protected_nodes",
+    )
+    if not math.isclose(
+        inner.bath_temperature,
+        outer.bath_temperature,
+        rel_tol=0.0,
+        abs_tol=0.0,
+    ):
+        raise ValueError("nested models must use the same bath temperature")
+    if (
+        inner.model.semantic_length_scale != outer.model.semantic_length_scale
+        or inner.model.conductance_floor != outer.model.conductance_floor
+    ):
+        raise ValueError("nested models must use the same semantic conductance")
+    inner_index = {node: row for row, node in enumerate(inner.nodes)}
+    outer_index = {node: row for row, node in enumerate(outer.nodes)}
+    for node in inner.nodes:
+        left = inner_index[node]
+        right = outer_index[node]
+        if not math.isclose(
+            float(inner.intrinsic_leakage_conductance[left]),
+            float(outer.intrinsic_leakage_conductance[right]),
+            rel_tol=1e-12,
+            abs_tol=1e-12,
+        ):
+            raise ValueError("nested models must use the same intrinsic leakage")
+        if set(inner.domain.neighbors[left]) != set(outer.domain.neighbors[right]):
+            raise ValueError("nested models must use the same incident graph")
+
+    common_outer = np.asarray(
+        [outer_index[node] for node in inner.nodes],
+        dtype=int,
+    )
+    outer_common_precision = outer.precision[
+        np.ix_(common_outer, common_outer)
+    ]
+    precision_scale = max(
+        float(np.max(np.abs(inner.precision), initial=0.0)),
+        float(np.max(np.abs(outer_common_precision), initial=0.0)),
+        np.finfo(float).tiny,
+    )
+    if not np.allclose(
+        inner.precision,
+        outer_common_precision,
+        rtol=1e-12,
+        atol=64.0 * np.finfo(float).eps * precision_scale,
+    ):
+        raise ValueError("nested models must use the same realized precision")
+    protected_inner = np.asarray([inner_index[node] for node in protected])
+    protected_outer = np.asarray([outer_index[node] for node in protected])
+    maximum_absolute = 0.0
+    maximum_relative = 0.0
+    minimum_increment = math.inf
+    response_scale = 1.0
+    for source_node in sources:
+        inner_rhs = np.zeros(len(inner.nodes))
+        outer_rhs = np.zeros(len(outer.nodes))
+        inner_rhs[inner_index[source_node]] = 1.0
+        outer_rhs[outer_index[source_node]] = 1.0
+        inner_response = inner.model.equilibrium_response(inner_rhs)[protected_inner]
+        outer_response = outer.model.equilibrium_response(outer_rhs)[protected_outer]
+        difference = outer_response - inner_response
+        maximum_absolute = max(
+            maximum_absolute,
+            float(np.max(np.abs(difference), initial=0.0)),
+        )
+        denominator = np.maximum(np.abs(outer_response), np.finfo(float).tiny)
+        maximum_relative = max(
+            maximum_relative,
+            float(np.max(np.abs(difference) / denominator, initial=0.0)),
+        )
+        minimum_increment = min(
+            minimum_increment,
+            float(np.min(difference, initial=math.inf)),
+        )
+        response_scale = max(
+            response_scale,
+            float(np.max(np.abs(outer_response), initial=0.0)),
+        )
+
+    inner_harmonic = inner.boundary_harmonic_measure()[protected_inner]
+    outer_harmonic = outer.boundary_harmonic_measure()[protected_outer]
+    tolerance = 1e-10 * response_scale
+    return NestedDomainDiagnostics(
+        source_nodes=sources,
+        protected_nodes=protected,
+        maximum_protected_absolute_error=maximum_absolute,
+        maximum_protected_relative_error=maximum_relative,
+        minimum_monotone_increment=minimum_increment,
+        monotonic=(minimum_increment >= -tolerance),
+        inner_boundary_harmonic_max=float(
+            np.max(inner_harmonic, initial=0.0)
+        ),
+        outer_boundary_harmonic_max=float(
+            np.max(outer_harmonic, initial=0.0)
+        ),
+    )

--- a/tests/test_local_grounded_diffusion.py
+++ b/tests/test_local_grounded_diffusion.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Tests for bounded grounded diffusion domains and bath boundaries."""
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from unifyweaver.graph.leaky_diffusion import (  # noqa: E402
+    build_grounded_semantic_diffusion,
+)
+from unifyweaver.graph.local_diffusion import (  # noqa: E402
+    build_local_grounded_semantic_diffusion,
+    LocalDiffusionDomain,
+    calibrate_uniform_leakage,
+    compare_nested_domains,
+    select_hop_local_domain,
+)
+
+
+def _neighbors(edges, extra=()):
+    output = {node: set() for node in extra}
+    for left, right in edges:
+        output.setdefault(left, set()).add(right)
+        output.setdefault(right, set()).add(left)
+    return {
+        node: tuple(sorted(adjacent))
+        for node, adjacent in output.items()
+    }
+
+
+def _provider(neighbors, calls=None):
+    def incident(node):
+        if calls is not None:
+            calls.append(node)
+        return neighbors.get(node, ())
+
+    return incident
+
+
+def _path(last):
+    return _neighbors(tuple((node, node + 1) for node in range(last)))
+
+
+def _source(nodes, node, magnitude=1.0):
+    value = np.zeros(len(nodes), dtype=float)
+    value[nodes.index(node)] = magnitude
+    return value
+
+
+def test_exact_k_hop_selection_is_deterministic_connected_and_lazy():
+    graph = _neighbors(
+        (
+            ("a", "b"),
+            ("a", "c"),
+            ("b", "d"),
+            ("c", "e"),
+            ("d", "f"),
+        )
+    )
+    calls = []
+    domain = select_hop_local_domain(
+        ("a",),
+        _provider(graph, calls),
+        maximum_nodes=4,
+    )
+
+    assert domain.nodes == ("a", "b", "c", "d")
+    assert domain.anchors == ("a",)
+    assert np.array_equal(domain.hop_distance, [0, 1, 1, 2])
+    assert calls == ["a", "b", "c", "d"]
+    assert set(domain.neighbor_mapping["a"]) == {"b", "c"}
+    assert set(domain.neighbor_mapping["b"]) == {"a", "d"}
+    assert set(domain.neighbor_mapping["c"]) == {"a", "e"}
+    assert domain.cutoff_distance == 2
+    assert domain.frontier_nodes == ("d",)
+
+
+def test_mapping_adjacency_requires_explicit_entries_for_every_visited_node():
+    with pytest.raises(
+        ValueError,
+        match="unable to read incident neighbors for 0",
+    ):
+        select_hop_local_domain((0,), {}, maximum_nodes=1)
+
+    with pytest.raises(
+        ValueError,
+        match="unable to read incident neighbors for 1",
+    ):
+        select_hop_local_domain(
+            (0,),
+            {0: (1,)},
+            maximum_nodes=2,
+        )
+
+    isolated = select_hop_local_domain(
+        ("isolated",),
+        {"isolated": ()},
+        maximum_nodes=1,
+    )
+    assert isolated.nodes == ("isolated",)
+
+
+def test_complete_distance_shell_may_exceed_k_while_truncation_breaks_ties():
+    graph = _neighbors(
+        (("a", "b"), ("a", "c"), ("a", "d"), ("a", "e"))
+    )
+
+    truncated = select_hop_local_domain(
+        ("a",),
+        _provider(graph),
+        maximum_nodes=3,
+    )
+    full_shell = select_hop_local_domain(
+        ("a",),
+        _provider(graph),
+        maximum_nodes=3,
+        complete_distance_shell=True,
+    )
+
+    assert truncated.nodes == ("a", "b", "c")
+    assert full_shell.nodes == ("a", "b", "c", "d", "e")
+    assert np.array_equal(truncated.hop_distance, [0, 1, 1])
+    assert np.array_equal(full_shell.hop_distance, [0, 1, 1, 1, 1])
+    assert truncated.truncated_tie_count == 2
+    assert full_shell.truncated_tie_count == 0
+
+
+def test_provider_is_not_called_beyond_the_expanded_bfs_prefix():
+    calls = []
+
+    def infinite_path(node):
+        calls.append(node)
+        return (node - 1, node + 1) if node else (1,)
+
+    domain = select_hop_local_domain(
+        (0,),
+        infinite_path,
+        maximum_nodes=3,
+    )
+
+    assert domain.nodes == (0, 1, 2)
+    assert calls == [0, 1, 2]
+
+
+def test_severed_path_edge_becomes_an_exact_boundary_bath_shunt():
+    graph = _path(3)
+    domain = select_hop_local_domain(
+        (0,),
+        _provider(graph),
+        maximum_nodes=3,
+    )
+    local = build_local_grounded_semantic_diffusion(domain)
+
+    assert domain.nodes == (0, 1, 2)
+    assert np.array_equal(local.cut_conductance, [0.0, 0.0, 1.0])
+    assert np.array_equal(
+        local.model.precision,
+        np.array(
+            [
+                [1.0, -1.0, 0.0],
+                [-1.0, 2.0, -1.0],
+                [0.0, -1.0, 2.0],
+            ]
+        ),
+    )
+    assert np.array_equal(local.cut_conductance, [0.0, 0.0, 1.0])
+
+
+def test_local_precision_is_the_full_grounded_precision_principal_block():
+    graph = _path(4)
+    alpha = 0.25
+    domain = select_hop_local_domain(
+        (0,),
+        _provider(graph),
+        maximum_nodes=3,
+    )
+    local = build_local_grounded_semantic_diffusion(
+        domain,
+        intrinsic_leakage_conductance=alpha,
+    )
+    full = build_grounded_semantic_diffusion(
+        tuple(range(5)),
+        graph,
+        leakage_conductance=alpha,
+    )
+    indices = [full.nodes.index(node) for node in domain.nodes]
+
+    assert np.allclose(
+        local.model.precision,
+        full.precision[np.ix_(indices, indices)],
+    )
+    full_green = full.green_kernel()[np.ix_(indices, indices)]
+    local_green = local.model.green_kernel()
+    assert not np.allclose(
+        local_green,
+        full_green,
+    )
+
+
+def test_naive_induced_subgraph_omits_the_cut_shunt_and_changes_response():
+    graph = _path(3)
+    alpha = 0.2
+    domain = select_hop_local_domain(
+        (0,),
+        _provider(graph),
+        maximum_nodes=3,
+    )
+    local = build_local_grounded_semantic_diffusion(
+        domain,
+        intrinsic_leakage_conductance=alpha,
+    )
+    naive = build_grounded_semantic_diffusion(
+        domain.nodes,
+        domain.neighbor_mapping,
+        leakage_conductance=alpha,
+    )
+    source = _source(domain.nodes, 0)
+
+    assert local.model.precision[-1, -1] == pytest.approx(
+        naive.precision[-1, -1] + 1.0
+    )
+    assert not np.allclose(
+        local.equilibrium_response(source),
+        naive.equilibrium_response(source),
+    )
+
+
+def test_semantic_cut_conductance_requires_exterior_endpoint_embedding():
+    graph = _path(2)
+    domain = select_hop_local_domain(
+        (0,),
+        _provider(graph),
+        maximum_nodes=2,
+    )
+    retained_only = {0: np.array([0.0]), 1: np.array([0.5])}
+
+    with pytest.raises(ValueError, match="cut neighbor.*embeddings"):
+        build_local_grounded_semantic_diffusion(
+            domain,
+            node_embeddings=retained_only,
+            length_scale=1.0,
+        )
+
+    embeddings = {**retained_only, 2: np.array([2.0])}
+    local = build_local_grounded_semantic_diffusion(
+        domain,
+        node_embeddings=embeddings,
+        length_scale=1.0,
+    )
+    expected_cut = np.exp(-0.5 * (2.0 - 0.5) ** 2)
+    assert local.cut_conductance[-1] == pytest.approx(expected_cut)
+
+
+def test_nonzero_bath_temperature_is_an_affine_equilibrium_term():
+    graph = _neighbors((("inside", "outside"),))
+    domain = select_hop_local_domain(
+        ("inside",),
+        _provider(graph),
+        maximum_nodes=1,
+    )
+    local = build_local_grounded_semantic_diffusion(
+        domain,
+        intrinsic_leakage_conductance=2.0,
+        bath_temperature=7.5,
+    )
+
+    zero_source = np.zeros(1)
+    assert local.equilibrium_response(zero_source) == pytest.approx([0.0])
+    assert local.equilibrium_response(
+        zero_source, absolute=True
+    ) == pytest.approx([7.5])
+    assert local.equilibrium_response(
+        np.array([2.0]), absolute=True
+    ) == pytest.approx([7.5 + 2.0 / 3.0])
+
+
+def test_uniform_leakage_calibration_hits_chain_frontier_target():
+    graph = _path(5)
+    domain = select_hop_local_domain(
+        (0,),
+        _provider(graph),
+        maximum_nodes=6,
+    )
+    target = float(np.exp(-1.0))
+    calibration = calibrate_uniform_leakage(
+        domain,
+        anchors=(0,),
+        shell_nodes=(5,),
+        target_attenuation=target,
+        relative_tolerance=1e-6,
+    )
+
+    assert calibration.leakage_conductance > 0.0
+    assert calibration.leakage_resistance == pytest.approx(
+        1.0 / calibration.leakage_conductance
+    )
+    assert calibration.achieved_attenuation <= target * (1.0 + 1e-6)
+    assert calibration.achieved_attenuation >= target * (1.0 - 2e-6)
+    source = _source(calibration.model.model.nodes, 0)
+    response = calibration.model.equilibrium_response(source)
+    assert response[-1] / response[0] == pytest.approx(
+        calibration.achieved_attenuation
+    )
+
+
+def test_leakage_calibration_reads_each_required_embedding_once():
+    graph = _path(2)
+    domain = select_hop_local_domain(
+        (0,),
+        graph,
+        maximum_nodes=2,
+    )
+    calls = {}
+    values = {
+        0: np.array([0.0]),
+        1: np.array([0.5]),
+        2: np.array([1.0]),
+    }
+
+    class CountingEmbeddings:
+        def __getitem__(self, node):
+            calls[node] = calls.get(node, 0) + 1
+            return values[node]
+
+    calibration = calibrate_uniform_leakage(
+        domain,
+        shell_nodes=(1,),
+        target_attenuation=float(np.exp(-1.0)),
+        node_embeddings=CountingEmbeddings(),
+        length_scale=1.0,
+        relative_tolerance=1e-6,
+    )
+
+    assert calibration.achieved_attenuation <= float(np.exp(-1.0)) * (
+        1.0 + 1e-6
+    )
+    assert calls == {0: 1, 1: 1, 2: 1}
+
+
+def test_nested_domain_diagnostics_report_boundary_influence_and_cut_current():
+    graph = _path(8)
+    inner_domain = select_hop_local_domain(
+        (0,),
+        _provider(graph),
+        maximum_nodes=4,
+    )
+    outer_domain = select_hop_local_domain(
+        (0,),
+        _provider(graph),
+        maximum_nodes=8,
+    )
+    inner = build_local_grounded_semantic_diffusion(
+        inner_domain,
+        intrinsic_leakage_conductance=0.2,
+    )
+    outer = build_local_grounded_semantic_diffusion(
+        outer_domain,
+        intrinsic_leakage_conductance=0.2,
+    )
+    diagnostics = compare_nested_domains(
+        inner,
+        outer,
+        source_nodes=(0,),
+        protected_nodes=(0, 1),
+    )
+
+    source = _source(inner.model.nodes, 0)
+    response = inner.equilibrium_response(source)
+    drained = float(
+        (inner.cut_conductance + inner.intrinsic_leakage_conductance)
+        @ response
+    )
+    assert drained == pytest.approx(np.sum(source))
+    harmonic = inner.boundary_harmonic_measure()
+    protected_indices = [
+        inner.model.nodes.index(node) for node in (0, 1)
+    ]
+    cut_fraction = inner.cut_current_fraction(source)
+    assert diagnostics.maximum_protected_absolute_error > 0.0
+    assert 0.0 < diagnostics.inner_boundary_harmonic_max < 1.0
+    assert diagnostics.inner_boundary_harmonic_max == pytest.approx(
+        np.max(harmonic[protected_indices])
+    )
+    assert 0.0 < cut_fraction < 1.0
+
+
+def test_k_2k_4k_responses_converge_and_diagnostics_improve_on_a_path():
+    graph = _path(16)
+    models = []
+    for size in (4, 8, 16):
+        domain = select_hop_local_domain(
+            (0,),
+            _provider(graph),
+            maximum_nodes=size,
+        )
+        models.append(
+            build_local_grounded_semantic_diffusion(
+                domain,
+                intrinsic_leakage_conductance=0.2,
+            )
+        )
+
+    anchor_responses = []
+    for model in models:
+        source = _source(model.model.nodes, 0)
+        anchor_responses.append(model.equilibrium_response(source)[0])
+    assert anchor_responses[0] < anchor_responses[1] < anchor_responses[2]
+
+    k_to_4k = compare_nested_domains(
+        models[0],
+        models[2],
+        source_nodes=(0,),
+        protected_nodes=(0, 1),
+    )
+    two_k_to_4k = compare_nested_domains(
+        models[1],
+        models[2],
+        source_nodes=(0,),
+        protected_nodes=(0, 1),
+    )
+    assert (
+        two_k_to_4k.maximum_protected_absolute_error
+        < k_to_4k.maximum_protected_absolute_error
+    )
+    assert (
+        two_k_to_4k.inner_boundary_harmonic_max
+        < k_to_4k.inner_boundary_harmonic_max
+    )
+    assert k_to_4k.monotonic
+    assert two_k_to_4k.monotonic
+    assert k_to_4k.minimum_monotone_increment >= 0.0
+
+
+def test_multiple_anchors_share_one_domain_and_one_precision_factorization():
+    graph = _path(6)
+    domain = select_hop_local_domain(
+        (1, 5),
+        _provider(graph),
+        maximum_nodes=7,
+    )
+    local = build_local_grounded_semantic_diffusion(
+        domain,
+        intrinsic_leakage_conductance=0.1,
+    )
+    sources = np.column_stack(
+        (
+            _source(local.model.nodes, 1),
+            _source(local.model.nodes, 5),
+        )
+    )
+    response = local.equilibrium_response(sources)
+
+    assert domain.anchors == (1, 5)
+    assert domain.nodes == (1, 5, 0, 2, 4, 6, 3)
+    assert response.shape == (7, 2)
+    assert np.allclose(local.model.precision @ response, sources)
+    assert local.model.precision_root.shape == (7, 7)
+
+
+def test_conditioning_floor_has_roundoff_guard():
+    graph = _path(1)
+    domain = select_hop_local_domain(
+        (0,),
+        _provider(graph),
+        maximum_nodes=2,
+    )
+
+    calibration = calibrate_uniform_leakage(
+        domain,
+        shell_nodes=(1,),
+        target_attenuation=1.0,
+    )
+
+    assert calibration.leakage_conductance > 0.0
+    assert (
+        calibration.model.model.reciprocal_condition_number
+        >= calibration.model.model.minimum_reciprocal_condition
+    )
+
+
+def test_leakage_calibration_fails_if_iteration_budget_cannot_converge():
+    graph = _path(5)
+    domain = select_hop_local_domain(
+        (0,),
+        _provider(graph),
+        maximum_nodes=6,
+    )
+
+    with pytest.raises(
+        np.linalg.LinAlgError,
+        match="exhausted|did not converge",
+    ):
+        calibrate_uniform_leakage(
+            domain,
+            shell_nodes=(5,),
+            target_attenuation=float(np.exp(-1.0)),
+            maximum_iterations=2,
+        )
+
+
+def test_nested_diagnostics_reject_changed_realized_edge_weights():
+    graph = _path(2)
+    inner_domain = select_hop_local_domain(
+        (0,),
+        _provider(graph),
+        maximum_nodes=2,
+    )
+    outer_domain = select_hop_local_domain(
+        (0,),
+        _provider(graph),
+        maximum_nodes=3,
+    )
+    inner = build_local_grounded_semantic_diffusion(
+        inner_domain,
+        intrinsic_leakage_conductance=0.2,
+        node_embeddings={
+            0: np.array([0.0]),
+            1: np.array([0.0]),
+            2: np.array([0.0]),
+        },
+        length_scale=1.0,
+    )
+    outer = build_local_grounded_semantic_diffusion(
+        outer_domain,
+        intrinsic_leakage_conductance=0.2,
+        node_embeddings={
+            0: np.array([0.0]),
+            1: np.array([3.0]),
+            2: np.array([3.0]),
+        },
+        length_scale=1.0,
+    )
+
+    with pytest.raises(ValueError, match="same realized precision"):
+        compare_nested_domains(inner, outer)
+
+
+def test_absolute_common_bath_overflow_fails_closed():
+    graph = _neighbors((("inside", "outside"),))
+    domain = select_hop_local_domain(
+        ("inside",),
+        _provider(graph),
+        maximum_nodes=1,
+    )
+    local = build_local_grounded_semantic_diffusion(
+        domain,
+        bath_temperature=1.0e308,
+    )
+
+    with pytest.raises(
+        np.linalg.LinAlgError,
+        match="absolute common-bath response is not finite",
+    ):
+        local.equilibrium_response(np.array([1.0e308]), absolute=True)
+
+
+def test_semantic_embeddings_are_snapshotted_once_per_required_node():
+    class SingleReadEmbeddings(dict):
+        def __init__(self, values):
+            super().__init__(values)
+            self.reads = {}
+
+        def __getitem__(self, key):
+            count = self.reads.get(key, 0) + 1
+            self.reads[key] = count
+            if count > 1:
+                raise AssertionError(f"embedding {key!r} was read more than once")
+            return super().__getitem__(key)
+
+    graph = _path(2)
+    domain = select_hop_local_domain(
+        (0,),
+        _provider(graph),
+        maximum_nodes=2,
+    )
+    embeddings = SingleReadEmbeddings(
+        {
+            0: np.array([0.0]),
+            1: np.array([0.5]),
+            2: np.array([1.0]),
+        }
+    )
+
+    local = build_local_grounded_semantic_diffusion(
+        domain,
+        intrinsic_leakage_conductance=0.2,
+        node_embeddings=embeddings,
+        length_scale=1.0,
+    )
+
+    assert local.precision.shape == (2, 2)
+    assert embeddings.reads == {0: 1, 1: 1, 2: 1}
+
+
+def test_direct_domain_rejects_edges_that_skip_a_hop_shell():
+    with pytest.raises(ValueError, match="cannot skip a hop shell"):
+        LocalDiffusionDomain(
+            nodes=("a", "b", "c"),
+            anchors=("a",),
+            hop_distance=np.array([0, 1, 2]),
+            neighbors=(("b", "c"), ("a", "c"), ("a", "b")),
+            maximum_nodes=3,
+            complete_distance_shell=True,
+            truncated_tie_count=0,
+        )
+
+
+def test_direct_domain_overrun_must_complete_only_the_final_shell():
+    with pytest.raises(ValueError, match="must complete one shell"):
+        LocalDiffusionDomain(
+            nodes=(0, 1, 2),
+            anchors=(0,),
+            hop_distance=np.array([0, 1, 2]),
+            neighbors=((1,), (0, 2), (1,)),
+            maximum_nodes=2,
+            complete_distance_shell=True,
+            truncated_tie_count=0,
+        )


### PR DESCRIPTION
## Summary

Follow-up to #3852: bound grounded graph diffusion by a query-local domain without pretending that omitted edges do not exist.

This PR adds both the theory and a dense float64 reference implementation for local grounded diffusion:

- select a deterministic multi-source hop-local domain with strict `K` truncation by default;
- convert every retained-to-omitted edge into an exact Dirichlet cut shunt;
- calibrate uniform leakage against a caller-selected raw Green-response e-fold shell;
- expose boundary-harmonic, cut-current, and nested-`K/2K/4K` diagnostics;
- document the numerical, statistical, and scaling contracts and rejected alternatives.

## Mathematical contract

For retained nodes `S`, omitted-edge conductance is

```
beta_i = sum_{j outside S} c_ij
```

and the local precision is

```
J_S = L(W_SS) + diag(alpha + beta).
```

This is exactly the full precision's principal block under a clamped exterior (a Dirichlet/common-bath condition). It is **not** the marginal principal block of the full Green kernel; that would require a Schur complement.

Cut edges therefore cannot be silently deleted: doing so changes the model to an insulating/Neumann boundary.

## Implementation

- New `unifyweaver.graph.local_diffusion` reference module.
- One frozen graph/embedding snapshot per build or calibration.
- Mapping adjacency fails closed on missing keys; an explicit empty neighbor list remains a genuine isolate.
- Common nonzero bath convention for intrinsic leakage and boundary shunts.
- Explicit conditioning floor and fail-closed leakage bracketing/convergence.
- Shared component constructor avoids duplicate dense assembly and inconsistent provider reads.
- Public exports and CI coverage for global + local diffusion.
- Theory and decisions:
  - `docs/design/LOCAL_GROUNDED_DIFFUSION.md`
  - `docs/design/LEAKY_GRAPH_DIFFUSION.md`
  - `prototypes/mu_cosine/DECISIONS_graph_geometry.md`

## Scale result and scope

The committed smoke benchmark uses an implicit fixed-degree graph with a 1,000,000-node universe. At `K=8,16,32`, it touches exactly `K` provider nodes and obtains residuals at or below `5.56e-16`.

For comparison, one global million-node float64 dense matrix is about **7.28 TiB**; the four persistent dense arrays in this reference representation would be about **29.1 TiB**, excluding temporaries.

This is explicitly a **compute-only microbenchmark**, not a deployment-latency or arbitrary-hub claim. Strict `K` bounds the retained dense solve, but the current exact selector still materializes incident lists and the candidate shell. A million-neighbor hub can therefore require universe-scale preprocessing. Streaming top-K adjacency, precomputed weighted degrees/cut conductance, sparse solvers, Nomic-resistance Dijkstra, and CUDA are documented follow-ups rather than claims of this PR.

## Validation

- `69 passed` across global/local diffusion and graph-geometry suites.
- Benchmark smoke is now part of CI.
- Focused regressions cover:
  - full-principal-block parity;
  - nonzero common-bath semantics;
  - leakage calibration and conditioning;
  - fail-closed calibration budgets;
  - missing adjacency keys;
  - single-read embedding snapshots;
  - nested-domain operator compatibility;
  - boundary harmonic and Kirchhoff current balance;
  - deterministic strict-`K` selection.

## Deliberately deferred

- Nomic/resistance-weighted Dijkstra selection.
- Streaming/indexed high-degree adjacency.
- Sparse or GPU factorization.
- Covariance-channel promotion into the square-root/QR conditioner.

Those need their own scale and statistical acceptance studies; this PR establishes the exact local operator they can build on.
