### PR TITLE
WAM/LLVM plawk: NR as a special in if/while condition guards

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -22,7 +22,7 @@ only (runtime pending) · ❌ missing.
 | `$N == "v"`, `$3 > 100` | ✅ | field-equality + numeric field guards |
 | `&& \|\| !` combinators | ✅ | awk precedence, parens, single-block lowering |
 | `~` / `!~` match | ✅ | POSIX ERE |
-| expression pattern (bare `NR==1`) | ◐ | comparison guards yes; arbitrary expr no |
+| expression pattern (bare `NR==1`) | ◐ | comparison guards yes; arbitrary expr no. **`NR` is a special in `if`/`while` condition guards** (`if (NR == 2)`, `if (NR >= 2 && NR <= 3)`) — the record counter, not a phantom scalar slot (a prior bug read it as an uninitialised var → always 0). Fixes the record-gated idioms (`if (NR == 1) { first = $1 }`, conditional accumulation). `NF` as a guard special is a follow-on (needs the field separator threaded into condition lowering; no value in an END condition) |
 | range pattern (`/a/,/b/`) | ◐ | `/start/,/end/ { … }` fires for records from a /start/ match through a /end/ match (inclusive), via a per-rule i1 latch global; re-arms for later ranges, runs to EOF if unterminated. Regex endpoints (v1); general-pattern endpoints (`NR==1,NR==3`) are a follow-on |
 
 ## Actions & control flow

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5215,6 +5215,7 @@ plawk_while_cond_ok(cmp(special(Name), Op, Rhs)) :-
 
 plawk_match_special('RSTART').
 plawk_match_special('RLENGTH').
+plawk_match_special('NR').
 
 plawk_while_cond_rhs_ok(int(N)) :- integer(N).
 plawk_while_cond_rhs_ok(var(_W)).
