### PR TITLE
WAM/LLVM plawk: NF as a comparison special in if/while guards

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -22,7 +22,7 @@ only (runtime pending) · ❌ missing.
 | `$N == "v"`, `$3 > 100` | ✅ | field-equality + numeric field guards |
 | `&& \|\| !` combinators | ✅ | awk precedence, parens, single-block lowering |
 | `~` / `!~` match | ✅ | POSIX ERE |
-| expression pattern (bare `NR==1`) | ◐ | comparison guards yes; arbitrary expr no. **`NR` is a special in `if`/`while` condition guards** (`if (NR == 2)`, `if (NR >= 2 && NR <= 3)`) — the record counter, not a phantom scalar slot (a prior bug read it as an uninitialised var → always 0). Fixes the record-gated idioms (`if (NR == 1) { first = $1 }`, conditional accumulation). `NF` as a guard special is a follow-on (needs the field separator threaded into condition lowering; no value in an END condition) |
+| expression pattern (bare `NR==1`) | ◐ | comparison guards yes; arbitrary expr no. **`NR` is a special in `if`/`while` condition guards** (`if (NR == 2)`, `if (NR >= 2 && NR <= 3)`) — the record counter, not a phantom scalar slot (a prior bug read it as an uninitialised var → always 0). Fixes the record-gated idioms (`if (NR == 1) { first = $1 }`, conditional accumulation). **`NF` is a guard special too** (`if (NF > 3)`, `if (NF >= 2 && NR == 1)`) — the field count of the current record, computed from `%line` via the field-count runtime with the active `FS` threaded into the condition lowering; works in `if`/`while`/`do-while` guards. `NF` in an END condition is a clean not-yet (no current record) |
 | range pattern (`/a/,/b/`) | ◐ | `/start/,/end/ { … }` fires for records from a /start/ match through a /end/ match (inclusive), via a per-rule i1 latch global; re-arms for later ranges, runs to EOF if unterminated. Regex endpoints (v1); general-pattern endpoints (`NR==1,NR==3`) are a follow-on |
 
 ## Actions & control flow

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -5260,6 +5260,7 @@ plawk_match_special('RSTART').
 plawk_match_special('RLENGTH').
 plawk_match_special('NR').
 plawk_match_special('ARGC').
+plawk_match_special('NF').
 
 plawk_while_cond_rhs_ok(int(N)) :- integer(N).
 plawk_while_cond_rhs_ok(var(_W)).
@@ -5294,33 +5295,60 @@ plawk_while_cond_vars(cmp(var(V), _Op, var(W)), [V, W]).
 %  (CondVar). Each variable's current value is its slot value in CondValues
 %  (head-phi values for `while`, body-output values for `do-while`);
 %  comparisons are i64 icmps, combined with `and`/`or i1`.
-plawk_while_cond_ir(Cond, Slots, CondValues, Base, CondVar, IR) :-
-    plawk_while_cond_build(Cond, Slots, CondValues, Base, '', CondVar, Lines),
+plawk_while_cond_ir(Cond, Slots, CondValues, FieldSeparator, Base, CondVar, IR) :-
+    plawk_while_cond_build(Cond, Slots, CondValues, FieldSeparator, Base, '', CondVar, Lines),
     atomic_list_concat(Lines, '\n', IR).
 
-plawk_while_cond_build(and(A, B), Slots, CV, Base, Path, CondVar, Lines) :-
+plawk_while_cond_build(and(A, B), Slots, CV, FS, Base, Path, CondVar, Lines) :-
     !,
     atom_concat(Path, 'l', PA),
     atom_concat(Path, 'r', PB),
-    plawk_while_cond_build(A, Slots, CV, Base, PA, VA, LA),
-    plawk_while_cond_build(B, Slots, CV, Base, PB, VB, LB),
+    plawk_while_cond_build(A, Slots, CV, FS, Base, PA, VA, LA),
+    plawk_while_cond_build(B, Slots, CV, FS, Base, PB, VB, LB),
     format(atom(CondVar), '%~w_cond~w', [Base, Path]),
     format(atom(Line), '  ~w = and i1 ~w, ~w', [CondVar, VA, VB]),
     append([LA, LB, [Line]], Lines).
-plawk_while_cond_build(or(A, B), Slots, CV, Base, Path, CondVar, Lines) :-
+plawk_while_cond_build(or(A, B), Slots, CV, FS, Base, Path, CondVar, Lines) :-
     !,
     atom_concat(Path, 'l', PA),
     atom_concat(Path, 'r', PB),
