### PR TITLE
WAM/LLVM plawk: getline var < &quot;file&quot; (getline phase 1)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -47,7 +47,7 @@ only (runtime pending) · ❌ missing.
 | `delete arr[k]` | ◐ | `delete arr[$k]` removes the entry keyed by a field (parity with `arr[$k]++`); backward-shift deletion in the runtime (later colliding keys stay reachable), missing key is a no-op. String-literal / var keys are a follow-on |
 | `exit [n]` | ✅ | stops the record loop, runs END, returns N (default 0); `exit` in a rule body, an `if`/`else` branch, or a loop (propagates past the loop) — scalar state at the exit point flows into END |
 | `delete arr[k]` | ❌ | |
-| `getline` | ❌ | the multi-pass / `over` readers cover much of its use |
+| `getline` | ◐ | **`getline var < "file"` landed** (phase 1): reads the next line of a file into a scalar, returning 1/0/-1. `status = getline var < "file"` captures the return (dual-slot: `var` string, `status` i64); a bare `getline var < "file"` discards it. Handles are keyed by **filename** in a process-wide registry (`@wam_getline_file`), so every site reading the same file shares one advancing handle (as in awk); EOF preserves `var`. Canonical loop is prime-then-re-read (`r = getline v < "f"; while (r > 0) { …; r = getline v < "f" }`). Follow-ons: `getline` inside a `while` **condition** (needs the loop lowering to let the condition produce a slot update), plain `getline` / `getline < file` into `$0`, `cmd | getline`, and `var` as a strnum source. The multi-pass / `over` readers still cover the bulk-scan use |
 
 ## Functions
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -12157,6 +12157,10 @@ plawk_scalar_update_action_name(Action, Name) :-
 % surfaces CountName so it gets its own (i64) slot.
 plawk_scalar_update_action_name(gsub_count(CountName, _Global, _Regex, _Repl, Target), Name) :-
     ( Name = Target ; Name = CountName ).
+% `status = getline var < "file"` writes both the Var string scalar and the
+% Status i64 slot; action_update reports Var, this surfaces Status too.
+plawk_scalar_update_action_name(getline_capture(Status, Var, _File), Name) :-
+    ( Name = Var ; Name = Status ).
 plawk_scalar_update_action_name(dynrec_bind(Vars, _Call, _Types), Name) :-
     plawk_dynrec_binding_names(Vars, Names),
     member(Name, Names).
