### PR TITLE
R-SWITCH-INDEX-CONFORMANCE: retire R classic xfails via existing fallthrough mappings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,6 +204,39 @@ jobs:
         run: |
           swipl -q -f init.pl -s tests/test_wam_cross_target_conformance.pl -g "seed_sampler,run_tests" -t halt
 
+  wam_r_conformance:
+    name: WAM R Conformance (interpreter + functions)
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CONFORMANCE_TARGETS: r,r_functions
+      CONFORMANCE_PROGRAMS: member,fib,ack,append,reverse,builtins
+      UW_SMOKE_TMPDIR: /tmp/unifyweaver-smoke
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install SWI-Prolog
+        run: bash scripts/ci/install_swi_prolog.sh
+
+      - name: Install R
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends r-base-core
+
+      - name: Create smoke temp root
+        run: mkdir -p "$UW_SMOKE_TMPDIR"
+
+      - name: Run R switch-index regressions
+        run: |
+          swipl -q -f init.pl -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:switch_on_constant_fallthrough_is_linear_noop,wam_r_generator:switch_on_term_a2_is_switch_on_term_noop,wam_r_generator:switch_on_constant_fallthrough_preserves_backtracking])" -t halt
+
+      - name: Run full R classic conformance
+        run: |
+          swipl -q -f init.pl -s tests/test_wam_cross_target_conformance.pl -g "run_tests" -t halt
+
   csharp_query_runtime_smoke:
     name: C# Query Runtime Smoke
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -30,7 +30,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | FS-FUNCTIONS-BUILTINS-LOWER ✅ | Conformance gap fix | F# | M | done — last-slash `parse_functor_fs` for `///2` (`cursor/fs-functions-builtins-lower-f421`); fsharp_functions/builtins green |
 | CONF-LLVM | Conformance adapter | LLVM | L | — |
 | CONF-R ✅ | Conformance adapter | R | M | done — opt-in; all classic programs green (R-SWITCH-INDEX-CONFORMANCE) |
-| R-SWITCH-INDEX-CONFORMANCE ✅ | Conformance gap fix | R | S | done — fallthrough/A2 reuse existing SwitchOnConstant / SwitchOnTerm |
+| R-SWITCH-INDEX-CONFORMANCE ✅ | Conformance gap fix | R | S | done — fallthrough/A2 reuse existing SwitchOnTerm no-op |
 | CONF-CLOJURE | Conformance adapter | Clojure | L | — |
 | CONF-LUA | Conformance adapter | Lua | M | — |
 | CONF-KOTLIN ✅ | Conformance adapter | Kotlin | M | done — opt-in (`cursor/conf-kotlin-f421`); append green, 5 xfails |
@@ -141,8 +141,8 @@ external toolchain.
   `runtime_parser(off)` (wrappers need no CLI parse; R default is `native(parse_term)`).
   Run cwd is `Dir/R` (`Rscript generated_program.R <key>`).
 - **Measured:** all classic programs green on interpreter + functions after
-  R-SWITCH-INDEX-CONFORMANCE (`switch_on_constant_fallthrough` → existing
-  `SwitchOnConstant`; `switch_on_term_a2` → existing `SwitchOnTerm()` no-op).
+  R-SWITCH-INDEX-CONFORMANCE (both missing indexing hints → existing
+  `SwitchOnTerm()` no-op, preserving the full linear choice chain).
 - **Acceptance:** `CONFORMANCE_TARGETS=r,r_functions swipl -g run_tests -t halt tests/test_wam_cross_target_conformance.pl` exits 0 (skips if `Rscript` absent).
 
 ### CONF-CLOJURE: Register Clojure in the cross-target conformance harness

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -26,10 +26,11 @@ self-contained so a single coding agent can pick it up in isolation.
 |---|---|---|---|---|
 | CONF-FSHARP ✅ | Conformance adapter | F# | M | done — opt-in; classic programs green on interpreter + functions |
 | FS-LIST-PARTIAL-TAIL ✅ | Conformance gap fix | F# | M | done — GetValue→unifyVal (`cursor/fs-list-partial-tail-f421`); append/reverse green on fsharp + fsharp_functions |
