### PR TITLE
mu_cosine: harden local diffusion provenance and boundary contracts

### DIFF
--- a/docs/design/LEAKY_GRAPH_DIFFUSION.md
+++ b/docs/design/LEAKY_GRAPH_DIFFUSION.md
@@ -11,14 +11,22 @@ The implementation in src/unifyweaver/graph/leaky_diffusion.py is a dense
 float64 correctness reference. It establishes the algebra and fail-closed API;
 it does not claim a CUDA crossover or authorize a learned cross-item
 covariance. The completed Stage-A repeated-judge source-power experiment
-failed closed and unlocked no candidate enumeration, Nomic use, judge calls,
-covariance deployment, independent batching, QR specialization, or CUDA
-claim. This primitive therefore remains outcome-blind infrastructure.
+failed closed and, within that dependence campaign, unlocked no
+dependence-candidate enumeration, Nomic packing, judge calls, covariance
+deployment, independent batching, QR specialization, or CUDA claim.
+This primitive therefore remains outcome-blind infrastructure.
 For million-node graphs, the bounded Dirichlet construction in
 [LOCAL_GROUNDED_DIFFUSION.md](LOCAL_GROUNDED_DIFFUSION.md) selects an
 outcome-blind topological neighborhood, aggregates every cut edge into an
 explicit bath shunt, and reuses the same operator and precision-root algebra
 on the retained domain.
+
+Separate deterministic application uses do not depend on that failed
+dependence gate: frozen-geometry candidate generation, raw per-anchor
+screening values as ranking features, and routing are allowed when geometry,
+leakage, and thresholds are chosen without placement or judge outcomes.
+They are not calibrated probabilities, learned covariance entries, or
+authorization for independent batching, QR, or sparse/CUDA claims.
 
 
 ## Separate topology, semantics, and grounding

--- a/docs/design/LOCAL_GROUNDED_DIFFUSION.md
+++ b/docs/design/LOCAL_GROUNDED_DIFFUSION.md
@@ -13,6 +13,27 @@ The construction is general graph infrastructure. It does not promote a
 Green kernel to learned measurement covariance, relax the failed Stage-A
 source-power gates, or make a CUDA performance claim.
 
+Separate outcome-blind application uses are authorized now: frozen-geometry
+candidate generation, per-anchor `h_s` screening values as ranking features
+(not calibrated probabilities or covariance entries), and routing. Selection
+of `D`, `K`, `ell`, `epsilon`, `alpha`, and screening thresholds may use
+topology, frozen embeddings, resource limits, and numerical diagnostics, but
+no placement or judge outcomes. Any learned downstream consumer still requires
+train-only selection and held evaluation. This does not reopen the failed
+Stage-A dependence campaign or authorize judge covariance, independent
+batching, QR, sparse/CUDA, or performance claims.
+
+For scale orientation, the legacy 5,004-tree RDF slice documented in
+[pearltrees_data_completion.md](../pearltrees_data_completion.md) needs
+200,320,128 bytes (191.04 MiB) per dense float64 square array. The current
+reference retains four square arrays, about 764.16 MiB before construction and
+linear-algebra workspaces. The current assembled Pearltrees DAG has 14,709
+nodes rather than 5,004: one array is about 1.61 GiB and four are about
+6.45 GiB before workspaces. Thus the dense path is plausible today for a
+measured export-slice or bounded candidate-domain study on a sufficiently
+provisioned host, not yet a whole-current-corpus deployment or latency claim.
+Record the exact node universe, peak RSS, and wall time.
+
 ## Why locality is necessary
 
 A Wikipedia-scale graph can have millions of nodes. A dense float64 matrix on
@@ -133,6 +154,16 @@ pass reads the outside endpoints of cut edges. Semantic conductance on a cut
 edge may require the outside endpoint's embedding, but that endpoint does not
 enter the factorization.
 
+Under the bounded conductance transform, `0 <= c_ij <= c0_ij`. If a cut edge's
+exterior embedding is unavailable, the dense correctness reference continues
+to fail closed. A scale adapter may explicitly substitute `c0_ij` for that cut
+edge only: this upper-bounds `beta` and, by grounded M-matrix inverse
+monotonicity, lowers nonnegative raw responses, so the degradation over-grounds
+rather than exaggerates influence. Record the fallback edge count and
+substituted cut mass. Substituting zero, applying this fallback to retained
+internal edges, or claiming that normalized `h_s` values or their ranking are
+conservative is not allowed.
+
 ### Nonzero grounding remains mandatory
 
 Every positive-conductance component of the induced graph must reach a