@@ -12250,6 +12254,14 @@ plawk_scalar_action_update(gsub_count(_CountName, Global, Regex, Repl, Target), 
     integer(Global),
     string(Regex),
     string(Repl).
+% `getline var < "file"` (and the count-capturing assignment): Var is a string
+% scalar holding the interned line. Reported as a Target string update so the
+% state plan types Var as scalar_string and the driver accepts the program; the
+% dedicated action-sequence clauses below emit the actual getline IR.
+plawk_scalar_action_update(getline_read(Var, File), Var, set_str(getline(File))) :-
+    string(File).
+plawk_scalar_action_update(getline_capture(_Status, Var, File), Var, set_str(getline(File))) :-
+    string(File).
 % Ternary assignment `x = COND ? A : B`: an i64 value via select (the operation
 % lowers through plawk_scalar_numeric_expr_ir(ternary(...)) -> plawk_i64_expr_ir).
 plawk_scalar_action_update(set(var(Name), ternary(cmp(Left, _Op, Right), Then, Else)),
@@ -12362,6 +12374,62 @@ plawk_scalar_action_sequence_pairs([dynrec_bind(Vars, Call, Types) | Rest], Slot
 % shared @plawk_gsub_count global; a following load moves that count into the
 % CountName i64 slot. Placed before the generic set-action clause so its
 % specific head wins.
+% Emit the getline IR for one site: the filename constant, an alloca for the
+% line id, the call to @wam_getline_file (which keys the open handle by filename
+% in a process-wide registry, so sites reading the same file share it), and the
+% awk EOF-preserve select (Var keeps its old value unless a line was actually
+% read). VarNext / StNext are the new Var / status SSA values. GlobalIR carries
+% just the filename constant.
+plawk_getline_ir(Prefix, OpIndex, File, VarInput, VarNext, StNext, GlobalIR, IR) :-
+    format(atom(Base), '~w_getline_~w', [Prefix, OpIndex]),
+    format(atom(PathName), '~w_path', [Base]),
+    llvm_emit_c_string_global(PathName, File, GlobalIR, PathLen, PathBytes),
+    format(atom(StNext), '%~w_status', [Base]),
+    format(atom(VarNext), '%~w_var', [Base]),
+    format(atom(IR),
+'  %~w_pathp = getelementptr [~w x i8], [~w x i8]* @.~w, i64 0, i64 0
+  %~w_lineid = alloca i64
+  ~w = call i64 @wam_getline_file(i8* %~w_pathp, i64 ~w, i64* %~w_lineid)
+  %~w_line = load i64, i64* %~w_lineid
+  %~w_got = icmp eq i64 ~w, 1
+  ~w = select i1 %~w_got, i64 %~w_line, i64 ~w',
+        [Base, PathBytes, PathBytes, PathName,
+         Base,
+         StNext, Base, PathLen, Base,
+         Base, Base,
+         Base, StNext,
+         VarNext, Base, Base, VarInput]).
+
+% `status = getline var < "file"`: read the next line into the Var string slot
+% and the 1/0/-1 status into the Status i64 slot (a dual-slot write). The file is
+% opened lazily and advanced one line per call via a per-site handle global.
+plawk_scalar_action_sequence_pairs([getline_capture(Status, Var, File) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { string(File),
+      nth0(VarIndex, Slots, VarSlot), plawk_slot_name(VarSlot, Var),
+      nth0(VarIndex, Values0, VarInput),
+      nth0(StIndex, Slots, StSlot), plawk_slot_name(StSlot, Status),
+      plawk_getline_ir(Prefix, OpIndex, File, VarInput, VarNext, StNext, GlobalIR, IR),
+      replace_nth0(VarIndex, Values0, VarNext, Values1),
+      replace_nth0(StIndex, Values1, StNext, Values2),
+      NextOpIndex is OpIndex + 1
+    },
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values2, Values, FinalOpIndex, ExitLabel, NextExits).
+% bare `getline var < "file"`: same, discarding the status.
+plawk_scalar_action_sequence_pairs([getline_read(Var, File) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { string(File),
+      nth0(VarIndex, Slots, VarSlot), plawk_slot_name(VarSlot, Var),
+      nth0(VarIndex, Values0, VarInput),
+      plawk_getline_ir(Prefix, OpIndex, File, VarInput, VarNext, _StNext, GlobalIR, IR),
+      replace_nth0(VarIndex, Values0, VarNext, Values1),
+      NextOpIndex is OpIndex + 1
+    },
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values1, Values, FinalOpIndex, ExitLabel, NextExits).
 plawk_scalar_action_sequence_pairs([gsub_count(CountName, Global, Regex, Repl, Target) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
         OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
     { integer(Global), string(Regex), string(Repl),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1587,6 +1587,9 @@ action(Action) -->
     add_assign_action(Action),
     !.
 action(Action) -->
+    getline_action(Action),
+    !.
+action(Action) -->
     assignment_action(Action),
     !.
 action(Action) -->
@@ -1601,6 +1604,24 @@ action(Action) -->
 action(Action) -->
     increment_action(Action),
     !.
+
+%% getline_action(-Action)//
+%
+%  `getline var < "file"` -- read the next line of a file into the scalar `var`,
+%  reusing the shared stream primitives (the file is opened once, then advanced
+%  one line per call). This bare statement form discards the 1/0/-1 status;
+%  `status = getline var < "file"` (an assignment) captures it (see
+%  assignment_action). v1: the file is a string literal, the target a scalar var;
+%  the canonical loop is `r = getline v < "f"; while (r > 0) { ...; r = getline v
+%  < "f" }` (getline inside a while CONDITION is a follow-on -- it needs the loop
+%  lowering to let the condition produce a slot update).
+getline_action(getline_read(Var, File)) -->
+    "getline",
+    required_ws,
+    identifier(Var),
+    ws, "<", ws,
+    quoted_string(FCodes),
+    { string_codes(File, FCodes) }.
 
 %% subgsub_action(-Action)//
 %
@@ -2151,6 +2172,21 @@ assignment_action(gsub_count(CountName, Global, Regex, Repl, Target)) -->
     ws, ",", ws,
     identifier(Target),
     ws, ")",
+    !.
+
+% `status = getline var < "file"` -- read the next line of the file into `var`
+% (a string scalar) and assign the 1/0/-1 status to `status` (an i64). A
+% dual-slot write. Tried before the generic scalar `set`; the `getline` keyword
+% after `=` is unambiguous.
+assignment_action(getline_capture(Status, Var, File)) -->
+    identifier(Status),
+    ws, "=", ws,
+    "getline",
+    required_ws,
+    identifier(Var),
+    ws, "<", ws,
+    quoted_string(FCodes),
+    { string_codes(File, FCodes) },
     !.
 
 assignment_action(set(var(Name), Value)) -->

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -7488,6 +7488,102 @@ sch.close:
   ret i1 %sch.ok
 }
 
+; awk `getline var < "file"`: read the next line of a file into a variable.
+; %pathptr/%pathlen name the file; %line_id_out receives the interned atom id of
+; the line on success. Returns 1 (a line was read), 0 (EOF), or -1 (open/read
+; error) -- the awk getline return contract.
+;
+; Handles are keyed by FILENAME in a small process-wide registry (so every
+; getline site reading the same file shares one open handle and advances through
+; it, matching awk), opened lazily on first use. Capacity is 64 distinct files.
+@wam_getline_reg_ids = internal global [64 x i64] zeroinitializer
+@wam_getline_reg_h = internal global [64 x i64] zeroinitializer
+@wam_getline_reg_n = internal global i64 0
+
+define i64 @wam_getline_file(i8* %pathptr, i64 %pathlen, i64* %line_id_out) {
+entry:
+  %gl.pid = call i64 @wam_intern_atom(i8* %pathptr, i64 %pathlen)
+  %gl.n = load i64, i64* @wam_getline_reg_n
+  br label %gl.scan
+
+gl.scan:
+  %gl.i = phi i64 [ 0, %entry ], [ %gl.i1, %gl.scan_next ]
+  %gl.done = icmp sge i64 %gl.i, %gl.n
+  br i1 %gl.done, label %gl.open, label %gl.scan_body
+
+gl.scan_body:
+  %gl.idp = getelementptr [64 x i64], [64 x i64]* @wam_getline_reg_ids, i64 0, i64 %gl.i
+  %gl.id = load i64, i64* %gl.idp
+  %gl.hit = icmp eq i64 %gl.id, %gl.pid
+  br i1 %gl.hit, label %gl.found, label %gl.scan_next
+
+gl.scan_next:
+  %gl.i1 = add i64 %gl.i, 1
+  br label %gl.scan
+
+gl.found:
+  %gl.fhp = getelementptr [64 x i64], [64 x i64]* @wam_getline_reg_h, i64 0, i64 %gl.i
+  %gl.fh = load i64, i64* %gl.fhp
+  br label %gl.ready
+
+gl.open:
+  %gl.full = icmp sge i64 %gl.n, 64
+  br i1 %gl.full, label %gl.err, label %gl.do_open
+
+gl.do_open:
+  %gl.pv0 = insertvalue %Value undef, i32 0, 0
+  %gl.pv = insertvalue %Value %gl.pv0, i64 %gl.pid, 1
+  %gl.hv = call %Value @wam_stream_open_value(%Value %gl.pv)
+  %gl.htag = extractvalue %Value %gl.hv, 0
+  %gl.hpay = extractvalue %Value %gl.hv, 1
+  %gl.hint = icmp eq i32 %gl.htag, 1
+  %gl.hpos = icmp sgt i64 %gl.hpay, 0
+  %gl.hok = and i1 %gl.hint, %gl.hpos
+  br i1 %gl.hok, label %gl.store, label %gl.err
+
+gl.store:
+  %gl.sidp = getelementptr [64 x i64], [64 x i64]* @wam_getline_reg_ids, i64 0, i64 %gl.n
+  store i64 %gl.pid, i64* %gl.sidp
+  %gl.shp = getelementptr [64 x i64], [64 x i64]* @wam_getline_reg_h, i64 0, i64 %gl.n
+  store i64 %gl.hpay, i64* %gl.shp
+  %gl.n1 = add i64 %gl.n, 1
+  store i64 %gl.n1, i64* @wam_getline_reg_n
+  br label %gl.ready
+
+gl.ready:
+  %gl.hcur = phi i64 [ %gl.fh, %gl.found ], [ %gl.hpay, %gl.store ]
+  %gl.hv0 = insertvalue %Value undef, i32 1, 0
+  %gl.hvr = insertvalue %Value %gl.hv0, i64 %gl.hcur, 1
+  %gl.line = call %Value @wam_stream_read_line_value(%Value %gl.hvr)
+  %gl.ltag = extractvalue %Value %gl.line, 0
+  %gl.lpay = extractvalue %Value %gl.line, 1
+  %gl.is_int = icmp eq i32 %gl.ltag, 1
+  %gl.neg = icmp slt i64 %gl.lpay, 0
+  %gl.readerr = and i1 %gl.is_int, %gl.neg
+  br i1 %gl.readerr, label %gl.err, label %gl.chk_atom
+
+gl.chk_atom:
+  %gl.is_atom = icmp eq i32 %gl.ltag, 0
+  br i1 %gl.is_atom, label %gl.chk_eof, label %gl.err
+
+gl.chk_eof:
+  %gl.ls = call i8* @wam_atom_to_string(i64 %gl.lpay)
+  %gl.eofp = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof_atom, i32 0, i32 0
+  %gl.cmp = call i32 @strcmp(i8* %gl.ls, i8* %gl.eofp)
+  %gl.iseof = icmp eq i32 %gl.cmp, 0
+  br i1 %gl.iseof, label %gl.eof, label %gl.line_ok
+
+gl.line_ok:
+  store i64 %gl.lpay, i64* %line_id_out
+  ret i64 1
+
+gl.eof:
+  ret i64 0
+
+gl.err:
+  ret i64 -1
+}
+
 define i1 @wam_atom_prefix_value(%Value %atom_value, i8* %prefix, i64 %prefix_len) {
 entry:
   %ap.t = call i32 @value_tag(%Value %atom_value)

--- a/tests/test_plawk_getline.pl
+++ b/tests/test_plawk_getline.pl
@@ -1,0 +1,110 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% getline from a file (phase 1): `getline var < "file"`.
+%   - `status = getline var < "file"` captures the 1/0/-1 return (a dual-slot
+%     write: var is a string scalar holding the line, status an i64).
+%   - `getline var < "file"` as a bare statement discards the status.
+% The file is opened lazily and advanced one line per call; the handle is keyed
+% by FILENAME in a process-wide registry, so every getline site reading the same
+% file shares it (as in awk). On EOF the status is 0 and var is unchanged; an
+% open/read error yields -1. The canonical loop is prime-then-re-read:
+%   r = getline v < "f"; while (r > 0) { ...; r = getline v < "f" }
+% (getline inside a while CONDITION is a follow-on; `getline` into $0, plain
+% `getline`, and `cmd | getline` are follow-ons.)
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_getline).
+
+% --- parsing ---------------------------------------------------------------
+
+test(getline_bare_parses) :-
+    plawk_parse_string("{ getline line < \"in.txt\" }\n",
+        program([], [rule(always, [getline_read(line, "in.txt")])], [])),
+    !.
+
+test(getline_capture_parses) :-
+    plawk_parse_string("{ r = getline line < \"in.txt\"; print r }\n",
+        program([], [rule(always,
+            [getline_capture(r, line, "in.txt"), print([var(r)])])], [])),
+    !.
+
+% --- runtime ---------------------------------------------------------------
+
+% the canonical loop: read every line of a file (one shared handle across the
+% two getline sites), printing each.
+test(getline_loop_reads_all, [condition(clang_available)]) :-
+    ldir(Dir),
+    data_file(Dir, 'data.txt', "alpha\nbeta\ngamma\n", DataPath),
+    format(atom(Src),
+        "{ r = getline line < \"~w\"; while (r > 0) { print line; r = getline line < \"~w\" } }\n",
+        [DataPath, DataPath]),
+    build_run(Dir, 'gll', Src, "trigger\n", Out, St),
+    assertion(St == 0), assertion(Out == "alpha\nbeta\ngamma\n"), !.
+
+% status is 1 for each line then 0 at EOF; the var is preserved on EOF.
+test(getline_status_and_eof, [condition(clang_available)]) :-
+    ldir(Dir),
+    data_file(Dir, 'two.txt', "one\ntwo\n", P),
+    format(atom(Src),
+        "{ r = getline v < \"~w\"; print r, v; r = getline v < \"~w\"; print r, v; r = getline v < \"~w\"; print r, v }\n",
+        [P, P, P]),
+    build_run(Dir, 'gse', Src, "t\n", Out, St),
+    assertion(St == 0), assertion(Out == "1 one\n1 two\n0 two\n"), !.
+
+% a missing file yields a -1 status.
+test(getline_missing_file, [condition(clang_available)]) :-
+    ldir(Dir),
+    directory_file_path(Dir, 'does_not_exist.txt', Missing),
+    format(atom(Src), "{ r = getline v < \"~w\"; print r }\n", [Missing]),
+    build_run(Dir, 'gmf', Src, "t\n", Out, St),
+    assertion(St == 0), assertion(Out == "-1\n"), !.
+
+% the bare statement form reads into the var (status discarded).
+test(getline_bare_reads, [condition(clang_available)]) :-
+    ldir(Dir),
+    data_file(Dir, 'bare.txt', "first\nsecond\n", P),
+    format(atom(Src), "{ getline v < \"~w\"; print v }\n", [P]),
+    build_run(Dir, 'gbr', Src, "t\n", Out, St),
+    assertion(St == 0), assertion(Out == "first\n"), !.
+
+:- end_tests(plawk_getline).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_getline', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+data_file(Dir, Name, Contents, Path) :-
+    directory_file_path(Dir, Name, Path),
+    setup_call_cleanup(open(Path, write, S, [encoding(utf8)]),
+        write(S, Contents), close(S)).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
## Summary

First slice of `getline`: **`getline var < "file"`** — read the next line of a file into a scalar, returning `1`/`0`/`-1`.

```awk
{ r = getline line < "data.txt"
  while (r > 0) { print line; r = getline line < "data.txt" } }
```

- `status = getline var < "file"` captures the return (a **dual-slot** write — `var` is a string scalar holding the line, `status` an i64).
- Bare `getline var < "file"` discards the status.

## Why this form first

plawk updates scalar slots in the action sequence, not inside expressions, so `getline` in a `while` **condition** (`while ((getline v < "f") > 0)`) would require reworking the loop lowering to let a condition produce a slot update — deferred. The assignment form fits the existing dual-slot pattern (same shape as gsub count-capture) and the prime-then-re-read loop covers the canonical use.

## What's here

- **Runtime** `@wam_getline_file(pathptr, pathlen, line_id_out) -> status` — reuses the existing stream primitives (open / read_line). **Open handles are keyed by filename** in a small process-wide registry (64 files), so every getline site reading the same file **shares one advancing handle** (as in awk) rather than each site re-opening from the top — this is what makes the prime + re-read loop actually walk the file. `1` = line read, `0` = EOF, `-1` = open/read error.
- **Parser**: `getline var < "file"` as a statement and as an assignment RHS (`status = getline var < "file"`).
- **Codegen**: dual-slot action-sequence clauses — `var` gets the interned line, `status` the return; an awk **EOF-preserve select** keeps `var` unchanged unless a line was actually read.

## Tests

`tests/test_plawk_getline.pl` — **6**: parse (bare + capture), the read-all loop (`alpha`/`beta`/`gamma` via a shared handle), status/EOF (`1`/`1`/`0` with `var` preserved), missing-file → `-1`, and the bare form. **Regression**: 10 scalar-machinery suites green.

## Follow-ons

`getline` in a `while` condition; plain `getline` / `getline < file` into `$0` (updates `NF`); `cmd | getline`; and `var` as a strnum source. The audit `getline` row moves from ❌ to ◐.

Based on the feature line `claude/plawk-llvm-wam-hybrid-p9ujut`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_