### PR TITLE
mu_cosine: freeze HOP-only fidelity study + per-anchor leakage calibration

### DIFF
--- a/prototypes/mu_cosine/PROTOCOL_bounded_diffusion_fidelity.md
+++ b/prototypes/mu_cosine/PROTOCOL_bounded_diffusion_fidelity.md
@@ -6,6 +6,18 @@ the protocol PR. If the real graph, embeddings, budgets, selectors, protected
 set, leakage rule, metric, or decision threshold must change, amend this file
 and its machine-readable manifest before running the affected comparison.
 
+The first confirmatory phase is prospective snapshot-relative HOP convergence
+only, and it is BLOCKED on a raw-source snapshot preparer. The current
+`assembled_dag` is legacy parity input, not an authoritative scientific asset:
+it loses relation type, privacy-propagation semantics, and visibility. The
+14,246-node scrubbed largest-component figure is an audit estimate, not the
+frozen study universe. Unknown visibility means `privacy_certified=false`. No real
+solve may start until the preparer contract in Section 2 is satisfied.
+No node IDs, titles, paths, embeddings, or node-level manifests may be published; only
+aggregate summaries and content hashes approved for the local provenance store
+may leave the machine. Results must be labeled relative to this scrubbed
+snapshot, never as coverage of the user’s complete Pearltrees corpus.
+
 This is an outcome-blind numerical study. Placement labels, judge outputs,
 filing ranks, and downstream MRR are prohibited inputs. A selector that wins
 here is only a better approximation to a larger grounded-diffusion system at a
@@ -14,19 +26,21 @@ covariance model.
 
 ## 1. Decision and estimand
 
-The practical question is which bounded domain best preserves the local
-grounded-diffusion geometry that would be obtained from a larger retained
-domain. The first decision compares the topology-first candidate skeleton with
-the ordinary hop-prefix baseline. A revision-pinned semantic-resistance
-selector is a gatekept secondary comparison. Sparse graph-derived boundary
-closure is a final, explicitly experimental comparison against the same selected
-domain with its exact Dirichlet boundary. For closure, semantic distance may
-filter expensive graph calculations, but never licenses a pair or sets bridge
-strength. This restriction does not apply to the separate semantic-operator
-and RESISTANCE-selector sensitivity in Section 2.
+The first confirmatory question is whether a deterministic HOP domain reaches
+prespecified fidelity as `K` increases toward one larger topology-only
+reference. Calibration chooses one `K` contrast; the untouched audit evaluates
+that contrast once. There is no selector-promotion claim in this phase.
+SKELETON, semantic RESISTANCE, and graph-derived closure remain prospective
+secondary phases gated on the asset and provenance requirements below.
+
+Topology-only and semantic conductance define DIFFERENT physical operators.
+Each regime therefore has its own candidate union, outer reference, calibration
+shell solves, and frozen scalar leakage. No candidate is compared across
+regimes, and neither a reference nor an alpha calibrated for one regime may be
+reused implicitly in the other.
 
 For anchor `s`, candidate domain `D`, common protected nodes `P`, and the
-larger reference `R`, let
+matching regime-specific larger reference `R`, let
 
     g_D^s = J_D^-1 e_s,
     h_D^s(i) = g_D^s(i) / g_D^s(s).
@@ -36,10 +50,14 @@ The primary per-anchor error is the relative raw-response error
     E_g(s,D) = ||g_D^s[P] - g_R^s[P]||_2
                / max(||g_R^s[P]||_2, tiny).
 
-Raw response is primary because it preserves the circuit units and the
-Dirichlet monotonicity interpretation. Normalized screening, selected grounded
-effective resistance, and rank fidelity are required noninferiority checks;
-none may be used post hoc to replace a failed primary endpoint.
+The population estimand is the EQUAL-STRATUM MACRO mean: first average the
+anchor-level contrast within each frozen degree stratum, then average
+those stratum means with equal weight over decision-bearing strata. It is not
+the pooled anchor mean, so a populous or easy stratum cannot dominate. Raw
+response is primary because it preserves circuit units and the Dirichlet
+monotonicity interpretation. Normalized screening, selected grounded effective
+resistance, and rank fidelity are required noninferiority checks; none may be
+used post hoc to replace a failed primary endpoint.
 
 An honest outcome may be: a smaller adequate domain; better fidelity at the
 same budget; no material difference, retaining the simpler hop default; no
@@ -48,123 +66,170 @@ results.
 
 ## 2. Frozen graph and conductance regimes
 
-The first real run uses one content-hashed Pearltrees snapshot. Freeze before
-anchor selection:
+Before ANY real solve, a content-hashed raw-source snapshot preparer must:
 
-- the typed node universe and complete undirected incident adjacency;
-- the directed principal-parent relation used only by the skeleton selector;
-- canonical node IDs, titles/text construction, and all exclusion reasons;
-- the largest eligible positive-edge connected component;
-- software commit, float64 backend, thread settings, and resource ceiling; and
-- every embedding model ID, exact revision, normalization, prefix, node order,
-  array hash, and missing-node manifest.
+- freeze every raw input hash, parser version, and deterministic rerun hash;
+- preserve source relation types and freeze an explicit physical-edge policy,
+  including named include/exclude treatment for containment, aliases, shortcuts,
+  and cross-links before reciprocal conductance adjacency is built;
+- propagate privacy from known-private roots through the frozen containment
+  relations, record how non-containment links are treated, and exclude affected
+  nodes before anchor selection;
+- preserve source visibility where known and set `privacy_certified=false` when
+  any required visibility is unknown;
+- emit local-only typed-node, exclusion, conflict, physical-edge, reciprocal
+  adjacency, component, and scrub manifests plus aggregate publishable counts;
+  and
+- freeze the resulting study-universe and largest-component hashes, software
+  commit, float64 backend, thread settings, and resource ceiling.
 
-Run two operator regimes without mixing their conclusions:
+The legacy assembled DAG may be compared only as a parity diagnostic; it cannot
+source the scientific adjacency, privacy decision, or study universe. Detailed
+preparer artifacts remain local-only. Any change to raw inputs, edge policy,
+privacy propagation, or visibility invalidates downstream anchor and domain
+manifests.
 
-1. **Topology-only primary:** unit base conductance on every graph edge. Compare
-   hop and candidate-skeleton selectors. This isolates domain construction from
-   embedding choice.
-2. **Semantic sensitivity:** use the frozen RBF-with-floor conductance in
-   `docs/design/LEAKY_GRAPH_DIFFUSION.md`. Set `epsilon=0.05`; set `ell` to the
-   median finite positive within-edge embedding distance on the frozen graph,
-   computed once before anchor sampling. Run Nomic only when its exact revision
-   and `clustering: ` text contract are available. MiniLM is descriptive
-   sensitivity. Do not substitute e5 silently.
+Only after that preparer gate passes, the first phase uses only the
+**topology-only HOP operator**, with unit base conductance on every canonical
+physical edge admitted by the frozen raw-source relation policy. It makes a snapshot-relative
+convergence claim, not a claim that aliases or shortcuts are physically correct.
+Changing their inclusion requires a prospective amendment and rebuilt hashed
+adjacency; the study runner must not guess directions or relation types.
 
-The semantic arm tests a selector for a frozen semantic operator. It cannot
-establish that Nomic is a better embedding model, semantic truth, or
-statistically independent of e5.
+SKELETON is unavailable for decision-bearing use. The clean Collection parent
+source covers only 1,324 of 14,520 nodes (9.1%), path records cover 1,283, and
+their union covers 2,542 (17.5%) with one directed cycle. SCC condensation can
+represent that cycle but cannot manufacture missing parents or roots. Before a
+future SKELETON phase, freeze a typed parent/root/missing/conflict manifest with
+positive root evidence and a prospective coverage threshold; failure of that
+threshold leaves SKELETON descriptive or unavailable.
+
+Semantic conductance and RESISTANCE are also later secondary phases. When
+licensed by a revision-pinned embedding/cache manifest, set `epsilon=0.05`, set
+`ell` to the median finite positive within-edge embedding distance, and freeze
+`c_ref=1.0` in `c_ref/c_ij`. Nomic requires its exact revision and `clustering: `
+text contract; MiniLM is descriptive, and e5 is never a silent substitute. A
+semantic phase must construct its own candidate union, reference, shell
+calibration, and scalar alpha rather than reusing topology artifacts.
 
 ## 3. Anchor batches and protected nodes
 
-Eligible anchors are non-isolated folder nodes in the frozen component. Their
-selection cannot use bookmark destinations, placement counts, judge outcomes,
-existing ranker scores, or previous fidelity results.
+Eligible anchors are ALL non-isolated folder nodes in the largest frozen
+positive-conductance component. They are explicitly not restricted to the
+sparse 1,504-row lineage/path export or to nodes for which one convenience path
+was materialized. Exclusions are determined from the frozen graph manifest
+before any metric is computed.
 
-Stratify eligible nodes by undirected degree quartile and principal-depth
-quartile, with missing depth as its own level. Within each stratum order nodes
-by SHA-256 of `(seed, typed_node_id)` using seed `3882001`. Select 128 anchors
-as evenly as possible across nonempty strata; redistribute deficits in
-lexicographic stratum order. Persist the ordered manifest and every stratum
-count. Form 32 consecutive batches of four anchors. Reserve the first eight batches (32
-anchors) for leakage calibration and implementation configuration; their fidelity
-metrics cannot enter a selector or closure claim. The remaining 24 batches (96
-anchors) form the untouched audit. The batch, not the anchor, is the resampling
-unit because four anchors share one domain and factorization.
+HOP consumes only the frozen reciprocal conductance adjacency. A memoized
+revisit during bounded traversal means path convergence or a cycle; it is not a
+cut point and must not create a ground shunt. Cuts are actual retained-to-omitted
+edges. No parent direction, root, or depth is inferred in phase one.
+
+Construct exactly four deterministic rank-based degree quartiles. Sort all
+eligible anchors by `(undirected_conductance_degree, stable_typed_node_id)` and
+split that ordered population into four contiguous groups whose sizes differ by
+at most one. Within each quartile order nodes by
+`SHA-256(3882001, "select", typed_node_id)` and select exactly 32 anchors. If
+any quartile cannot supply 32, phase one is coverage-inadequate before solves.
+
+Within each quartile reorder the 32 selected anchors by the independent key
+`SHA-256(3882001, "split", typed_node_id)`: the first 8 are calibration and the
+remaining 24 are untouched audit. Reorder each split within quartile by
+`SHA-256(3882001, "batch", typed_node_id)`. Calibration batch `j` and audit
+batch `j` contain exactly the `j`th anchor from each of the four quartiles, for
+8 calibration and 24 audit batches. Persist the quartile boundaries, ordered
+memberships, split, and batch IDs. Every batch is therefore exactly balanced;
+calibration metrics cannot enter the final contrast.
 
 For each anchor independently, freeze its source-relative ordinary-hop order
 with the canonical tie key. Its protected set is the anchor plus its first 16
-reachable non-anchor nodes. The batch protected set is the union across its
-four anchors. This set is fixed before any selector is scored. A family/budget
-that does not retain the complete protected set fails that batch; do not form a
+reachable non-anchor nodes. The batch protected set is the union across its four
+anchors. This set is fixed before any selector is scored. A phase-one HOP budget that
+does not retain the complete protected set fails that batch; do not form a
 post-hoc intersection and do not rank missing nodes last.
 
-Report source-to-source hop distances within each batch. The primary result
-averages the prespecified 24 audit batches rather than selecting only
-convenient local or dispersed batches. Degree/depth and distance-stratified
-summaries are descriptive.
+Report source-to-source hop distances within each batch. Primary summaries use
+the equal-stratum macro estimand from Section 1. If reference failure or method
+coverage leaves fewer than 18 of the 24 complete
+balanced audit batches, demote the whole contrast to descriptive. A failed batch
+is never decomposed into surviving anchors; never redistribute quartile weight
+or fall back to an unbalanced pooled mean. Degree and distance-stratified
+summaries beyond the frozen macro estimand are descriptive.
 
-## 4. Domain families and matched budgets
+## 4. Frozen HOP budgets and gated future families
 
-Freeze one maximum-budget ordering per family and take deterministic prefixes,
-so within a family
+Freeze one maximum-budget HOP ordering and take deterministic prefixes, so
 
     S_256 subset S_512 subset S_1024.
 
 Every domain is one union-of-anchors system with one precision matrix and one
-factorization. Its budget includes anchors, retained connecting paths, and all
-other retained nodes.
+factorization. Its budget includes anchors and every retained node. HOP uses the
+deterministic multi-source ordering with the existing stable final-shell tie
+rule. Use nominal retained budgets `K={256,512,1024}`. A required protected set
+that exceeds `K` is a recorded coverage failure. Complete final-shell runs may
+be reported descriptively, but the decision-bearing comparison uses strict
+prefix budgets.
 
