### PR TITLE
WAM/LLVM plawk: ARGC / ARGV[N] command-line arguments (rule bodies)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -64,7 +64,8 @@ only (runtime pending) · ❌ missing.
 | Feature | Status | Notes |
 |---|---|---|
 | `$0` `$N` `NR` `NF` `FS` `OFS` | ✅ | `FS` accepts a **multi-char / regex** value (a POSIX ERE, awk semantics): a length-≥2 `BEGIN { FS = "…" }` compiles to a reserved sentinel separator byte that the field runtime dispatches to `@wam_fs_regex_field_slice_value` / `_count_value` (lazily `regcomp`ed, one FS per program). Because the numeric / `length` / `eq` / `cmp` field projectors all delegate to the core slice, the regex FS reaches `$N` reads, `NF`, guards, and concat uniformly; `$0` and EOF are unaffected. A single-char `FS` stays a literal byte (awk treats a one-char FS literally). **Field assignment splits on a regex FS too** (via `@wam_fields_new_re`), and `split()` takes its own multi-char/regex separator. Remaining: multi-char `OFS` (still a single byte), and regex FS inside the multipass / dyncall record-view drivers (which read a non-`%line` record). |
-| `FNR` `FILENAME` `ARGV` `ARGC` `RS` `ORS` `SUBSEP` | ❌ | single newline-delimited record model |
+| `ARGV[N]` `ARGC` | ◐ | **command-line arguments landed** (rule bodies): the plawk driver is a native binary, so `ARGV`/`ARGC` read straight from the process `argv` via `/proc/self/cmdline` (`@wam_argc`, `@wam_argv_get`) — `ARGV[0]` the program, `ARGV[1]` the first argument (the input path; `-` = stdin), `ARGV[2..]` extras, matching awk. `ARGC` is an i64 usable anywhere an i64 special is (`print ARGC`, `if (ARGC > 1)`, `n = ARGC - 1`, `c = ARGC`, concat). `ARGV[N]` (a non-negative integer-literal index) is a string scalar: `print ARGV[N]`, `x = ARGV[N]` (then prints / string-compares); an out-of-range index is `""`. Follow-ons: `ARGV`/`ARGC` in **BEGIN**/**END** blocks (their print/action pipelines are separate — BEGIN print is string-literal-only), a direct `ARGV[N]` comparison operand (`if (ARGV[2]=="x")` — use assign-then-compare), `ARGV[N]` in juxtaposition-concat (parses as an assoc read), and a variable/expression index. Linux-specific (`/proc/self/cmdline`) |
+| `FNR` `FILENAME` `RS` `ORS` `SUBSEP` | ❌ | single newline-delimited record model |
 | `ENVIRON["NAME"]` | ◐ | **read-only env lookup landed** (getenv via `@wam_environ_get`): `x = ENVIRON["NAME"]` (a string scalar — so it prints and string-compares) and `print ENVIRON["NAME"]`; an unset variable is `""` (awk semantics). v1 takes a string-literal key. Follow-ons: a non-literal key, `for (k in ENVIRON)`, and ENVIRON in juxtaposition-concat |
 | `RSTART` `RLENGTH` | ✅ | set by `match(SRC, /re/)`, readable as i64 specials in `print` (backed by `@plawk_rstart`/`@plawk_rlength`) |
 | arithmetic `+ - * / % //` | ✅ | i64, awk precedence, safe div/mod |
@@ -191,5 +192,6 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
 
 Deferred by design (the DSL's model diverges here): `RS`/multi-char record
 separators, `getline` (the `over`/multi-pass readers subsume most uses),
-multi-file `ARGV`/`FILENAME`/`FNR`, C-style `for(;;)` / `do-while` (the `while`
+multi-file `FILENAME`/`FNR` (`ARGV[N]`/`ARGC` themselves are landed for rule
+bodies — see the table), C-style `for(;;)` / `do-while` (the `while`
 runtime + for-in cover the loop needs).

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5216,6 +5216,7 @@ plawk_while_cond_ok(cmp(special(Name), Op, Rhs)) :-
 plawk_match_special('RSTART').
 plawk_match_special('RLENGTH').
 plawk_match_special('NR').
+plawk_match_special('ARGC').
 
 plawk_while_cond_rhs_ok(int(N)) :- integer(N).
 plawk_while_cond_rhs_ok(var(_W)).
@@ -5379,6 +5380,11 @@ plawk_while_cond_operand(special('RLENGTH'), _Slots, _CondValues, Base, Path, Si
     !,
     format(atom(Ref), '%~w_cond~w_~w_rlength', [Base, Path, Side]),
     format(atom(Line), '  ~w = load i64, i64* @plawk_rlength', [Ref]).
+% ARGC: the command-line argument count -- a call, no per-record state.
+plawk_while_cond_operand(special('ARGC'), _Slots, _CondValues, Base, Path, Side, Ref, [Line]) :-
+    !,
+    format(atom(Ref), '%~w_cond~w_~w_argc', [Base, Path, Side]),
+    format(atom(Line), '  ~w = call i64 @wam_argc()', [Ref]).
 % NR: the current record number. In a rule-body condition it is the loop's
 % %current_nr; in an END condition it is %plawk_nr (the final record count, the
 % same SSA the END expression path reads). No extra line -- both are existing
@@ -11441,6 +11447,8 @@ plawk_rule_body_print_field(var(_)).
 plawk_rule_body_print_field(special('NR')).
 plawk_rule_body_print_field(special('NF')).
 plawk_rule_body_print_field(environ(Key)) :- string(Key).
+plawk_rule_body_print_field(argv_at(N)) :- integer(N), N >= 0.
+plawk_rule_body_print_field(special('ARGC')).
 plawk_rule_body_print_field(int(field(_))).
 plawk_rule_body_print_field(Expr) :-
     plawk_i64_general_binary_expr(Expr).
@@ -12110,6 +12118,7 @@ plawk_substitute_end_reads(Expr, _StatePlan, Expr).
 
 plawk_i64_binary_primary_expr(special('NR')).
 plawk_i64_binary_primary_expr(special('NF')).
+plawk_i64_binary_primary_expr(special('ARGC')).
 plawk_i64_binary_primary_expr(int(field(FieldIndex))) :-
     FieldIndex >= 0.
 plawk_i64_binary_primary_expr(length(field(FieldIndex))) :-
@@ -12132,6 +12141,7 @@ plawk_i64_scalar_primary_expr(match_expr(field(FieldIndex), Regex)) :-
     string(Regex).
 plawk_i64_scalar_primary_expr(special('RSTART')).
 plawk_i64_scalar_primary_expr(special('RLENGTH')).
+plawk_i64_scalar_primary_expr(special('ARGC')).
 
 plawk_i64_binary_expr(add_i64(Left, Right), add, add, Left, Right).
 plawk_i64_binary_expr(sub_i64(Left, Right), sub, sub, Left, Right).
@@ -12235,6 +12245,9 @@ plawk_scalar_action_update(set(var(Name), string(Value)), Name, set_str(string(V
 % `x = ENVIRON["NAME"]`: the env var value as a string scalar (via getenv).
 plawk_scalar_action_update(set(var(Name), environ(Key)), Name, set_str(environ(Key))) :-
     string(Key).
+% `x = ARGV[N]`: the N-th command-line argument as a string scalar.
+plawk_scalar_action_update(set(var(Name), argv_at(N)), Name, set_str(argv_at(N))) :-
+    integer(N), N >= 0.
 % `x = sprintf("fmt", args)`: format into a string scalar.
 plawk_scalar_action_update(set(var(Name), sprintf(string(Format), Args)), Name,
         set_str(sprintf(string(Format), Args))) :-
@@ -13017,6 +13030,14 @@ plawk_str_build_ir(environ(Name), _FieldSeparator, Base, IdValueIR,
         '  %~w_envid = call i64 @wam_environ_get(i8* %~w_envkeyp)',
         [Base, Base]),
     format(atom(IdValueIR), '%~w_envid', [Base]).
+% `ARGV[N]`: the N-th command-line argument as a string scalar. wam_argv_get
+% interns the argument bytes and returns the atom id (0 = out of range -> empty).
+plawk_str_build_ir(argv_at(N), _FieldSeparator, Base, IdValueIR,
+        [], [CallLine]) :-
+    integer(N), N >= 0,
+    format(atom(CallLine),
+        '  %~w_argvid = call i64 @wam_argv_get(i64 ~w)', [Base, N]),
+    format(atom(IdValueIR), '%~w_argvid', [Base]).
 plawk_str_build_ir(concat(Parts), FieldSeparator, Base, IdValueIR,
         [FmtGlobal, EmptyGlobal], SetupLines) :-
     plawk_str_concat_format(Parts, FmtAtom),
@@ -13508,6 +13529,10 @@ plawk_i64_expr_ir(special('RSTART'), _FieldSeparator, Base, _GlobalBase,
 plawk_i64_expr_ir(special('RLENGTH'), _FieldSeparator, Base, _GlobalBase,
         ValueIR, [], [Line]) :-
     format(atom(Line), '  %~w = load i64, i64* @plawk_rlength', [Base]),
+    format(atom(ValueIR), '%~w', [Base]).
+plawk_i64_expr_ir(special('ARGC'), _FieldSeparator, Base, _GlobalBase,
+        ValueIR, [], [Line]) :-
+    format(atom(Line), '  %~w = call i64 @wam_argc()', [Base]),
     format(atom(ValueIR), '%~w', [Base]).
 % Ternary `COND ? A : B` over i64 values. COND is a single comparison
 % `L <op> R`; both branches are evaluated (no side effects in an i64 expr) and
@@ -15189,6 +15214,26 @@ plawk_emit_print_expr_for_context(environ(Key), _FieldSeparator, Context,
         '  %~w_sptr = select i1 %~w_empty_c, i8* getelementptr ([1 x i8], [1 x i8]* @.~w, i64 0, i64 0), i8* %~w_s',
         [Base, Base, EmptyName, Base]),
     format(atom(PtrIR), '%~w_sptr', [Base]).
+% `print ARGV[N]`: fetch the N-th argument's atom id then print it as text
+% (id 0 -> empty), same id-resolve pattern as ENVIRON.
+plawk_emit_print_expr_for_context(argv_at(N), _FieldSeparator, Context,
+        string(Base, PtrIR), [EmptyGlobal],
+        [ArgvCall, StrCall, IsEmpty, SelPtr]) :-
+    integer(N), N >= 0,
+    plawk_print_expr_value_base(Context, string, Base),
+    format(atom(ArgvCall),
+        '  %~w_argvid = call i64 @wam_argv_get(i64 ~w)', [Base, N]),
+    format(atom(EmptyName), '~w_empty', [Base]),
+    format(atom(EmptyGlobal),
+        '@.~w = private constant [1 x i8] zeroinitializer', [EmptyName]),
+    format(atom(StrCall),
+        '  %~w_s = call i8* @wam_atom_to_string(i64 %~w_argvid)', [Base, Base]),
+    format(atom(IsEmpty),
+        '  %~w_empty_c = icmp eq i64 %~w_argvid, 0', [Base, Base]),
+    format(atom(SelPtr),
+        '  %~w_sptr = select i1 %~w_empty_c, i8* getelementptr ([1 x i8], [1 x i8]* @.~w, i64 0, i64 0), i8* %~w_s',
+        [Base, Base, EmptyName, Base]),
+    format(atom(PtrIR), '%~w_sptr', [Base]).
 plawk_emit_print_expr_for_context(ssa_str(Value), FieldSeparator, Context,
         Out, Globals, Setup) :-
     plawk_emit_print_str_id(Value, FieldSeparator, Context, Out, Globals, Setup).
@@ -15311,6 +15356,13 @@ plawk_emit_print_expr_for_context(special('RLENGTH'), FieldSeparator, Context,
     plawk_print_expr_value_base(Context, rlength, Base),
     plawk_print_expr_output_names(Context, rlength, FmtPrefix, PrintPrefix),
     plawk_i64_expr_ir(special('RLENGTH'), FieldSeparator, Base, Base,
+        ValueIR, GlobalParts, SetupParts).
+
+plawk_emit_print_expr_for_context(special('ARGC'), FieldSeparator, Context,
+        i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
+    plawk_print_expr_value_base(Context, argc, Base),
+    plawk_print_expr_output_names(Context, argc, FmtPrefix, PrintPrefix),
+    plawk_i64_expr_ir(special('ARGC'), FieldSeparator, Base, Base,
         ValueIR, GlobalParts, SetupParts).
 
 plawk_emit_print_expr_for_context(substr(field(FieldIndex), Start, Len), FieldSeparator, Context,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1863,6 +1863,9 @@ match_special_name('RLENGTH') --> "RLENGTH".
 % (NF is a follow-on: it needs the field separator threaded into the condition
 % lowering, and has no defined value in an END condition.)
 match_special_name('NR') --> "NR".
+% ARGC (the command-line argument count) is a numeric special in a guard too:
+% `if (ARGC > 1)`.
+match_special_name('ARGC') --> "ARGC".
 
 while_cmp_rhs(int(N)) -->
     signed_integer_value(N),
@@ -2306,6 +2309,11 @@ scalar_value_expr(string(Value)) -->
 scalar_value_expr(Environ) -->
     environ_expr(Environ),
     !.
+% `x = ARGV[N]`: the N-th command-line argument as a string scalar (empty if out
+% of range). Tried before the bare scalar expr; the `ARGV[` prefix is unambiguous.
+scalar_value_expr(Argv) -->
+    argv_expr(Argv),
+    !.
 scalar_value_expr(Value) -->
     scalar_delta_expr(Value).
 
@@ -2316,6 +2324,15 @@ environ_expr(environ(Name)) -->
     "ENVIRON", ws, "[", ws,
     quoted_string(KCodes), ws, "]",
     { string_codes(Name, KCodes) }.
+
+%% argv_expr(-Argv)//
+%  `ARGV[N]` -- the N-th command-line argument (a non-negative integer-literal
+%  index). Parses to argv_at(N). ARGV[0] is the program, ARGV[1] the first arg.
+argv_expr(argv_at(N)) -->
+    "ARGV", ws, "[", ws,
+    integer_codes(NCodes),
+    { NCodes \== [], number_codes(N, NCodes), N >= 0 },
+    ws, "]".
 
 % match/RSTART/RLENGTH as a scalar RHS: `n = match($0, /re/)`, `x = RSTART`.
 % Tried before the arithmetic clause so the `match(` keyword and the special
@@ -2351,6 +2368,8 @@ scalar_delta_expr(special('NR')) -->
     "NR".
 scalar_delta_expr(special('NF')) -->
     "NF".
+scalar_delta_expr(special('ARGC')) -->
+    "ARGC".
 scalar_delta_expr(field(Index)) -->
     "$",
     integer_codes(IndexCodes),
@@ -2569,6 +2588,9 @@ print_fields_rest([]) -->
 print_field_expr(Environ) -->
     environ_expr(Environ),
     !.
+print_field_expr(Argv) -->
+    argv_expr(Argv),
+    !.
 print_field_expr(Ternary) -->
     ternary_expr(Ternary),
     !.
@@ -2641,6 +2663,8 @@ field_expr(special('NR')) -->
     "NR".
 field_expr(special('NF')) -->
     "NF".
+field_expr(special('ARGC')) -->
+    "ARGC".
 
 %% regex_arg(-Regex)//
 %
@@ -3182,6 +3206,8 @@ i64_binary_primary_expr(special('NR')) -->
     "NR".
 i64_binary_primary_expr(special('NF')) -->
     "NF".
+i64_binary_primary_expr(special('ARGC')) -->
+    "ARGC".
 i64_binary_primary_expr(Expr) -->
     int_field_expr(Expr).
 i64_binary_primary_expr(length(Field)) -->

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -7604,6 +7604,117 @@ env.unset:
   ret i64 0
 }
 
+; awk ARGC / ARGV[i]: the command-line arguments. Read once (cached) from
+; /proc/self/cmdline, a buffer of NUL-separated argv segments -- so ARGV[i]
+; maps directly to the compiled binary argv (ARGV[0] the program, ARGV[1] the
+; first argument), matching awk. Linux-specific; a follow-on would capture
+; argc/argv in main for portability.
+@.plawk_cmdline_path = private constant [19 x i8] c"/proc/self/cmdline\00"
+@plawk_cmdline_buf = internal global [65536 x i8] zeroinitializer
+@plawk_cmdline_len = internal global i64 -1
+
+; Load /proc/self/cmdline into the buffer once; return its byte length (0 on
+; error or if empty). Cached in @plawk_cmdline_len (-1 = not yet loaded).
+define i64 @plawk_cmdline_load() {
+entry:
+  %cl.cached = load i64, i64* @plawk_cmdline_len
+  %cl.done = icmp sge i64 %cl.cached, 0
+  br i1 %cl.done, label %cl.ret, label %cl.load
+
+cl.load:
+  %cl.path = getelementptr [19 x i8], [19 x i8]* @.plawk_cmdline_path, i64 0, i64 0
+  %cl.fd = call i32 @open(i8* %cl.path, i32 0, i32 0)
+  %cl.fdok = icmp sge i32 %cl.fd, 0
+  br i1 %cl.fdok, label %cl.read, label %cl.fail
+
+cl.read:
+  %cl.buf = getelementptr [65536 x i8], [65536 x i8]* @plawk_cmdline_buf, i64 0, i64 0
+  %cl.n = call i64 @read(i32 %cl.fd, i8* %cl.buf, i64 65535)
+  %cl.c = call i32 @close(i32 %cl.fd)
+  %cl.neg = icmp slt i64 %cl.n, 0
+  %cl.len = select i1 %cl.neg, i64 0, i64 %cl.n
+  store i64 %cl.len, i64* @plawk_cmdline_len
+  ret i64 %cl.len
+
+cl.fail:
+  store i64 0, i64* @plawk_cmdline_len
+  ret i64 0
+
+cl.ret:
+  ret i64 %cl.cached
+}
+
+; ARGC: the number of NUL-terminated segments in the cmdline buffer.
+define i64 @wam_argc() {
+entry:
+  %ac.len = call i64 @plawk_cmdline_load()
+  %ac.buf = getelementptr [65536 x i8], [65536 x i8]* @plawk_cmdline_buf, i64 0, i64 0
+  br label %ac.loop
+
+ac.loop:
+  %ac.i = phi i64 [ 0, %entry ], [ %ac.i1, %ac.step ]
+  %ac.count = phi i64 [ 0, %entry ], [ %ac.count2, %ac.step ]
+  %ac.atend = icmp sge i64 %ac.i, %ac.len
+  br i1 %ac.atend, label %ac.ret, label %ac.step
+
+ac.step:
+  %ac.p = getelementptr i8, i8* %ac.buf, i64 %ac.i
+  %ac.ch = load i8, i8* %ac.p
+  %ac.isnul = icmp eq i8 %ac.ch, 0
+  %ac.inc = zext i1 %ac.isnul to i64
+  %ac.count2 = add i64 %ac.count, %ac.inc
+  %ac.i1 = add i64 %ac.i, 1
+  br label %ac.loop
+
+ac.ret:
+  ret i64 %ac.count
+}
+
+; ARGV[idx]: intern the idx-th NUL-terminated segment and return its atom id, or
+; 0 (empty) when idx is out of range. Segment idx starts right after the idx-th
+; NUL (segment 0 at offset 0).
+define i64 @wam_argv_get(i64 %idx) {
+entry:
+  %av.len = call i64 @plawk_cmdline_load()
+  %av.buf = getelementptr [65536 x i8], [65536 x i8]* @plawk_cmdline_buf, i64 0, i64 0
+  %av.negidx = icmp slt i64 %idx, 0
+  br i1 %av.negidx, label %av.zero, label %av.scan
+
+av.scan:
+  %av.i = phi i64 [ 0, %entry ], [ %av.i1, %av.step ]
+  %av.seen = phi i64 [ 0, %entry ], [ %av.seen2, %av.step ]
+  %av.start = phi i64 [ 0, %entry ], [ %av.start2, %av.step ]
+  %av.reached = icmp eq i64 %av.seen, %idx
+  br i1 %av.reached, label %av.found, label %av.more
+
+av.more:
+  %av.atend = icmp sge i64 %av.i, %av.len
+  br i1 %av.atend, label %av.zero, label %av.step
+
+av.step:
+  %av.p = getelementptr i8, i8* %av.buf, i64 %av.i
+  %av.ch = load i8, i8* %av.p
+  %av.isnul = icmp eq i8 %av.ch, 0
+  %av.i1 = add i64 %av.i, 1
+  %av.next_seen = add i64 %av.seen, 1
+  %av.seen2 = select i1 %av.isnul, i64 %av.next_seen, i64 %av.seen
+  %av.start2 = select i1 %av.isnul, i64 %av.i1, i64 %av.start
+  br label %av.scan
+
+av.found:
+  %av.oob = icmp sge i64 %av.start, %av.len
+  br i1 %av.oob, label %av.zero, label %av.emit
+
+av.emit:
+  %av.segp = getelementptr i8, i8* %av.buf, i64 %av.start
+  %av.seglen = call i64 @strlen(i8* %av.segp)
+  %av.id = call i64 @wam_intern_atom(i8* %av.segp, i64 %av.seglen)
+  ret i64 %av.id
+
+av.zero:
+  ret i64 0
+}
+
 define i1 @wam_atom_prefix_value(%Value %atom_value, i8* %prefix, i64 %prefix_len) {
 entry:
   %ap.t = call i32 @value_tag(%Value %atom_value)

--- a/tests/test_plawk_argv.pl
+++ b/tests/test_plawk_argv.pl
@@ -1,0 +1,131 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% ARGC / ARGV[N] -- the command-line arguments of the compiled program. The
+% plawk driver is a native binary, so ARGV maps directly to the process argv
+% read from /proc/self/cmdline: ARGV[0] is the program, ARGV[1] the first
+% argument (the input path -- "-" selects stdin), ARGV[2..] any extras. ARGC is
+% the count. v1 surface: rule bodies only -- ARGC as an i64 (print/guard/
+% arithmetic/scalar-assign), ARGV[N] as a string scalar (print / `x = ARGV[N]`
+% then string-compare). BEGIN/END prints, a direct ARGV[N] comparison operand,
+% and a variable/expression index are follow-ons.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_argv).
+
+% --- parsing ---------------------------------------------------------------
+
+test(argv_print_parses) :-
+    plawk_parse_string("{ print ARGV[1] }\n",
+        program([], [rule(always, [print([argv_at(1)])])], [])),
+    !.
+
+test(argv_assign_parses) :-
+    plawk_parse_string("{ x = ARGV[2]; print x }\n",
+        program([], [rule(always, [set(var(x), argv_at(2)), print([var(x)])])], [])),
+    !.
+
+test(argc_print_parses) :-
+    plawk_parse_string("{ print ARGC }\n",
+        program([], [rule(always, [print([special('ARGC')])])], [])),
+    !.
+
+% --- runtime ---------------------------------------------------------------
+% The binary is invoked with a leading "-" (stdin) so the driver reads the
+% piped record; extra args land in ARGV[2..], and ARGC counts them all.
+
+% ARGC counts the process arguments (bin, "-", foo, bar -> 4).
+test(argc_count, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run_args(Dir, 'ac', "{ print ARGC }\n",
+        "t\n", ['-', foo, bar], Out, St),
+    assertion(St == 0), assertion(Out == "4\n"), !.
+
+% ARGV[0] is the program path (ends in the built binary name).
+test(argv0_is_program, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run_args(Dir, 'a0', "{ print ARGV[0] }\n",
+        "t\n", ['-'], Out, St),
+    assertion(St == 0),
+    assertion(sub_string(Out, _, _, _, "a0_bin")), !.
+
+% ARGV[1] is the first argument (here the input selector "-").
+test(argv1_first_arg, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run_args(Dir, 'a1', "{ print ARGV[1] }\n",
+        "t\n", ['-', foo], Out, St),
+    assertion(St == 0), assertion(Out == "-\n"), !.
+
+% ARGV[2] is the first extra argument.
+test(argv2_extra_arg, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run_args(Dir, 'a2', "{ print ARGV[2] }\n",
+        "t\n", ['-', hello], Out, St),
+    assertion(St == 0), assertion(Out == "hello\n"), !.
+
+% an out-of-range index is the empty string (assign-then-concat; ARGV[N]
+% directly inside a juxtaposition concat parses as an assoc read -- a follow-on).
+test(argv_out_of_range_empty, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run_args(Dir, 'ao', "{ x = ARGV[5]; print \"[\" x \"]\" }\n",
+        "t\n", ['-'], Out, St),
+    assertion(St == 0), assertion(Out == "[]\n"), !.
+
+% `x = ARGV[N]` binds a string scalar that prints and string-compares.
+test(argv_assign_and_compare, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run_args(Dir, 'aa',
+        "{ x = ARGV[2]; if (x == \"foo\") print \"yes\"; else print \"no\" }\n",
+        "t\n", ['-', foo], Out, St),
+    assertion(St == 0), assertion(Out == "yes\n"), !.
+
+% ARGC as a guard operand: `if (ARGC > 2)`.
+test(argc_guard, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run_args(Dir, 'ag',
+        "{ if (ARGC > 2) print \"many\"; else print \"few\" }\n",
+        "t\n", ['-', foo], Out, St),
+    assertion(St == 0), assertion(Out == "many\n"), !.
+
+% ARGC in arithmetic and concat.
+test(argc_arith_concat, [condition(clang_available)]) :-
+    ldir(Dir),
+    build_run_args(Dir, 'ar', "{ print \"n=\" (ARGC - 1) }\n",
+        "t\n", ['-', foo], Out, St),
+    assertion(St == 0), assertion(Out == "n=2\n"), !.
+
+:- end_tests(plawk_argv).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ldir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_argv', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run_args(Dir, Name, Src, Input, Args, Out, RunStatus) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, Args,
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
## Summary

Adds awk's `ARGC` and `ARGV[N]` to plawk. The plawk driver is a native binary, so `ARGV`/`ARGC` read straight from the process `argv` via `/proc/self/cmdline` (Linux): `ARGV[0]` the program, `ARGV[1]` the first argument (the driver's input path — `-` selects stdin), `ARGV[2..]` any extras — matching awk, where `ARGV[1]` is the first file argument. The buffer is loaded once and cached.

## Surface (rule bodies)

- **`ARGC`** — an `i64` usable wherever an i64 special (`NR`/`RSTART`) is: `print ARGC`, `if (ARGC > 1)`, `n = ARGC - 1`, `c = ARGC`, and in concat (`"n=" ARGC`).
- **`ARGV[N]`** — a non-negative integer-literal index; a string scalar: `print ARGV[N]`, `x = ARGV[N]` (then prints / string-compares). An out-of-range index is `""`.

Lowering mirrors the existing patterns: `ARGV[N]` follows the ENVIRON string-source path (`wam_argv_get` → interned atom id → resolve to text), `ARGC` follows the RSTART i64-special path (a `call i64 @wam_argc()`).

## Runtime

New helpers in `wam_llvm_target.pl`: `@plawk_cmdline_load` (cached read of `/proc/self/cmdline`), `@wam_argc` (counts NUL-separated segments), `@wam_argv_get(i64)` (interns the N-th segment; `0` = out of range → empty).

## Follow-ons (documented in the audit)

- `ARGV`/`ARGC` in **BEGIN**/**END** blocks (their print/action pipelines are separate — BEGIN print is string-literal-only; both are pre-existing limitations independent of this change).
- A direct `ARGV[N]` comparison operand (`if (ARGV[2]=="x")`) — use assign-then-compare today.
- `ARGV[N]` in juxtaposition-concat (parses as an assoc read).
- A variable/expression index; portability beyond Linux (`/proc/self/cmdline`).

## Tests

- `tests/test_plawk_argv.pl` — 11 tests (3 parse, 8 runtime: ARGC count, ARGV[0/1/2], out-of-range empty, assign-and-compare, ARGC guard, ARGC arithmetic/concat).
- Regression cross-section (10 suites: environ, getline, strnum, nr_guard, concat, end_if, exit, fieldassign, delete, assoc_print) — all green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_