-| FS-ARITH-INT-DIV | Conformance gap fix | F# | S | CONF-FSHARP |
+| FS-ARITH-INT-DIV ✅ | Conformance gap fix | F# | S | done — `//` in evalArith (`37debf71`) |
 | FS-FUNCTIONS-BUILTINS-LOWER ✅ | Conformance gap fix | F# | M | done — last-slash `parse_functor_fs` for `///2` (`cursor/fs-functions-builtins-lower-f421`); fsharp_functions/builtins green |
 | CONF-LLVM | Conformance adapter | LLVM | L | — |
-| CONF-R ✅ | Conformance adapter | R | M | done — opt-in; append/reverse/builtins green; member/fib/ack xfail (Raw switch stubs) |
+| CONF-R ✅ | Conformance adapter | R | M | done — opt-in; all classic programs green (R-SWITCH-INDEX-CONFORMANCE) |
+| R-SWITCH-INDEX-CONFORMANCE ✅ | Conformance gap fix | R | S | done — fallthrough/A2 reuse existing SwitchOnConstant / SwitchOnTerm |
 | CONF-CLOJURE | Conformance adapter | Clojure | L | — |
 | CONF-LUA | Conformance adapter | Lua | M | — |
 | CONF-KOTLIN ✅ | Conformance adapter | Kotlin | M | done — opt-in (`cursor/conf-kotlin-f421`); append green, 5 xfails |
@@ -106,11 +107,10 @@ external toolchain.
 - **Goal:** Make non-empty ground `append`/`reverse` answers succeed under the classic harness (empty-list append base already passes).
 - **Acceptance:** Drop `ct_xfail(fsharp, append/reverse)` and the `fsharp_functions` twins; both emit modes green on those programs.
 
-### FS-ARITH-INT-DIV: F# `evalArith` missing `//`
+### FS-ARITH-INT-DIV ✅: F# `evalArith` missing `//`
 - **Lever:** Conformance gap fix  **Target:** F#  **Size:** S  **Depends on:** CONF-FSHARP
-- **Goal:** `cbi_arith(28)` succeeds (`17 // 5` + `17 mod 5` with the rest of the fold).
-- **Root cause (measured):** `WamTypes.evalArith` handles `+,-,*,/,mod` but not `Str ("//", [a;b])`; the compiler emits `PutStructure ("//", 2, …)` for integer div, so `is_lax` binds nothing and the wrapper fails. (`mod` already works.)
-- **Acceptance:** Drop `ct_xfail(fsharp, builtins)`; builtins suite green under `CONFORMANCE_TARGETS=fsharp`.
+- **Status:** ✅ **Landed** in `37debf71` — `Str ("//", …)` arm in generated + reference `evalArith`; `ct_xfail(fsharp, builtins)` retired. Do not reimplement.
+- **Acceptance:** builtins suite green under `CONFORMANCE_TARGETS=fsharp`.
 
 ### FS-FUNCTIONS-BUILTINS-LOWER: `emit_mode(functions)` stalls on builtins
 - **Lever:** Conformance gap fix  **Target:** F#  **Size:** M  **Depends on:** CONF-FSHARP
@@ -140,10 +140,9 @@ external toolchain.
   `conformance_main(true)` in `templates/targets/r_wam/program.R.mustache`; harness pins
   `runtime_parser(off)` (wrappers need no CLI parse; R default is `native(parse_term)`).
   Run cwd is `Dir/R` (`Rscript generated_program.R <key>`).
-- **Measured:** append / reverse / builtins green on interpreter + functions. member / fib /
-  ack are `ct_xfail` — `wam_parts_to_r/2` lacks `switch_on_constant_fallthrough` and
-  `switch_on_term_a2`, so those emit `Raw(...)` and the step dispatcher `stop()`s (negatives
-  still return false → success channel discriminates).
+- **Measured:** all classic programs green on interpreter + functions after
+  R-SWITCH-INDEX-CONFORMANCE (`switch_on_constant_fallthrough` → existing
+  `SwitchOnConstant`; `switch_on_term_a2` → existing `SwitchOnTerm()` no-op).
 - **Acceptance:** `CONFORMANCE_TARGETS=r,r_functions swipl -g run_tests -t halt tests/test_wam_cross_target_conformance.pl` exits 0 (skips if `Rscript` absent).
 
 ### CONF-CLOJURE: Register Clojure in the cross-target conformance harness