-1. **HOP:** deterministic multi-source hop ordering with the existing stable
-   final-shell tie rule.
-2. **SKELETON:** retain anchors, principal ancestors, and shared/common parents
-   with their connecting paths first; use deterministic multi-source local
-   expansion to fill the remaining budget. The exact priority and tie order are
-   part of the fingerprint. Missing or cyclic parent data fail this family
-   rather than falling back silently.
-3. **RESISTANCE:** secondary only. Run truncated Dijkstra on existing graph
-   edges with positive length `c_ref/c_ij`. Embeddings may change resistance on
-   an existing edge but may not create a shortcut edge in this selector.
+### Gated future families (not phase-one decisions)
 
-Use nominal retained budgets `K={256,512,1024}`. A required protected set or
-connecting closure that exceeds `K` is a recorded coverage failure. Complete
-final-shell runs may be reported descriptively, but the decision-bearing
-comparison uses the strict matched budgets.
+SKELETON requires the prospective parent/root/missing/conflict coverage gate in
+Section 2. If licensed later, freeze `ancestor_depth=3`, SCC-condense the full
+typed `child -> principal_parent` relation, and treat traversal collisions as
+cycle convergence rather than cuts. RESISTANCE requires the semantic cache gate
+and uses only existing graph edges with frozen length `c_ref/c_ij`,
+`c_ref=1.0`; embeddings never create shortcut edges. Neither family enters the
+phase-one candidate union, calibration, reference, or audit contrast.
 
-Exact one-port Kron reductions are a future family until an implementation has
-an exact small-graph oracle and a provenance-preserving expansion map.
-Multi-port elimination may create fill and must never be mislabeled a scalar
-tree shunt.
+Exact one-port Kron reductions and multi-port sparse closure remain future
+families until their separate gates are satisfied. Multi-port elimination may
+create fill and must never be mislabeled a scalar tree shunt.
 
-## 5. Common larger-domain reference and leakage
+## 5. Regime-specific larger-domain references and leakage
 
-For each batch and conductance regime, form `U` as the union of every available
-family's frozen `S_1024`. Build an exact-Dirichlet model on `U`. Then expand
-from `U` by the frozen hop ordering to at most 4,096 retained nodes, preserving
-all of `U`, and build the outer reference `R`. If `U` itself exceeds 4,096 or
-the resource contract cannot build `R`, the batch is reference-inadequate and
-cannot promote a selector. If the connected component is exhausted, the whole
-component is an exact admissible reference.
+For phase one, `U_top` is exactly the frozen HOP `S_1024` domain for that
+batch. Build its exact-Dirichlet model, then expand from `U_top` by the same
+frozen hop ordering to at most 4,096 retained nodes, preserving all of `U_top`,
+to obtain `R_top`. If `U_top` exceeds the resource contract or `R_top` cannot
+be built, that batch is reference-inadequate and cannot support a convergence
+claim. If the connected component is exhausted, the whole component is an
+exact admissible reference.
 
-`R` is a bounded reference, not whole-graph truth. It is adequate only if the
-model on `U` versus `R`, on the frozen protected set, has:
+A later licensed semantic phase must independently construct `U_sem` from only
+the families compared under that semantic operator, then build `R_sem`; it may
+not reuse `U_top`, `R_top`, or their calibration merely because node hashes
+happen to match.
 
-- 90th-percentile `E_g <= 0.01`;
-- 90th-percentile maximum absolute `h` error `<=0.005`; and
-- 10th-percentile top-8 overlap `>=0.98`.
+Each `R` is a bounded regime-specific reference, not whole-graph truth. It is
+adequate only if its `U` versus `R`, on the frozen protected set, has:
 
-Failure is reported as right-censored domain convergence. Do not choose a
-different outer size after inspecting which family wins.
+- conservative 90th-percentile `E_g <= 0.01`;
+- conservative 90th-percentile maximum absolute `h` error `<=0.005`; and
+- conservative 10th-percentile top-8 overlap `>=0.98`.
 
-On the first eight calibration batches, find the anchor-specific uniform leakage
-needed on each `R` for the graph-hop radius-3 shell and target `exp(-1)`, as
-specified by `LOCAL_GROUNDED_DIFFUSION.md`. Every shell node must be reachable
-and strictly interior (`beta=0`) in its reference. Freeze the single largest
-required value as the study-wide `alpha`, then apply it unchanged to every
-calibration and audit reference, `U`, and candidate domain. Recalibrating each candidate
-would confound boundary approximation with a different physical model and is
-not allowed in the primary comparison. Per-domain recalibration and censoring
-may be reported as a secondary operational diagnostic.
+Compute every upper-tail percentile as the observed higher order statistic and
+every lower-tail percentile as the observed lower order statistic; do not use
+linear interpolation that moves a tail estimate toward the center. Failure is
+reported as right-censored domain convergence. Do not choose a different outer
+size after inspecting which K looks best.
+
+On the hash-balanced calibration batches only, calibrate anchor-specific uniform
+leakage on `R_top` for the topology operator. A later semantic phase repeats
+this independently on `R_sem` rather than importing `alpha_top`, using the
+graph-hop radius-3 shell and target `exp(-1)` from
+`LOCAL_GROUNDED_DIFFUSION.md`. Every shell node must be reachable and strictly
+interior (`beta=0`) in its own reference. Freeze the single largest required
+value as the phase-one `alpha_top` and apply it unchanged to every calibration
+and audit reference, union, and candidate. A
+later `alpha_sem` is a distinct scalar parameter even if its numeric value
+happens to match.
+
+A frozen scalar alpha is finite and nonnegative; zero is allowed and no hidden
+numerical floor or jitter may be inserted. A zero-alpha system must still pass
+grounding, SPD, reciprocal-condition, and residual checks from its represented
+Dirichlet boundary, otherwise that batch fails closed. Node-varying alpha and
+per-domain recalibration are descriptive alternatives only. Recalibrating each
+candidate would change the physical model and is prohibited in the primary
+comparison.
 
 ## 6. Fidelity and boundary metrics
 
@@ -186,31 +251,36 @@ explicit omitted flag; the reduced run cannot resolve the resistance part of
 For every batch/family/budget also report:
 
 - retained/boundary node counts, cut-edge count and cut mass;
-- per-anchor cut-current fraction and the protected-set maximum of
-  `p=J_D^-1 beta`;
-- calibrated and numerical-minimum `alpha`, realized e-fold radius and censor
-  flag for every anchor;
+- per-anchor cut-current fraction;
+- the batch/domain protected-set maximum of `p=J_D^-1 beta`;
+- regime-specific frozen scalar `alpha`, realized e-fold radius and censor flag
+  for every anchor;
 - reciprocal condition number, M-matrix sign check, Cholesky/solve residuals;
 - adjacency calls or touched weighted degree where observable;
 - selection, assembly, factorization, metric, and total wall times; and
 - projected dense bytes, peak RSS, backend identity, and thread settings.
 
-An individual family/budget is **adequate** only with 100% protected coverage,
+An individual phase-one HOP budget is **adequate** only with 100% protected coverage,
+using higher-order-statistic Q90 and lower-order-statistic Q10 summaries,
 all numerical checks passing, and across anchors:
 
 - 90th-percentile `E_g <= 0.05`;
 - 90th-percentile maximum absolute `h` error `<=0.025`;
 - 90th-percentile rank-inversion fraction `<=0.05`;
-- 10th-percentile top-8 overlap `>=0.90`; and
-- 90th-percentile protected boundary-harmonic maximum `<=0.10`.
+- 10th-percentile top-8 overlap `>=0.90`.
 
+Across decision-bearing batches, the conservative higher-order-statistic Q90
+of the batch/domain protected boundary-harmonic maximum must be `<=0.10`.
 When resistance is evaluated, its 90th-percentile relative error must also be
 `<=0.05`. These are deliberately conservative engineering tolerances on a
 unit-normalized screening field, not claims about downstream filing loss.
 
-## 7. Experimental graph-derived boundary closure
+## 7. Gated future graph-derived boundary closure
 
-Plain exact Dirichlet remains the baseline: every omitted edge contributes to
+This section is implemented and synthetic-tested but is NOT part of the first
+confirmatory corpus phase. After HOP convergence, a separate prospective
+amendment may license this topology-only closure rule. Plain exact Dirichlet
+remains the baseline: every omitted edge contributes to
 the boundary shunt `beta`. For an omitted exterior `E`, the exact multi-port
 target is its Dirichlet-to-Neumann/Schur response, not a collection of semantic
 similarities. If `B` denotes the nonnegative Schur term subtracted from the
@@ -277,7 +347,8 @@ cycle-correct minimum-distance and caret mixing-boundary routines in the
 are examples for bounded search and common-parent stopping, not physical Schur
 oracles. [Tarjan SCC
 condensation](../../src/unifyweaver/core/advanced/scc_detection.pl) is