-    plawk_while_cond_build(A, Slots, CV, Base, PA, VA, LA),
-    plawk_while_cond_build(B, Slots, CV, Base, PB, VB, LB),
+    plawk_while_cond_build(A, Slots, CV, FS, Base, PA, VA, LA),
+    plawk_while_cond_build(B, Slots, CV, FS, Base, PB, VB, LB),
     format(atom(CondVar), '%~w_cond~w', [Base, Path]),
     format(atom(Line), '  ~w = or i1 ~w, ~w', [CondVar, VA, VB]),
     append([LA, LB, [Line]], Lines).
+% NF (the field count of the current record) as a comparison operand. Computed
+% from %line via the field-count runtime (the field separator threaded in), so
+% it is only valid where a record is in scope -- rejected in an END condition
+% (Base is `plawk_endif...`), leaving `NF` in END a clean not-yet. Handles NF on
+% either side; the RHS is an integer literal or a loop variable.
+plawk_while_cond_build(cmp(special('NF'), Op, Rhs), Slots, CondValues, FS, Base,
+        Path, CondVar, Lines) :-
+    \+ sub_atom(Base, 0, _, _, plawk_endif),
+    !,
+    format(atom(NfBase), '~w_nf~w', [Base, Path]),
+    llvm_emit_atom_field_count('%line', FS, NfBase, CountLine),
+    plawk_while_cond_operand(Rhs, Slots, CondValues, Base, Path, r, ROperand, RLines),
+    plawk_icmp_pred(Op, Pred),
+    format(atom(CondVar), '%~w_cond~w', [Base, Path]),
+    format(atom(Line), '  ~w = icmp ~w i64 %~w, ~w', [CondVar, Pred, NfBase, ROperand]),
+    append([[CountLine], RLines, [Line]], Lines).
+plawk_while_cond_build(cmp(Lhs, Op, special('NF')), Slots, CondValues, FS, Base,
+        Path, CondVar, Lines) :-
+    \+ sub_atom(Base, 0, _, _, plawk_endif),
+    !,
+    format(atom(NfBase), '~w_nf~w', [Base, Path]),
+    llvm_emit_atom_field_count('%line', FS, NfBase, CountLine),
+    plawk_while_cond_operand(Lhs, Slots, CondValues, Base, Path, l, LOperand, LLines),
+    plawk_icmp_pred(Op, Pred),
+    format(atom(CondVar), '%~w_cond~w', [Base, Path]),
+    format(atom(Line), '  ~w = icmp ~w i64 ~w, %~w', [CondVar, Pred, LOperand, NfBase]),
+    append([[CountLine], LLines, [Line]], Lines).
 % strnum-vs-integer-literal comparison (step 3b): resolve the strnum id to text
 % and dispatch to @wam_strnum_cmp_int, which decides numeric (strnum looks
 % numeric) vs lexical (against the integer formatted as a decimal string) by the
 % runtime content, then compare its sign to 0. `x OP N`.
