### PR TITLE
test(wam): deduplicate recursive-kernel parity harness

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -53,13 +53,14 @@ self-contained so a single coding agent can pick it up in isolation.
 | ISO-R | ISO three-form (new) | R | L | — |
 | ISO-PYTHON | ISO three-form (finish) | Python | S | — |
 | ISO-FSHARP | ISO three-form (finish) | F# | S | — |
-| KERN-FSHARP ⚡ | Finish F# native kernel acceleration | F# | L | gate+TC2+TD3+TPD4+TSPD5+WSP3 done; A* draft |
+| KERN-FSHARP ✅ | Finish F# native kernel acceleration | F# | L | gate+TC2+TD3+TPD4+TSPD5+WSP3+A* done |
 | TC2-CONTRACT-PARITY ✅ | Fleet-wide `transitive_closure2` strict R+ contract | multi | M | done (`#3817`) |
 | TD3-CONTRACT-PARITY-FS ✅ | Fleet-wide `transitive_distance3` dist+ + F# native | multi | M | done (`#3821`) |
 | TPD4-CONTRACT-PARITY-FS ✅ | Fleet-wide `transitive_parent_distance4` + F# native | multi | M | done (`#3830`) |
 | TSPD5-CONTRACT-PARITY-FS ✅ | Fleet-wide correlated TSPD5 + F# native | multi | M | done (`#3838`) |
 | WSP3-CONTRACT-PARITY-FS ✅ | Fleet-wide WSP3 Dijkstra + F# native | multi | M | done (`#3847`) |
-| ASTAR4-CONTRACT-PARITY-FS ⚡ | Fleet-wide A* Dijkstra-minimum + F# native | multi | M | draft — not landed until merge |
+| ASTAR4-CONTRACT-PARITY-FS ✅ | Fleet-wide A* Dijkstra-minimum + F# native | multi | M | done (`#3856`) |
+| WAM-KERNEL-PARITY-HARNESS-DRY ⚡ | Deduplicate recursive-kernel parity harness | test | S | draft — shared helper + drop algorithm replicas |
 | EMIT-ILASM | Lowered emitter | ILAsm | L | — |
 | EMIT-JVM | Lowered emitter | JVM | L | — |
 | EMIT-KOTLIN ✅ | Lowered emitter | Kotlin | M | done — flat facts/unify (`cursor/emit-kotlin-lowered-f421`) |
@@ -490,10 +491,10 @@ plumbing there.
 - **FS-TPD4 ✅ (landed `#3830`):** `nativeKernel_transitive_parent_distance` Mustache + allow-list entry; streams `(atom,atom,int)` via the three-output `FFIStreamRetry` binder.
 - **FS-TSPD5 ✅ (landed `#3838`):** `nativeKernel_transitive_step_parent_distance` Mustache + allow-list; streams `(atom,atom,atom,int)` via the four-output `FFIStreamRetry` binder.
 - **FS-WSP3 ✅ (landed `#3847`):** `nativeKernel_weighted_shortest_path` Mustache + allow-list + `WcFfiWeightedFacts` materialization; streams `(atom,float)` via the two-output `FFIStreamRetry` binder.
-- **FS-ASTAR4 (draft):** `nativeKernel_astar_shortest_path` Mustache + allow-list + dual relation-keyed `WcFfiWeightedFacts` materialization for edge and heuristic triples; streams the singleton float cost via the existing single-output `FFIStreamRetry` binder. Mark landed only after the ASTAR4 parity PR merges.
-- **Remaining gated shared kinds:** none for missing F# handlers. A* remains draft contract-parity work, but is no longer intentionally excluded by the F# native-kernel capability gate.
+- **FS-ASTAR4 ✅ (landed `#3856`):** `nativeKernel_astar_shortest_path` Mustache + allow-list + dual relation-keyed `WcFfiWeightedFacts` materialization for edge and heuristic triples; streams the singleton float cost via the existing single-output `FFIStreamRetry` binder.
+- **Remaining gated shared kinds:** none for missing F# handlers.
 - **Tests:** `tests/core/test_wam_fsharp_kernel_gate_tc.pl`
-- **Acceptance (gate+TC2+TD3+TPD4+TSPD5+WSP3+A* draft):** `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_kernel_gate_tc.pl`.
+- **Acceptance (gate+TC2+TD3+TPD4+TSPD5+WSP3+A*):** `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_kernel_gate_tc.pl`.
 
 ---
 
@@ -535,19 +536,25 @@ plumbing there.
 - **Contract:** [`docs/design/WAM_WEIGHTED_SHORTEST_PATH3_CONTRACT.md`](design/WAM_WEIGHTED_SHORTEST_PATH3_CONTRACT.md) — one `(Target, FloatCost)` per reachable non-Source target; finite nonnegative weights (zero OK); Source always excluded (even self-loop/cycle); reachable invalid rows fail the complete call; integral sums emit as float; all four Target/Cost modes; transactional pair stream (`FFIStreamRetry` / established ABIs).
 - **Oracle / fixtures:** `tests/fixtures/wsp3_contract_oracle.pl` (literal expected pairs + independent Dijkstra).
 - **Handler align:** Rust/Haskell/LLVM/C/Go/Scala/R/Elixir — float costs, invalid-row fail, Source excluded; C replaces fixed-256/first-only/global bag with relation-isolated dynamic Dijkstra + pair stream. Preserve TPD4/TSPD5/A*.