-available if a future directed variant needs cycle contraction. [Node-only
+the repository precedent for preprocessing the typed parent relation before
+principal depth or SKELETON ancestry is computed. [Node-only
 memoization](../../scripts/parent_histogram_recurrence.py) is not licensed for
 simple-path counts or other path-state-dependent transfer quantities; this PR
 uses global component memoization only for connectivity. Semantic
@@ -285,32 +356,40 @@ uses global component memoization only for connectivity. Semantic
 propose searches, but an embedding MST or kNN cut is never a cut in the
 original graph.
 
-Freeze one primary closure rule before the real run:
+A future closure amendment must freeze this primary rule before its real run:
 
-- identify cut exterior components and their retained boundary ports from the
-  graph; exact two-port reductions have first priority;
-- for a resource-bounded multi-port component, semantics may retain at most
-  `q=2` plausible non-adjacent port pairs per boundary node before graph solves,
-  but may not determine `kappa` or `sigma`;
-- derive `kappa` and `sigma` from topology-only `c0` graph resistance or
-  selected Schur solves;
-- apply the exact ledger of a fully traversed two-port component without `rho`
-  truncation or an approximate bridge cap; a simple series path is naturally
-  weaker than each constituent branch, but parallel exterior paths can be
-  stronger and must not be clipped if the reduction is called exact;
-- for an approximate multi-port reduction only, cap each bridge at one half of
-  the minimum positive ordinary retained graph-edge conductance and consume at
-  most `rho=0.25` of any `beta_i` through
-  `sigma_i + sum_j kappa_ij`, leaving the rest grounded; and
-- apply deterministic pair ordering and reject shared-path pairwise composition
-  unless it is represented by one joint sparse-DtN calculation.
+- deterministically discover every exterior component inside the matching
+  topology reference `R_top \ D` and collect all retained ports from actual cut
+  edges;
+- include EVERY fully traversed component with exactly two retained ports,
+  aggregating parallel components between the same pair in one audited ledger;
+- compute its complete two-port `kappa` and self-return from topology-only `c0`
+  Schur solves, without embeddings, semantic prescreening, a pair budget, `rho`
+  truncation, or an approximate bridge cap;
+- leave every one-port, multi-port, traversal-incomplete, or numerically failed
+  component fully grounded under its exact Dirichlet beta; and
+- reject shared-path pairwise composition unless one future method represents it
+  by a single audited joint sparse-DtN calculation.
 
-Exact graph two-port reductions do not require embeddings. If no
-revision-pinned semantic embedding is available, only the optional multi-port
-pair filter is unavailable; do not substitute e5 after results. Other
-`q/rho/cap` values are exploratory sensitivities with family-wise labels.
+The implementation distinguishes failure scopes conservatively. If the frozen
+component-size cap interrupts exterior discovery, the component partition is
+not known to be complete, so the entire closure arm becomes a recorded no-op
+and the unchanged full-Dirichlet baseline remains the result. After discovery
+has completed, a numerical failure in one two-port Schur solve grounds only
+that complete component; other successfully reduced complete two-port
+components may remain in the ledger. Record stable reason counts and a
+content-based failure fingerprint in either case. Malformed, incomplete, or
+nonreciprocal graph input is an integrity failure and still aborts rather than
+being mislabeled a conservative numerical fallback.
 
-The SKELETON selector is the primary way to avoid boundary error: it retains
+A simple exterior series path is naturally weaker than each constituent branch,
+but parallel exterior paths can be stronger and must not be clipped if the
+reduction is called exact. Approximate multi-port closure, semantic proposal
+filters, and `q/rho/cap` sweeps are separate exploratory future families. They
+are not primary fallbacks and cannot rescue a failed or empty exact two-port
+closure result.
+
+In a future licensed selector phase, SKELETON may avoid boundary error by retaining
 common parents and other high-value junctions before spending budget on local
 fill. Closure is considered only for residual boundary ports joined by an
 actual path through one represented omitted component. It must never force a
@@ -323,84 +402,116 @@ cannot materially improve the selected-domain solution.
 Report, before any response comparison, the number of exterior components with
 two or more retained ports, the number of graph-connected port pairs proposed
 and realized, total transfer degree relative to original cut mass, and
-`||B_hat||_F / ||J_D||_F`. For the optional semantic filter, also report the
-fraction of graph-derived transfer mass captured by its top-`q` proposals.
-That recall diagnostic evaluates search efficiency only: missing a pair leaves
-its mass grounded, while semantic proximity alone never licenses a bridge.
-If the realized closure is empty, record a no-op and do not manufacture an
+`||B_hat||_F / ||J_D||_F`. If the realized closure is empty, record a
+no-op and do not manufacture an
 experimental arm. If it is nonempty but small, still report the ledger and
-paired response comparison; retain plain Dirichlet unless the fixed Section 8
-promotion gate is met.
+paired response comparison; retain plain Dirichlet unless a future frozen
+closure amendment meets the
+Section 8 efficacy and noninferiority form on untouched data.
 
 Before the corpus run, exact small-graph tests must include equal and unequal
 exterior series paths, exterior leakage, and a multi-terminal shared-path case,
 plus oversubscribed, asymmetric, self-edge, already-adjacent, ungrounded, and
-double-counted-beta failures. On the corpus, compare closure with plain
-Dirichlet on the identical selected domain, protected set, `alpha`, and
+double-counted-beta failures. When a future corpus closure phase is licensed, compare closure with
+plain Dirichlet on the identical selected domain, protected set, `alpha`, and
 reference.
 
-## 8. Decision hierarchy and paired uncertainty
+## 8. Fixed HOP convergence contrast and paired uncertainty
 
-Use 9,999 deterministic percentile bootstrap resamples of the 24 audit anchor
-batches with seed `3882002`. Within a resample, apply identical batch weights
-to both methods. The interval describes variation over the frozen structural
-anchor-sampling design, not solver randomness.
+Calibration may inspect all three HOP budgets. It freezes `K_low` as the smallest
+calibration-adequate value in `{256,512,1024}` and freezes `K_high` as the next
+larger HOP budget; when `K_low=1024`, `R_top` is the high/reference endpoint and
+only absolute adequacy, not a finite-budget plateau claim, is available. If no
+HOP budget is adequate on calibration, phase one is right-censored and the audit
+reports diagnostics without a convergence claim. No audit result may change the
+chosen pair.
 
-Apply this gatekeeping hierarchy:
+Use 9,999 deterministic paired bootstrap resamples of the 24 audit four-anchor
+batches with seed `3882002`. Apply identical batch multiplicities to both
+budgets. Every resampled batch contains one anchor from each quartile, so
+recompute the four quartile means and average them equally; no replicate can omit a quartile
+and no redraw rule is needed. The one-sided 95% upper endpoint is the higher
+observed bootstrap order statistic at 0.95, and the lower endpoint is the lower
+observed order statistic
+at 0.05. These intervals describe the frozen structural sampling design, not
+solver randomness.
 
-1. Verify outer-reference adequacy. If it fails, make no selector claim.
-2. Find each topology family's smallest adequate `K`. Prefer the family that
-   is adequate at a strictly smaller `K`. If both first pass at the same `K`,
-   compare batch-mean `log(E_g + 1e-15)`. Promote SKELETON over HOP only when
-   its geometric-mean error is at least 10% lower and the upper endpoint of the
-   paired 95% interval for the log-error difference is below zero. Otherwise
-   retain HOP.
-3. In the semantic regime only, compare RESISTANCE with the selected topology
-   family by the same rule. A win is scoped to that frozen semantic operator.
-4. Compare graph-derived experimental closure with plain Dirichlet on the
-   selected topology-only domain and topology-only `c0` operator. Semantic
-   filtering may reduce which graph solves are attempted, but there is no
-   semantic-conductance closure arm. Enable closure only when it reduces
-   geometric-mean `E_g` by at least
-   10%, the paired upper interval is below zero, and every noninferiority and
-   safety gate still passes.
+For a finite `K_high`, define the primary paired log-error contrast
 
-At every stage, `h`, resistance, rank inversion, top-8 overlap, and resources
-are noninferiority gates: the candidate may worsen no metric by more than 10%
-relative or 0.01 absolute for unit-interval metrics, and may not increase peak
-memory or total wall time by more than 25% at the same `K` unless it achieves a
-smaller adequate `K`. Report all tested families, budgets, batches, and losses.
+    Delta_hi_lo = macro_s mean[log(E_g(high)) - log(E_g(low))].
 
-The hierarchy supplies one decision-bearing comparison at a time. MiniLM,
-complete-shell domains, alternate anchor strata, alternate closure strengths,
-per-domain `alpha`, and degree/depth subgroups remain descriptive and cannot
-rescue a failed primary comparison.
+Use extended-real zero handling without an epsilon: equal zeros contribute
+zero; zero numerator with positive denominator contributes negative infinity;
+positive numerator with zero denominator contributes positive infinity. A
+material larger-domain efficacy finding requires the one-sided upper endpoint
+of `Delta_hi_lo` to be strictly below `log(0.9)`, not merely below zero. The
+smaller domain is declared converged only when it independently passes the
+absolute Section 6 adequacy gates and the full noninferiority intersection below,
+while `K_high` does not meet that efficacy rule. If larger-domain efficacy and
+smaller-domain noninferiority conflict or neither resolves, report an
+inconclusive frontier rather than choosing post hoc. When `K_high=R_top`, report
+only the absolute adequacy of `S_1024` and reference convergence; do not call the
+reference trivially lower error an efficacy result.
+
+Noninferiority is a one-sided INTERSECTION-UNION TEST: EVERY named endpoint
+must pass its own 95% one-sided upper bound with these frozen margins:
+
+- primary `log(E_g(low))-log(E_g(high)) < log(1.10)`, with the same
+  extended-real zero convention;
+- maximum absolute `h` error and rank-inversion fraction: paired
+  low-minus-high harm `<0.01` absolute;
+- batch-level protected boundary-harmonic maximum: paired low-minus-high harm
+  `<0.01` absolute;
+- top-8 overlap: paired high-minus-low loss `<0.01` absolute; and
+- effective-resistance relative error and source-diagonal relative error:
+  paired low-minus-high harm `<0.01` absolute.
+
+Use the corresponding bootstrap upper endpoint for each strict inequality.
+M-matrix signs, grounding, reciprocal condition, Cholesky/solve residuals, and
+maximum-principle checks are deterministic safety gates, not noisy
+noninferiority endpoints; any failure fails immediately. Resource use is
+reported as a frontier rather than hidden inside statistical fidelity: the
+smaller K must actually use fewer retained nodes, and projected bytes, peak RSS,
+and wall time are reported for both endpoints. No endpoint may rescue another.
+
+SKELETON, RESISTANCE, semantic conductance, closure, alternate strata, alternate
+alpha, and complete-shell domains are not phase-one confirmatory contrasts. A
+future licensed method comparison uses the same paired equal-stratum machinery,
+the `log(0.9)` efficacy threshold, and the noninferiority IUT, but requires its
+own prospective amendment and untouched audit data.
 
 ## 9. Reproducibility and fail-closed rules
 
 The run fingerprint covers content rather than machine-local paths:
 
-- source snapshot, canonical graph/parent manifests, and all byte hashes;
-- anchor, batch, protected-node, family-ordering, domain, boundary, and
+- raw-source and parser hashes, deterministic preparer hash, physical-edge
+  policy, privacy-propagation and visibility-limitation manifests, frozen
+  reciprocal adjacency, and all approved byte hashes;
+- anchor, balanced-batch, protected-node, HOP-ordering, domain, boundary, and
   reference manifests;
-- embedding identity/revision/text contract, arrays, `ell`, `epsilon`, and
-  missing-node manifest;
-- `K`, shell, `alpha`, selector priorities, stable tie keys, and closure ledger;
+- parent or embedding manifests only in a future phase that has passed their
+  prospective coverage gate;
+- `K`, shell, `alpha_top`, stable tie keys, and any future licensed selector or
+  closure ledger;
 - metric definitions, tolerances, bootstrap seeds/resamples, and software SHA;
 - float dtype, numerical thresholds, backend/thread identity without absolute
   library paths; and
 - per-phase timings, peak RSS, cache keys, and deterministic-rerun hashes.
 
-Fail closed on incomplete or asymmetric adjacency, missing required parent or
-embedding data, duplicate/unknown IDs, non-nested family prefixes, missing
-protected nodes, stale caches, changed edge weights between candidate and
+Fail closed on a missing or mismatched raw-source preparer manifest, unfrozen
+physical-edge policy, incomplete privacy propagation, incomplete or asymmetric
+adjacency, duplicate/unknown IDs,
+non-nested HOP prefixes, missing protected nodes, stale caches, changed edge
+weights between candidate and
 reference, nonfinite values, closure-ledger error, an ungrounded component,
 M-matrix sign failure, insufficient reciprocal condition, solve residual above
 the recorded tolerance, or reference/calibration inadequacy. Numerical jitter,
 zero cut conductance, insulating truncation, and hidden embedding fallback are
 not repairs.
 
-The final report must separate synthetic correctness, topology-only primary,
-semantic sensitivity, closure experiment, reference failures, and resource
-failures. No geometry result may be described as a filing improvement,
+The phase-one report must separate synthetic correctness, snapshot-relative
+topology-only HOP convergence, reference failures, coverage failures, and
+resource failures. Any later semantic, SKELETON, or closure report is a
+separate prospectively licensed artifact. No geometry result may be described
+as a filing improvement,
 covariance estimate, CUDA crossover, or Stage-A dependence promotion.

--- a/prototypes/mu_cosine/benchmark_bounded_diffusion_fidelity.py
+++ b/prototypes/mu_cosine/benchmark_bounded_diffusion_fidelity.py
@@ -129,6 +129,22 @@ def _topology_two_port_schur(
     intrinsic_leakage,
     topology_conductance,
 ):
+    """Return the nonnegative two-port Schur return B = C J_E^-1 C.T.
+
+    Eliminating the exterior component E changes the retained precision by
+    subtracting B from its Dirichlet principal block; B[0, 1] is the bridge
+    conductance kappa and B[i, i] is the self-return at port i. Thus this matrix
+    is not itself the reduced precision, whose off-diagonal bridge entries have
+    the opposite sign.
+
+    For one exterior node with port conductances c_l and c_r, leakage a, and
+    d = c_l + c_r + a, this gives
+    B = [[c_l**2, c_l*c_r], [c_l*c_r, c_r**2]] / d. The downstream closure
+    ledger subtracts both transfer and self-return from the exact Dirichlet
+    shunt before checking nonnegative residual ground, M-matrix signs, and SPD;
+    it never adds this return on top of the shunt.
+    """
+
     nodes = component.nodes
     ports = component.ports
     node_index = {node: row for row, node in enumerate(nodes)}

--- a/prototypes/mu_cosine/benchmark_bounded_diffusion_fidelity.py
+++ b/prototypes/mu_cosine/benchmark_bounded_diffusion_fidelity.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Synthetic smoke harness for outcome-blind bounded-domain fidelity.
 
-The harness freezes one larger exact-Dirichlet hop-union reference and one
-plain-hop protected set before evaluating any selector.  Every family uses the
-same intrinsic leakage and semantic conductance configuration.  A selector
+The harness freezes separate topology-only and semantic exact-Dirichlet
+hop-union references plus one plain-hop protected set before evaluating any
+selector.  Each operator regime has its own explicitly recorded scalar
+intrinsic leakage; candidate and reference share that scalar only within the
+regime.  A selector
 that omits a protected node emits a distinct ``coverage_failure`` record; the
 harness never intersects node sets post hoc or ranks missing nodes last.
 
@@ -15,6 +17,7 @@ separate experimental variant and is never enabled by default.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 from pathlib import Path
@@ -28,6 +31,7 @@ sys.path.insert(0, str(REPO_ROOT / "src"))
 
 from unifyweaver.graph.bounded_diffusion_fidelity import (  # noqa: E402
     ExperimentalBoundaryClosureConfig,
+    ExteriorTraversalLimitError,
     ProtectedSetCoverageError,
     discover_exterior_components,
     ensure_matched_budget,
@@ -50,6 +54,13 @@ def _positive_float(value):
     parsed = float(value)
     if not math.isfinite(parsed) or parsed <= 0.0:
         raise argparse.ArgumentTypeError("expected a positive finite number")
+    return parsed
+
+
+def _nonnegative_float(value):
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0.0:
+        raise argparse.ArgumentTypeError("expected a nonnegative finite number")
     return parsed
 
 
@@ -87,6 +98,20 @@ def _embeddings(node_count):
 def _stable_identifier_key(value):
     value_type = type(value)
     return (value_type.__module__, value_type.__qualname__, repr(value))
+
+
+def _stable_identifier_token(value):
+    return list(_stable_identifier_key(value))
+
+
+def _failure_fingerprint(records):
+    payload = json.dumps(
+        records,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("ascii")
+    return hashlib.sha256(payload).hexdigest()
 
 
 def _semantic_pair_score(left, right, embeddings, length_scale):
@@ -152,21 +177,67 @@ def _exact_two_port_exterior_dtn(
     """Discover complete exterior components and reduce exact two-port cases.
 
     The graph alone licenses every pair and topology-only ``c0`` determines
-    both transfer and self-return.  Optional frozen embeddings only rank already graph-connected pairs when the
-    pair budget binds; exact reduction itself is embedding-free.
+    both transfer and self-return.  With ``maximum_pairs=None`` every fully
+    traversed exact two-port component is retained and embeddings have no role.
+    A finite pair budget is a non-primary smoke sensitivity; optional frozen
+    embeddings may rank only pairs already licensed by graph connectivity.
     """
 
-    discovery = discover_exterior_components(
-        selection.domain,
-        graph,
-        allowed_exterior_nodes=allowed_exterior_nodes,
-        maximum_component_nodes=maximum_component_nodes,
-    )
+    exhaustive = maximum_pairs is None
+    try:
+        discovery = discover_exterior_components(
+            selection.domain,
+            graph,
+            allowed_exterior_nodes=allowed_exterior_nodes,
+            maximum_component_nodes=maximum_component_nodes,
+        )
+    except ExteriorTraversalLimitError as exc:
+        failure = {
+            "reason": "exterior_traversal_limit",
+            "component_start": _stable_identifier_token(exc.component_start),
+            "maximum_component_nodes": exc.maximum_component_nodes,
+            "visited_nodes": [
+                _stable_identifier_token(node) for node in exc.visited_nodes
+            ],
+            "blocked_neighbor": _stable_identifier_token(exc.blocked_neighbor),
+        }
+        failures = [failure]
+        return (), {}, {
+            "source": "exact_component_schur",
+            "strength_source": "topology_only_c0",
+            "topology_conductance": topology_conductance,
+            "semantic_role": "none" if exhaustive or embeddings is None else (
+                "rank_graph_connected_pairs_only"
+            ),
+            "status": "traversal_incomplete_grounded_no_op",
+            "eligible_two_port_components": 0,
+            "reduced_two_port_components": 0,
+            "numerically_failed_two_port_components": 0,
+            "grounded_one_port_components": 0,
+            "joint_dtn_required_components": 0,
+            "parallel_retained_edge_pairs": 0,
+            "approximate_caps_applied": False,
+            "aggregated_pair_candidates": 0,
+            "discarded_above_bridge_cap": 0,
+            "discarded_for_pair_budget": 0,
+            "realized_pairs": 0,
+            "no_op": True,
+            "failure_count": 1,
+            "failure_reasons": {"exterior_traversal_limit": 1},
+            "failure_fingerprint": _failure_fingerprint(failures),
+            "failures": failures,
+            "discovery": {
+                "status": "traversal_incomplete",
+                "maximum_component_nodes": maximum_component_nodes,
+            },
+        }
     grouped = {}
     one_port = 0
     multi_port = 0
     existing_edge = 0
     eligible_two_port = 0
+    reduced_two_port = 0
+    numerical_failures = []
     for component in discovery.components:
         if len(component.ports) == 1:
             one_port += 1
@@ -178,12 +249,25 @@ def _exact_two_port_exterior_dtn(
         if right in graph[left]:
             existing_edge += 1
         eligible_two_port += 1
-        update = _topology_two_port_schur(
-            component,
-            graph,
-            intrinsic_leakage=intrinsic_leakage,
-            topology_conductance=topology_conductance,
-        )
+        try:
+            update = _topology_two_port_schur(
+                component,
+                graph,
+                intrinsic_leakage=intrinsic_leakage,
+                topology_conductance=topology_conductance,
+            )
+        except np.linalg.LinAlgError as exc:
+            numerical_failures.append(
+                {
+                    "reason": "two_port_schur_numerical_failure",
+                    "component_fingerprint": component.component_fingerprint,
+                    "error_type": (
+                        type(exc).__module__ + "." + type(exc).__qualname__
+                    ),
+                }
+            )
+            continue
+        reduced_two_port += 1
         pair = (left, right)
         record = grouped.setdefault(
             pair,
@@ -192,7 +276,10 @@ def _exact_two_port_exterior_dtn(
                 "left_return": 0.0,
                 "right_return": 0.0,
                 "semantic_score": _semantic_pair_score(
-                    left, right, embeddings, length_scale
+                    left,
+                    right,
+                    None if exhaustive else embeddings,
+                    length_scale,
                 ),
                 "components": [],
             },
@@ -202,16 +289,30 @@ def _exact_two_port_exterior_dtn(
         record["right_return"] += float(update[1, 1])
         record["components"].append(component.component_fingerprint)
 
-    candidates = sorted(
-        grouped.items(),
-        key=lambda item: (
-            -item[1]["semantic_score"],
-            -item[1]["kappa"],
-            _stable_identifier_key(item[0][0]),
-            _stable_identifier_key(item[0][1]),
-        ),
-    )
-    chosen = candidates[:maximum_pairs]
+    if exhaustive:
+        candidates = sorted(
+            grouped.items(),
+            key=lambda item: (
+                -item[1]["kappa"],
+                _stable_identifier_key(item[0][0]),
+                _stable_identifier_key(item[0][1]),
+            ),
+        )
+    else:
+        candidates = sorted(
+            grouped.items(),
+            key=lambda item: (
+                -item[1]["semantic_score"],
+                -item[1]["kappa"],
+                _stable_identifier_key(item[0][0]),
+                _stable_identifier_key(item[0][1]),
+            ),
+        )
+    if maximum_pairs is None:
+        chosen = candidates
+    else:
+        maximum_pairs = _positive_integer(maximum_pairs)
+        chosen = candidates[:maximum_pairs]
     pairs = []
     self_return = {}
     for (left, right), record in chosen:
@@ -222,8 +323,13 @@ def _exact_two_port_exterior_dtn(
         "source": "exact_component_schur",
         "strength_source": "topology_only_c0",
         "topology_conductance": topology_conductance,
-        "semantic_role": "rank_graph_connected_pairs_only",
+        "semantic_role": "none" if exhaustive or embeddings is None else (
+            "rank_graph_connected_pairs_only"
+        ),
+        "status": "ok_with_grounded_failures" if numerical_failures else "ok",
         "eligible_two_port_components": eligible_two_port,
+        "reduced_two_port_components": reduced_two_port,
+        "numerically_failed_two_port_components": len(numerical_failures),
         "grounded_one_port_components": one_port,
         "joint_dtn_required_components": multi_port,
         "parallel_retained_edge_pairs": existing_edge,
@@ -233,6 +339,18 @@ def _exact_two_port_exterior_dtn(
         "discarded_for_pair_budget": max(len(candidates) - len(chosen), 0),
         "realized_pairs": len(pairs),
         "no_op": not pairs,
+        "failure_count": len(numerical_failures),
+        "failure_reasons": (
+            {"two_port_schur_numerical_failure": len(numerical_failures)}
+            if numerical_failures
+            else {}
+        ),
+        "failure_fingerprint": (
+            _failure_fingerprint(numerical_failures)
+            if numerical_failures
+            else None
+        ),
+        "failures": numerical_failures,
         "discovery": discovery.provenance_dict(),
     }
     return tuple(pairs), self_return, provenance
@@ -251,9 +369,15 @@ def main():
     parser.add_argument("--k", type=_positive_integer, default=32)
     parser.add_argument("--reference-k", type=_positive_integer, default=96)
     parser.add_argument("--protected", type=_positive_integer, default=12)
-    parser.add_argument("--alpha", type=_positive_float, default=0.2)
+    parser.add_argument("--alpha", type=_nonnegative_float, default=0.2)
+    parser.add_argument(
+        "--semantic-alpha", type=_nonnegative_float, default=0.3
+    )
     parser.add_argument("--length-scale", type=_positive_float, default=2.0)
     parser.add_argument("--conductance-floor", type=_unit_interval, default=0.1)
+    parser.add_argument(
+        "--reference-conductance", type=_positive_float, default=1.0
+    )
     parser.add_argument("--effective-resistance", action="store_true")
     parser.add_argument("--experimental-closure", action="store_true")
     parser.add_argument(
@@ -276,28 +400,45 @@ def main():
         anchors, graph, maximum_nodes=args.protected
     )
     protected_nodes = protected_selector.domain.nodes
-    selections = (
-        select_hop_budget_domain(anchors, graph, maximum_nodes=args.k),
-        select_topology_skeleton_domain(
-            anchors,
-            graph,
-            parents,
-            maximum_nodes=args.k,
-            ancestor_depth=3,
-        ),
-        select_semantic_resistance_domain(
-            anchors,
-            graph,
-            embeddings,
-            maximum_nodes=args.k,
-            length_scale=args.length_scale,
-            conductance_floor=args.conductance_floor,
-        ),
+    ancestor_depth = 3
+    hop_selection = select_hop_budget_domain(
+        anchors, graph, maximum_nodes=args.k
     )
-    ensure_matched_budget(selections)
-    reference = select_union_hop_reference(
-        selections, graph, maximum_nodes=args.reference_k
+    skeleton_selection = select_topology_skeleton_domain(
+        anchors,
+        graph,
+        parents,
+        maximum_nodes=args.k,
+        ancestor_depth=ancestor_depth,
     )
+    resistance_selection = select_semantic_resistance_domain(
+        anchors,
+        graph,
+        embeddings,
+        maximum_nodes=args.k,
+        length_scale=args.length_scale,
+        conductance_floor=args.conductance_floor,
+        reference_conductance=args.reference_conductance,
+    )
+    topology_selections = (hop_selection, skeleton_selection)
+    semantic_selections = (
+        hop_selection,
+        skeleton_selection,
+        resistance_selection,
+    )
+    ensure_matched_budget(semantic_selections)
+    references = {
+        "topology_only_c0": select_union_hop_reference(
+            topology_selections, graph, maximum_nodes=args.reference_k
+        ),
+        "semantic_rbf": select_union_hop_reference(
+            semantic_selections, graph, maximum_nodes=args.reference_k
+        ),
+    }
+    alpha_by_regime = {
+        "topology_only_c0": args.alpha,
+        "semantic_rbf": args.semantic_alpha,
+    }
     manifest = {
         "record_type": "manifest",
         "outcome_blind": True,
@@ -305,11 +446,16 @@ def main():
         "anchors": list(anchors),
         "requested_k": args.k,
         "reference_k": args.reference_k,
-        "reference_fingerprint": reference.selection_fingerprint,
+        "reference_fingerprints": {
+            regime: reference.selection_fingerprint
+            for regime, reference in references.items()
+        },
         "protected_nodes": list(protected_nodes),
-        "alpha": args.alpha,
+        "alpha_by_regime": alpha_by_regime,
+        "ancestor_depth": ancestor_depth,
         "length_scale": args.length_scale,
         "conductance_floor": args.conductance_floor,
+        "reference_conductance": args.reference_conductance,
         "effective_resistance": args.effective_resistance,
         "experimental_closure_requested": args.experimental_closure,
         "maximum_exterior_component_nodes": (
@@ -319,17 +465,23 @@ def main():
     }
     print(json.dumps(manifest, sort_keys=True))
 
-    maximum_closure_edges = max(1, args.k // 8)
     topology_conductance = 1.0
     closure_cap = float(np.nextafter(topology_conductance, 0.0))
-    for selection in selections:
-        if selection.strategy == "semantic_resistance":
-            operator_regime = "semantic_rbf"
+    regime_entries = tuple(
+        (selection, "topology_only_c0")
+        for selection in topology_selections
+    ) + tuple(
+        (selection, "semantic_rbf")
+        for selection in semantic_selections
+    )
+    for selection, operator_regime in regime_entries:
+        reference = references[operator_regime]
+        intrinsic_leakage = alpha_by_regime[operator_regime]
+        if operator_regime == "semantic_rbf":
             operator_embeddings = embeddings
             operator_length_scale = args.length_scale
             operator_floor = args.conductance_floor
         else:
-            operator_regime = "topology_only_c0"
             operator_embeddings = None
             operator_length_scale = None
             operator_floor = 0.0
@@ -346,11 +498,11 @@ def main():
             pairs, self_return, closure_provenance = _exact_two_port_exterior_dtn(
                 selection,
                 graph,
-                embeddings,
-                intrinsic_leakage=args.alpha,
+                None,
+                intrinsic_leakage=intrinsic_leakage,
                 length_scale=args.length_scale,
                 topology_conductance=topology_conductance,
-                maximum_pairs=maximum_closure_edges,
+                maximum_pairs=None,
                 maximum_component_nodes=(
                     args.maximum_exterior_component_nodes
                 ),
@@ -360,7 +512,7 @@ def main():
             )
             if pairs:
                 closure_config = ExperimentalBoundaryClosureConfig(
-                    maximum_edges=maximum_closure_edges,
+                    maximum_edges=len(pairs),
                     closure_mass_fraction=1.0,
                     ordinary_branch_conductance=topology_conductance,
                     bridge_conductance_cap=closure_cap,
@@ -409,6 +561,8 @@ def main():
                 "strategy": selection.strategy,
                 "variant": variant,
                 "operator_regime": operator_regime,
+                "reference_fingerprint": reference.selection_fingerprint,
+                "intrinsic_leakage": intrinsic_leakage,
                 "selection": selection.provenance_dict(),
             }
             if closure_provenance is not None:
@@ -418,7 +572,7 @@ def main():
                     selection,
                     reference,
                     protected_nodes=protected_nodes,
-                    intrinsic_leakage_conductance=args.alpha,
+                    intrinsic_leakage_conductance=intrinsic_leakage,
                     node_embeddings=operator_embeddings,
                     length_scale=operator_length_scale,
                     conductance_floor=operator_floor,

--- a/src/unifyweaver/graph/__init__.py
+++ b/src/unifyweaver/graph/__init__.py
@@ -7,18 +7,22 @@ from .leaky_diffusion import (
     semantic_conductance_matrix,
 )
 from .local_diffusion import (
+    AnchorLeakageCalibrationResult,
     AnchorScreeningProvenance,
     LeakageCalibrationResult,
     LocalDiffusionDomain,
     LocalGroundedSemanticDiffusion,
     NestedDomainDiagnostics,
+    PerAnchorLeakageCalibrationResult,
     build_local_grounded_semantic_diffusion,
     calibrate_uniform_leakage,
+    calibrate_uniform_leakage_per_anchor,
     compare_nested_domains,
     select_hop_local_domain,
 )
 
 __all__ = [
+    "AnchorLeakageCalibrationResult",
     "AnchorScreeningProvenance",
     "GroundedSemanticDiffusion",
     "build_grounded_semantic_diffusion",
@@ -26,8 +30,10 @@ __all__ = [
     "LocalDiffusionDomain",
     "LocalGroundedSemanticDiffusion",
     "NestedDomainDiagnostics",
+    "PerAnchorLeakageCalibrationResult",
     "build_local_grounded_semantic_diffusion",
     "calibrate_uniform_leakage",
+    "calibrate_uniform_leakage_per_anchor",
     "compare_nested_domains",
     "select_hop_local_domain",
     "combinatorial_laplacian",

--- a/src/unifyweaver/graph/bounded_diffusion_fidelity.py
+++ b/src/unifyweaver/graph/bounded_diffusion_fidelity.py
@@ -859,7 +859,10 @@ def select_topology_skeleton_domain(
                         "from incident adjacency"
                     )
                 if reaches_parent(parent, child):
-                    raise ValueError("cyclic parent data are not permitted")
+                    raise ValueError(
+                        "cyclic parent data are not permitted; provide the "
+                        "complete typed relation after SCC condensation"
+                    )
                 parent_relation.setdefault(child, set()).add(parent)
                 parent_children.setdefault(parent, set()).add(child)
                 if parent not in selected:
@@ -959,10 +962,14 @@ def select_semantic_resistance_domain(
     maximum_nodes,
     length_scale,
     conductance_floor=0.0,
+    reference_conductance=1.0,
 ):
     """Select a truncated Dijkstra prefix using resistance on existing edges.
 
-    Semantics changes edge cost but never creates an edge.  Zero-conductance
+    Semantics changes edge cost but never creates an edge.
+    ``reference_conductance`` is the positive frozen ``c_ref`` scale in
+    ``c_ref / c_ij``; it changes distance units but not the ordering.
+    Zero-conductance
     edges (possible only with a zero floor) are not traversable in the weighted
     selector.  The returned physical model still uses the exact same semantic
     conductance formula and full Dirichlet cut aggregation.
@@ -974,6 +981,9 @@ def select_semantic_resistance_domain(
         raise ValueError("maximum_nodes must be at least the number of anchors")
     length_scale = _positive_finite("length_scale", length_scale)
     floor = _unit_interval("conductance_floor", conductance_floor)
+    reference_conductance = _positive_finite(
+        "reference_conductance", reference_conductance
+    )
     snapshot = _NeighborSnapshot(incident_neighbors)
     embeddings = _EmbeddingSnapshot(node_embeddings)
     started = time.perf_counter()
@@ -994,7 +1004,7 @@ def select_semantic_resistance_domain(
             conductance = floor + (1.0 - floor) * radial
             if conductance <= 0.0:
                 continue
-            candidate = distance + 1.0 / conductance
+            candidate = distance + reference_conductance / conductance
             if not math.isfinite(candidate):
                 raise ValueError("semantic resistance path length is not finite")
             old = distances.get(neighbor)
@@ -1021,6 +1031,7 @@ def select_semantic_resistance_domain(
         parameters={
             "length_scale": length_scale,
             "conductance_floor": floor,
+            "reference_conductance": reference_conductance,
             "edge_support": "topology_only",
         },
         snapshot=snapshot,
@@ -1660,9 +1671,21 @@ def _leakage_for_nodes(value, nodes, all_required_nodes):
             for node in nodes
         }
     else:
-        scalar = _positive_finite("intrinsic_leakage_conductance", value)
+        scalar = _finite_nonnegative("intrinsic_leakage_conductance", value)
         output = scalar
     return output
+
+
+def _conservative_upper_quantile(values, quantile):
+    """Return an observed upper order statistic without tail interpolation."""
+
+    return float(np.quantile(values, quantile, method="higher"))
+
+
+def _conservative_lower_quantile(values, quantile):
+    """Return an observed lower order statistic without tail interpolation."""
+
+    return float(np.quantile(values, quantile, method="lower"))
 
 
 def _rank_order(nodes, values):
@@ -2177,8 +2200,8 @@ def evaluate_bounded_domain_fidelity(
             )
             for source_column in range(len(sources))
         )
-        resistance_relative_p90 = float(
-            np.quantile(per_anchor_resistance_relative, 0.9)
+        resistance_relative_p90 = _conservative_upper_quantile(
+            per_anchor_resistance_relative, 0.9
         )
     candidate_harmonic = candidate_model.boundary_harmonic_measure()[
         candidate_protected
@@ -2221,16 +2244,18 @@ def evaluate_bounded_domain_fidelity(
         per_anchor_source_diagonal_relative_error=tuple(
             float(value) for value in per_anchor_diagonal_relative
         ),
-        raw_relative_l2_error_90th_percentile=float(
-            np.quantile(per_anchor_raw_relative_l2, 0.9)
+        raw_relative_l2_error_90th_percentile=_conservative_upper_quantile(
+            per_anchor_raw_relative_l2, 0.9
         ),
-        maximum_h_absolute_error_90th_percentile=float(
-            np.quantile(per_anchor_maximum_h, 0.9)
+        maximum_h_absolute_error_90th_percentile=_conservative_upper_quantile(
+            per_anchor_maximum_h, 0.9
         ),
-        rank_inversion_fraction_90th_percentile=float(
-            np.quantile(inversions, 0.9)
+        rank_inversion_fraction_90th_percentile=_conservative_upper_quantile(
+            inversions, 0.9
         ),
-        top_k_overlap_10th_percentile=float(np.quantile(overlaps, 0.1)),
+        top_k_overlap_10th_percentile=_conservative_lower_quantile(
+            overlaps, 0.1
+        ),
         candidate_nodes=candidate.realized_nodes,
         reference_nodes=reference.realized_nodes,
         protected_nodes_count=len(protected),

--- a/src/unifyweaver/graph/local_diffusion.py
+++ b/src/unifyweaver/graph/local_diffusion.py
@@ -44,13 +44,16 @@ from .leaky_diffusion import (
 
 
 __all__ = [
+    "AnchorLeakageCalibrationResult",
     "AnchorScreeningProvenance",
     "LeakageCalibrationResult",
     "LocalDiffusionDomain",
     "LocalGroundedSemanticDiffusion",
     "NestedDomainDiagnostics",
+    "PerAnchorLeakageCalibrationResult",
     "build_local_grounded_semantic_diffusion",
     "calibrate_uniform_leakage",
+    "calibrate_uniform_leakage_per_anchor",
     "compare_nested_domains",
     "select_hop_local_domain",
 ]
@@ -862,6 +865,203 @@ class LeakageCalibrationResult:
         object.__setattr__(self, "numerical_minimum_leakage", numeric)
 
 
+@dataclass(frozen=True)
+class AnchorLeakageCalibrationResult:
+    """Independent leakage requirement and screening provenance for one anchor.
+
+    ``added_leakage_conductance`` is the scalar shunt added uniformly on top of
+    the caller-provided intrinsic leakage vector. Both screening records use
+    this anchor's own shell. The first is evaluated at the anchor's independently
+    selected leakage; the second is evaluated at the conservative shared study
+    leakage (the maximum independent requirement across anchors).
+    """
+
+    anchor: object
+    shell_nodes: tuple
+    added_leakage_conductance: float
+    achieved_attenuation: float
+    iterations: int
+    numerical_minimum_added_leakage: float
+    screening_at_selected_leakage: AnchorScreeningProvenance
+    screening_at_study_leakage: AnchorScreeningProvenance
+
+    def __post_init__(self):
+        try:
+            hash(self.anchor)
+        except TypeError as exc:
+            raise ValueError("anchor must be hashable") from exc
+        shell = _canonical_unique(self.shell_nodes, name="shell_nodes")
+        added = _finite_scalar(
+            "added_leakage_conductance",
+            self.added_leakage_conductance,
+        )
+        numerical = _finite_scalar(
+            "numerical_minimum_added_leakage",
+            self.numerical_minimum_added_leakage,
+        )
+        if added < 0.0 or numerical < 0.0:
+            raise ValueError("added leakage values must be nonnegative")
+        scale = max(abs(added), abs(numerical), np.finfo(float).tiny)
+        if added + 64.0 * np.finfo(float).eps * scale < numerical:
+            raise ValueError("selected leakage is below the numerical minimum")
+        achieved = _finite_scalar(
+            "achieved_attenuation",
+            self.achieved_attenuation,
+        )
+        if achieved < 0.0 or achieved > 1.0 + 1e-8:
+            raise ValueError("achieved_attenuation must be in [0, 1]")
+        if (
+            isinstance(self.iterations, (bool, np.bool_))
+            or int(self.iterations) != self.iterations
+            or self.iterations <= 0
+        ):
+            raise ValueError("iterations must be a positive integer")
+        iterations = int(self.iterations)
+        selected = self.screening_at_selected_leakage
+        study = self.screening_at_study_leakage
+        if not isinstance(selected, AnchorScreeningProvenance) or not isinstance(
+            study,
+            AnchorScreeningProvenance,
+        ):
+            raise TypeError("screening provenance must use AnchorScreeningProvenance")
+        if selected.anchor != self.anchor or study.anchor != self.anchor:
+            raise ValueError("screening provenance anchor must match the result")
+        if not math.isclose(
+            selected.attenuation_threshold,
+            study.attenuation_threshold,
+            rel_tol=1e-12,
+            abs_tol=0.0,
+        ):
+            raise ValueError("selected and study screening thresholds must match")
+        observed_scale = max(
+            abs(achieved),
+            abs(selected.shell_attenuation),
+            np.finfo(float).tiny,
+        )
+        if abs(achieved - selected.shell_attenuation) > (
+            64.0 * np.finfo(float).eps * observed_scale
+        ):
+            raise ValueError(
+                "achieved attenuation must equal selected-leakage screening"
+            )
+        if study.shell_attenuation > selected.shell_attenuation + 1e-8:
+            raise ValueError(
+                "shared study leakage cannot weaken shell attenuation"
+            )
+        object.__setattr__(self, "shell_nodes", shell)
+        object.__setattr__(self, "added_leakage_conductance", added)
+        object.__setattr__(self, "achieved_attenuation", achieved)
+        object.__setattr__(self, "iterations", iterations)
+        object.__setattr__(self, "numerical_minimum_added_leakage", numerical)
+
+
+@dataclass(frozen=True)
+class PerAnchorLeakageCalibrationResult:
+    """One-factor study model plus independent per-anchor leakage requirements.
+
+    The returned ``model`` uses ``base_intrinsic_leakage_conductance`` plus
+    ``study_added_leakage_conductance``. The study addition is the maximum of
+    the independently calibrated anchor additions, so one shared precision can
+    safely serve the whole batch without pretending that the intrinsic leakage
+    was learned or replaced.
+    """
+
+    model: LocalGroundedSemanticDiffusion
+    base_intrinsic_leakage_conductance: np.ndarray
+    study_added_leakage_conductance: float
+    target_attenuation: float
+    numerical_minimum_added_leakage: float
+    per_anchor: tuple
+    total_evaluations: int
+    eigendecomposition_count: int = 1
+
+    def __post_init__(self):
+        if not isinstance(self.model, LocalGroundedSemanticDiffusion):
+            raise TypeError("model must be a LocalGroundedSemanticDiffusion")
+        base = np.asarray(self.base_intrinsic_leakage_conductance, dtype=float)
+        if base.shape != (len(self.model.nodes),):
+            raise ValueError("base intrinsic leakage must align with model nodes")
+        if not np.isfinite(base).all() or np.any(base < 0.0):
+            raise ValueError("base intrinsic leakage must be finite and nonnegative")
+        target = _positive_unit_interval(
+            "target_attenuation",
+            self.target_attenuation,
+        )
+        study = _finite_scalar(
+            "study_added_leakage_conductance",
+            self.study_added_leakage_conductance,
+        )
+        numerical = _finite_scalar(
+            "numerical_minimum_added_leakage",
+            self.numerical_minimum_added_leakage,
+        )
+        if study < 0.0 or numerical < 0.0:
+            raise ValueError("added leakage values must be nonnegative")
+        records = tuple(self.per_anchor)
+        if not records or not all(
+            isinstance(record, AnchorLeakageCalibrationResult)
+            for record in records
+        ):
+            raise ValueError("per_anchor must contain anchor calibration results")
+        anchors = tuple(record.anchor for record in records)
+        if anchors != tuple(sorted(set(anchors), key=_stable_key)):
+            raise ValueError("per-anchor results must use canonical unique anchors")
+        if any(
+            not math.isclose(
+                record.screening_at_selected_leakage.attenuation_threshold,
+                target,
+                rel_tol=1e-12,
+                abs_tol=0.0,
+            )
+            for record in records
+        ):
+            raise ValueError("all per-anchor thresholds must match the batch target")
+        required = max(record.added_leakage_conductance for record in records)
+        required_scale = max(abs(required), abs(study), np.finfo(float).tiny)
+        if abs(required - study) > 64.0 * np.finfo(float).eps * required_scale:
+            raise ValueError("study leakage must equal the maximum anchor requirement")
+        expected_intrinsic = base + study
+        intrinsic_scale = max(
+            float(np.max(np.abs(expected_intrinsic), initial=0.0)),
+            np.finfo(float).tiny,
+        )
+        if not np.allclose(
+            self.model.intrinsic_leakage_conductance,
+            expected_intrinsic,
+            rtol=1e-12,
+            atol=64.0 * np.finfo(float).eps * intrinsic_scale,
+        ):
+            raise ValueError(
+                "study model intrinsic leakage must equal base plus added leakage"
+            )
+        if (
+            isinstance(self.total_evaluations, (bool, np.bool_))
+            or int(self.total_evaluations) != self.total_evaluations
+            or self.total_evaluations <= 0
+        ):
+            raise ValueError("total_evaluations must be a positive integer")
+        total = int(self.total_evaluations)
+        if total != sum(record.iterations for record in records):
+            raise ValueError("total evaluations must equal per-anchor iterations")
+        if self.eigendecomposition_count != 1:
+            raise ValueError("per-anchor calibration must use one eigendecomposition")
+        object.__setattr__(self, "base_intrinsic_leakage_conductance", _readonly(base))
+        object.__setattr__(self, "study_added_leakage_conductance", study)
+        object.__setattr__(self, "target_attenuation", target)
+        object.__setattr__(self, "numerical_minimum_added_leakage", numerical)
+        object.__setattr__(self, "per_anchor", records)
+        object.__setattr__(self, "total_evaluations", total)
+        object.__setattr__(self, "eigendecomposition_count", 1)
+
+    @property
+    def by_anchor(self):
+        return {record.anchor: record for record in self.per_anchor}
+
+    @property
+    def screening_provenance_semantics(self):
+        return "per_anchor_selected_and_shared_study_added_leakage"
+
+
 def _positive_conductance_hop_distances(conductance, source_row):
     """Return source-relative hops inside one realized conductance component."""
 
@@ -1250,6 +1450,460 @@ def calibrate_uniform_leakage(
         anchor_screening=anchor_screening,
         iterations=evaluations,
         numerical_minimum_leakage=numerical_minimum,
+    )
+
+
+def _attenuation_from_selected_spectral_rows(
+    eigenvalues,
+    eigenvectors,
+    *,
+    leakage,
+    source_row,
+    shell_rows,
+):
+    """Evaluate one shell without materializing a full Green response."""
+
+    denominators = eigenvalues + leakage
+    if np.any(denominators <= 0.0) or not np.isfinite(denominators).all():
+        return math.inf
+    source_eigenvector = eigenvectors[source_row, :]
+    weighted_source = source_eigenvector / denominators
+    source_value = float(source_eigenvector @ weighted_source)
+    shell_values = eigenvectors[np.asarray(shell_rows, dtype=np.int64), :] @ (
+        weighted_source
+    )
+    if source_value <= 0.0 or not math.isfinite(source_value):
+        return math.inf
+    if not np.isfinite(shell_values).all():
+        return math.inf
+    scale = max(
+        abs(source_value),
+        float(np.max(np.abs(shell_values), initial=0.0)),
+        1.0,
+    )
+    if float(np.min(shell_values, initial=0.0)) < -1e-10 * scale:
+        raise np.linalg.LinAlgError("spectral Green shell response is negative")
+    return float(np.max(np.maximum(shell_values, 0.0)) / source_value)
+
+
+def _full_spectral_response(
+    eigenvalues,
+    eigenvectors,
+    *,
+    leakage,
+    source_row,
+):
+    denominators = eigenvalues + leakage
+    if np.any(denominators <= 0.0) or not np.isfinite(denominators).all():
+        raise np.linalg.LinAlgError("spectral Green response is singular")
+    response = eigenvectors @ (eigenvectors[source_row, :] / denominators)
+    scale = max(float(np.max(np.abs(response), initial=0.0)), 1.0)
+    if (
+        not np.isfinite(response).all()
+        or response[source_row] <= 0.0
+        or float(np.min(response, initial=0.0)) < -1e-10 * scale
+    ):
+        raise np.linalg.LinAlgError("spectral Green response is not nonnegative")
+    return response
+
+
+def _screening_from_response(
+    anchor,
+    source_row,
+    shell_rows,
+    distances,
+    response,
+    *,
+    threshold,
+):
+    source_value = float(response[source_row])
+    attenuation = np.maximum(response, 0.0) / source_value
+    if float(np.max(attenuation)) > 1.0 + 1e-8:
+        raise np.linalg.LinAlgError("per-anchor Green attenuation left [0, 1]")
+    attenuation = np.clip(attenuation, 0.0, 1.0)
+    shell_attenuation = float(np.max(attenuation[list(shell_rows)]))
+    reachable = distances >= 0
+    lower, upper, censored, maximum = _tail_envelope_crossing(
+        distances[reachable],
+        attenuation[reachable],
+        threshold,
+    )
+    return AnchorScreeningProvenance(
+        anchor=anchor,
+        shell_attenuation=shell_attenuation,
+        attenuation_threshold=threshold,
+        radius_lower=lower,
+        radius_upper=upper,
+        right_censored=censored,
+        maximum_observed_radius=maximum,
+        distance_metric="realized_positive_conductance_hops",
+    )
+
+
+def _minimum_uniform_leakage_for_spectrum(
+    minimum,
+    maximum,
+    *,
+    required_rcond,
+):
+    if required_rcond == 1.0 and maximum > minimum:
+        raise ValueError(
+            "finite uniform leakage cannot make a nonscalar spectrum exact"
+        )
+    if required_rcond == 1.0:
+        numerical_minimum = 0.0
+    else:
+        numerical_minimum = max(
+            0.0,
+            (required_rcond * maximum - minimum) / (1.0 - required_rcond),
+        )
+        if numerical_minimum > 0.0:
+            numerical_minimum += (
+                64.0 * np.finfo(float).eps * max(maximum, np.finfo(float).tiny)
+            )
+    representable = np.nextafter(1.0 / np.finfo(float).max, math.inf)
+    numerical_minimum = max(numerical_minimum, representable - minimum, 0.0)
+    if numerical_minimum > 0.0:
+        numerical_minimum = float(np.nextafter(numerical_minimum, math.inf))
+    return float(numerical_minimum)
+
+
+def _calibrate_one_anchor_from_spectrum(
+    eigenvalues,
+    eigenvectors,
+    *,
+    source_row,
+    shell_rows,
+    target,
+    numerical_minimum,
+    maximum_allowed,
+    typical_conductance,
+    radius,
+    tolerance,
+    maximum_iterations,
+):
+    evaluations = 0
+
+    def evaluate(leakage):
+        nonlocal evaluations
+        evaluations += 1
+        return _attenuation_from_selected_spectral_rows(
+            eigenvalues,
+            eigenvectors,
+            leakage=leakage,
+            source_row=source_row,
+            shell_rows=shell_rows,
+        )
+
+    lower = numerical_minimum
+    lower_value = evaluate(lower)
+    if lower_value <= target:
+        return lower, lower_value, evaluations
+
+    gamma = math.log(1.0 / target) / max(radius, 1)
+    try:
+        chain_seed = 2.0 * typical_conductance * (math.cosh(gamma) - 1.0)
+    except OverflowError:
+        chain_seed = math.inf
+    upper = max(
+        float(np.nextafter(lower, math.inf)) * 2.0,
+        chain_seed,
+        np.finfo(float).tiny,
+    )
+    upper = min(upper, maximum_allowed)
+    upper_value = evaluate(upper)
+    while upper_value > target and evaluations < maximum_iterations:
+        if upper >= maximum_allowed or not math.isfinite(upper):
+            break
+        candidate = min(upper * 2.0, maximum_allowed)
+        if candidate <= upper:
+            break
+        upper = candidate
+        upper_value = evaluate(upper)
+    if upper_value > target:
+        if evaluations >= maximum_iterations:
+            raise np.linalg.LinAlgError(
+                "leakage calibration exhausted evaluations before bracketing"
+            )
+        raise np.linalg.LinAlgError(
+            "no allowed uniform leakage meets the attenuation target"
+        )
+
+    while evaluations < maximum_iterations:
+        scale = max(abs(upper), np.finfo(float).tiny)
+        if upper - lower <= tolerance * scale:
+            break
+        if lower > 0.0 and upper / lower > 4.0:
+            middle = math.sqrt(lower * upper)
+        else:
+            middle = lower + 0.5 * (upper - lower)
+        middle_value = evaluate(middle)
+        if middle_value <= target:
+            upper = middle
+            upper_value = middle_value
+        else:
+            lower = middle
+    scale = max(abs(upper), np.finfo(float).tiny)
+    if upper - lower > tolerance * scale:
+        raise np.linalg.LinAlgError(
+            "leakage calibration did not converge within maximum_iterations"
+        )
+    return upper, upper_value, evaluations
+
+
+def calibrate_uniform_leakage_per_anchor(
+    domain,
+    *,
+    anchors=None,
+    shell_nodes_by_anchor,
+    target_attenuation=math.exp(-1.0),
+    intrinsic_leakage_conductance=0.0,
+    node_embeddings=None,
+    length_scale=None,
+    conductance_floor=0.0,
+    bath_temperature=0.0,
+    minimum_reciprocal_condition=None,
+    maximum_leakage_conductance=None,
+    relative_tolerance=1e-8,
+    maximum_iterations=80,
+):
+    """Calibrate independent anchor shells with one shared eigendecomposition.
+
+    Each anchor is calibrated only against its own explicitly supplied shell.
+    The base precision includes the caller's existing intrinsic leakage and the
+    exact Dirichlet cut. The returned per-anchor values are *added* uniform
+    leakage requirements; they do not replace or relabel intrinsic leakage.
+
+    Bisection evaluates only the source and shell rows of the spectral Green
+    response. Full response vectors are formed once per anchor at its selected
+    leakage and at the maximum shared study leakage solely to record robust
+    realized screening-radius provenance.
+    """
+
+    if not isinstance(domain, LocalDiffusionDomain):
+        raise TypeError("domain must be a LocalDiffusionDomain")
+    if not isinstance(shell_nodes_by_anchor, Mapping):
+        raise TypeError("shell_nodes_by_anchor must be a mapping")
+    target = _positive_unit_interval("target_attenuation", target_attenuation)
+    tolerance = _positive_finite("relative_tolerance", relative_tolerance)
+    maximum_iterations = _positive_integer(
+        "maximum_iterations",
+        maximum_iterations,
+    )
+    source_nodes = _selected_nodes(
+        domain.nodes,
+        domain.anchors if anchors is None else anchors,
+        name="anchors",
+    )
+    try:
+        supplied_anchors = set(shell_nodes_by_anchor)
+    except TypeError as exc:
+        raise ValueError("shell mapping anchors must be hashable") from exc
+    expected_anchors = set(source_nodes)
+    if supplied_anchors != expected_anchors:
+        missing = expected_anchors.difference(supplied_anchors)
+        extra = supplied_anchors.difference(expected_anchors)
+        details = []
+        if missing:
+            details.append(
+                "missing " + ", ".join(sorted((repr(node) for node in missing)))
+            )
+        if extra:
+            details.append(
+                "extra " + ", ".join(sorted((repr(node) for node in extra)))
+            )
+        raise ValueError(
+            "shell_nodes_by_anchor keys must exactly match anchors ("
+            + "; ".join(details)
+            + ")"
+        )
+
+    index = {node: row for row, node in enumerate(domain.nodes)}
+    source_rows = {node: index[node] for node in source_nodes}
+    shells = {}
+    shell_rows = {}
+    for anchor in source_nodes:
+        shell = _selected_nodes(
+            domain.nodes,
+            shell_nodes_by_anchor[anchor],
+            name=f"shell_nodes_by_anchor[{anchor!r}]",
+        )
+        shells[anchor] = shell
+        shell_rows[anchor] = tuple(index[node] for node in shell)
+
+    conductance, laplacian, intrinsic, cut = _assemble_local_components(
+        domain,
+        intrinsic_leakage_conductance=intrinsic_leakage_conductance,
+        node_embeddings=node_embeddings,
+        length_scale=length_scale,
+        conductance_floor=conductance_floor,
+    )
+    distances = {
+        anchor: _positive_conductance_hop_distances(
+            conductance,
+            source_rows[anchor],
+        )
+        for anchor in source_nodes
+    }
+    for anchor in source_nodes:
+        source_row = source_rows[anchor]
+        invalid = tuple(
+            domain.nodes[row]
+            for row in shell_rows[anchor]
+            if row == source_row or distances[anchor][row] <= 0
+        )
+        if invalid:
+            labels = ", ".join(repr(node) for node in invalid)
+            raise ValueError(
+                "each anchor shell must contain only reachable non-source "
+                f"nodes; anchor {anchor!r} has invalid shell nodes: {labels}"
+            )
+
+    base_precision = laplacian + np.diag(intrinsic + cut)
+    eigenvalues, eigenvectors = np.linalg.eigh(base_precision)
+    spectral_scale = max(float(np.max(np.abs(eigenvalues), initial=0.0)), 1.0)
+    if float(eigenvalues[0]) < -1e-12 * spectral_scale:
+        raise np.linalg.LinAlgError(
+            "local base precision is not positive semidefinite"
+        )
+    eigenvalues = np.maximum(eigenvalues, 0.0)
+    spectral_minimum = float(eigenvalues[0])
+    spectral_maximum = float(eigenvalues[-1])
+    required_rcond = (
+        _DEFAULT_MINIMUM_RECIPROCAL_CONDITION
+        if minimum_reciprocal_condition is None
+        else _positive_unit_interval(
+            "minimum_reciprocal_condition",
+            minimum_reciprocal_condition,
+        )
+    )
+    numerical_minimum = _minimum_uniform_leakage_for_spectrum(
+        spectral_minimum,
+        spectral_maximum,
+        required_rcond=required_rcond,
+    )
+
+    if maximum_leakage_conductance is None:
+        maximum_allowed = math.inf
+    else:
+        maximum_allowed = _finite_scalar(
+            "maximum_leakage_conductance",
+            maximum_leakage_conductance,
+        )
+        if maximum_allowed < 0.0:
+            raise ValueError("maximum_leakage_conductance must be nonnegative")
+    if numerical_minimum > maximum_allowed:
+        raise np.linalg.LinAlgError(
+            "numerical conditioning requires leakage above the allowed maximum"
+        )
+
+    positive_edges = conductance[conductance > 0.0]
+    typical_conductance = (
+        float(np.median(positive_edges)) if len(positive_edges) else 1.0
+    )
+    selected = {}
+    selected_screening = {}
+    total_evaluations = 0
+    for anchor in source_nodes:
+        added, _, evaluations = _calibrate_one_anchor_from_spectrum(
+            eigenvalues,
+            eigenvectors,
+            source_row=source_rows[anchor],
+            shell_rows=shell_rows[anchor],
+            target=target,
+            numerical_minimum=numerical_minimum,
+            maximum_allowed=maximum_allowed,
+            typical_conductance=typical_conductance,
+            radius=max(domain.cutoff_distance, 1),
+            tolerance=tolerance,
+            maximum_iterations=maximum_iterations,
+        )
+        response = _full_spectral_response(
+            eigenvalues,
+            eigenvectors,
+            leakage=added,
+            source_row=source_rows[anchor],
+        )
+        provenance = _screening_from_response(
+            anchor,
+            source_rows[anchor],
+            shell_rows[anchor],
+            distances[anchor],
+            response,
+            threshold=target,
+        )
+        if provenance.shell_attenuation > target * (
+            1.0 + max(tolerance, 1e-10)
+        ):
+            raise np.linalg.LinAlgError(
+                f"final model missed the attenuation target for {anchor!r}"
+            )
+        selected[anchor] = (added, evaluations)
+        selected_screening[anchor] = provenance
+        total_evaluations += evaluations
+
+    study_added = max(value[0] for value in selected.values())
+    study_screening = {}
+    for anchor in source_nodes:
+        response = _full_spectral_response(
+            eigenvalues,
+            eigenvectors,
+            leakage=study_added,
+            source_row=source_rows[anchor],
+        )
+        provenance = _screening_from_response(
+            anchor,
+            source_rows[anchor],
+            shell_rows[anchor],
+            distances[anchor],
+            response,
+            threshold=target,
+        )
+        if provenance.shell_attenuation > target * (
+            1.0 + max(tolerance, 1e-10)
+        ):
+            raise np.linalg.LinAlgError(
+                f"shared study leakage missed the target for {anchor!r}"
+            )
+        study_screening[anchor] = provenance
+
+    study_model = _build_local_from_components(
+        domain,
+        conductance,
+        laplacian,
+        intrinsic + study_added,
+        cut,
+        semantic_length_scale=(
+            None if node_embeddings is None else float(length_scale)
+        ),
+        conductance_floor=float(conductance_floor),
+        bath_temperature=bath_temperature,
+        minimum_reciprocal_condition=required_rcond,
+    )
+    records = tuple(
+        AnchorLeakageCalibrationResult(
+            anchor=anchor,
+            shell_nodes=shells[anchor],
+            added_leakage_conductance=selected[anchor][0],
+            achieved_attenuation=(
+                selected_screening[anchor].shell_attenuation
+            ),
+            iterations=selected[anchor][1],
+            numerical_minimum_added_leakage=numerical_minimum,
+            screening_at_selected_leakage=selected_screening[anchor],
+            screening_at_study_leakage=study_screening[anchor],
+        )
+        for anchor in source_nodes
+    )
+    return PerAnchorLeakageCalibrationResult(
+        model=study_model,
+        base_intrinsic_leakage_conductance=intrinsic,
+        study_added_leakage_conductance=study_added,
+        target_attenuation=target,
+        numerical_minimum_added_leakage=numerical_minimum,
+        per_anchor=records,
+        total_evaluations=total_evaluations,
+        eigendecomposition_count=1,
     )
 
 

--- a/tests/test_bounded_diffusion_fidelity.py
+++ b/tests/test_bounded_diffusion_fidelity.py
@@ -8,11 +8,15 @@ import sys
 import numpy as np
 import pytest
 
+import prototypes.mu_cosine.benchmark_bounded_diffusion_fidelity as fidelity_benchmark
+
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
 from unifyweaver.graph.bounded_diffusion_fidelity import (  # noqa: E402
+    _conservative_lower_quantile,
+    _conservative_upper_quantile,
     ExperimentalBoundaryClosure,
     ExperimentalBoundaryClosureConfig,
     ExteriorTraversalLimitError,
@@ -911,7 +915,7 @@ def test_exact_reduction_needs_no_embeddings_and_sorts_heterogeneous_ports():
 
     assert len(pairs) == 2
     assert set(self_return) == {0, 1, "a", "b"}
-    assert provenance["semantic_role"] == "rank_graph_connected_pairs_only"
+    assert provenance["semantic_role"] == "none"
 
 
 def test_fidelity_emits_protocol_per_anchor_top8_and_resistance_endpoints():
@@ -986,3 +990,234 @@ def test_fidelity_rejects_changed_shared_node_adjacency_snapshot():
             protected_nodes=(0, 1),
             intrinsic_leakage_conductance=0.2,
         )
+
+
+def test_semantic_resistance_records_frozen_c_ref_without_changing_prefix():
+    graph = _neighbors((("s", "a"), ("a", "b"), ("s", "c")))
+    embeddings = {
+        "s": np.array([0.0]),
+        "a": np.array([0.1]),
+        "b": np.array([0.2]),
+        "c": np.array([3.0]),
+    }
+    unit = select_semantic_resistance_domain(
+        ("s",),
+        graph,
+        embeddings,
+        maximum_nodes=3,
+        length_scale=1.0,
+        conductance_floor=0.1,
+        reference_conductance=1.0,
+    )
+    scaled = select_semantic_resistance_domain(
+        ("s",),
+        graph,
+        embeddings,
+        maximum_nodes=3,
+        length_scale=1.0,
+        conductance_floor=0.1,
+        reference_conductance=2.0,
+    )
+
+    assert unit.domain.nodes == scaled.domain.nodes
+    assert np.allclose(scaled.selection_distance, 2.0 * unit.selection_distance)
+    assert dict(scaled.selector_parameters)["reference_conductance"] == 2.0
+    assert scaled.selection_fingerprint != unit.selection_fingerprint
+
+
+def test_fidelity_accepts_shared_zero_scalar_alpha_when_cuts_ground_both_models():
+    graph = _path(3)
+    candidate = select_hop_budget_domain((0,), graph, maximum_nodes=2)
+    reference = select_hop_budget_domain((0,), graph, maximum_nodes=3)
+
+    result = evaluate_bounded_domain_fidelity(
+        candidate,
+        reference,
+        protected_nodes=(0, 1),
+        intrinsic_leakage_conductance=0.0,
+    )
+
+    assert result.candidate_reciprocal_condition > 0.0
+    assert result.reference_reciprocal_condition > 0.0
+
+
+def test_fidelity_tail_summaries_use_conservative_observed_order_statistics():
+    values = (0.0, 1.0, 2.0, 3.0)
+
+    assert _conservative_upper_quantile(values, 0.9) == 3.0
+    assert _conservative_lower_quantile(values, 0.1) == 0.0
+
+
+def test_primary_exact_two_port_closure_is_exhaustive_and_embedding_free():
+    graph = _neighbors(
+        (
+            ("p", "x"),
+            ("x", "q"),
+            ("r", "y"),
+            ("y", "s"),
+            ("p", "w"),
+            ("r", "w"),
+            ("s", "w"),
+        )
+    )
+    selection = select_hop_budget_domain(
+        ("p", "q", "r", "s"), graph, maximum_nodes=4
+    )
+
+    pairs, _, provenance = _exact_two_port_exterior_dtn(
+        selection,
+        graph,
+        None,
+        intrinsic_leakage=0.2,
+        length_scale=1.0,
+        topology_conductance=1.0,
+        maximum_pairs=None,
+        maximum_component_nodes=8,
+    )
+
+    assert {(left, right) for left, right, _ in pairs} == {
+        ("p", "q"),
+        ("r", "s"),
+    }
+    assert provenance["semantic_role"] == "none"
+    assert provenance["eligible_two_port_components"] == 2
+    assert provenance["joint_dtn_required_components"] == 1
+    assert provenance["discarded_for_pair_budget"] == 0
+
+
+
+def test_exhaustive_exact_two_port_output_ignores_embeddings_entirely():
+    graph = _neighbors(
+        (("p", "x"), ("x", "q"), ("r", "y"), ("y", "s"))
+    )
+    selection = select_hop_budget_domain(
+        ("p", "q", "r", "s"), graph, maximum_nodes=4
+    )
+    first_embeddings = {
+        "p": np.array([0.0]),
+        "q": np.array([0.0]),
+        "r": np.array([-10.0]),
+        "s": np.array([10.0]),
+    }
+    second_embeddings = {
+        "p": np.array([-10.0]),
+        "q": np.array([10.0]),
+        "r": np.array([0.0]),
+        "s": np.array([0.0]),
+    }
+    arguments = {
+        "intrinsic_leakage": 0.2,
+        "length_scale": 1.0,
+        "topology_conductance": 1.0,
+        "maximum_pairs": None,
+        "maximum_component_nodes": 8,
+    }
+
+    first = _exact_two_port_exterior_dtn(
+        selection, graph, first_embeddings, **arguments
+    )
+    second = _exact_two_port_exterior_dtn(
+        selection, graph, second_embeddings, **arguments
+    )
+
+    assert first == second
+    assert first[2]["semantic_role"] == "none"
+
+
+def test_traversal_limit_returns_stable_grounded_no_op():
+    graph = _neighbors((("p", "x"), ("x", "y"), ("y", "q")))
+    selection = select_hop_budget_domain(
+        ("p", "q"), graph, maximum_nodes=2
+    )
+
+    first = _exact_two_port_exterior_dtn(
+        selection,
+        graph,
+        None,
+        intrinsic_leakage=0.2,
+        length_scale=None,
+        topology_conductance=1.0,
+        maximum_pairs=None,
+        maximum_component_nodes=1,
+    )
+    second = _exact_two_port_exterior_dtn(
+        selection,
+        graph,
+        None,
+        intrinsic_leakage=0.2,
+        length_scale=None,
+        topology_conductance=1.0,
+        maximum_pairs=None,
+        maximum_component_nodes=1,
+    )
+
+    assert first == second
+    pairs, self_return, provenance = first
+    assert pairs == ()
+    assert self_return == {}
+    assert provenance["status"] == "traversal_incomplete_grounded_no_op"
+    assert provenance["no_op"] is True
+    assert provenance["failure_count"] == 1
+    assert provenance["failure_reasons"] == {"exterior_traversal_limit": 1}
+    assert len(provenance["failure_fingerprint"]) == 64
+
+
+def test_numerically_failed_two_port_stays_grounded_while_others_reduce(
+    monkeypatch,
+):
+    graph = _neighbors(
+        (("p", "x"), ("x", "q"), ("r", "y"), ("y", "s"))
+    )
+    selection = select_hop_budget_domain(
+        ("p", "q", "r", "s"), graph, maximum_nodes=4
+    )
+    original = fidelity_benchmark._topology_two_port_schur
+
+    def fail_one_component(component, *args, **kwargs):
+        if component.nodes == ("x",):
+            raise np.linalg.LinAlgError("synthetic numerical failure")
+        return original(component, *args, **kwargs)
+
+    monkeypatch.setattr(
+        fidelity_benchmark,
+        "_topology_two_port_schur",
+        fail_one_component,
+    )
+    pairs, self_return, provenance = _exact_two_port_exterior_dtn(
+        selection,
+        graph,
+        None,
+        intrinsic_leakage=0.2,
+        length_scale=None,
+        topology_conductance=1.0,
+        maximum_pairs=None,
+        maximum_component_nodes=8,
+    )
+
+    assert {(left, right) for left, right, _ in pairs} == {("r", "s")}
+    assert provenance["eligible_two_port_components"] == 2
+    assert provenance["reduced_two_port_components"] == 1
+    assert provenance["numerically_failed_two_port_components"] == 1
+    assert provenance["failure_reasons"] == {
+        "two_port_schur_numerical_failure": 1
+    }
+    assert len(provenance["failure_fingerprint"]) == 64
+
+    config = ExperimentalBoundaryClosureConfig(
+        maximum_edges=1,
+        closure_mass_fraction=1.0,
+        ordinary_branch_conductance=1.0,
+        bridge_conductance_cap=0.25,
+        pair_conductance_source="exact_component_schur",
+        ledger_mode="explicit_self_return",
+    )
+    closure = build_experimental_boundary_closure(
+        selection.domain,
+        intrinsic_leakage_conductance=0.2,
+        pair_conductances=pairs,
+        self_return_conductance=self_return,
+        config=config,
+    )
+    index = {node: row for row, node in enumerate(closure.model.nodes)}
+    assert closure.residual_ground_conductance[index["p"]] == pytest.approx(1.0)
+    assert closure.residual_ground_conductance[index["q"]] == pytest.approx(1.0)

--- a/tests/test_local_grounded_diffusion.py
+++ b/tests/test_local_grounded_diffusion.py
@@ -20,6 +20,7 @@ from unifyweaver.graph.local_diffusion import (  # noqa: E402
     LocalDiffusionDomain,
     _tail_envelope_crossing,
     calibrate_uniform_leakage,
+    calibrate_uniform_leakage_per_anchor,
     compare_nested_domains,
     select_hop_local_domain,
 )
@@ -751,3 +752,206 @@ def test_direct_domain_overrun_must_complete_only_the_final_shell():
             complete_distance_shell=True,
             truncated_tie_count=0,
         )
+
+
+def _asymmetric_two_anchor_calibration_fixture():
+    graph = {
+        "a0": ("a1",),
+        "a1": ("a0", "a2"),
+        "a2": ("a1",),
+        "b0": ("b1",),
+        "b1": ("b0", "b2"),
+        "b2": ("b1",),
+    }
+    domain = select_hop_local_domain(
+        ("a0", "b0"),
+        graph,
+        maximum_nodes=6,
+    )
+    embeddings = {
+        "a0": np.array([0.0]),
+        "a1": np.array([0.0]),
+        "a2": np.array([0.0]),
+        "b0": np.array([10.0]),
+        "b1": np.array([13.5]),
+        "b2": np.array([17.0]),
+    }
+    shells = {"a0": ("a2",), "b0": ("b2",)}
+    return domain, embeddings, shells
+
+
+def test_per_anchor_calibration_reuses_one_eigendecomposition_and_matches_singles(
+    monkeypatch,
+):
+    domain, embeddings, shells = _asymmetric_two_anchor_calibration_fixture()
+    original_eigh = np.linalg.eigh
+    calls = []
+
+    def counted_eigh(*args, **kwargs):
+        calls.append(args[0].shape)
+        return original_eigh(*args, **kwargs)
+
+    monkeypatch.setattr(np.linalg, "eigh", counted_eigh)
+    batched = calibrate_uniform_leakage_per_anchor(
+        domain,
+        shell_nodes_by_anchor=shells,
+        node_embeddings=embeddings,
+        length_scale=1.0,
+        relative_tolerance=1e-6,
+    )
+    assert calls == [(6, 6)]
+    assert batched.eigendecomposition_count == 1
+
+    monkeypatch.setattr(np.linalg, "eigh", original_eigh)
+    singles = {
+        anchor: calibrate_uniform_leakage(
+            domain,
+            anchors=(anchor,),
+            shell_nodes=shells[anchor],
+            node_embeddings=embeddings,
+            length_scale=1.0,
+            relative_tolerance=1e-6,
+        )
+        for anchor in ("a0", "b0")
+    }
+    for anchor, record in batched.by_anchor.items():
+        single = singles[anchor]
+        assert record.added_leakage_conductance == pytest.approx(
+            single.leakage_conductance,
+            rel=2e-10,
+        )
+        assert record.achieved_attenuation == pytest.approx(
+            single.achieved_attenuation,
+            rel=2e-10,
+        )
+        assert record.screening_at_selected_leakage.radius_lower == (
+            single.anchor_screening[0].radius_lower
+        )
+        assert record.screening_at_selected_leakage.radius_upper == (
+            single.anchor_screening[0].radius_upper
+        )
+
+    requirements = {
+        record.anchor: record.added_leakage_conductance
+        for record in batched.per_anchor
+    }
+    assert requirements["a0"] > requirements["b0"]
+    assert batched.study_added_leakage_conductance == max(
+        requirements.values()
+    )
+    assert batched.by_anchor["b0"].screening_at_study_leakage.shell_attenuation < (
+        batched.by_anchor["b0"].achieved_attenuation
+    )
+
+
+def test_per_anchor_calibration_is_anchor_and_mapping_order_invariant():
+    domain, embeddings, shells = _asymmetric_two_anchor_calibration_fixture()
+    forward = calibrate_uniform_leakage_per_anchor(
+        domain,
+        anchors=("a0", "b0"),
+        shell_nodes_by_anchor=shells,
+        node_embeddings=embeddings,
+        length_scale=1.0,
+        relative_tolerance=1e-6,
+    )
+    reversed_order = calibrate_uniform_leakage_per_anchor(
+        domain,
+        anchors=("b0", "a0"),
+        shell_nodes_by_anchor={"b0": ("b2",), "a0": ("a2",)},
+        node_embeddings=embeddings,
+        length_scale=1.0,
+        relative_tolerance=1e-6,
+    )
+
+    assert tuple(record.anchor for record in forward.per_anchor) == ("a0", "b0")
+    assert tuple(record.anchor for record in reversed_order.per_anchor) == (
+        "a0",
+        "b0",
+    )
+    assert forward.study_added_leakage_conductance == pytest.approx(
+        reversed_order.study_added_leakage_conductance
+    )
+    assert {
+        key: value.added_leakage_conductance
+        for key, value in forward.by_anchor.items()
+    } == pytest.approx(
+        {
+            key: value.added_leakage_conductance
+            for key, value in reversed_order.by_anchor.items()
+        }
+    )
+
+
+def test_per_anchor_calibration_rejects_source_only_and_unreachable_shells():
+    domain, embeddings, _ = _asymmetric_two_anchor_calibration_fixture()
+
+    with pytest.raises(ValueError, match="reachable non-source.*'a0'"):
+        calibrate_uniform_leakage_per_anchor(
+            domain,
+            anchors=("a0",),
+            shell_nodes_by_anchor={"a0": ("a0",)},
+            node_embeddings=embeddings,
+            length_scale=1.0,
+        )
+
+    with pytest.raises(ValueError, match="reachable non-source.*'b2'"):
+        calibrate_uniform_leakage_per_anchor(
+            domain,
+            anchors=("a0",),
+            shell_nodes_by_anchor={"a0": ("b2",)},
+            node_embeddings=embeddings,
+            length_scale=1.0,
+        )
+
+
+def test_per_anchor_calibration_allows_zero_and_records_finite_provenance():
+    graph = _path(2)
+    domain = select_hop_local_domain((0,), graph, maximum_nodes=3)
+    result = calibrate_uniform_leakage_per_anchor(
+        domain,
+        shell_nodes_by_anchor={0: (2,)},
+        target_attenuation=0.9,
+        intrinsic_leakage_conductance=1.0,
+    )
+
+    assert result.study_added_leakage_conductance == 0.0
+    assert result.numerical_minimum_added_leakage == 0.0
+    assert np.array_equal(
+        result.base_intrinsic_leakage_conductance,
+        np.ones(3),
+    )
+    assert np.array_equal(
+        result.model.intrinsic_leakage_conductance,
+        result.base_intrinsic_leakage_conductance,
+    )
+    assert result.screening_provenance_semantics == (
+        "per_anchor_selected_and_shared_study_added_leakage"
+    )
+    assert result.total_evaluations == 1
+
+    record = result.per_anchor[0]
+    assert record.added_leakage_conductance == 0.0
+    finite_values = [
+        result.study_added_leakage_conductance,
+        result.target_attenuation,
+        result.numerical_minimum_added_leakage,
+        record.added_leakage_conductance,
+        record.achieved_attenuation,
+        record.numerical_minimum_added_leakage,
+    ]
+    for screening in (
+        record.screening_at_selected_leakage,
+        record.screening_at_study_leakage,
+    ):
+        finite_values.extend(
+            [
+                screening.shell_attenuation,
+                screening.attenuation_threshold,
+                screening.radius_lower,
+                screening.maximum_observed_radius,
+            ]
+        )
+        if screening.radius_upper is not None:
+            finite_values.append(screening.radius_upper)
+    assert np.isfinite(finite_values).all()
+    assert np.isfinite(result.base_intrinsic_leakage_conductance).all()


### PR DESCRIPTION
## Summary

[Read the frozen protocol](https://github.com/s243a/UnifyWeaver/blob/codex/pearltrees-diffusion-fidelity/prototypes/mu_cosine/PROTOCOL_bounded_diffusion_fidelity.md).

This follow-up to #3885 freezes the first statistically honest bounded-diffusion fidelity study and hardens the numerical primitives it needs.

The prospective first phase is deliberately **HOP-only**. Preflight inspection showed that the current assembled Pearltrees TSV is useful for legacy adjacency parity, but it has lost relation provenance, has incomplete visibility evidence, and covers too little authoritative parent/root structure for the proposed lineage skeleton. Accordingly, this PR records **no real-corpus outcome** and blocks that run until a raw-source snapshot preparer can reproduce the physical graph and privacy state.

## What changed

- preregisters degree-stratified anchor sampling, calibration/audit separation, conservative quantiles, explicit noninferiority margins, and one-sided efficacy gates
- separates topology and semantic operators, references, and leakage parameters
- adds per-anchor shell calibration with one shared study leakage equal to the maximum independently required addition
- permits a legitimate zero added leakage when the numerical gates pass
- defines exact two-port boundary closure as an exhaustive, embedding-independent graph reference
- makes traversal-limit and component numerical failures conservatively remain grounded with stable provenance
- fixes resistance-length scaling and conservative tail-quantile conventions
- documents why SKELETON, semantic resistance, and learned closure remain gated future phases

## Statistical boundary

- 4 deterministic degree quartiles
- 32 anchors per quartile: 8 calibration and 24 audit
- every four-anchor batch contains one anchor per quartile
- calibration chooses the HOP domain contrast; the audit set evaluates it once
- primary efficacy requires the one-sided upper confidence bound to be below `log(0.9)`
- normalized-error noninferiority margin is 0.01; the primary log-ratio margin is `log(1.10)`
- detailed node, edge, title, path, and embedding artifacts remain local-only

## Why no Pearltrees result is included

The present assembled graph cannot establish which raw relations created an edge, whether visibility evidence is complete, or which relations may propagate privacy. It also provides authoritative parent evidence for only a small minority of the usable graph. SCC condensation can remove cycles, but it cannot manufacture missing parents or positive root evidence.

The next PR is therefore a fail-closed raw-source snapshot preparer with content-based fingerprints, relation evidence, privacy propagation, deterministic components/anchor eligibility, and legacy-TSV parity checks. Only a verified snapshot may unlock the preregistered run.

## Validation

- `97 passed` across leaky diffusion, local grounded diffusion, and bounded-fidelity tests
- the one-node two-port identity pins `kappa = sigma = 1 / 3.2` under two bath boundaries
- Python syntax compilation passed
- final synthetic benchmark completed with finite output
- staged diff and whitespace checks passed
- independent numerical review found and verified fixes for embedding-dependent exhaustive closure and conservative numerical/traversal fallback

No filing-performance, covariance-deployment, CUDA, or real-corpus fidelity claim is unlocked by this PR.