@@ -167,6 +198,41 @@ over-grounding. If the upper bracket violates the float64 conditioning or
 physical-scale contract, calibration fails rather than adding hidden jitter.
 Calibration uses the raw Green response ratio; unit-diagonal correlation
 normalization does not have the required monotone interpretation.
+The API therefore requires `shell_nodes` explicitly and never substitutes the
+hard truncation frontier by default. The caller must preregister an interior
+shell; the implementation validates membership and reachability but cannot
+infer scientific interiority from node identifiers alone.
+
+### Per-anchor realized screening radius
+
+One uniform `alpha` is set by the tightest anchor and can over-ground the
+others. Preserve that heterogeneity instead of reporting only the joint
+maximum. For a frozen outcome-blind source-relative distance `d_s`, define the
+radial tail envelope
+
+    A_s(r) = max over reachable i with d_s(i) >= r of h_s(i).
+
+Unlike individual shell values, `A_s(r)` is nonincreasing by construction even
+when an irregular graph's exact-distance shell responses rebound. For target
+`q`, define
+
+    R_s(q) = min {r > 0 : A_s(r) <= q}.
+
+At `q=exp(-1)` this is the realized e-fold radius. For any other target it is
+the realized `q`-screening radius; do not infer or interpolate an exponential
+length from one shell value. Report each anchor's calibration-shell
+attenuation, threshold, distance metric, and discrete crossing bracket
+`(r_previous, r_crossing]`. If no crossing occurs inside the retained
+positive-conductance component, right-censor the result beyond the maximum
+observed radius.
+
+The current hop implementation recomputes source-relative hops inside each
+anchor's realized positive-conductance retained component. It excludes
+disconnected components rather than treating their zero Green response as
+instant attenuation, and it fails closed unless every calibration anchor has
+a reachable non-source shell node. A future weighted selector must supply its
+own frozen source-relative distances rather than reuse the multi-source
+minimum distance.
 
 ### Chain initializer
 
@@ -182,6 +248,11 @@ Setting `kappa=1/R_e` gives the exact one-dimensional initializer
 
 Using a robust typical internal conductance for `c` supplies a bracket seed,
 not a final calibration on an irregular graph.
+
+Tree-like outward branching can attenuate faster than a chain at the same
+`alpha`, so the chain seed can be conservatively high and over-ground.
+Cycles, bottlenecks, and degree heterogeneity can shift it in either direction.
+The frozen-shell bisection, not `alpha_0`, determines the final model.
 
 ### Screening radius is not truncation radius
 
@@ -310,8 +381,9 @@ An implementation of local grounded diffusion must:
    and reciprocal-condition contracts from the global design;
 4. retain the Cholesky/solve-first interface and never require an explicit
    inverse for primary computation;
-5. expose killed-response, harmonic-measure, cut-current, and nested-domain
-   diagnostics with finite-value and Kirchhoff-residual checks;
+5. expose killed-response, per-anchor realized screening-radius,
+   harmonic-measure, cut-current, and nested-domain diagnostics with
+   finite-value and Kirchhoff-residual checks;
 6. keep model leakage, Dirichlet cut conductance, and any future numerical
    jitter as three separately named quantities;
 7. preserve the node map, selector provenance, requested and realized `K`,

--- a/prototypes/mu_cosine/DECISIONS_graph_geometry.md
+++ b/prototypes/mu_cosine/DECISIONS_graph_geometry.md
@@ -327,11 +327,19 @@ per-anchor matrices presented as one joint kernel; or tuning `D`, `K`, or
 
 **Implementation status:** this change ships the strict-`K` multi-source hop
 selector, exact cut-shunt assembly, common-bath dense factor, leakage
-calibration, and nested-domain diagnostics. It also ships a constant-degree
-CPU microbenchmark. Nomic-resistance Dijkstra, hub-streaming adjacency,
-precomputed weighted cut degrees, sparse solvers, and CUDA remain follow-ups.
+calibration, per-anchor realized screening-radius provenance, and nested-domain
+diagnostics. It also ships a constant-degree CPU microbenchmark.
+Nomic-resistance Dijkstra, hub-streaming adjacency, precomputed weighted cut
+degrees, sparse solvers, and CUDA remain follow-ups. A scale adapter may
+explicitly upper-bound an unavailable exterior semantic conductance by its
+base topological `c0`, but must record fallback count and mass; the dense
+reference continues to fail closed.
 
 **Not authorized:** learned judge covariance, relaxed source-power gates,
 sparse/CUDA performance claims, or hidden numerical jitter. Sparse direct and
 iterative backends remain engineering candidates only after parity with the
 dense local reference and a matched end-to-end crossover benchmark.