-- **F# native:** `templates/targets/fsharp_wam/kernel_weighted_shortest_path.fs.mustache` + allow-list + relation-keyed `WcFfiWeightedFacts` materialization from inline edge facts; two-output `FFIStreamRetry`. A* contract parity is now a separate draft card.
+- **F# native:** `templates/targets/fsharp_wam/kernel_weighted_shortest_path.fs.mustache` + allow-list + relation-keyed `WcFfiWeightedFacts` materialization from inline edge facts; two-output `FFIStreamRetry`.
 - **Tests:** `tests/test_wam_wsp3_contract_parity.pl` + F# gate suite + TSPD5/TPD4 non-regression.
 - **Acceptance:** `swipl -q -g run_tests -t halt tests/test_wam_wsp3_contract_parity.pl` (plus TSPD5 + TPD4 + F# gate).
 
-### ASTAR4-CONTRACT-PARITY-FS: Fleet-wide `astar_shortest_path4` correctness-safe A* + F# native
+### ASTAR4-CONTRACT-PARITY-FS ✅: Fleet-wide `astar_shortest_path4` correctness-safe A* + F# native
 - **Lever:** Shared recursive-kernel contract parity  **Target:** multi  **Size:** M  **Depends on:** WSP3-CONTRACT-PARITY-FS (`#3847`)
-- **Status:** Implemented in draft branch; **not landed** until merge. Do not describe as done in status docs before merge.
+- **Status:** ✅ Landed (`#3856`).
 - **Contract:** [`docs/design/WAM_ASTAR_SHORTEST_PATH4_CONTRACT.md`](design/WAM_ASTAR_SHORTEST_PATH4_CONTRACT.md) — goal-directed shortest path returns the finite Dijkstra minimum from Source to bound Target as a singleton float stream; heuristic and Dim affect scheduling only; missing heuristic is 0.0; Source=Target emits 0.0; invalid reachable edge or relevant heuristic rows fail the call.
 - **Oracle / fixtures:** `tests/fixtures/astar4_contract_oracle.pl` (literal expected costs + independent Dijkstra coverage for overestimating heuristic, missing heuristic, zero cycles, large chains, and multi-predicate isolation).
-- **Handler align:** F# adds native template + allow-list + weighted edge/heuristic materialization; Haskell uses empty-stream failure for invalid rows; Scala rejects non-atom Source/Target with `ForeignFail`; fleet targets keep the correctness-safe Dijkstra-minimum contract.
+- **Handler align:** F# native template + allow-list + weighted edge/heuristic materialization; Haskell empty-stream failure for invalid rows; Scala rejects non-atom Source/Target with `ForeignFail`; fleet targets keep the correctness-safe Dijkstra-minimum contract.
 - **F# native:** `templates/targets/fsharp_wam/kernel_astar_shortest_path.fs.mustache` + allow-list + relation-keyed `WcFfiWeightedFacts` for both `edge_pred/3` and `direct_dist_pred/3`; singleton float via the existing single-output `FFIStreamRetry` binder.
 - **Tests:** `tests/test_wam_astar4_contract_parity.pl` + F# gate suite + WSP3/TSPD5/TPD4 non-regression.
 - **Acceptance:** `swipl -q -g run_tests -t halt tests/test_wam_astar4_contract_parity.pl` (plus WSP3 + F# gate).
+
+### WAM-KERNEL-PARITY-HARNESS-DRY: Deduplicate recursive-kernel parity harness
+- **Lever:** Shared recursive-kernel contract parity  **Target:** test  **Size:** S  **Depends on:** ASTAR4-CONTRACT-PARITY-FS (`#3856`)
+- **Status:** Draft — behavior-preserving test maintenance only (no production target changes).
+- **Goal:** One shared Prolog helper (`tests/helpers/wam_kernel_parity_harness.pl`, reusing `smoke_paths`) for toolchain detection, tmp dirs, file I/O, and dotnet build/run; remove standalone target-language BFS/Dijkstra/A* replicas that did not execute generated runtime; keep independent oracles + structural markers + true generated-runtime e2e.
+- **Acceptance:** all six `tests/test_wam_*_contract_parity.pl` suites + F# gate + `run_wam_fsharp_tests.pl` + `git diff --check`.
 
 ---
 

--- a/docs/WAM_FSHARP_STATUS.md
+++ b/docs/WAM_FSHARP_STATUS.md
@@ -41,9 +41,9 @@ for the allow-listed native kinds:
 `category_ancestor`, `bidirectional_ancestor`, `transitive_closure2`,
 `transitive_distance3`, `transitive_parent_distance4`,
 `transitive_step_parent_distance5`, `weighted_shortest_path3`, and
-`astar_shortest_path4`. WSP3 landed in #3847; A* is implemented in draft
-contract-parity work. Missing handlers no longer emit undefined
-`nativeKernel_*` calls. Benchmarks centre on `category_ancestor/4`.
+`astar_shortest_path4`. WSP3 landed in #3847; A* landed in #3856.
+Missing handlers no longer emit undefined `nativeKernel_*` calls.
+Benchmarks centre on `category_ancestor/4`.
 **Bidirectional** upgrade is computed but **off by default** — requires
 `allow_bidirectional_kernel_swap(true)`. CSR reverse-index reader
 (`CsrLookupSource`) and cost/strategy analyzers ship.
@@ -80,13 +80,10 @@ classic `wam_conformance_smoke` matrix with Scala/Elixir.
 
 ## Gaps
 
-- ASTAR4 (`astar_shortest_path4`) is implemented in draft fleet-parity
-  work (Mustache + allow-list + dual weighted edge/heuristic
-  materialization + singleton `FFIStreamRetry`); treat as landed only
-  after that PR merges.
-- No shared recursive kernel is currently listed as remaining gated for a
-  missing F# handler; keep the ASTAR4 draft parity suite green before
-  claiming full fleet parity.
+- ASTAR4 (`astar_shortest_path4`) landed in #3856 (Mustache + allow-list
+  + dual weighted edge/heuristic materialization + singleton
+  `FFIStreamRetry`).
+- No shared recursive kernel remains gated for a missing F# handler.
 - Bidirectional off by default; enable after cost-model confidence.
 - Classic conformance (**CONF-FSHARP**, 2026-07-15): registered
   opt-in (`fsharp` / `fsharp_functions`) with additive

--- a/tests/helpers/wam_kernel_parity_harness.pl
+++ b/tests/helpers/wam_kernel_parity_harness.pl
@@ -1,0 +1,113 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% wam_kernel_parity_harness.pl — shared helpers for recursive-kernel
+% contract parity suites (TC2/TD3/TPD4/TSPD5/WSP3/ASTAR4).
+%
+% Reuses smoke_paths for writable tmp roots. Does not implement any
+% graph algorithm; parity suites keep independent Prolog oracles and
+% generated-runtime drivers locally.
+
+:- module(wam_kernel_parity_harness,
+          [ dotnet_available/0,
+            gcc_available/0,
+            cargo_available/0,
+            elixir_available/0,
+            go_available/0,
+            scala_available/0,
+            rscript_available/0,
+            ghc_available/0,
+            llvm_tools_available/0,
+            executable_available/1,
+            tmp_dir/2,
+            read_file_string/2,
+            write_file_string/2,
+            run_dotnet_build/3,
+            run_dotnet_run/3,
+            dotnet_status_exit/2
+          ]).
+
+:- use_module(library(filesex),
+              [make_directory_path/1, directory_file_path/3]).
+:- use_module(library(process)).
+:- use_module(library(readutil)).
+:- use_module('smoke_paths', [tmp_root/1, clean_dir/1]).
+
+toolchain_available(Cmd, Args) :-
+    catch(
+        ( process_create(path(Cmd), Args,
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, exit(0)) ),
+        _, fail).
+
+dotnet_available :- toolchain_available(dotnet, ['--version']).
+gcc_available     :- toolchain_available(gcc, ['--version']).
+cargo_available   :- toolchain_available(cargo, ['--version']).
+elixir_available  :- toolchain_available(elixir, ['--version']).
+go_available      :- toolchain_available(go, [version]).
+scala_available   :- toolchain_available(scalac, ['-version']).
+rscript_available :- toolchain_available('Rscript', ['--version']).
+ghc_available     :- toolchain_available(ghc, ['--version']).
+
+executable_available(Name) :-
+    toolchain_available(Name, ['--version']).
+
+llvm_tools_available :-
+    executable_available(llc),
+    executable_available(clang).
+
+%! tmp_dir(+Tag, -Dir) is det.
+%  Unique writable directory under smoke_paths:tmp_root/1.
+tmp_dir(Tag, Dir) :-
+    tmp_root(Root),
+    get_time(T),
+    Stamp is round(T * 1000000),
+    format(atom(Leaf), 'uw_wam_parity_~w_~w', [Tag, Stamp]),
+    directory_file_path(Root, Leaf, Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir).
+
+read_file_string(Path, String) :-
+    read_file_to_string(Path, String, []).
+
+write_file_string(Path, String) :-
+    setup_call_cleanup(
+        open(Path, write, Out, [encoding(utf8)]),
+        write(Out, String),
+        close(Out)).
+
+run_dotnet_build(Dir, Exit, Out) :-
+    setup_call_cleanup(
+        process_create(path(dotnet),
+            ['build', '--nologo', '-v', 'q', '-c', 'Release'],
+            [cwd(Dir),
+             environment([
+                 'DOTNET_NOLOGO'='1',
+                 'DOTNET_ROLL_FORWARD'='Major'
+             ]),
+             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
+        ( read_string(SO, _, S1), read_string(SE, _, S2),
+          process_wait(Pid, Status),
+          dotnet_status_exit(Status, Exit),
+          string_concat(S1, S2, Out) ),
+        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
+
+run_dotnet_run(Dir, Exit, Out) :-
+    setup_call_cleanup(
+        process_create(path(dotnet),
+            ['run', '--no-build', '-c', 'Release', '--no-launch-profile', '--'],
+            [cwd(Dir),
+             environment([
+                 'DOTNET_NOLOGO'='1',
+                 'DOTNET_ROLL_FORWARD'='Major'
+             ]),
+             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
+        ( read_string(SO, _, S1), read_string(SE, _, S2),
+          process_wait(Pid, Status),
+          dotnet_status_exit(Status, Exit),
+          string_concat(S1, S2, Out) ),
+        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
+
+dotnet_status_exit(exit(Code), Code).
+dotnet_status_exit(killed(Signal), Code) :-
+    Code is 128 + Signal.

--- a/tests/helpers/wam_kernel_parity_harness.pl
+++ b/tests/helpers/wam_kernel_parity_harness.pl
@@ -33,12 +33,20 @@
 :- use_module(library(readutil)).
 :- use_module('smoke_paths', [tmp_root/1, clean_dir/1]).
 
+% Missing executables fail the capability condition.  A command that starts
+% but returns nonzero is broken, not missing, and must fail the suite loudly.
 toolchain_available(Cmd, Args) :-
-    catch(
-        ( process_create(path(Cmd), Args,
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
+    absolute_file_name(path(Cmd), Executable,
+                       [access(execute), file_errors(fail)]),
+    process_create(Executable, Args,
+                   [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, Status),
+    (   Status == exit(0)
+    ->  true
+    ;   throw(error(toolchain_probe_failed(Cmd, Status),
+                    context(toolchain_available/2,
+                            'toolchain version probe failed')))
+    ).
 
 dotnet_available :- toolchain_available(dotnet, ['--version']).
 gcc_available     :- toolchain_available(gcc, ['--version']).

--- a/tests/run_wam_fsharp_tests.pl
+++ b/tests/run_wam_fsharp_tests.pl
@@ -9,6 +9,9 @@
 %%   tests/test_wam_fsharp_target.pl
 %%     - Source-level codegen assertions.  Runs everywhere swipl is
 %%       available; no external toolchain required.
+%%   tests/test_wam_tc2_contract_parity.pl
+%%     - fleet TC2 strict R+ oracle/structural checks plus executable F#/C/Rust
+%%       retry, binding-mode, cycle, and native-vs-oracle coverage.
 %%   tests/test_wam_td3_contract_parity.pl
 %%     - fleet TD3 dist+ oracle/structural checks plus executable F#/C/Rust
 %%       retry, binding-mode, cycle, and no-kernels coverage.
@@ -64,6 +67,8 @@ fsharp_test('tests/test_wam_fsharp_target.pl',
 fsharp_test('tests/core/test_wam_fsharp_kernel_gate_tc.pl',
             'F# WAM kernel capability gate + native transitive_closure2',
             run_tests).
+fsharp_test('tests/test_wam_tc2_contract_parity.pl',
+            'TC2 strict R+ fleet contract + F# native kernel', run_tests).
 fsharp_test('tests/test_wam_td3_contract_parity.pl',
             'TD3 strict dist+ fleet contract + F# native kernel', run_tests).
 fsharp_test('tests/test_wam_tpd4_contract_parity.pl',

--- a/tests/test_wam_astar4_contract_parity.pl
+++ b/tests/test_wam_astar4_contract_parity.pl
@@ -49,6 +49,8 @@
 :- use_module('../src/unifyweaver/core/recursive_kernel_detection',
               [detect_recursive_kernel/4]).
 
+:- use_module('helpers/wam_kernel_parity_harness').
+
 :- dynamic user:a_edge/3.
 :- dynamic user:a_heur/3.
 :- dynamic user:astar/4.
@@ -62,47 +64,6 @@
 :- dynamic user:dimensionality/1.
 :- dynamic user:astar_cut/3.
 :- dynamic user:astar_after/3.
-
-dotnet_available :-
-    catch(
-        ( process_create(path(dotnet), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-gcc_available :-
-    catch(
-        ( process_create(path(gcc), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-cargo_available :-
-    catch(
-        ( process_create(path(cargo), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-llvm_tools_available :-
-    executable_available(llc),
-    executable_available(clang).
-
-executable_available(Name) :-
-    catch(
-        ( process_create(path(Name), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-tmp_dir(Tag, Dir) :-
-    get_time(T),
-    format(atom(Stamp), '~w', [T]),
-    format(atom(Dir), '/tmp/uw_astar4_~w_~w', [Tag, Stamp]),
-    make_directory_path(Dir).
-
-read_file_string(Path, String) :-
-    read_file_to_string(Path, String, []).
 
 assert_astar_detour_program :-
     retractall(user:a_edge(_, _, _)),
@@ -450,42 +411,6 @@ run_llvm_astar_script(File) :-
     process_create(Swipl, ['-q', '-s', File], [process(Pid)]),
     process_wait(Pid, Status),
     assertion(Status == exit(0)).
-
-run_dotnet_build(Dir, Exit, Out) :-
-    setup_call_cleanup(
-        process_create(path(dotnet),
-            ['build', '--nologo', '-v', 'q', '-c', 'Release'],
-            [cwd(Dir),
-             environment([
-                 'DOTNET_NOLOGO'='1',
-                 'DOTNET_ROLL_FORWARD'='Major'
-             ]),
-             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
-        ( read_string(SO, _, S1), read_string(SE, _, S2),
-          process_wait(Pid, Status),
-          dotnet_status_exit(Status, Exit),
-          string_concat(S1, S2, Out) ),
-        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
-
-run_dotnet_run(Dir, Exit, Out) :-
-    setup_call_cleanup(
-        process_create(path(dotnet),
-            ['run', '--no-build', '-c', 'Release', '--no-launch-profile', '--'],
-            [cwd(Dir),
-             environment([
-                 'DOTNET_NOLOGO'='1',
-                 'DOTNET_ROLL_FORWARD'='Major'
-             ]),
-             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
-        ( read_string(SO, _, S1), read_string(SE, _, S2),
-          process_wait(Pid, Status),
-          dotnet_status_exit(Status, Exit),
-          string_concat(S1, S2, Out) ),
-        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
-
-dotnet_status_exit(exit(Code), Code).
-dotnet_status_exit(killed(Signal), Code) :-
-    Code is 128 + Signal.
 
 %% Driver uses Predicates.declaredWeightedEdgeFacts / buildWeightedFfiFacts.
 astar4_write_fsharp_driver(ProgPath) :-

--- a/tests/test_wam_tc2_contract_parity.pl
+++ b/tests/test_wam_tc2_contract_parity.pl
@@ -44,41 +44,12 @@
 :- use_module('../src/unifyweaver/core/recursive_kernel_detection',
               [detect_recursive_kernel/4]).
 
+:- use_module('helpers/wam_kernel_parity_harness').
+
 :- dynamic user:tc_edge/2.
 :- dynamic user:tc/2.
 :- dynamic user:tc_parent/2.
 :- dynamic user:tc_ancestor/2.
-
-dotnet_available :-
-    catch(
-        ( process_create(path(dotnet), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, _) ),
-        _, fail).
-
-gcc_available :-
-    catch(
-        ( process_create(path(gcc), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, _) ),
-        _, fail).
-
-cargo_available :-
-    catch(
-        ( process_create(path(cargo), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, _) ),
-        _, fail).
-
-tmp_dir(Tag, Dir) :-
-    get_time(T),
-    Stamp is round(T * 1000000),
-    format(atom(Dir), '/tmp/uw_tc2_~w_~w', [Tag, Stamp]),
-    catch(delete_directory_and_contents(Dir), _, true),
-    make_directory_path(Dir).
-
-read_file_string(Path, String) :-
-    read_file_to_string(Path, String, []).
 
 assert_tc_cycle_program :-
     retractall(user:tc_edge(_, _)),
@@ -410,28 +381,6 @@ test(cyclic_generic_wam_is_not_the_oracle) :-
 % ============================================================
 % Helpers
 % ============================================================
-
-run_dotnet_build(Dir, Exit, Out) :-
-    setup_call_cleanup(
-        process_create(path(dotnet),
-            ['build', '--nologo', '-v', 'q', '-c', 'Release'],
-            [cwd(Dir), stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
-        ( read_string(SO, _, S1), read_string(SE, _, S2),
-          process_wait(Pid, exit(Exit)),
-          string_concat(S1, S2, Out) ),
-        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
-
-run_dotnet_run(Dir, Exit, Out) :-
-    setup_call_cleanup(
-        process_create(path(dotnet),
-            ['run', '--no-build', '-c', 'Release', '--no-launch-profile', '--'],
-            [cwd(Dir),
-             environment(['DOTNET_NOLOGO'='1', 'DOTNET_ROLL_FORWARD'='Major']),
-             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
-        ( read_string(SO, _, S1), read_string(SE, _, S2),
-          process_wait(Pid, exit(Exit)),
-          string_concat(S1, S2, Out) ),
-        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
 
 tc2_write_fsharp_rplus_driver(ProgPath) :-
     Driver =

--- a/tests/test_wam_td3_contract_parity.pl
+++ b/tests/test_wam_td3_contract_parity.pl
@@ -36,6 +36,8 @@
 :- use_module('../src/unifyweaver/core/recursive_kernel_detection',
               [detect_recursive_kernel/4]).
 
+:- use_module('helpers/wam_kernel_parity_harness').
+
 :- dynamic user:td_edge/2.
 :- dynamic user:td/3.
 :- dynamic user:td_tail/2.
@@ -44,37 +46,6 @@
 :- dynamic user:td_call_after/2.
 :- dynamic user:td_parent/2.
 :- dynamic user:tc_distance/3.
-
-dotnet_available :-
-    catch(
-        ( process_create(path(dotnet), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-gcc_available :-
-    catch(
-        ( process_create(path(gcc), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-cargo_available :-
-    catch(
-        ( process_create(path(cargo), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-tmp_dir(Tag, Dir) :-
-    get_time(T),
-    Stamp is round(T * 1000000),
-    format(atom(Dir), '/tmp/uw_td3_~w_~w', [Tag, Stamp]),
-    catch(delete_directory_and_contents(Dir), _, true),
-    make_directory_path(Dir).
-
-read_file_string(Path, String) :-
-    read_file_to_string(Path, String, []).
 
 assert_td_cycle_program :-
     retractall(user:td_edge(_, _)),
@@ -413,42 +384,6 @@ test(fsharp_no_kernels_fallback_builds, [condition(dotnet_available)]) :-
 % ============================================================
 % Helpers
 % ============================================================
-
-run_dotnet_build(Dir, Exit, Out) :-
-    setup_call_cleanup(
-        process_create(path(dotnet),
-            ['build', '--nologo', '-v', 'q', '-c', 'Release'],
-            [cwd(Dir),
-             environment([
-                 'DOTNET_NOLOGO'='1',
-                 'DOTNET_ROLL_FORWARD'='Major'
-             ]),
-             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
-        ( read_string(SO, _, S1), read_string(SE, _, S2),
-          process_wait(Pid, Status),
-          dotnet_status_exit(Status, Exit),
-          string_concat(S1, S2, Out) ),
-        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
-
-run_dotnet_run(Dir, Exit, Out) :-
-    setup_call_cleanup(
-        process_create(path(dotnet),
-            ['run', '--no-build', '-c', 'Release', '--no-launch-profile', '--'],
-            [cwd(Dir),
-             environment([
-                 'DOTNET_NOLOGO'='1',
-                 'DOTNET_ROLL_FORWARD'='Major'
-             ]),
-             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
-        ( read_string(SO, _, S1), read_string(SE, _, S2),
-          process_wait(Pid, Status),
-          dotnet_status_exit(Status, Exit),
-          string_concat(S1, S2, Out) ),
-        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
-
-dotnet_status_exit(exit(Code), Code).
-dotnet_status_exit(killed(Signal), Code) :-
-    Code is 128 + Signal.
 
 td3_write_fsharp_driver(ProgPath) :-
     Driver =

--- a/tests/test_wam_tpd4_contract_parity.pl
+++ b/tests/test_wam_tpd4_contract_parity.pl
@@ -36,6 +36,8 @@
 :- use_module('../src/unifyweaver/core/recursive_kernel_detection',
               [detect_recursive_kernel/4]).
 
+:- use_module('helpers/wam_kernel_parity_harness').
+
 :- dynamic user:tpd_edge/2.
 :- dynamic user:tpd/4.
 :- dynamic user:tpd_tail/3.
@@ -44,44 +46,6 @@
 :- dynamic user:tpd_call_after/3.
 :- dynamic user:pd_parent/2.
 :- dynamic user:pd/4.
-
-dotnet_available :-
-    catch(
-        ( process_create(path(dotnet), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-gcc_available :-
-    catch(
-        ( process_create(path(gcc), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-cargo_available :-
-    catch(
-        ( process_create(path(cargo), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-elixir_available :-
-    catch(
-        ( process_create(path(elixir), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-tmp_dir(Tag, Dir) :-
-    get_time(T),
-    Stamp is round(T * 1000000),
-    format(atom(Dir), '/tmp/uw_tpd4_~w_~w', [Tag, Stamp]),
-    catch(delete_directory_and_contents(Dir), _, true),
-    make_directory_path(Dir).
-
-read_file_string(Path, String) :-
-    read_file_to_string(Path, String, []).
 
 assert_tpd_cycle_program :-
     retractall(user:tpd_edge(_, _)),
@@ -478,42 +442,6 @@ test(fsharp_no_kernels_fallback_builds, [condition(dotnet_available)]) :-
 % ============================================================
 % Helpers
 % ============================================================
-
-run_dotnet_build(Dir, Exit, Out) :-
-    setup_call_cleanup(
-        process_create(path(dotnet),
-            ['build', '--nologo', '-v', 'q', '-c', 'Release'],
-            [cwd(Dir),
-             environment([
-                 'DOTNET_NOLOGO'='1',
-                 'DOTNET_ROLL_FORWARD'='Major'
-             ]),
-             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
-        ( read_string(SO, _, S1), read_string(SE, _, S2),
-          process_wait(Pid, Status),
-          dotnet_status_exit(Status, Exit),
-          string_concat(S1, S2, Out) ),
-        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
-
-run_dotnet_run(Dir, Exit, Out) :-
-    setup_call_cleanup(
-        process_create(path(dotnet),
-            ['run', '--no-build', '-c', 'Release', '--no-launch-profile', '--'],
-            [cwd(Dir),
-             environment([
-                 'DOTNET_NOLOGO'='1',
-                 'DOTNET_ROLL_FORWARD'='Major'
-             ]),
-             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
-        ( read_string(SO, _, S1), read_string(SE, _, S2),
-          process_wait(Pid, Status),
-          dotnet_status_exit(Status, Exit),
-          string_concat(S1, S2, Out) ),
-        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
-
-dotnet_status_exit(exit(Code), Code).
-dotnet_status_exit(killed(Signal), Code) :-
-    Code is 128 + Signal.
 
 tpd4_write_fsharp_driver(ProgPath) :-
     Driver =

--- a/tests/test_wam_tpd4_contract_parity.pl
+++ b/tests/test_wam_tpd4_contract_parity.pl
@@ -393,6 +393,7 @@ test(rust_collect_tpd4_unit, [condition(cargo_available)]) :-
     ),
     !.
 
+% Generated-kernel unit; it does not claim dispatch/register end-to-end coverage.
 test(elixir_collect_triples_unit, [condition(elixir_available)]) :-
     tmp_dir(ex_e2e, Dir),
     compile_wam_runtime_snippet_for_elixir_tpd4(Dir),

--- a/tests/test_wam_tspd5_contract_parity.pl
+++ b/tests/test_wam_tspd5_contract_parity.pl
@@ -36,6 +36,8 @@
 :- use_module('../src/unifyweaver/core/recursive_kernel_detection',
               [detect_recursive_kernel/4]).
 
+:- use_module('helpers/wam_kernel_parity_harness').
+
 :- dynamic user:tspd_edge/2.
 :- dynamic user:tspd/5.
 :- dynamic user:tspd_tail/4.
@@ -46,51 +48,6 @@
 :- dynamic user:edge_b/2.
 :- dynamic user:tspd_a/5.
 :- dynamic user:tspd_b/5.
-
-dotnet_available :-
-    catch(
-        ( process_create(path(dotnet), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-gcc_available :-
-    catch(
-        ( process_create(path(gcc), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-cargo_available :-
-    catch(
-        ( process_create(path(cargo), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-elixir_available :-
-    catch(
-        ( process_create(path(elixir), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-go_available :-
-    catch(
-        ( process_create(path(go), ['version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-tmp_dir(Tag, Dir) :-
-    get_time(T),
-    Stamp is round(T * 1000000),
-    format(atom(Dir), '/tmp/uw_tspd5_~w_~w', [Tag, Stamp]),
-    catch(delete_directory_and_contents(Dir), _, true),
-    make_directory_path(Dir).
-
-read_file_string(Path, String) :-
-    read_file_to_string(Path, String, []).
 
 assert_tspd_cycle_program :-
     retractall(user:tspd_edge(_, _)),
@@ -469,28 +426,17 @@ test(elixir_collect_quads_unit, [condition(elixir_available)]) :-
     ),
     !.
 
-test(go_standalone_correlated_diamond, [condition(go_available)]) :-
-    tmp_dir(go_e2e, Dir),
-    directory_file_path(Dir, 'go.mod', ModPath),
-    setup_call_cleanup(
-        open(ModPath, write, ModOut, [encoding(utf8)]),
-        write(ModOut, "module tspd5algo\n\ngo 1.21\n"),
-        close(ModOut)),
-    directory_file_path(Dir, 'tspd5_algo_test.go', GoPath),
-    tspd5_write_go_standalone(GoPath),
-    format(atom(Cmd),
-        'cd ~w && go test -run TestTspd5CorrelatedDiamond -count=1 >~w/go.out 2>~w/go.err',
-        [Dir, Dir, Dir]),
-    shell(Cmd, Exit),
-    ( Exit =:= 0 -> true
-    ; directory_file_path(Dir, 'go.err', ErrPath),
-      directory_file_path(Dir, 'go.out', OutPath),
-      ( exists_file(ErrPath) -> read_file_string(ErrPath, Err) ; Err = "" ),
-      ( exists_file(OutPath) -> read_file_string(OutPath, Out) ; Out = "" ),
-      format(user_error, 'go tspd5 standalone failed:~n~w~n~w~n', [Out, Err]),
-      fail
-    ),
-    !.
+% Former Go standalone BFS/correlated-pair replica removed — not generated
+% runtime. Contract remains via oracle + structural go_correlated_pair_sets.
+test(go_correlated_diamond_oracle_and_markers) :-
+    tspd5_fixture(correlated_diamond, Edges, _),
+    tspd5_fixture_expected(correlated_diamond, a, Want),
+    tspd5_oracle_quads(Edges, a, Got),
+    assertion(Got == Want),
+    \+ tspd5_oracle_has(Edges, a, t, b, q, 3),
+    \+ tspd5_oracle_has(Edges, a, t, c, p, 3),
+    read_file_string('src/unifyweaver/targets/wam_go_target.pl', Go),
+    assertion(sub_string(Go, _, _, _, "pairSets")).
 
 :- end_tests(tspd5_executable).
 
@@ -522,42 +468,6 @@ test(fsharp_no_kernels_omits_native_body, [condition(dotnet_available)]) :-
 % ============================================================
 % Helpers
 % ============================================================
-
-run_dotnet_build(Dir, Exit, Out) :-
-    setup_call_cleanup(
-        process_create(path(dotnet),
-            ['build', '--nologo', '-v', 'q', '-c', 'Release'],
-            [cwd(Dir),
-             environment([
-                 'DOTNET_NOLOGO'='1',
-                 'DOTNET_ROLL_FORWARD'='Major'
-             ]),
-             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
-        ( read_string(SO, _, S1), read_string(SE, _, S2),
-          process_wait(Pid, Status),
-          dotnet_status_exit(Status, Exit),
-          string_concat(S1, S2, Out) ),
-        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
-
-run_dotnet_run(Dir, Exit, Out) :-
-    setup_call_cleanup(
-        process_create(path(dotnet),
-            ['run', '--no-build', '-c', 'Release', '--no-launch-profile', '--'],
-            [cwd(Dir),
-             environment([
-                 'DOTNET_NOLOGO'='1',
-                 'DOTNET_ROLL_FORWARD'='Major'
-             ]),
-             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
-        ( read_string(SO, _, S1), read_string(SE, _, S2),
-          process_wait(Pid, Status),
-          dotnet_status_exit(Status, Exit),
-          string_concat(S1, S2, Out) ),
-        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
-
-dotnet_status_exit(exit(Code), Code).
-dotnet_status_exit(killed(Signal), Code) :-
-    Code is 128 + Signal.
 
 tspd5_write_fsharp_driver(ProgPath) :-
     Driver =
@@ -1007,117 +917,5 @@ IO.puts("OK elixir_tspd5")
 ',
     setup_call_cleanup(
         open(Script, write, Out, [encoding(utf8)]),
-        write(Out, Code),
-        close(Out)).
-
-tspd5_write_go_standalone(Path) :-
-    Code =
-'// Shortest-positive correlated step/parent (TSPD5) standalone algorithm check.
-package tspd5algo
-
-import (
-	"reflect"
-	"sort"
-	"testing"
-)
-
-type quad struct {
-	T, Step, P string
-	D          int
-}
-
-func collectTspd5(edges [][2]string, source string) []quad {
-	adj := map[string][]string{}
-	for _, e := range edges {
-		adj[e[0]] = append(adj[e[0]], e[1])
-	}
-	dist := map[string]int{}
-	pairSets := map[string]map[[2]string]bool{}
-	type item struct {
-		node string
-		d    int
-	}
-	queue := []item{{source, 0}}
-	for len(queue) > 0 {
-		cur := queue[0]
-		queue = queue[1:]
-		nd := cur.d + 1
-		for _, n := range adj[cur.node] {
-			var cands [][2]string
-			if cur.node == source {
-				cands = [][2]string{{n, source}}
-			} else {
-				seenStep := map[string]bool{}
-				for pair := range pairSets[cur.node] {
-					if !seenStep[pair[0]] {
-						seenStep[pair[0]] = true
-						cands = append(cands, [2]string{pair[0], cur.node})
-					}
-				}
-			}
-			if d0, ok := dist[n]; !ok {
-				dist[n] = nd
-				set := map[[2]string]bool{}
-				for _, c := range cands {
-					set[c] = true
-				}
-				pairSets[n] = set
-				queue = append(queue, item{n, nd})
-			} else if d0 == nd {
-				for _, c := range cands {
-					pairSets[n][c] = true
-				}
-			}
-		}
-	}
-	var out []quad
-	for t, d := range dist {
-		for pair := range pairSets[t] {
-			out = append(out, quad{t, pair[0], pair[1], d})
-		}
-	}
-	sort.Slice(out, func(i, j int) bool {
-		a, b := out[i], out[j]
-		if a.T != b.T {
-			return a.T < b.T
-		}
-		if a.Step != b.Step {
-			return a.Step < b.Step
-		}
-		if a.P != b.P {
-			return a.P < b.P
-		}
-		return a.D < b.D
-	})
-	return out
-}
-
-func TestTspd5CorrelatedDiamond(t *testing.T) {
-	edges := [][2]string{
-		{"a", "b"}, {"a", "c"}, {"b", "p"}, {"c", "q"}, {"p", "t"}, {"q", "t"},
-	}
-	got := collectTspd5(edges, "a")
-	want := []quad{
-		{"b", "b", "a", 1},
-		{"c", "c", "a", 1},
-		{"p", "b", "b", 2},
-		{"q", "c", "c", 2},
-		{"t", "b", "p", 3},
-		{"t", "c", "q", 3},
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %#v want %#v", got, want)
-	}
-	for _, bad := range []quad{{"t", "b", "q", 3}, {"t", "c", "p", 3}} {
-		for _, q := range got {
-			if q == bad {
-				t.Fatalf("unexpected cross-product %#v", bad)
-			}
-		}
-	}
-}
-',
-    setup_call_cleanup(
-        open(Path, write, Out, [encoding(utf8)]),
         write(Out, Code),
         close(Out)).

--- a/tests/test_wam_tspd5_contract_parity.pl
+++ b/tests/test_wam_tspd5_contract_parity.pl
@@ -407,6 +407,7 @@ test(rust_collect_tspd5_unit, [condition(cargo_available)]) :-
     ),
     !.
 
+% Generated-kernel unit; it does not claim dispatch/register end-to-end coverage.
 test(elixir_collect_quads_unit, [condition(elixir_available)]) :-
     tmp_dir(ex_e2e, Dir),
     compile_wam_runtime_snippet_for_elixir_tspd5(Dir),
@@ -425,18 +426,6 @@ test(elixir_collect_quads_unit, [condition(elixir_available)]) :-
       fail
     ),
     !.
-
-% Former Go standalone BFS/correlated-pair replica removed — not generated
-% runtime. Contract remains via oracle + structural go_correlated_pair_sets.
-test(go_correlated_diamond_oracle_and_markers) :-
-    tspd5_fixture(correlated_diamond, Edges, _),
-    tspd5_fixture_expected(correlated_diamond, a, Want),
-    tspd5_oracle_quads(Edges, a, Got),
-    assertion(Got == Want),
-    \+ tspd5_oracle_has(Edges, a, t, b, q, 3),
-    \+ tspd5_oracle_has(Edges, a, t, c, p, 3),
-    read_file_string('src/unifyweaver/targets/wam_go_target.pl', Go),
-    assertion(sub_string(Go, _, _, _, "pairSets")).
 
 :- end_tests(tspd5_executable).
 

--- a/tests/test_wam_wsp3_contract_parity.pl
+++ b/tests/test_wam_wsp3_contract_parity.pl
@@ -56,6 +56,8 @@
 :- use_module('../src/unifyweaver/core/recursive_kernel_detection',
               [detect_recursive_kernel/4]).
 
+:- use_module('helpers/wam_kernel_parity_harness').
+
 :- dynamic user:w_edge/3.
 :- dynamic user:wsp/3.
 :- dynamic user:w_edge_alt/3.
@@ -68,71 +70,6 @@
 :- dynamic user:wsp_after/2.
 :- dynamic user:wsp_cut/2.
 :- dynamic user:wsp_call_after/2.
-
-dotnet_available :-
-    catch(
-        ( process_create(path(dotnet), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-gcc_available :-
-    catch(
-        ( process_create(path(gcc), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-cargo_available :-
-    catch(
-        ( process_create(path(cargo), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-elixir_available :-
-    catch(
-        ( process_create(path(elixir), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-go_available :-
-    catch(
-        ( process_create(path(go), ['version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-scala_available :-
-    catch(
-        ( process_create(path(scalac), ['-version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-rscript_available :-
-    catch(
-        ( process_create(path('Rscript'), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-ghc_available :-
-    catch(
-        ( process_create(path(ghc), ['--version'],
-                         [stdout(null), stderr(null), process(Pid)]),
-          process_wait(Pid, exit(0)) ),
-        _, fail).
-
-tmp_dir(Tag, Dir) :-
-    get_time(T),
-    format(atom(Stamp), '~w', [T]),
-    format(atom(Dir), '/tmp/uw_wsp3_~w_~w', [Tag, Stamp]),
-    make_directory_path(Dir).
-
-read_file_string(Path, String) :-
-    read_file_to_string(Path, String, []).
 
 assert_wsp_detour_program :-
     retractall(user:w_edge(_, _, _)),
@@ -447,6 +384,7 @@ test(rust_collect_wsp3_unit, [condition(cargo_available)]) :-
     !.
 
 test(elixir_collect_pairs_unit, [condition(elixir_available)]) :-
+    % Generated-runtime e2e: slice WeightedShortestPath from compile_wam_runtime_to_elixir/2.
     tmp_dir(ex_e2e, Dir),
     compile_wam_runtime_snippet_for_elixir_wsp3(Dir),
     directory_file_path(Dir, 'wsp3_unit.exs', Script),
@@ -465,125 +403,48 @@ test(elixir_collect_pairs_unit, [condition(elixir_available)]) :-
     ),
     !.
 
-test(go_standalone_cheaper_detour, [condition(go_available)]) :-
-    tmp_dir(go_e2e, Dir),
-    directory_file_path(Dir, 'go.mod', ModPath),
-    setup_call_cleanup(
-        open(ModPath, write, ModOut, [encoding(utf8)]),
-        write(ModOut, "module wsp3algo\n\ngo 1.21\n"),
-        close(ModOut)),
-    directory_file_path(Dir, 'wsp3_algo_test.go', GoPath),
-    wsp3_write_go_standalone(GoPath),
-    format(atom(Cmd),
-        'cd ~w && go test -run TestWsp3CheaperDetour -count=1 >~w/go.out 2>~w/go.err',
-        [Dir, Dir, Dir]),
-    shell(Cmd, Exit),
-    ( Exit =:= 0 -> true
-    ; directory_file_path(Dir, 'go.err', ErrPath),
-      directory_file_path(Dir, 'go.out', OutPath),
-      ( exists_file(ErrPath) -> read_file_string(ErrPath, Err) ; Err = "" ),
-      ( exists_file(OutPath) -> read_file_string(OutPath, Out) ; Out = "" ),
-      format(user_error, 'go wsp3 unit failed:~n~w~n~w~n', [Out, Err]),
-      fail
-    ),
-    !.
+% Former Go/Haskell/R/Scala standalone Dijkstra replicas removed — they did
+% not execute generated runtime. Semantic cases remain via the Prolog oracle
+% and structural handler markers (always run; not capability-gated skips).
+test(go_cheaper_detour_oracle_and_markers) :-
+    wsp3_oracle_cheaper_detour_edges(E),
+    wsp3_oracle_cheaper_detour_expected(Want),
+    assertion(wsp3_oracle_matches_expected(E, a, Want)),
+    read_file_string('src/unifyweaver/targets/wam_go_target.pl', Go),
+    assertion(sub_string(Go, _, _, _,
+        "docs/design/WAM_WEIGHTED_SHORTEST_PATH3_CONTRACT.md")).
 
-test(haskell_standalone_cheaper_detour, [condition(ghc_available)]) :-
-    tmp_dir(hs_e2e, Dir),
-    directory_file_path(Dir, 'Wsp3Algo.hs', HsPath),
-    wsp3_write_haskell_standalone(HsPath),
-    format(atom(Cmd),
-        'cd ~w && ghc -O0 -package containers Wsp3Algo.hs -o wsp3algo >~w/ghc.out 2>~w/ghc.err && ./wsp3algo >~w/run.out 2>~w/run.err',
-        [Dir, Dir, Dir, Dir, Dir]),
-    shell(Cmd, Exit),
-    ( Exit =:= 0 -> true
-    ; format(user_error, 'haskell wsp3 failed exit=~w~n', [Exit]),
-      fail
-    ),
-    directory_file_path(Dir, 'run.out', OutPath),
-    read_file_string(OutPath, Out),
-    assertion(sub_string(Out, _, _, _, "OK")),
-    !.
+test(haskell_cheaper_detour_oracle_and_markers) :-
+    wsp3_oracle_cheaper_detour_edges(E),
+    wsp3_oracle_cheaper_detour_expected(Want),
+    assertion(wsp3_oracle_matches_expected(E, a, Want)),
+    read_file_string(
+        'templates/targets/haskell_wam/kernel_weighted_shortest_path.hs.mustache', S),
+    assertion(sub_string(S, _, _, _, "nativeKernel_weighted_shortest_path")),
+    assertion(sub_string(S, _, _, _, "maybe [] id")).
 
-test(r_standalone_cheaper_detour, [condition(rscript_available)]) :-
-    tmp_dir(r_e2e, Dir),
-    directory_file_path(Dir, 'wsp3_algo.R', RPath),
-    wsp3_write_r_standalone(RPath),
-    format(atom(Cmd),
-        'cd ~w && Rscript wsp3_algo.R >~w/r.out 2>~w/r.err',
-        [Dir, Dir, Dir]),
-    shell(Cmd, Exit),
-    ( Exit =:= 0 -> true
-    ; directory_file_path(Dir, 'r.err', ErrPath),
-      directory_file_path(Dir, 'r.out', OutPath),
-      ( exists_file(ErrPath) -> read_file_string(ErrPath, Err) ; Err = "" ),
-      ( exists_file(OutPath) -> read_file_string(OutPath, Out) ; Out = "" ),
-      format(user_error, 'R wsp3 failed:~n~w~n~w~n', [Out, Err]),
-      fail
-    ),
-    directory_file_path(Dir, 'r.out', OutPath),
-    read_file_string(OutPath, Out),
-    assertion(sub_string(Out, _, _, _, "OK")),
-    !.
+test(r_cheaper_detour_oracle_and_markers) :-
+    wsp3_oracle_cheaper_detour_edges(E),
+    wsp3_oracle_cheaper_detour_expected(Want),
+    assertion(wsp3_oracle_matches_expected(E, a, Want)),
+    read_file_string('templates/targets/r_wam/runtime.R.mustache', R),
+    assertion(sub_string(R, _, _, _, "weighted_shortest_path3")),
+    assertion(sub_string(R, _, _, _, "FloatTerm")).
 
-test(scala_standalone_cheaper_detour, [condition(scala_available)]) :-
-    tmp_dir(sc_e2e, Dir),
-    directory_file_path(Dir, 'Wsp3Algo.scala', ScPath),
-    wsp3_write_scala_standalone(ScPath),
-    format(atom(Cmd),
-        'cd ~w && scalac Wsp3Algo.scala >~w/sc.out 2>~w/sc.err && scala Wsp3Algo >~w/run.out 2>~w/run.err',
-        [Dir, Dir, Dir, Dir, Dir]),
-    shell(Cmd, Exit),
-    ( Exit =:= 0 -> true
-    ; format(user_error, 'scala wsp3 failed exit=~w~n', [Exit]),
-      fail
-    ),
-    directory_file_path(Dir, 'run.out', OutPath),
-    read_file_string(OutPath, Out),
-    assertion(sub_string(Out, _, _, _, "OK")),
-    !.
+test(scala_cheaper_detour_oracle_and_markers) :-
+    wsp3_oracle_cheaper_detour_edges(E),
+    wsp3_oracle_cheaper_detour_expected(Want),
+    assertion(wsp3_oracle_matches_expected(E, a, Want)),
+    read_file_string('src/unifyweaver/targets/wam_scala_target.pl', Sc),
+    assertion(sub_string(Sc, _, _, _,
+        "docs/design/WAM_WEIGHTED_SHORTEST_PATH3_CONTRACT.md")),
+    assertion(sub_string(Sc, _, _, _, "case a @ Atom(_)")).
 
 :- end_tests(wsp3_executable).
 
 % ============================================================
 % Helpers
 % ============================================================
-
-run_dotnet_build(Dir, Exit, Out) :-
-    setup_call_cleanup(
-        process_create(path(dotnet),
-            ['build', '--nologo', '-v', 'q', '-c', 'Release'],
-            [cwd(Dir),
-             environment([
-                 'DOTNET_NOLOGO'='1',
-                 'DOTNET_ROLL_FORWARD'='Major'
-             ]),
-             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
-        ( read_string(SO, _, S1), read_string(SE, _, S2),
-          process_wait(Pid, Status),
-          dotnet_status_exit(Status, Exit),
-          string_concat(S1, S2, Out) ),
-        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
-
-run_dotnet_run(Dir, Exit, Out) :-
-    setup_call_cleanup(
-        process_create(path(dotnet),
-            ['run', '--no-build', '-c', 'Release', '--no-launch-profile', '--'],
-            [cwd(Dir),
-             environment([
-                 'DOTNET_NOLOGO'='1',
-                 'DOTNET_ROLL_FORWARD'='Major'
-             ]),
-             stdout(pipe(SO)), stderr(pipe(SE)), process(Pid)]),
-        ( read_string(SO, _, S1), read_string(SE, _, S2),
-          process_wait(Pid, Status),
-          dotnet_status_exit(Status, Exit),
-          string_concat(S1, S2, Out) ),
-        ( catch(close(SO), _, true), catch(close(SE), _, true) )).
-
-dotnet_status_exit(exit(Code), Code).
-dotnet_status_exit(killed(Signal), Code) :-
-    Code is 128 + Signal.
 
 %% Driver uses Predicates.declaredWeightedEdgeFacts / buildWeightedFfiFacts
 %% — the generated project's real materialized facts, not a hand-built map.
@@ -859,308 +720,49 @@ mod wsp3_contract {
         write(Out, Combined),
         close(Out)).
 
+:- use_module('../src/unifyweaver/targets/wam_elixir_target',
+              [compile_wam_runtime_to_elixir/2]).
+
 compile_wam_runtime_snippet_for_elixir_wsp3(Dir) :-
-    directory_file_path(Dir, 'wsp3_runtime.ex', Path),
-    Code =
-"defmodule Wsp3Runtime do
-  def collect_pairs(edges, source) do
-    case dijkstra(edges, :gb_sets.singleton({0.0, source}), %{source => 0.0}) do
-      :invalid -> []
-      dist ->
-        dist
-        |> Enum.reject(fn {n, _} -> n == source end)
-        |> Enum.sort_by(fn {n, _} -> n end)
-    end
-  end
-
-  defp dijkstra(_edges, pq, dist) do
-    if :gb_sets.is_empty(pq) do
-      dist
-    else
-      {{cost, node}, pq2} = :gb_sets.take_smallest(pq)
-      best = Map.get(dist, node, 1.0e300)
-      if cost > best do
-        dijkstra(_edges, pq2, dist)
-      else
-        case Enum.reduce_while(Map.get(_edges, node, []), {:ok, pq2, dist}, &relax(cost, &1, &2)) do
-          :invalid -> :invalid
-          {:ok, pq3, dist2} -> dijkstra(_edges, pq3, dist2)
-        end
-      end
-    end
-  end
-
-  defp relax(cost, {nxt, w}, {:ok, q, d}) do
-    cond do
-      not is_number(w) or w < 0 or w != w -> {:halt, :invalid}
-      true ->
-        nc = cost + w
-        prev = Map.get(d, nxt, 1.0e300)
-        if nc < prev do
-          {:cont, {:ok, :gb_sets.add_element({nc, nxt}, q), Map.put(d, nxt, nc)}}
-        else
-          {:cont, {:ok, q, d}}
-        end
-    end
-  end
-end
-",
-    setup_call_cleanup(
-        open(Path, write, Out, [encoding(utf8)]),
-        write(Out, Code),
-        close(Out)).
+    compile_wam_runtime_to_elixir([], RuntimeCode),
+    Pattern = "defmodule WamRuntime.GraphKernel.WeightedShortestPath do",
+    EndPattern = "defmodule WamRuntime.GraphKernel.AstarShortestPath do",
+    sub_string(RuntimeCode, Start, _, _, Pattern),
+    sub_string(RuntimeCode, End, _, _, EndPattern),
+    End > Start,
+    BodyLen is End - Start,
+    sub_string(RuntimeCode, Start, BodyLen, _, Body),
+    directory_file_path(Dir, 'wsp3_kernel.ex', Path),
+    write_file_string(Path, Body).
 
 wsp3_write_elixir_unit(Script) :-
     Code =
-"Code.require_file(\"wsp3_runtime.ex\")
-edges = %{
-  \"a\" => [{\"b\", 10.0}, {\"c\", 1.0}],
-  \"c\" => [{\"b\", 1.0}],
-  \"b\" => [{\"d\", 1.0}]
-}
-got = Wsp3Runtime.collect_pairs(edges, \"a\")
-want = [{\"b\", 2.0}, {\"c\", 1.0}, {\"d\", 3.0}]
-if got != want do
-  IO.puts(:stderr, \"mismatch #{inspect(got)}\")
+'Code.require_file("wsp3_kernel.ex")
+
+edges = fn
+  "a" -> [{"a", "b", 10.0}, {"a", "c", 1.0}]
+  "c" -> [{"c", "b", 1.0}]
+  "b" -> [{"b", "d", 1.0}]
+  _ -> []
+end
+
+got = WamRuntime.GraphKernel.WeightedShortestPath.collect_path_costs(edges, "a")
+     |> Enum.sort()
+want = [{"b", 2.0}, {"c", 1.0}, {"d", 3.0}]
+unless got == want do
+  IO.puts(:stderr, "mismatch #{inspect(got)}")
   System.halt(1)
 end
-bad = Wsp3Runtime.collect_pairs(%{\"a\" => [{\"b\", -1.0}]}, \"a\")
-if bad != [] do
-  IO.puts(:stderr, \"invalid should fail\")
+
+bad_edges = fn
+  "a" -> [{"a", "b", -1.0}]
+  _ -> []
+end
+bad = WamRuntime.GraphKernel.WeightedShortestPath.collect_path_costs(bad_edges, "a")
+unless bad == :invalid do
+  IO.puts(:stderr, "invalid should fail, got #{inspect(bad)}")
   System.halt(2)
 end
-IO.puts(\"OK\")
-",
-    setup_call_cleanup(
-        open(Script, write, Out, [encoding(utf8)]),
-        write(Out, Code),
-        close(Out)).
-
-wsp3_write_go_standalone(Path) :-
-    Code =
-"package wsp3algo
-
-import (
-        \"math\"
-        \"sort\"
-        \"testing\"
-)
-
-func dijkstra(edges map[string][]struct {
-        To string
-        W  float64
-}, source string) ([]struct {
-        To string
-        W  float64
-}, bool) {
-        dist := map[string]float64{source: 0}
-        type item struct {
-                n string
-                c float64
-        }
-        pq := []item{{source, 0}}
-        for len(pq) > 0 {
-                best := 0
-                for i := 1; i < len(pq); i++ {
-                        if pq[i].c < pq[best].c {
-                                best = i
-                        }
-                }
-                u := pq[best]
-                pq = append(pq[:best], pq[best+1:]...)
-                if d, ok := dist[u.n]; ok && u.c > d {
-                        continue
-                }
-                for _, e := range edges[u.n] {
-                        if math.IsNaN(e.W) || math.IsInf(e.W, 0) || e.W < 0 {
-                                return nil, false
-                        }
-                        nc := u.c + e.W
-                        if prev, ok := dist[e.To]; !ok || nc < prev {
-                                dist[e.To] = nc
-                                pq = append(pq, item{e.To, nc})
-                        }
-                }
-        }
-        var out []struct {
-                To string
-                W  float64
-        }
-        for n, c := range dist {
-                if n != source {
-                        out = append(out, struct {
-                                To string
-                                W  float64
-                        }{n, c})
-                }
-        }
-        sort.Slice(out, func(i, j int) bool { return out[i].To < out[j].To })
-        return out, true
-}
-
-func TestWsp3CheaperDetour(t *testing.T) {
-        edges := map[string][]struct {
-                To string
-                W  float64
-        }{
-                \"a\": {{\"b\", 10}, {\"c\", 1}},
-                \"c\": {{\"b\", 1}},
-                \"b\": {{\"d\", 1}},
-        }
-        got, ok := dijkstra(edges, \"a\")
-        if !ok || len(got) != 3 || got[0].To != \"b\" || got[0].W != 2 ||
-                got[1].To != \"c\" || got[1].W != 1 || got[2].To != \"d\" || got[2].W != 3 {
-                t.Fatalf(\"got %#v\", got)
-        }
-        _, ok2 := dijkstra(map[string][]struct {
-                To string
-                W  float64
-        }{\"a\": {{\"b\", -1}}}, \"a\")
-        if ok2 {
-                t.Fatal(\"invalid should fail\")
-        }
-}
-",
-    setup_call_cleanup(
-        open(Path, write, Out, [encoding(utf8)]),
-        write(Out, Code),
-        close(Out)).
-
-wsp3_write_haskell_standalone(Path) :-
-    Code =
-"import qualified Data.Map.Strict as M
-import qualified Data.Set as S
-import Data.List (sort)
-
-dijkstra2 edges source =
-  go (S.singleton (0.0 :: Double, source)) (M.singleton source 0.0)
-  where
-    go pq dist =
-      case S.minView pq of
-        Nothing ->
-          Right $ sort [ (n, c) | (n, c) <- M.toList dist, n /= source ]
-        Just ((cost, node), pq') ->
-          let best = M.findWithDefault (1/0) node dist
-          in if cost > best then go pq' dist else
-             let neighbors = M.findWithDefault [] node edges
-             in case foldl (relax cost) (Right (pq', dist)) neighbors of
-                  Left e -> Left e
-                  Right (q2, d2) -> go q2 d2
-    relax _ (Left e) _ = Left e
-    relax cost (Right (q, d)) (nxt, w)
-      | isNaN w || isInfinite w || w < 0 = Left \"invalid\"
-      | otherwise =
-          let nc = cost + w
-              prev = M.findWithDefault (1/0) nxt d
-          in if nc < prev
-               then Right (S.insert (nc, nxt) q, M.insert nxt nc d)
-               else Right (q, d)
-
-main :: IO ()
-main = do
-  let edges = M.fromList
-        [ (\"a\", [(\"b\", 10.0), (\"c\", 1.0)])
-        , (\"c\", [(\"b\", 1.0)])
-        , (\"b\", [(\"d\", 1.0)])
-        ]
-  case dijkstra2 edges \"a\" of
-    Right got | got == [(\"b\", 2.0), (\"c\", 1.0), (\"d\", 3.0)] ->
-      putStrLn \"OK\"
-    other -> error (show other)
-",
-    setup_call_cleanup(
-        open(Path, write, Out, [encoding(utf8)]),
-        write(Out, Code),
-        close(Out)).
-
-wsp3_write_r_standalone(Path) :-
-    Code =
-"dijkstra <- function(edges, source) {
-  dist <- new.env(parent = emptyenv())
-  assign(source, 0, envir = dist)
-  pq <- list(list(cost = 0, node = source))
-  while (length(pq) > 0) {
-    costs <- vapply(pq, function(x) x$cost, numeric(1))
-    best <- which.min(costs)
-    u <- pq[[best]]
-    pq <- pq[-best]
-    known <- if (exists(u$node, envir = dist, inherits = FALSE)) get(u$node, envir = dist) else Inf
-    if (u$cost > known) next
-    outs <- edges[[u$node]]
-    if (is.null(outs)) outs <- list()
-    for (e in outs) {
-      w <- e[[2]]
-      if (!is.finite(w) || w < 0) return(NULL)
-      nc <- u$cost + w
-      prev <- if (exists(e[[1]], envir = dist, inherits = FALSE)) get(e[[1]], envir = dist) else Inf
-      if (nc < prev) {
-        assign(e[[1]], nc, envir = dist)
-        pq[[length(pq) + 1]] <- list(cost = nc, node = e[[1]])
-      }
-    }
-  }
-  keys <- ls(dist)
-  keys <- keys[keys != source]
-  pairs <- lapply(keys, function(k) list(k, get(k, envir = dist)))
-  pairs[order(vapply(pairs, function(p) p[[1]], character(1)))]
-}
-edges <- list(
-  a = list(list(\"b\", 10), list(\"c\", 1)),
-  c = list(list(\"b\", 1)),
-  b = list(list(\"d\", 1))
-)
-got <- dijkstra(edges, \"a\")
-stopifnot(!is.null(got), length(got) == 3,
-          got[[1]][[1]] == \"b\", abs(got[[1]][[2]] - 2) < 1e-9,
-          got[[2]][[1]] == \"c\", abs(got[[2]][[2]] - 1) < 1e-9,
-          got[[3]][[1]] == \"d\", abs(got[[3]][[2]] - 3) < 1e-9)
-bad <- dijkstra(list(a = list(list(\"b\", -1))), \"a\")
-stopifnot(is.null(bad))
-cat(\"OK\\n\")
-",
-    setup_call_cleanup(
-        open(Path, write, Out, [encoding(utf8)]),
-        write(Out, Code),
-        close(Out)).
-
-wsp3_write_scala_standalone(Path) :-
-    Code =
-"object Wsp3Algo {
-  def dijkstra(edges: Map[String, List[(String, Double)]], source: String)
-      : Option[List[(String, Double)]] = {
-    import scala.collection.mutable
-    val dist = mutable.Map(source -> 0.0)
-    val pq = mutable.PriorityQueue.empty[(Double, String)](Ordering.by(-_._1))
-    pq.enqueue((0.0, source))
-    while (pq.nonEmpty) {
-      val (cost, node) = pq.dequeue()
-      if (!(dist.contains(node) && cost > dist(node))) {
-        for ((nxt, w) <- edges.getOrElse(node, Nil)) {
-          if (w.isNaN || w.isInfinity || w < 0) return None
-          val nc = cost + w
-          if (!dist.contains(nxt) || nc < dist(nxt)) {
-            dist(nxt) = nc
-            pq.enqueue((nc, nxt))
-          }
-        }
-      }
-    }
-    Some(dist.toList.filter(_._1 != source).sortBy(_._1))
-  }
-  def main(args: Array[String]): Unit = {
-    val edges = Map(
-      \"a\" -> List((\"b\", 10.0), (\"c\", 1.0)),
-      \"c\" -> List((\"b\", 1.0)),
-      \"b\" -> List((\"d\", 1.0))
-    )
-    val got = dijkstra(edges, \"a\")
-    require(got.contains(List((\"b\", 2.0), (\"c\", 1.0), (\"d\", 3.0))))
-    require(dijkstra(Map(\"a\" -> List((\"b\", -1.0))), \"a\").isEmpty)
-    println(\"OK\")
-  }
-}
-",
-    setup_call_cleanup(
-        open(Path, write, Out, [encoding(utf8)]),
-        write(Out, Code),
-        close(Out)).
+IO.puts("OK")
+',
+    write_file_string(Script, Code).

--- a/tests/test_wam_wsp3_contract_parity.pl
+++ b/tests/test_wam_wsp3_contract_parity.pl
@@ -384,7 +384,9 @@ test(rust_collect_wsp3_unit, [condition(cargo_available)]) :-
     !.
 
 test(elixir_collect_pairs_unit, [condition(elixir_available)]) :-
-    % Generated-runtime e2e: slice WeightedShortestPath from compile_wam_runtime_to_elixir/2.
+    % Generated-kernel unit: execute the production WeightedShortestPath
+    % module emitted by compile_wam_runtime_to_elixir/2.  This deliberately
+    % does not claim dispatch/register/streaming end-to-end coverage.
     tmp_dir(ex_e2e, Dir),
     compile_wam_runtime_snippet_for_elixir_wsp3(Dir),
     directory_file_path(Dir, 'wsp3_unit.exs', Script),
@@ -402,43 +404,6 @@ test(elixir_collect_pairs_unit, [condition(elixir_available)]) :-
       fail
     ),
     !.
-
-% Former Go/Haskell/R/Scala standalone Dijkstra replicas removed — they did
-% not execute generated runtime. Semantic cases remain via the Prolog oracle
-% and structural handler markers (always run; not capability-gated skips).
-test(go_cheaper_detour_oracle_and_markers) :-
-    wsp3_oracle_cheaper_detour_edges(E),
-    wsp3_oracle_cheaper_detour_expected(Want),
-    assertion(wsp3_oracle_matches_expected(E, a, Want)),
-    read_file_string('src/unifyweaver/targets/wam_go_target.pl', Go),
-    assertion(sub_string(Go, _, _, _,
-        "docs/design/WAM_WEIGHTED_SHORTEST_PATH3_CONTRACT.md")).
-
-test(haskell_cheaper_detour_oracle_and_markers) :-
-    wsp3_oracle_cheaper_detour_edges(E),
-    wsp3_oracle_cheaper_detour_expected(Want),
-    assertion(wsp3_oracle_matches_expected(E, a, Want)),
-    read_file_string(
-        'templates/targets/haskell_wam/kernel_weighted_shortest_path.hs.mustache', S),
-    assertion(sub_string(S, _, _, _, "nativeKernel_weighted_shortest_path")),
-    assertion(sub_string(S, _, _, _, "maybe [] id")).
-
-test(r_cheaper_detour_oracle_and_markers) :-
-    wsp3_oracle_cheaper_detour_edges(E),
-    wsp3_oracle_cheaper_detour_expected(Want),
-    assertion(wsp3_oracle_matches_expected(E, a, Want)),
-    read_file_string('templates/targets/r_wam/runtime.R.mustache', R),
-    assertion(sub_string(R, _, _, _, "weighted_shortest_path3")),
-    assertion(sub_string(R, _, _, _, "FloatTerm")).
-
-test(scala_cheaper_detour_oracle_and_markers) :-
-    wsp3_oracle_cheaper_detour_edges(E),
-    wsp3_oracle_cheaper_detour_expected(Want),
-    assertion(wsp3_oracle_matches_expected(E, a, Want)),
-    read_file_string('src/unifyweaver/targets/wam_scala_target.pl', Sc),
-    assertion(sub_string(Sc, _, _, _,
-        "docs/design/WAM_WEIGHTED_SHORTEST_PATH3_CONTRACT.md")),
-    assertion(sub_string(Sc, _, _, _, "case a @ Atom(_)")).
 
 :- end_tests(wsp3_executable).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Behavior-preserving DRY of the six recursive-kernel contract parity suites after `#3856` landed. **No production target algorithm changes.**

Review follow-up in `31413c26`:

- Missing executables still skip capability-gated checks, but an installed toolchain whose version probe fails now fails the suite loudly instead of being misreported as unavailable.
- TC2 is now part of `tests/run_wam_fsharp_tests.pl`, so the aggregate continuously runs all six contract-parity suites.
- Removed five redundant mixed-category WSP3/TSPD5 tests that repeated existing oracle and structural assertions.
- Corrected the Elixir checks' classification: they execute generated production module slices, but are kernel units rather than dispatch/register/streaming end-to-end tests.

## Reuse map

| Concern | Before | After |
|---|---|---|
| Writable temp roots | Hardcoded `/tmp/uw_*` in each suite | `smoke_paths:tmp_root/1` + `clean_dir/1` via harness `tmp_dir/2` |
| Toolchain detection | Duplicated `*_available/0` in each suite | `tests/helpers/wam_kernel_parity_harness.pl` |
| File I/O | Local `read_file_string/2` | Shared read/write helpers |
| Dotnet build/run | Copied process/status/env blocks | Shared helpers |
| Capability skips | Per-suite conditions | Same imported predicates; missing skips, broken installed tools fail |
| Graph oracles | Existing `tests/fixtures/*_contract_oracle.pl` | Unchanged independent oracles |
| Kernel-specific drivers | Local F#/C/Rust/Elixir code | Kept local where assertions differ by kernel |

## Size

| Measure | Result |
|---|---:|
| Whole PR | **+204 / −982 (net −778)** |
| Test code | **+181 / −963 (net −782)** |
| Six parity suites | **5,850 → 4,942 (−908)** |
| Shared harness | **121 lines** |
| Suites + harness | **5,850 → 5,063 (−787)** |

The earlier PR description's 5,823 → 4,987 figures were incorrect. Files still over 600 lines contain kernel-specific generated drivers and assertions: TPD4 1,059; TSPD5 910; TD3 809; TC2 749; WSP3 733; ASTAR4 682.

## Removed duplication

- Shared duplicated temp/toolchain/file/dotnet helpers across all six suites.
- Removed standalone Go/Haskell/R/Scala WSP3 Dijkstra replicas.
- Removed the standalone Go TSPD5 correlated-BFS replica.
- Removed redundant replacement tests that combined already-covered oracle and marker assertions.
- Kept independent Prolog contract oracles and production-generated executable checks.

## Coverage classification

| Kernel | Always-on oracle + structural checks | Generated-runtime dispatch/stream path | Generated-kernel units | Additional executable coverage |
|---|---|---|---|---|
| TC2 | yes | F# / C | Rust | — |
| TD3 | yes | F# / C | Rust | — |
| TPD4 | yes | F# / C | Rust / Elixir | — |
| TSPD5 | yes | F# / C | Rust / Elixir | — |
| WSP3 | yes | F# / C | Rust / Elixir | — |
| ASTAR4 | yes | F# / C | Rust | LLVM generated-runtime suites when `llc` + `clang` exist |

Elixir units execute modules extracted from `compile_wam_runtime_to_elixir/2`; they intentionally do not claim generated dispatch/register/streaming coverage. Capability conditions skip only genuinely missing executables.

## Docs

- ASTAR4 marked landed in `#3856`.
- Added the `WAM-KERNEL-PARITY-HARNESS-DRY` task card.
- Updated the F# status note to reflect the completed shared-kernel set.

## Verification

- [GitHub Actions run #13631](https://github.com/s243a/UnifyWeaver/actions/runs/29653744536): **11/11 jobs green**.
- Hosted aggregate: **F# WAM suite 20/20 passed**, including the newly registered TC2 parity suite.
- Fleet conformance jobs: Scala, Rust, WAT, Elixir, Haskell, C++, C, Go, and Python all green.
- `git diff --check`: pass.
- Local SWI-Prolog installation was unavailable in the review environment, so executable verification was taken from the replacement hosted run. The Elixir module-unit and LLVM conditional checks are not exercised by the aggregate job unless those toolchains are present.

**Production behavior was not changed.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