--- a/docs/WAM_HYBRID_TARGETS_COMPARISON.md
+++ b/docs/WAM_HYBRID_TARGETS_COMPARISON.md
@@ -183,8 +183,8 @@ is still non-WAM `go_target.pl`.
 [`WAM_R_TARGET.md`](WAM_R_TARGET.md) + session handoff: ~30-PR parity
 campaign; **7/7 kernels**; rich builtins; **native parser default**;
 optional LMDB (load-everything). Generator suite ~94 plunit cases;
-classic conformance **opt-in** (`CONF-R`): append/reverse/builtins green;
-member/fib/ack xfail (`Raw` switch stubs).
+classic conformance **opt-in** (`CONF-R`): all classic programs green
+after R-SWITCH-INDEX-CONFORMANCE (fallthrough/A2 → existing handlers).
 
 ## Tier C — mid maturity
 

--- a/docs/WAM_HYBRID_TARGETS_COMPARISON.md
+++ b/docs/WAM_HYBRID_TARGETS_COMPARISON.md
@@ -184,7 +184,7 @@ is still non-WAM `go_target.pl`.
 campaign; **7/7 kernels**; rich builtins; **native parser default**;
 optional LMDB (load-everything). Generator suite ~94 plunit cases;
 classic conformance **opt-in** (`CONF-R`): all classic programs green
-after R-SWITCH-INDEX-CONFORMANCE (fallthrough/A2 → existing handlers).
+after R-SWITCH-INDEX-CONFORMANCE (fallthrough/A2 → safe linear no-op).
 
 ## Tier C — mid maturity
 

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -44,10 +44,10 @@ lazy/cached tiers of F#/Haskell).
 
 ## Gaps (relative to Rust / Haskell / F#)
 
-- **Classic conformance (CONF-R, 2026-07-15):** opt-in adapter registered
-  (`r` / `r_functions`). Green: append, reverse, builtins. xfail: member,
-  fib, ack — `switch_on_term_a2` / `switch_on_constant_fallthrough` fall to
-  `Raw(...)` in `wam_parts_to_r/2` and abort the step loop.
+- **Classic conformance (CONF-R):** opt-in adapter (`r` / `r_functions`).
+  All classic programs green after R-SWITCH-INDEX-CONFORMANCE mapped
+  `switch_on_constant_fallthrough` → existing `SwitchOnConstant` and
+  `switch_on_term_a2` → existing `SwitchOnTerm()` no-op (no new runtime).
 - **LMDB is load-everything** — no lazy/cached two-level policies.
 - **ISO error support** is `tryCatch`-level only, not the three-form
   contract.
@@ -55,11 +55,9 @@ lazy/cached tiers of F#/Haskell).
 
 ## Path forward
 
-1. Map `switch_on_constant_fallthrough` / `switch_on_term_a2` in
-   `wam_parts_to_r/2` (Scala-class fix) to retire the three xfails.
-2. Lazy/cached LMDB policies over the load-everything path.
-3. ISO three-form adoption if R joins the error-fidelity set.
-4. Effective-distance cross-target matrix row.
+1. Lazy/cached LMDB policies over the load-everything path.
+2. ISO three-form adoption if R joins the error-fidelity set.
+3. Effective-distance cross-target matrix row.
 
 ## Document status
 

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -45,9 +45,9 @@ lazy/cached tiers of F#/Haskell).
 ## Gaps (relative to Rust / Haskell / F#)
 
 - **Classic conformance (CONF-R):** opt-in adapter (`r` / `r_functions`).