+
+**Authorized application lane:** outcome-blind candidate generation,
+per-anchor screening values as ranking features, and routing, with no placement
+or judge outcomes in `D`, `K`, `ell`, `epsilon`, `alpha`, or threshold choice.

--- a/src/unifyweaver/graph/__init__.py
+++ b/src/unifyweaver/graph/__init__.py
@@ -7,6 +7,7 @@ from .leaky_diffusion import (
     semantic_conductance_matrix,
 )
 from .local_diffusion import (
+    AnchorScreeningProvenance,
     LeakageCalibrationResult,
     LocalDiffusionDomain,
     LocalGroundedSemanticDiffusion,
@@ -18,6 +19,7 @@ from .local_diffusion import (
 )
 
 __all__ = [
+    "AnchorScreeningProvenance",
     "GroundedSemanticDiffusion",
     "build_grounded_semantic_diffusion",
     "LeakageCalibrationResult",

--- a/src/unifyweaver/graph/local_diffusion.py
+++ b/src/unifyweaver/graph/local_diffusion.py
@@ -21,6 +21,8 @@ require a Schur complement.
 
 from __future__ import annotations
 
+from collections import deque
+
 from dataclasses import dataclass
 import math
 from typing import Mapping
@@ -42,6 +44,7 @@ from .leaky_diffusion import (
 
 
 __all__ = [
+    "AnchorScreeningProvenance",
     "LeakageCalibrationResult",
     "LocalDiffusionDomain",
     "LocalGroundedSemanticDiffusion",
@@ -451,7 +454,7 @@ def _assemble_local_components(
 
 @dataclass(frozen=True)
 class LocalGroundedSemanticDiffusion:
-    """A bath-clamped local operator with shunt provenance kept separate."""
+    """A local operator whose intrinsic and cut shunts share one common bath."""
 
     domain: LocalDiffusionDomain
     model: GroundedSemanticDiffusion
@@ -512,7 +515,13 @@ class LocalGroundedSemanticDiffusion:
         return self.model.precision
 
     def equilibrium_response(self, source, *, absolute=False):
-        """Return deviation from the bath, or absolute common-bath state."""
+        """Return bath-relative deviation, or the absolute common-bath state.
+
+        ``absolute=True`` assumes that both intrinsic leakage ``alpha`` and the
+        Dirichlet cut ``beta`` terminate at ``bath_temperature``.  It does not
+        model an exterior-only bath with intrinsic leakage held at another
+        reference potential.
+        """
 
         response = self.model.equilibrium_response(source)
         if absolute:
@@ -681,19 +690,83 @@ def build_local_grounded_semantic_diffusion(
 
 
 @dataclass(frozen=True)
+class AnchorScreeningProvenance:
+    """One anchor's discrete raw-response screening-radius provenance."""
+
+    anchor: object
+    shell_attenuation: float
+    attenuation_threshold: float
+    radius_lower: float
+    radius_upper: float | None
+    right_censored: bool
+    maximum_observed_radius: float
+    distance_metric: str
+
+    def __post_init__(self):
+        try:
+            hash(self.anchor)
+        except TypeError as exc:
+            raise ValueError("anchor must be hashable") from exc
+        attenuation = _finite_scalar(
+            "shell_attenuation", self.shell_attenuation
+        )
+        if attenuation < 0.0 or attenuation > 1.0 + 1e-8:
+            raise ValueError("shell_attenuation must be in [0, 1]")
+        threshold = _positive_unit_interval(
+            "attenuation_threshold", self.attenuation_threshold
+        )
+        lower = _finite_scalar("radius_lower", self.radius_lower)
+        maximum = _finite_scalar(
+            "maximum_observed_radius", self.maximum_observed_radius
+        )
+        if lower < 0.0 or maximum < 1.0 or lower > maximum:
+            raise ValueError("screening radii must be nonnegative and ordered")
+        if not isinstance(self.right_censored, (bool, np.bool_)):
+            raise ValueError("right_censored must be boolean")
+        censored = bool(self.right_censored)
+        if censored:
+            if self.radius_upper is not None or lower != maximum:
+                raise ValueError(
+                    "a right-censored radius must end at the observed maximum"
+                )
+            upper = None
+        else:
+            upper = _finite_scalar("radius_upper", self.radius_upper)
+            if upper <= lower or upper > maximum:
+                raise ValueError("screening-radius bracket must be ordered")
+        metric = str(self.distance_metric)
+        if not metric:
+            raise ValueError("distance_metric must be non-empty")
+        object.__setattr__(self, "shell_attenuation", attenuation)
+        object.__setattr__(self, "attenuation_threshold", threshold)
+        object.__setattr__(self, "radius_lower", lower)
+        object.__setattr__(self, "radius_upper", upper)
+        object.__setattr__(self, "right_censored", censored)
+        object.__setattr__(self, "maximum_observed_radius", maximum)
+        object.__setattr__(self, "distance_metric", metric)
+
+
+@dataclass(frozen=True)
 class LeakageCalibrationResult:
     model: LocalGroundedSemanticDiffusion
     leakage_conductance: float
     leakage_resistance: float
     target_attenuation: float
     achieved_attenuation: float
+    source_nodes: tuple
     shell_nodes: tuple
+    anchor_screening: tuple
     iterations: int
     numerical_minimum_leakage: float
 
     def __post_init__(self):
         if not isinstance(self.model, LocalGroundedSemanticDiffusion):
             raise TypeError("model must be a LocalGroundedSemanticDiffusion")
+        sources = _selected_nodes(
+            self.model.nodes,
+            self.source_nodes,
+            name="source_nodes",
+        )
         shell = _selected_nodes(
             self.model.nodes,
             self.shell_nodes,
@@ -702,7 +775,12 @@ class LeakageCalibrationResult:
         leakage = _finite_scalar("leakage_conductance", self.leakage_conductance)
         if leakage < 0.0:
             raise ValueError("leakage_conductance must be nonnegative")
-        resistance = float(self.leakage_resistance)
+        try:
+            resistance = float(self.leakage_resistance)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "leakage_resistance must be reciprocal conductance"
+            ) from exc
         expected = math.inf if leakage == 0.0 else 1.0 / leakage
         if leakage == 0.0 and resistance != math.inf:
             raise ValueError("leakage_resistance must be reciprocal conductance")
@@ -714,11 +792,52 @@ class LeakageCalibrationResult:
         target = _positive_unit_interval(
             "target_attenuation", self.target_attenuation
         )
+        screening = tuple(self.anchor_screening)
+        if not screening or not all(
+            isinstance(item, AnchorScreeningProvenance)
+            for item in screening
+        ):
+            raise ValueError(
+                "anchor_screening must contain per-anchor provenance"
+            )
+        if tuple(item.anchor for item in screening) != sources:
+            raise ValueError(
+                "anchor_screening must align exactly with source_nodes"
+            )
+        for item in screening:
+            if not math.isclose(
+                item.attenuation_threshold,
+                target,
+                rel_tol=1e-12,
+                abs_tol=0.0,
+            ):
+                raise ValueError(
+                    "per-anchor attenuation thresholds must match the target"
+                )
         achieved = _finite_scalar("achieved_attenuation", self.achieved_attenuation)
         if achieved < 0.0 or achieved > target * (1.0 + 1e-8):
             raise ValueError("calibrated attenuation does not meet its target")
-        if int(self.iterations) != self.iterations or self.iterations < 0:
+        per_anchor_maximum = max(
+            item.shell_attenuation for item in screening
+        )
+        achieved_scale = max(
+            abs(achieved),
+            abs(per_anchor_maximum),
+            np.finfo(float).tiny,
+        )
+        if abs(achieved - per_anchor_maximum) > (
+            64.0 * np.finfo(float).eps * achieved_scale
+        ):
+            raise ValueError(
+                "achieved attenuation must equal the per-anchor maximum"
+            )
+        if (
+            isinstance(self.iterations, (bool, np.bool_))
+            or int(self.iterations) != self.iterations
+            or self.iterations < 0
+        ):
             raise ValueError("iterations must be a nonnegative integer")
+        iterations = int(self.iterations)
         numeric = _finite_scalar(
             "numerical_minimum_leakage", self.numerical_minimum_leakage
         )
@@ -732,7 +851,133 @@ class LeakageCalibrationResult:
             or leakage + 64.0 * np.finfo(float).eps * numeric_scale < numeric
         ):
             raise ValueError("selected leakage is below the numerical minimum")
+        object.__setattr__(self, "source_nodes", sources)
         object.__setattr__(self, "shell_nodes", shell)
+        object.__setattr__(self, "anchor_screening", screening)
+        object.__setattr__(self, "leakage_conductance", leakage)
+        object.__setattr__(self, "leakage_resistance", resistance)
+        object.__setattr__(self, "target_attenuation", target)
+        object.__setattr__(self, "achieved_attenuation", achieved)
+        object.__setattr__(self, "iterations", iterations)
+        object.__setattr__(self, "numerical_minimum_leakage", numeric)
+
+
+def _positive_conductance_hop_distances(conductance, source_row):
+    """Return source-relative hops inside one realized conductance component."""
+
+    conductance = np.asarray(conductance, dtype=float)
+    if conductance.ndim != 2 or conductance.shape[0] != conductance.shape[1]:
+        raise ValueError("conductance must be square")
+    size = conductance.shape[0]
+    if not 0 <= source_row < size:
+        raise ValueError("source_row must index conductance")
+    distances = np.full(size, -1, dtype=np.int64)
+    distances[source_row] = 0
+    pending = deque((source_row,))
+    while pending:
+        row = pending.popleft()
+        for neighbor in np.flatnonzero(conductance[row] > 0.0):
+            neighbor = int(neighbor)
+            if distances[neighbor] >= 0:
+                continue
+            distances[neighbor] = distances[row] + 1
+            pending.append(neighbor)
+    return distances
+
+
+def _tail_envelope_crossing(distances, attenuation, threshold):
+    """Bracket the first threshold crossing of a monotone radial tail envelope."""
+
+    distances = np.asarray(distances, dtype=float)
+    attenuation = np.asarray(attenuation, dtype=float)
+    if distances.shape != attenuation.shape or distances.ndim != 1:
+        raise ValueError("distances and attenuation must be aligned vectors")
+    if (
+        not np.isfinite(distances).all()
+        or not np.isfinite(attenuation).all()
+        or np.any(distances < 0.0)
+        or np.any(attenuation < 0.0)
+        or np.any(attenuation > 1.0 + 1e-8)
+    ):
+        raise ValueError("screening profile must be finite and in [0, 1]")
+    threshold = _positive_unit_interval("attenuation_threshold", threshold)
+    positive_radii = np.unique(distances[distances > 0.0])
+    if not len(positive_radii):
+        raise ValueError("screening profile needs a reachable non-source node")
+    maximum = float(positive_radii[-1])
+    previous = 0.0
+    for radius in positive_radii:
+        tail = float(np.max(attenuation[distances >= radius]))
+        if tail <= threshold:
+            return previous, float(radius), False, maximum
+        previous = float(radius)
+    return maximum, None, True, maximum
+
+
+def _anchor_screening_provenance(
+    local,
+    source_nodes,
+    shell_rows,
+    source_distances,
+    *,
+    threshold,
+):
+    """Summarize shell tightness and robust per-anchor screening radii."""
+
+    index = {node: row for row, node in enumerate(local.nodes)}
+    records = []
+    for source_node, distances in zip(source_nodes, source_distances):
+        source_row = index[source_node]
+        source = np.zeros(len(local.nodes), dtype=float)
+        source[source_row] = 1.0
+        response = local.model.equilibrium_response(source)
+        scale = max(float(np.max(np.abs(response), initial=0.0)), 1.0)
+        if (
+            not np.isfinite(response).all()
+            or response[source_row] <= 0.0
+            or np.min(response) < -1e-10 * scale
+        ):
+            raise np.linalg.LinAlgError(
+                "per-anchor Green response is not nonnegative"
+            )
+        attenuation = np.maximum(response, 0.0) / float(response[source_row])
+        if float(np.max(attenuation)) > 1.0 + 1e-8:
+            raise np.linalg.LinAlgError(
+                "per-anchor Green attenuation left [0, 1]"
+            )
+        attenuation = np.clip(attenuation, 0.0, 1.0)
+        reachable_shell = tuple(
+            row
+            for row in shell_rows
+            if row != source_row and distances[row] > 0
+        )
+        if not reachable_shell:
+            raise ValueError(
+                "calibration shell must include a reachable non-source "
+                f"node for anchor {source_node!r}"
+            )
+        shell_attenuation = float(
+            np.max(attenuation[list(reachable_shell)])
+        )
+        reachable = distances >= 0
+        lower, upper, censored, maximum = _tail_envelope_crossing(
+            distances[reachable],
+            attenuation[reachable],
+            threshold,
+        )
+        records.append(
+            AnchorScreeningProvenance(
+                anchor=source_node,
+                shell_attenuation=shell_attenuation,
+                attenuation_threshold=threshold,
+                radius_lower=lower,
+                radius_upper=upper,
+                right_censored=censored,
+                maximum_observed_radius=maximum,
+                distance_metric="realized_positive_conductance_hops",
+            )
+        )
+    return tuple(records)
 
 
 def _attenuation_from_eigendecomposition(
@@ -816,6 +1061,23 @@ def calibrate_uniform_leakage(
         length_scale=length_scale,
         conductance_floor=conductance_floor,
     )
+    source_distances = tuple(
+        _positive_conductance_hop_distances(conductance, source_row)
+        for source_row in source_rows
+    )
+    for source_node, source_row, distances in zip(
+        source_nodes,
+        source_rows,
+        source_distances,
+    ):
+        if not any(
+            row != source_row and distances[row] > 0
+            for row in shell_rows
+        ):
+            raise ValueError(
+                "calibration shell must include a reachable non-source "
+                f"node for anchor {source_node!r}"
+            )
     base_precision = laplacian + np.diag(intrinsic + cut)
     eigenvalues, eigenvectors = np.linalg.eigh(base_precision)
     spectral_scale = max(float(np.max(np.abs(eigenvalues), initial=0.0)), 1.0)
@@ -957,7 +1219,24 @@ def calibrate_uniform_leakage(
         bath_temperature=bath_temperature,
         minimum_reciprocal_condition=required_rcond,
     )
-    observed = local.frontier_attenuation(source_nodes, shell)
+    anchor_screening = _anchor_screening_provenance(
+        local,
+        source_nodes,
+        shell_rows,
+        source_distances,
+        threshold=target,
+    )
+    observed = max(
+        item.shell_attenuation for item in anchor_screening
+    )
+    direct_observed = local.frontier_attenuation(source_nodes, shell)
+    observed_scale = max(abs(observed), abs(direct_observed), 1.0)
+    if abs(observed - direct_observed) > (
+        64.0 * np.finfo(float).eps * observed_scale
+    ):
+        raise np.linalg.LinAlgError(
+            "per-anchor screening provenance disagrees with the final model"
+        )
     if observed > target * (1.0 + max(tolerance, 1e-10)):
         raise np.linalg.LinAlgError("final model missed the attenuation target")
     return LeakageCalibrationResult(
@@ -966,7 +1245,9 @@ def calibrate_uniform_leakage(
         leakage_resistance=(math.inf if selected == 0.0 else 1.0 / selected),
         target_attenuation=target,
         achieved_attenuation=observed,
+        source_nodes=source_nodes,
         shell_nodes=shell,
+        anchor_screening=anchor_screening,
         iterations=evaluations,
         numerical_minimum_leakage=numerical_minimum,
     )
@@ -982,6 +1263,71 @@ class NestedDomainDiagnostics:
     monotonic: bool
     inner_boundary_harmonic_max: float
     outer_boundary_harmonic_max: float
+
+    def __post_init__(self):
+        sources = _canonical_unique(self.source_nodes, name="source_nodes")
+        protected = _canonical_unique(
+            self.protected_nodes,
+            name="protected_nodes",
+        )
+        maximum_absolute = _finite_scalar(
+            "maximum_protected_absolute_error",
+            self.maximum_protected_absolute_error,
+        )
+        maximum_relative = _finite_scalar(
+            "maximum_protected_relative_error",
+            self.maximum_protected_relative_error,
+        )
+        if maximum_absolute < 0.0 or maximum_relative < 0.0:
+            raise ValueError("protected-domain errors must be nonnegative")
+        minimum_increment = _finite_scalar(
+            "minimum_monotone_increment",
+            self.minimum_monotone_increment,
+        )
+        if not isinstance(self.monotonic, (bool, np.bool_)):
+            raise ValueError("monotonic must be boolean")
+        monotonic = bool(self.monotonic)
+        inner_harmonic = _finite_scalar(
+            "inner_boundary_harmonic_max",
+            self.inner_boundary_harmonic_max,
+        )
+        outer_harmonic = _finite_scalar(
+            "outer_boundary_harmonic_max",
+            self.outer_boundary_harmonic_max,
+        )
+        if (
+            not 0.0 <= inner_harmonic <= 1.0
+            or not 0.0 <= outer_harmonic <= 1.0
+        ):
+            raise ValueError("boundary harmonic maxima must be in [0, 1]")
+        object.__setattr__(self, "source_nodes", sources)
+        object.__setattr__(self, "protected_nodes", protected)
+        object.__setattr__(
+            self,
+            "maximum_protected_absolute_error",
+            maximum_absolute,
+        )
+        object.__setattr__(
+            self,
+            "maximum_protected_relative_error",
+            maximum_relative,
+        )
+        object.__setattr__(
+            self,
+            "minimum_monotone_increment",
+            minimum_increment,
+        )
+        object.__setattr__(self, "monotonic", monotonic)
+        object.__setattr__(
+            self,
+            "inner_boundary_harmonic_max",
+            inner_harmonic,
+        )
+        object.__setattr__(
+            self,
+            "outer_boundary_harmonic_max",
+            outer_harmonic,
+        )
 
 
 def compare_nested_domains(
@@ -1026,11 +1372,18 @@ def compare_nested_domains(
     for node in inner.nodes:
         left = inner_index[node]
         right = outer_index[node]
+        inner_leakage = float(inner.intrinsic_leakage_conductance[left])
+        outer_leakage = float(outer.intrinsic_leakage_conductance[right])
+        leakage_scale = max(
+            abs(inner_leakage),
+            abs(outer_leakage),
+            np.finfo(float).tiny,
+        )
         if not math.isclose(
-            float(inner.intrinsic_leakage_conductance[left]),
-            float(outer.intrinsic_leakage_conductance[right]),
+            inner_leakage,
+            outer_leakage,
             rel_tol=1e-12,
-            abs_tol=1e-12,
+            abs_tol=64.0 * np.finfo(float).eps * leakage_scale,
         ):
             raise ValueError("nested models must use the same intrinsic leakage")
         if set(inner.domain.neighbors[left]) != set(outer.domain.neighbors[right]):
@@ -1060,7 +1413,7 @@ def compare_nested_domains(
     maximum_absolute = 0.0
     maximum_relative = 0.0
     minimum_increment = math.inf
-    response_scale = 1.0
+    response_scale = np.finfo(float).tiny
     for source_node in sources:
         inner_rhs = np.zeros(len(inner.nodes))
         outer_rhs = np.zeros(len(outer.nodes))

--- a/tests/test_local_grounded_diffusion.py
+++ b/tests/test_local_grounded_diffusion.py
@@ -15,12 +15,28 @@ from unifyweaver.graph.leaky_diffusion import (  # noqa: E402
     build_grounded_semantic_diffusion,
 )
 from unifyweaver.graph.local_diffusion import (  # noqa: E402
+    AnchorScreeningProvenance,
     build_local_grounded_semantic_diffusion,
     LocalDiffusionDomain,
+    _tail_envelope_crossing,
     calibrate_uniform_leakage,
     compare_nested_domains,
     select_hop_local_domain,
 )
+
+
+def test_anchor_screening_provenance_requires_a_boolean_censor_flag():
+    with pytest.raises(ValueError, match="right_censored must be boolean"):
+        AnchorScreeningProvenance(
+            anchor="a",
+            shell_attenuation=0.25,
+            attenuation_threshold=0.5,
+            radius_lower=1.0,
+            radius_upper=None,
+            right_censored="false",
+            maximum_observed_radius=1.0,
+            distance_metric="hops",
+        )
 
 
 def _neighbors(edges, extra=()):
@@ -307,6 +323,119 @@ def test_uniform_leakage_calibration_hits_chain_frontier_target():
     assert response[-1] / response[0] == pytest.approx(
         calibration.achieved_attenuation
     )
+    assert calibration.source_nodes == (0,)
+    assert len(calibration.anchor_screening) == 1
+    screening = calibration.anchor_screening[0]
+    assert screening.anchor == 0
+    assert screening.shell_attenuation == pytest.approx(
+        calibration.achieved_attenuation
+    )
+    assert screening.attenuation_threshold == pytest.approx(target)
+    assert screening.radius_lower == 4.0
+    assert screening.radius_upper == 5.0
+    assert not screening.right_censored
+    assert screening.maximum_observed_radius == 5.0
+    assert screening.distance_metric == "realized_positive_conductance_hops"
+
+
+def test_multi_anchor_calibration_reports_tight_and_overgrounded_radii():
+    graph = {
+        "a0": ("a1",),
+        "a1": ("a0", "a2"),
+        "a2": ("a1",),
+        "b0": ("b1",),
+        "b1": ("b0", "b2"),
+        "b2": ("b1",),
+    }
+    domain = select_hop_local_domain(
+        ("a0", "b0"),
+        graph,
+        maximum_nodes=6,
+    )
+    embeddings = {
+        "a0": np.array([0.0]),
+        "a1": np.array([0.0]),
+        "a2": np.array([0.0]),
+        "b0": np.array([10.0]),
+        "b1": np.array([13.5]),
+        "b2": np.array([17.0]),
+    }
+
+    calibration = calibrate_uniform_leakage(
+        domain,
+        shell_nodes=("a2", "b2"),
+        node_embeddings=embeddings,
+        length_scale=1.0,
+        relative_tolerance=1e-6,
+    )
+
+    tight, overgrounded = calibration.anchor_screening
+    assert (tight.anchor, overgrounded.anchor) == ("a0", "b0")
+    assert tight.shell_attenuation == pytest.approx(
+        calibration.achieved_attenuation
+    )
+    assert tight.radius_upper == 2.0
+    assert overgrounded.shell_attenuation < tight.shell_attenuation
+    assert overgrounded.radius_upper == 1.0
+
+
+def test_tail_envelope_rejects_an_early_nonmonotone_shell_crossing():
+    lower, upper, censored, maximum = _tail_envelope_crossing(
+        np.array([0.0, 1.0, 2.0, 3.0]),
+        np.array([1.0, 0.2, 0.8, 0.1]),
+        0.5,
+    )
+
+    assert (lower, upper, censored, maximum) == (2.0, 3.0, False, 3.0)
+    lower, upper, censored, maximum = _tail_envelope_crossing(
+        np.array([0.0, 1.0, 2.0]),
+        np.array([1.0, 0.9, 0.8]),
+        0.5,
+    )
+    assert (lower, upper, censored, maximum) == (2.0, None, True, 2.0)
+
+
+def test_calibration_requires_a_reachable_shell_node_for_every_anchor():
+    graph = {
+        "a0": ("a1",),
+        "a1": ("a0",),
+        "b0": ("b1",),
+        "b1": ("b0",),
+    }
+    domain = select_hop_local_domain(
+        ("a0", "b0"),
+        graph,
+        maximum_nodes=4,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="reachable non-source node for anchor 'b0'",
+    ):
+        calibrate_uniform_leakage(
+            domain,
+            shell_nodes=("a1",),
+        )
+
+
+def test_non_e_fold_target_is_recorded_as_a_generic_threshold():
+    graph = _path(3)
+    domain = select_hop_local_domain(
+        (0,),
+        graph,
+        maximum_nodes=4,
+    )
+
+    calibration = calibrate_uniform_leakage(
+        domain,
+        shell_nodes=(3,),
+        target_attenuation=0.5,
+        relative_tolerance=1e-6,
+    )
+
+    screening = calibration.anchor_screening[0]
+    assert screening.attenuation_threshold == 0.5
+    assert screening.radius_upper is not None
 
 
 def test_leakage_calibration_reads_each_required_embedding_once():


### PR DESCRIPTION
## Summary

Post-merge follow-up to #3857. The review-driven corrections were complete locally when #3857 was merged, so this PR brings the implementation back into alignment with the reviewed design and the final #3857 description.

## What changed

- records per-anchor realized screening-radius provenance from the monotone raw-response tail envelope;
- uses the tightest anchor for multi-anchor leakage calibration and exposes over-grounding at the other anchors;
- requires callers to name the calibration shell explicitly and fails closed on unreachable shells;
- snapshots graph/embedding components once and reuses the validated local operator construction;
- tightens public result invariants, tiny-scale nested-domain comparisons, and boolean/reciprocal validation;
- makes the common-bath convention explicit for intrinsic leakage and cut shunts;
- documents the safe missing-exterior-embedding fallback as the topological conductance upper bound, with fallback mass/count provenance;
- records the chain-initializer branching caveat, accurate Pearltrees dense-memory scope, and the outcome-blind application uses now sanctioned.

The exterior remains an exact Dirichlet cut:
```
J_S = L(W_SS) + diag(alpha + beta)
```
No covariance marginalization or insulating-boundary approximation is claimed.

## Validation

- `74 passed` across local/global diffusion and graph-geometry suites.
- Benchmark smoke passed at `K=8,16,32` on the implicit 1,000,000-node universe; provider calls equaled `K`, with residual infinity norm at or below `5.56e-16`.
- `git diff --check` clean.

## Scope

This is still the dense float64 correctness reference. Streaming high-degree selection, sparse/GPU factorization, and learned Nomic-resistance selection remain deferred.