@@ -5378,6 +5379,16 @@ plawk_while_cond_operand(special('RLENGTH'), _Slots, _CondValues, Base, Path, Si
     !,
     format(atom(Ref), '%~w_cond~w_~w_rlength', [Base, Path, Side]),
     format(atom(Line), '  ~w = load i64, i64* @plawk_rlength', [Ref]).
+% NR: the current record number. In a rule-body condition it is the loop's
+% %current_nr; in an END condition it is %plawk_nr (the final record count, the
+% same SSA the END expression path reads). No extra line -- both are existing
+% SSA values in scope. The END base is plawk_endif (see plawk_end_if lowering).
+plawk_while_cond_operand(special('NR'), _Slots, _CondValues, Base, _Path, _Side, Ref, []) :-
+    !,
+    ( sub_atom(Base, 0, _, _, plawk_endif)
+    -> Ref = '%plawk_nr'
+    ;  Ref = '%current_nr'
+    ).
 plawk_while_cond_operand(var(Name), Slots, CondValues, _Base, _Path, _Side, Ref, []) :-
     nth0(Idx, Slots, Slot),
     plawk_slot_name(Slot, Name),
@@ -6991,14 +7002,39 @@ plawk_actions_scalar_update_expr(Actions, Expr) :-
     member(Action, ReachableActions),
     plawk_action_scalar_update_expr(Action, Expr).
 
-plawk_action_scalar_update_expr(if(_Pattern, ThenActions, ElseActions), Expr) :-
+plawk_action_scalar_update_expr(if(Pattern, ThenActions, ElseActions), Expr) :-
     !,
-    (   plawk_actions_scalar_update_expr(ThenActions, Expr)
+    (   plawk_pattern_cond_operand_expr(Pattern, Expr)
+    ;   plawk_actions_scalar_update_expr(ThenActions, Expr)
     ;   plawk_actions_scalar_update_expr(ElseActions, Expr)
+    ).
+plawk_action_scalar_update_expr(while_loop(Cond, Body), Expr) :-
+    !,
+    (   plawk_cond_operand_expr(Cond, Expr)
+    ;   plawk_actions_scalar_update_expr(Body, Expr)
+    ).
+plawk_action_scalar_update_expr(do_while_loop(Body, Cond), Expr) :-
+    !,
+    (   plawk_cond_operand_expr(Cond, Expr)
+    ;   plawk_actions_scalar_update_expr(Body, Expr)
     ).
 plawk_action_scalar_update_expr(Action, Expr) :-
     plawk_scalar_action_update(Action, _Name, Operation),
     plawk_scalar_operation_expr(Operation, Expr).
+
+% Expose the operands of a scalar `if`/`while` condition so specials used only in
+% a guard (e.g. `if (NR > 1)`) are seen by the NR-usage detector (and any other
+% expr scan), so the record counter %current_nr is defined. A non-scalar
+% (field/pattern) guard contributes no scalar operands.
+plawk_pattern_cond_operand_expr(scalar_if(Cond), Expr) :-
+    plawk_cond_operand_expr(Cond, Expr).
+
+plawk_cond_operand_expr(and(A, B), Expr) :-
+    ( plawk_cond_operand_expr(A, Expr) ; plawk_cond_operand_expr(B, Expr) ).
+plawk_cond_operand_expr(or(A, B), Expr) :-
+    ( plawk_cond_operand_expr(A, Expr) ; plawk_cond_operand_expr(B, Expr) ).
+plawk_cond_operand_expr(cmp(Left, _Op, Right), Expr) :-
+    ( Expr = Left ; Expr = Right ).
 
 plawk_scalar_operation_expr(add(Expr), Expr).
 plawk_scalar_operation_expr(set(Expr), Expr).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1761,6 +1761,11 @@ while_cmp(cmp(var(V), Op, Rhs)) -->
 
 match_special_name('RSTART') --> "RSTART".
 match_special_name('RLENGTH') --> "RLENGTH".
+% NR (the record number) is a special in a comparison guard too, so `if (NR > 1)`
+% / `while (NR < 3)` read the record counter rather than a phantom scalar slot.
+% (NF is a follow-on: it needs the field separator threaded into the condition
+% lowering, and has no defined value in an END condition.)
+match_special_name('NR') --> "NR".
 
 while_cmp_rhs(int(N)) -->
     signed_integer_value(N),

--- a/tests/test_plawk_nr_guard.pl
+++ b/tests/test_plawk_nr_guard.pl
@@ -1,0 +1,124 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% NR as a special in an if / while comparison guard. Previously `if (NR > 1)`
+% parsed NR as a bare identifier -> a phantom scalar slot (always 0), so the
+% guard was always false. Now NR in a condition is recognised as the record
+% counter (special('NR')), matching the print/expr contexts. This also makes the
+% record-gated idioms (`if (NR == 1) { first = ... }`, conditional accumulation)
+% behave correctly -- the nested assignment itself was never broken, it was only
+% ever reached on the false branch because the NR guard misread.
+% (NF as a guard special is a documented follow-on: it needs the field separator
+% threaded into the condition lowering and has no value in an END condition.)
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_nr_guard).
+
+% --- parsing ---------------------------------------------------------------
+
+test(nr_guard_parses_as_special) :-
+    plawk_parse_string("{ if (NR >= 1) print 1 }\n",
+        program(_, [rule(always, [if(scalar_if(Cond), _Then, _Else)])], _)),
+    Cond == cmp(special('NR'), ge, int(1)),
+    !.
+
+% a variable whose name merely starts with NR is still an identifier.
+test(nrx_still_identifier) :-
+    plawk_parse_string("{ if (NRx > 1) print 1 }\n",
+        program(_, [rule(always, [if(scalar_if(Cond), _Then, _Else)])], _)),
+    Cond == cmp(var('NRx'), gt, int(1)),
+    !.
+
+% --- runtime ---------------------------------------------------------------
+
+% NR >= 1 is true on every record (the guard reads the counter, not a 0 slot).
+test(nr_ge_1_all, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'nge', "{ if (NR >= 1) print \"H\"; else print \"-\" }\n",
+        "x\ny\n", Out, St),
+    assertion(St == 0), assertion(Out == "H\nH\n"), !.
+
+% select a specific record by number.
+test(nr_eq_selects_record, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'neq', "{ if (NR == 2) print \"second\" }\n",
+        "a\nb\nc\n", Out, St),
+    assertion(St == 0), assertion(Out == "second\n"), !.
+
+% ordering comparison against the counter.
+test(nr_lt, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'nlt', "{ if (NR < 2) print \"early\"; else print \"late\" }\n",
+        "a\nb\nc\n", Out, St),
+    assertion(St == 0), assertion(Out == "early\nlate\nlate\n"), !.
+
+% NR in an && combination (a record range).
+test(nr_range_and, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'nrg', "{ if (NR >= 2 && NR <= 3) print \"mid\" }\n",
+        "a\nb\nc\nd\n", Out, St),
+    assertion(St == 0), assertion(Out == "mid\nmid\n"), !.
+
+% a block gated by NR, whose assignment is used AFTER the block -- the value
+% propagates (nested-assign-then-use works; only the NR guard was wrong before).
+test(nr_gated_block_use_after, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ngb', "{ if (NR >= 1) { c = 5 }; print c }\n",
+        "x\n", Out, St),
+    assertion(St == 0), assertion(Out == "5\n"), !.
+
+% a value captured on a specific record persists to later records.
+test(nr_capture_persists, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'ncp', "{ if (NR == 2) { c = 9 }; print c }\n",
+        "a\nb\nc\n", Out, St),
+    assertion(St == 0), assertion(Out == "0\n9\n9\n"), !.
+
+% conditional accumulation over records (sum of positive fields).
+test(nr_conditional_accumulate, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'nca', "{ if ($1 > 0) { pos = pos + $1 } } END { print pos }\n",
+        "3\n-1\n5\n", Out, St),
+    assertion(St == 0), assertion(Out == "8\n"), !.
+
+% NR still works in a print field (regression).
+test(nr_in_print_unchanged, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run(Dir, 'nrp', "{ print NR, $0 }\n", "a\nb\n", Out, St),
+    assertion(St == 0), assertion(Out == "1 a\n2 b\n"), !.
+
+:- end_tests(plawk_nr_guard).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_nr_guard', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
## Summary

Fixes a **silent-miscompile** bug: `NR` in an `if`/`while` comparison guard parsed as a bare identifier → a phantom scalar slot (always `0`), so the guard was always false.

```awk
{ if (NR == 2) print "second" }     # never printed anything (NR read as 0)
{ if (NR == 1) { first = $1 } … }   # the capture block never ran
```

**This corrects my earlier diagnosis.** While investigating step 4 I thought nested-block assignment (`if (c) { v = … }; use v`) was broken. It isn't — nested-assign-then-use works fine. The real cause was that the `NR` *guard* never took its true branch, so the block was never entered. With NR fixed, the record-gated idioms (capture-on-record-N, conditional accumulation) all work.

## What's here

- **Parser**: `match_special_name` recognizes `NR` (alongside `RSTART`/`RLENGTH`), so a condition `NR` becomes `special('NR')`, not `var('NR')`. A name that merely *starts* with `NR` (`NRx`) stays an identifier via the boundary check.
- **Codegen**: `plawk_match_special('NR')`; the condition-operand emitter yields the record counter — `%current_nr` in a rule-body condition, `%plawk_nr` in an END condition.
- **NR-usage detection**: `%current_nr` is only emitted when the program is detected to use `NR`, and that scan covered print/update expressions but **not** condition operands — so a guard-only `NR` referenced an undefined SSA (`use of undefined value '%current_nr'`). Extended the scalar-expr collector to expose `if`/`while`/`do-while` condition operands (and to recurse into loop bodies), so the counter is defined whenever a guard uses `NR`.

`NF` as a guard special is a documented follow-on (it needs the field separator threaded into condition lowering, and has no value in an END condition).

## Tests

`tests/test_plawk_nr_guard.pl` — **10**: parse (`NR`→special vs `NRx`→identifier), `NR >=` / `==` / `<` guards, an `&&` record range, a block gated by `NR` with use-after, capture-persists-across-records, conditional accumulation, and the `NR`-in-`print` regression. **Regression**: 17 plawk suites green (`loop_control`, `end_if`, guards, strnum, …).

## Context: closing the step-4 gaps

This is the first of the gaps flagged at the end of the strnum work. It turned the "nested-block field copies" item from "blocked on broken control flow" into "the guard bug is fixed; nested field copies remain i64 only because step 4 scoped strnum to top-level, a separate choice." The other gaps (`getline`/`ARGV`/`ENVIRON`, `split()` strnum) remain and are larger features.

Based on the feature line `claude/plawk-llvm-wam-hybrid-p9ujut`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_