-  All classic programs green after R-SWITCH-INDEX-CONFORMANCE mapped
-  `switch_on_constant_fallthrough` → existing `SwitchOnConstant` and
-  `switch_on_term_a2` → existing `SwitchOnTerm()` no-op (no new runtime).
+  All classic programs green after R-SWITCH-INDEX-CONFORMANCE mapped both
+  missing indexing hints to the existing `SwitchOnTerm()` no-op, preserving
+  the full linear choice chain without adding a runtime.
 - **LMDB is load-everything** — no lazy/cached two-level policies.
 - **ISO error support** is `tryCatch`-level only, not the three-form
   contract.

--- a/docs/WAM_SWITCH_INDEXING_CROSS_TARGET.md
+++ b/docs/WAM_SWITCH_INDEXING_CROSS_TARGET.md
@@ -95,7 +95,7 @@ emitter (not the token-parser predicates several targets also define).
 | rust | N | Y | N | N | N | `/* unknown */` (drop) | safe; missed opt |
 | go | N | N | N | N | N | `// TODO` (drop) | safe; missed opt |
 | python | N | N | N | N | N | `# SKIP` (drop) | safe; missed opt (confirmed) |
-| r | N | N | N | N | N | `Raw(...)` (drop-style) | safe; missed opt (verify) |
+| **r** (fixed) | Y | N | N | Y | N | `Raw(...)` (now unreachable for these) | safe linear no-op; classic conformance fixed |
 | lua | N | Y | N | N | N | `I.Raw(...)` (drop-style) | safe; missed opt (verify) |
 | clojure | N | N | N | N | N | `{:op :raw}` stub | depends on step-loop `:raw` |
 | llvm | N | Y | N | partial(nop) | N | `; TODO` (switch is design-nop) | safe (chain preserved) |
@@ -213,7 +213,7 @@ after runtime validation — see "Runtime validation" above.**
    that target's toolchain.
 
 2. **Drop-style targets — optimization gaps, not bugs.** rust, go,
-   python, r, lua (and clojure/llvm pending step-loop confirmation)
+   python, lua (and clojure/llvm pending step-loop confirmation)
    produce correct results today; adding the a2/fallthrough handlers
    only restores the indexing speedup. Lower priority; do alongside
    per-target perf work.
@@ -234,6 +234,9 @@ after runtime validation — see "Runtime validation" above.**
   runtime instructions, defaulting to 1).
 - **C++** — `src/unifyweaver/targets/wam_cpp_target.pl` (full coverage incl. `struct_a2`).
 - **Elixir lowered emitter** — `src/unifyweaver/targets/wam_elixir_lowered_emitter.pl` (full coverage).
+- **R** — `src/unifyweaver/targets/wam_r_target.pl` maps
+  `switch_on_constant_fallthrough` and `switch_on_term_a2` to the existing
+  `SwitchOnTerm()` no-op, preserving the complete linear choice chain.
 
 ## Toolchain note
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -411,11 +411,11 @@ wam_parts_to_r(["switch_on_constant" | Cases], Lit) :-
     atomic_list_concat(CaseLits, ', ', CasesStr),
     format(string(Lit), 'SwitchOnConstant(list(~w))', [CasesStr]).
 
-% Fallthrough form: same encoding as switch_on_constant. The existing
-% SwitchOnConstant runtime already advances PC on miss/"default", which
-% is exactly the fallthrough semantics used by fib/ack indexing.
-wam_parts_to_r(["switch_on_constant_fallthrough" | Cases], Lit) :-
-    wam_parts_to_r(["switch_on_constant" | Cases], Lit).
+% Fallthrough indexes precede the linear try/retry/trust chain.  A direct
+% indexed hit would bypass TryMeElse and lose the trailing variable clause
+% as a backtracking alternative, so preserve correctness by using the
+% existing fall-through no-op.
+wam_parts_to_r(["switch_on_constant_fallthrough" | _], 'SwitchOnTerm()').
 
 % --- Switch on term (type-mixed dispatch) ---
 % Emitted by the WAM compiler when a predicate's clauses have a mix

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -411,6 +411,12 @@ wam_parts_to_r(["switch_on_constant" | Cases], Lit) :-
     atomic_list_concat(CaseLits, ', ', CasesStr),
     format(string(Lit), 'SwitchOnConstant(list(~w))', [CasesStr]).
 