-plawk_while_cond_build(cmp(var(L), Op, int(N)), Slots, CondValues, Base,
+plawk_while_cond_build(cmp(var(L), Op, int(N)), Slots, CondValues, _FS, Base,
         Path, CondVar, Lines) :-
     plawk_cond_var_is_strnum(L, Slots),
     integer(N),
@@ -5329,7 +5357,7 @@ plawk_while_cond_build(cmp(var(L), Op, int(N)), Slots, CondValues, Base,
     plawk_icmp_pred(Op, Pred),
     plawk_strnum_cmp_int_lines(Base, Path, LId, N, Pred, CondVar, Lines).
 % `N OP x`: swap to `x swap(Op) N` so the strnum stays the left operand.
-plawk_while_cond_build(cmp(int(N), Op, var(R)), Slots, CondValues, Base,
+plawk_while_cond_build(cmp(int(N), Op, var(R)), Slots, CondValues, _FS, Base,
         Path, CondVar, Lines) :-
     plawk_cond_var_is_strnum(R, Slots),
     integer(N),
@@ -5344,7 +5372,7 @@ plawk_while_cond_build(cmp(int(N), Op, var(R)), Slots, CondValues, Base,
 % look numeric -> numeric; otherwise strcmp), then compare its sign to 0 with the
 % surface comparison predicate. This is the "10 9" (numeric) vs "10 9x" (lexical)
 % fix. Tried before the generic i64 icmp clause.
-plawk_while_cond_build(cmp(var(L), Op, var(R)), Slots, CondValues, Base,
+plawk_while_cond_build(cmp(var(L), Op, var(R)), Slots, CondValues, _FS, Base,
         Path, CondVar, Lines) :-
     plawk_cond_var_is_strnum(L, Slots),
     plawk_cond_var_is_strnum(R, Slots),
@@ -5363,7 +5391,7 @@ plawk_while_cond_build(cmp(var(L), Op, var(R)), Slots, CondValues, Base,
     format(atom(LineCmp),
         '  ~w = icmp ~w i32 %~w_sn~w_rc, 0', [CondVar, Pred, Base, Path]),
     Lines = [LineLS, LineRS, LineRC, LineCmp].
-plawk_while_cond_build(cmp(Left, Op, Rhs), Slots, CondValues, Base,
+plawk_while_cond_build(cmp(Left, Op, Rhs), Slots, CondValues, _FS, Base,
         Path, CondVar, Lines) :-
     % Fail-closed: if either operand is a strnum slot and this is not one of the
     % supported strnum cases above (strnum-vs-strnum, strnum-vs-integer-literal),
@@ -5503,10 +5531,10 @@ plawk_if_cond_ir(scalar_if(cmp(var(Name), Op, string(Value))), Slots, Values0,
          GlobalBase, GlobalBase, BytesLen, BytesLen, LitName, Len, GlobalBase,
          GlobalBase, GlobalBase, GlobalBase,
          GlobalBase, Pred, GlobalBase]).
-plawk_if_cond_ir(scalar_if(Cond), Slots, Values0, _FieldSeparator, GlobalBase,
+plawk_if_cond_ir(scalar_if(Cond), Slots, Values0, FieldSeparator, GlobalBase,
         CondValue, ''-GuardIR) :-
     !,
-    plawk_while_cond_ir(Cond, Slots, Values0, GlobalBase, CondValue, GuardIR).
+    plawk_while_cond_ir(Cond, Slots, Values0, FieldSeparator, GlobalBase, CondValue, GuardIR).
 plawk_if_cond_ir(Pattern, _Slots, _Values0, FieldSeparator, GlobalBase,
         CondValue, GuardGlobalIR-GuardIR) :-
     format(atom(CondValue), '%~w_cond', [GlobalBase]),
@@ -12960,7 +12988,7 @@ plawk_scalar_action_sequence_pairs([while_loop(Cond, Body) | Rest],
       % head phi carries continue values; the after phi carries break values
       plawk_while_head_phi_ir(Slots, Values0, BodyOutValues, Continues,
           Base, EntryLabel, BodyDoneLabel, HeadPhiIR),
-      plawk_while_cond_ir(Cond, Slots, HeadValues, Base, CondVar, CondIR),
+      plawk_while_cond_ir(Cond, Slots, HeadValues, FieldSeparator, Base, CondVar, CondIR),
       plawk_loop_after_ir(Slots, HeadValues, HeadLabel, Breaks, Base,
           AfterValues, AfterPhiIR),
       format(atom(IR),
@@ -13041,7 +13069,7 @@ plawk_scalar_action_sequence_pairs([do_while_loop(Body, Cond) | Rest],
       phrase(plawk_foreach_head_phi_lines(Slots, Values0, BdValues,
           Base, EntryLabel, BodyDoneLabel, 0), HeadPhiLines),
       atomic_list_concat(HeadPhiLines, '\n', HeadPhiIR),
-      plawk_while_cond_ir(Cond, Slots, BdValues, Base, CondVar, CondIR),
+      plawk_while_cond_ir(Cond, Slots, BdValues, FieldSeparator, Base, CondVar, CondIR),
       plawk_loop_after_ir(Slots, BdValues, BodyDoneLabel, Breaks, Base,
           AfterValues, AfterPhiIR),
       format(atom(IR),
@@ -14370,7 +14398,7 @@ plawk_scalar_end_if_ir(Cond, ThenActions, ElseActions, StatePlan, FieldSeparator
         OutputSeparator, GlobalIR, IR) :-
     plawk_state_plan_slots(StatePlan, Slots),
     plawk_final_slot_values(StatePlan, FinalValues),
-    plawk_while_cond_ir(Cond, Slots, FinalValues, plawk_endif, CondVar, CondIR),
+    plawk_while_cond_ir(Cond, Slots, FinalValues, FieldSeparator, plawk_endif, CondVar, CondIR),
     plawk_end_if_branch_ir(ThenActions, Slots, FinalValues, FieldSeparator,
         OutputSeparator, plawk_endif_then, ThenGlobal, ThenIR),
     plawk_end_if_branch_ir(ElseActions, Slots, FinalValues, FieldSeparator,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1870,9 +1870,11 @@ match_special_name('RSTART') --> "RSTART".
 match_special_name('RLENGTH') --> "RLENGTH".
 % NR (the record number) is a special in a comparison guard too, so `if (NR > 1)`
 % / `while (NR < 3)` read the record counter rather than a phantom scalar slot.
-% (NF is a follow-on: it needs the field separator threaded into the condition
-% lowering, and has no defined value in an END condition.)
 match_special_name('NR') --> "NR".
+% NF (the field count of the current record) is a guard special too: `if (NF > 3)`.
+% The condition lowering threads the field separator to compute it from the
+% record; it has no defined value in an END condition (no current record).
+match_special_name('NF') --> "NF".
 % ARGC (the command-line argument count) is a numeric special in a guard too:
 % `if (ARGC > 1)`.
 match_special_name('ARGC') --> "ARGC".

--- a/tests/test_plawk_nf_guard.pl
+++ b/tests/test_plawk_nf_guard.pl
@@ -1,0 +1,85 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% NF as a comparison special in an `if`/`while` guard: `if (NF > 3)`. NF is the
+% field count of the current record, computed from %line via the field-count
+% runtime with the field separator threaded into the condition lowering (the
+% reason it was a follow-on after NR). It is only valid where a record is in
+% scope -- an END condition (no current record) is a clean not-yet.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_nf_guard).
+
+% --- parsing ---------------------------------------------------------------
+
+% `if (NF > 3)` parses to a scalar_if over a special('NF') comparison, not a
+% phantom scalar slot named NF.
+test(nf_guard_parses) :-
+    plawk_parse_string("{ if (NF > 3) print $0 }\n",
+        program([], [rule(always,
+            [if(scalar_if(cmp(special('NF'), gt, int(3))), [print([field(0)])], [])])], [])),
+    !.
+
+% --- runtime ---------------------------------------------------------------
+
+% `if (NF > 2)` keeps records with more than two (whitespace) fields.
+test(nf_gt, [condition(clang_available)]) :-
+    ndir(Dir),
+    build_run(Dir, 'gt', "{ if (NF > 2) print $0 }\n", "a b c\nx y\np q r s\n", Out),
+    assertion(Out == "a b c\np q r s\n"), !.
+
+% `if (NF == 2)` -- exact field count.
+test(nf_eq, [condition(clang_available)]) :-
+    ndir(Dir),
+    build_run(Dir, 'eq', "{ if (NF == 2) print \"two:\", $0 }\n", "a b\nc\nd e\n", Out),
+    assertion(Out == "two: a b\ntwo: d e\n"), !.
+
+% NF is computed against the active FS (here a comma), not whitespace.
+test(nf_with_fs, [condition(clang_available)]) :-
+    ndir(Dir),
+    build_run(Dir, 'fs', "BEGIN { FS=\",\" }\n{ if (NF >= 3) print $1 }\n",
+        "a,b,c\nx,y\np,q,r,s\n", Out),
+    assertion(Out == "a\np\n"), !.
+
+% NF combined in a boolean guard with NR.
+test(nf_and_nr, [condition(clang_available)]) :-
+    ndir(Dir),
+    build_run(Dir, 'an', "{ if (NF >= 2 && NR == 1) print $0 }\n",
+        "a b\nc d\n", Out),
+    assertion(Out == "a b\n"), !.
+
+:- end_tests(plawk_nf_guard).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+ndir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_nf_guard', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_run(Dir, Name, Src, Input, Out) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    process_create(path(swipl), ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~w", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(0)).


### PR DESCRIPTION
## Summary

Follow-on #2 of 3 (**stacked on #3878**). `NF` (the field count of the current record) is now a guard special like `NR`:

```awk
{ if (NF > 2) print $0 }                    # keep records with >2 fields
{ if (NF == 2) print "two:", $0 }
BEGIN { FS="," } { if (NF >= 3) print $1 }  # NF against the active FS
{ if (NF >= 2 && NR == 1) print $0 }        # combined with NR
```

It's computed from `%line` via the field-count runtime (`@wam_atom_field_count`) with the active `FS` **threaded into the condition lowering** — which is why it was a follow-on after NR (NR needed no FS).

## How

- **Parser**: `match_special_name('NF')`.
- **Codegen**: `FieldSeparator` threaded through `plawk_while_cond_ir` / `plawk_while_cond_build` and their four callers (the `if`, `while`, `do-while`, and `END-if` cond sites — all had FS in scope). A dedicated `cmp(special('NF'), Op, Rhs)` build clause (plus the swapped RHS form) computes NF and `icmp`s it. The field count needs a record, so **NF is rejected in an END condition** (`Base` is `plawk_endif…`) — a clean not-yet. `NF` added to `plawk_match_special` so the acceptance gate admits it.

The operand emitter is untouched (NF is handled at the build level, so no FS needed in `plawk_while_cond_operand`).

## Scope

Works in `if`/`while`/`do-while` guards, alone or in `&&`/`||` combinations. `NF` in an END condition is a documented not-yet (no current record). Base is #3878 (body concat).

## Tests

- `tests/test_plawk_nf_guard.pl` (new, 5): parse, `NF > 2`, `NF == 2`, `NF` with a custom FS, and `NF && NR`.
- No regressions: `nr_guard`, `strnum`, `while`, `loop_control`, `forin_val_strnum` (all exercise the shared condition-lowering path the FS threading touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_