### PR TITLE
Add Rust WAM halt builtins

### DIFF
--- a/templates/targets/rust_wam/process_builtin.rs.mustache
+++ b/templates/targets/rust_wam/process_builtin.rs.mustache
@@ -123,4 +123,13 @@
                 std::thread::sleep(duration);
                 self.pc += 1; true
             }
+            "halt/0" => std::process::exit(0),
+            "halt/1" => {
+                let code = match self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::Integer(code)) => code,
+                    _ => return false,
+                };
+                std::process::exit(code as i32)
+            }
 {{/match}}

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -116,6 +116,17 @@ t_process_commands(Status, Output) :-
 :- dynamic t_sleep/0.
 t_sleep :- sleep(0.001).
 
+:- dynamic t_halt_zero/0.
+t_halt_zero :- halt.
+
+:- dynamic t_halt_code/1.
+t_halt_code(Code) :- halt(Code).
+
+:- dynamic t_halt_sum/0.
+t_halt_sum :-
+    Code is 2 + 3,
+    halt(Code).
+
 :- dynamic t_environment_mutation/1.
 t_environment_mutation(Value) :-
     setenv('UNIFYWEAVER_RUST_WAM_COMPILED_ENV_8C19', first),
@@ -323,6 +334,50 @@ run_output_probe(TmpDir, ExitCode, Output) :-
     close(Stream),
     process_wait(Pid, exit(ExitCode)).
 
+write_halt_probe(TmpDir) :-
+    directory_file_path(TmpDir, 'src/bin', BinDir),
+    make_directory_path(BinDir),
+    directory_file_path(BinDir, 'halt_probe.rs', ProbePath),
+    ProbeContent = '
+use builtin_parity_test::state::WamState;
+use builtin_parity_test::value::Value;
+use builtin_parity_test::{t_halt_code_1, t_halt_sum_0, t_halt_zero_0};
+use std::collections::HashMap;
+
+fn main() {
+    let mode = std::env::args().nth(1).unwrap_or_default();
+    let mut vm = WamState::new(vec![], HashMap::new());
+    let returned = match mode.as_str() {
+        "zero" => t_halt_zero_0(&mut vm),
+        "seven" => t_halt_code_1(&mut vm, Value::Integer(7)),
+        "sum" => t_halt_sum_0(&mut vm),
+        "invalid" => t_halt_code_1(&mut vm, Value::Atom("bad".to_string())),
+        _ => std::process::exit(94),
+    };
+    if mode == "invalid" && !returned {
+        return;
+    }
+    std::process::exit(95);
+}
+',
+    setup_call_cleanup(
+        open(ProbePath, write, Out, [encoding(utf8)]),
+        write(Out, ProbeContent),
+        close(Out)).
+
+run_halt_probe(TmpDir, Mode, ExitCode) :-
+    process_create(path(cargo),
+                   ['run', '--quiet', '--bin', 'halt_probe', '--', Mode],
+                   [cwd(TmpDir), stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, exit(ExitCode)).
+
+run_halt_probes(TmpDir, Results) :-
+    findall(Mode-ExitCode,
+            ( member(Mode, [zero, seven, sum, invalid]),
+              run_halt_probe(TmpDir, Mode, ExitCode)
+            ),
+            Results).
+
 test_builtin_parity_execution :-
     Test = 'WAM-Rust builtin parity: end-to-end execution (cargo test)',
     TmpDir = 'output/test_wam_rust_builtin_parity',
@@ -346,6 +401,9 @@ test_builtin_parity_execution :-
              user:t_system_queries/3,
              user:t_process_commands/2,
              user:t_sleep/0,
+             user:t_halt_zero/0,
+             user:t_halt_code/1,
+             user:t_halt_sum/0,
              user:t_environment_mutation/1,
              user:t_split_string/1, user:t_atom_split/1, user:t_atom_checks/0,
              user:t_text_inspection/2,
@@ -2414,7 +2472,15 @@ fn test_environment_mutation_direct() {
             ExpectedOutput = "xy'two words'node('has space', 7)F1~|node(1)/hello/42/ok\n",
             (   ProbeExitCode == 0,
                 ProbeOutput == ExpectedOutput
-            ->  pass(Test)
+            ->  write_halt_probe(TmpDir),
+                run_halt_probes(TmpDir, HaltResults),
+                ExpectedHaltResults = [zero-0, seven-7, sum-5, invalid-0],
+                (   HaltResults == ExpectedHaltResults
+                ->  pass(Test)
+                ;   format('--- halt probes ---~nexpected: ~q~nactual:   ~q~n--- end ---~n',
+                           [ExpectedHaltResults, HaltResults]),
+                    fail_test(Test, 'halt probes failed')
+                )
             ;   format('--- output probe ---~nexpected: ~q~nactual:   ~q~n--- end ---~n',
                        [ExpectedOutput, ProbeOutput]),
                 fail_test(Test, 'output probe failed')

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -471,6 +471,8 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, '"system_to_atom/2"'),
         sub_string(S, _, _, _, '"atom_to_system/2"'),
         sub_string(S, _, _, _, '"sleep/1"'),
+        sub_string(S, _, _, _, '"halt/0"'),
+        sub_string(S, _, _, _, '"halt/1"'),
         sub_string(S, _, _, _, 'print!("{}", derefed)'),
         sub_string(S, _, _, _, 'nl/0'),
         sub_string(S, _, _, _, 'atom/1'),


### PR DESCRIPTION
## Summary

- Add Rust hybrid WAM support for `halt/0`
- Add integer-validated `halt/1`
- Preserve LLVM-compatible narrowing from the Prolog integer to the process exit code
- Keep both predicates in the existing process builtin template
- Test actual process termination through isolated generated child binaries

No dependencies, runtime fields, or shared compiler behavior are changed.

## Testing

- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `swipl -q -s tests/test_wam_rust_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_rust_builtin_parity.pl`
- `git diff --cached --check`