+% Fallthrough form: same encoding as switch_on_constant. The existing
+% SwitchOnConstant runtime already advances PC on miss/"default", which
+% is exactly the fallthrough semantics used by fib/ack indexing.
+wam_parts_to_r(["switch_on_constant_fallthrough" | Cases], Lit) :-
+    wam_parts_to_r(["switch_on_constant" | Cases], Lit).
+
 % --- Switch on term (type-mixed dispatch) ---
 % Emitted by the WAM compiler when a predicate's clauses have a mix
 % of first-arg types (constant + struct + list). The runtime
@@ -419,6 +425,10 @@ wam_parts_to_r(["switch_on_constant" | Cases], Lit) :-
 % filters non-matching ones, so correctness is preserved without
 % the optimisation.
 wam_parts_to_r(["switch_on_term" | _], 'SwitchOnTerm()').
+
+% A2 form: same correctness-preserving no-op as switch_on_term.
+% member/2 emits switch_on_term_a2 ahead of a complete try/trust chain.
+wam_parts_to_r(["switch_on_term_a2" | _], 'SwitchOnTerm()').
 
 % --- Switch on structure (functor-shape dispatch) ---
 % Each case is "F/N:label". Behaviour parallels switch_on_constant: when

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -310,23 +310,11 @@ ct_default_target(elixir).
 %  queries use 0-arity wrappers (no CLI term parsing); R's default is
 %  native(parse_term), which is unused on the wrapper path.
 %
-%  Measured maturity (interpreter + functions, same gap set):
-%   - GREEN: append, reverse, builtins
-%   - xfail member / fib / ack — see ct_xfail(r, ...) below
-%  Success channel discriminates: negatives return false (XPASS under
-%  xfail), not blanket-true. Root cause for all three xfails is the same
-%  family: wam_parts_to_r/2 has no clause for switch_on_constant_fallthrough
-%  (fib/ack) or switch_on_term_a2 (member), so those instructions emit as
-%  Raw(...) and the R step dispatcher stop()s — tryCatch in the
-%  conformance driver maps that to false. (switch_on_constant and
-%  switch_on_term A1 variants already emit real constructors; fallthrough
-%  / _a2 are the missing Scala-class mapping.)
-ct_xfail(r, member).            % Raw(switch_on_term_a2) → stop
-ct_xfail(r, fib).               % Raw(switch_on_constant_fallthrough) → stop
-ct_xfail(r, ack).               % Raw(switch_on_constant_fallthrough) → stop
-ct_xfail(r_functions, member).  % same as r — Raw(switch_on_term_a2) → stop
-ct_xfail(r_functions, fib).     % same as r — Raw(switch_on_constant_fallthrough) → stop
-ct_xfail(r_functions, ack).     % same as r — Raw(switch_on_constant_fallthrough) → stop
+%  Measured maturity (interpreter + functions): all classic programs green
+%  after R-SWITCH-INDEX-CONFORMANCE — switch_on_constant_fallthrough maps to
+%  existing SwitchOnConstant (miss/"default" already falls through);
+%  switch_on_term_a2 maps to existing SwitchOnTerm() no-op ahead of the
+%  try/retry/trust chain. No new runtime/indexing machinery.
 
 % ============================================================
 % Toolchain probes

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -311,10 +311,10 @@ ct_default_target(elixir).
 %  native(parse_term), which is unused on the wrapper path.
 %
 %  Measured maturity (interpreter + functions): all classic programs green
-%  after R-SWITCH-INDEX-CONFORMANCE — switch_on_constant_fallthrough maps to
-%  existing SwitchOnConstant (miss/"default" already falls through);
-%  switch_on_term_a2 maps to existing SwitchOnTerm() no-op ahead of the
-%  try/retry/trust chain. No new runtime/indexing machinery.
+%  after R-SWITCH-INDEX-CONFORMANCE. Both switch_on_constant_fallthrough
+%  and switch_on_term_a2 map to the existing SwitchOnTerm() no-op so the
+%  complete try/retry/trust chain retains every backtracking alternative.
+%  No new runtime/indexing machinery.
 
 % ============================================================
 % Toolchain probes

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -4819,6 +4819,23 @@ test(r_wam_bindings_list_parity) :-
     assertion(r_wam_bindings:r_wam_binding(is_list/1, _, _, _, _)),
     assertion(r_wam_bindings:r_wam_binding(ground/1, _, _, _, _)).
 
+% ------------------------------------------------------------------
+% R-SWITCH-INDEX-CONFORMANCE: fallthrough / A2 reuse existing handlers
+% ------------------------------------------------------------------
+test(switch_on_constant_fallthrough_matches_constant) :-
+    init_r_atom_intern_table,
+    Cases = ["0:default", "1:L_cfib_2_2"],
+    once(wam_parts_to_r(["switch_on_constant"|Cases], [], LitConst)),
+    once(wam_parts_to_r(["switch_on_constant_fallthrough"|Cases], [], LitFt)),
+    assertion(LitFt == LitConst),
+    atom_string(LitFt, S),
+    assertion(sub_string(S, _, _, _, "SwitchOnConstant")),
+    assertion(\+ sub_string(S, _, _, _, "Raw(")).
+
+test(switch_on_term_a2_is_switch_on_term_noop) :-
+    once(wam_parts_to_r(["switch_on_term_a2", "0", "0", "default"], [], Lit)),
+    assertion(Lit == 'SwitchOnTerm()').
+
 :- end_tests(wam_r_generator).
 
 % ------------------------------------------------------------------

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -36,6 +36,8 @@
 :- dynamic user:wam_r_parser_dep/0.
 :- dynamic user:wam_r_t2a_forward/0.
 :- dynamic user:wam_r_t2a_reverse/0.
+:- dynamic user:r_switch_ft/2.
+:- dynamic user:r_switch_ft_backtracks/0.
 
 user:wam_r_fact(a).
 user:wam_r_choice_fact(a).
@@ -4820,21 +4822,43 @@ test(r_wam_bindings_list_parity) :-
     assertion(r_wam_bindings:r_wam_binding(ground/1, _, _, _, _)).
 
 % ------------------------------------------------------------------
-% R-SWITCH-INDEX-CONFORMANCE: fallthrough / A2 reuse existing handlers
+% R-SWITCH-INDEX-CONFORMANCE: indexing hints reuse the safe linear no-op
 % ------------------------------------------------------------------
-test(switch_on_constant_fallthrough_matches_constant) :-
-    init_r_atom_intern_table,
-    Cases = ["0:default", "1:L_cfib_2_2"],
-    once(wam_parts_to_r(["switch_on_constant"|Cases], [], LitConst)),
-    once(wam_parts_to_r(["switch_on_constant_fallthrough"|Cases], [], LitFt)),
-    assertion(LitFt == LitConst),
-    atom_string(LitFt, S),
-    assertion(sub_string(S, _, _, _, "SwitchOnConstant")),
-    assertion(\+ sub_string(S, _, _, _, "Raw(")).
+test(switch_on_constant_fallthrough_is_linear_noop) :-
+    once(wam_parts_to_r(
+        ["switch_on_constant_fallthrough", "0:default", "1:L_cfib_2_2"],
+        [], Lit)),
+    assertion(Lit == 'SwitchOnTerm()').
 
 test(switch_on_term_a2_is_switch_on_term_noop) :-
     once(wam_parts_to_r(["switch_on_term_a2", "0", "0", "default"], [], Lit)),
     assertion(Lit == 'SwitchOnTerm()').
+
+test(switch_on_constant_fallthrough_preserves_backtracking,
+     [condition(rscript_available)]) :-
+    retractall(user:r_switch_ft(_, _)),
+    retractall(user:r_switch_ft_backtracks),
+    assertz(user:r_switch_ft(a, first)),
+    assertz(user:r_switch_ft(b, specific)),
+    assertz(user:r_switch_ft(_, fallback)),
+    assertz((user:r_switch_ft_backtracks :-
+        user:r_switch_ft(b, Value), Value = fallback)),
+    unique_r_tmp_dir('tmp_r_switch_ft', TmpDir),
+    call_cleanup(
+        ( write_wam_r_project(
+              [user:r_switch_ft/2, user:r_switch_ft_backtracks/0],
+              [emit_mode(interpreter), fact_table_layout(off)], TmpDir),
+          directory_file_path(TmpDir, 'R', RDir),
+          run_rscript_query(RDir, 'r_switch_ft_backtracks/0', Out),
+          assertion(sub_string(Out, _, _, _, "true"))
+        ),
+        ( ( exists_directory(TmpDir)
+          -> delete_directory_and_contents(TmpDir)
+          ;  true
+          ),
+          retractall(user:r_switch_ft(_, _)),
+          retractall(user:r_switch_ft_backtracks)
+        )).
 
 :- end_tests(wam_r_generator).
 

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -4850,7 +4850,7 @@ test(switch_on_constant_fallthrough_preserves_backtracking,
               [emit_mode(interpreter), fact_table_layout(off)], TmpDir),
           directory_file_path(TmpDir, 'R', RDir),
           run_rscript_query(RDir, 'r_switch_ft_backtracks/0', Out),
-          assertion(sub_string(Out, _, _, _, "true"))
+          assertion(once(sub_string(Out, _, _, _, "true")))
         ),
         ( ( exists_directory(TmpDir)
           -> delete_directory_and_contents(TmpDir)

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -4858,7 +4858,8 @@ test(switch_on_constant_fallthrough_preserves_backtracking,
           ),
           retractall(user:r_switch_ft(_, _)),
           retractall(user:r_switch_ft_backtracks)
-        )).
+        )),
+    !.
 
 :- end_tests(wam_r_generator).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Retire R's six classic conformance xfails (`member` / `fib` / `ack` × `r` / `r_functions`) by mapping two missing index hints to the existing correctness-preserving linear no-op. No new runtime, indexing algorithm, or dispatcher.

## Review correction

The original implementation reused `SwitchOnConstant` for `switch_on_constant_fallthrough`. That is first-solution-correct for the classic fixtures, but not backtracking-correct: an indexed hit on a later constant clause can jump past the leading `TryMeElse`, so the trailing variable clause is lost as an alternative.

Both affected hints now preserve the complete linear try/retry/trust chain:

- `switch_on_constant_fallthrough` → `SwitchOnTerm()` no-op
- `switch_on_term_a2` → `SwitchOnTerm()` no-op

This is a correctness fallback, not an indexing optimization. `templates/targets/r_wam/runtime.R.mustache` remains untouched.

## Tests and CI

- Added focused generator mapping regressions.
- Added a deterministic Rscript end-to-end regression proving a specific constant match can backtrack to a trailing variable clause.
- Removed the six R classic-conformance xfails.
- Added a dedicated hosted `WAM R Conformance (interpreter + functions)` job, covering the targeted regressions and full R classic matrix.
- Updated the R status, fleet-gap, hybrid-target, and cross-target switch-indexing docs.
- Corrected the stale **FS-ARITH-INT-DIV** ledger entry: completed in `37debf71`; do not reimplement it.

Hosted result on review head `2ecaf52`:

- targeted R switch-index regressions: **PASS**, warning-free
- full `r,r_functions` classic conformance: **PASS**
- all ten sampled fleet WAM jobs: **PASS**
- repository-wide `test` and C# smoke jobs: still running at last review poll

Local SWI-Prolog/R execution was unavailable in the review environment and package installation was blocked, so the hosted R job is the runtime authority. Local YAML parsing and `git diff --check` pass.

## Scope

| | |
|---|---:|
| Additions | **113** |
| Deletions | **40** |
| Net | **+73** |
| Files | **8** |

Production behavior outside these two opcode mappings is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
