### PR TITLE
R-A2-INDEX-FALLBACK-COVERAGE: replace remaining R A2 Raw hints with safe linear fallback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Create smoke temp root
         run: mkdir -p "$UW_SMOKE_TMPDIR"
 
-      - name: Run R switch-index regressions
+      - name: Run R switch-index regressions (A1 + A2)
         run: |
           swipl -q -f init.pl -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:switch_on_constant_fallthrough_is_linear_noop,wam_r_generator:switch_on_term_a2_is_switch_on_term_noop,wam_r_generator:switch_on_constant_fallthrough_preserves_backtracking,wam_r_generator:r_a2_switch_hints_are_linear_noop,wam_r_generator:r_a2_fallthrough_preserves_backtracking])" -t halt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run R switch-index regressions
         run: |
-          swipl -q -f init.pl -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:switch_on_constant_fallthrough_is_linear_noop,wam_r_generator:switch_on_term_a2_is_switch_on_term_noop,wam_r_generator:switch_on_constant_fallthrough_preserves_backtracking])" -t halt
+          swipl -q -f init.pl -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:switch_on_constant_fallthrough_is_linear_noop,wam_r_generator:switch_on_term_a2_is_switch_on_term_noop,wam_r_generator:switch_on_constant_fallthrough_preserves_backtracking,wam_r_generator:r_a2_switch_hints_are_linear_noop,wam_r_generator:r_a2_fallthrough_preserves_backtracking])" -t halt
 
       - name: Run full R classic conformance
         run: |

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -45,9 +45,10 @@ lazy/cached tiers of F#/Haskell).
 ## Gaps (relative to Rust / Haskell / F#)
 
 - **Classic conformance (CONF-R):** opt-in adapter (`r` / `r_functions`).
-  All classic programs green after R-SWITCH-INDEX-CONFORMANCE mapped both
-  missing indexing hints to the existing `SwitchOnTerm()` no-op, preserving
-  the full linear choice chain without adding a runtime.
+  All classic programs green. Indexing hints — including remaining A2
+  forms (`switch_on_constant_a2`, `_a2_fallthrough`, `switch_on_structure_a2`)
+  — map to the existing `SwitchOnTerm()` linear no-op (not optimized A2
+  dispatch), preserving the full try/retry/trust chain.
 - **LMDB is load-everything** — no lazy/cached two-level policies.
 - **ISO error support** is `tryCatch`-level only, not the three-form
   contract.

--- a/docs/WAM_SWITCH_INDEXING_CROSS_TARGET.md
+++ b/docs/WAM_SWITCH_INDEXING_CROSS_TARGET.md
@@ -95,7 +95,7 @@ emitter (not the token-parser predicates several targets also define).
 | rust | N | Y | N | N | N | `/* unknown */` (drop) | safe; missed opt |
 | go | N | N | N | N | N | `// TODO` (drop) | safe; missed opt |
 | python | N | N | N | N | N | `# SKIP` (drop) | safe; missed opt (confirmed) |
-| **r** (fixed) | Y | N | N | Y | N | `Raw(...)` (now unreachable for these) | safe linear no-op; classic conformance fixed |
+| **r** (fixed) | Y | Y | Y | Y | Y | `Raw(...)` (now unreachable for these) | safe linear no-op for all A1/A2 hints; classic conformance fixed |
 | lua | N | Y | N | N | N | `I.Raw(...)` (drop-style) | safe; missed opt (verify) |
 | clojure | N | N | N | N | N | `{:op :raw}` stub | depends on step-loop `:raw` |
 | llvm | N | Y | N | partial(nop) | N | `; TODO` (switch is design-nop) | safe (chain preserved) |
@@ -235,8 +235,11 @@ after runtime validation — see "Runtime validation" above.**
 - **C++** — `src/unifyweaver/targets/wam_cpp_target.pl` (full coverage incl. `struct_a2`).
 - **Elixir lowered emitter** — `src/unifyweaver/targets/wam_elixir_lowered_emitter.pl` (full coverage).
 - **R** — `src/unifyweaver/targets/wam_r_target.pl` maps
-  `switch_on_constant_fallthrough` and `switch_on_term_a2` to the existing
-  `SwitchOnTerm()` no-op, preserving the complete linear choice chain.
+  `switch_on_constant_fallthrough`, `switch_on_term_a2`,
+  `switch_on_constant_a2`, `switch_on_constant_a2_fallthrough`, and
+  `switch_on_structure_a2` to the existing `SwitchOnTerm()` no-op
+  (safe linear fallback — not optimized A2 dispatch), preserving the
+  complete try/retry/trust choice chain.
 
 ## Toolchain note
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -430,6 +430,13 @@ wam_parts_to_r(["switch_on_term" | _], 'SwitchOnTerm()').
 % member/2 emits switch_on_term_a2 ahead of a complete try/trust chain.
 wam_parts_to_r(["switch_on_term_a2" | _], 'SwitchOnTerm()').
 
+% Remaining A2 indexing hints (constant / constant-fallthrough / structure)
+% also lower to the linear no-op. Do not reuse SwitchOnConstant here: an
+% indexed jump can bypass TryMeElse and drop trailing clauses on backtrack.
+wam_parts_to_r(["switch_on_constant_a2" | _], 'SwitchOnTerm()').
+wam_parts_to_r(["switch_on_constant_a2_fallthrough" | _], 'SwitchOnTerm()').
+wam_parts_to_r(["switch_on_structure_a2" | _], 'SwitchOnTerm()').
+
 % --- Switch on structure (functor-shape dispatch) ---
 % Each case is "F/N:label". Behaviour parallels switch_on_constant: when
 % the first arg is a struct of matching shape, jump to the labelled

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -4861,6 +4861,67 @@ test(switch_on_constant_fallthrough_preserves_backtracking,
         )),
     !.
 
+% ------------------------------------------------------------------
+% R-A2-INDEX-FALLBACK-COVERAGE: remaining A2 hints → SwitchOnTerm()
+% ------------------------------------------------------------------
+r_a2_switch_token(["switch_on_constant_a2", "a:default", "b:L2"]).
+r_a2_switch_token(["switch_on_constant_a2_fallthrough", "a:default", "b:L2"]).
+r_a2_switch_token(["switch_on_structure_a2", "f/1:default", "g/1:L2"]).
+
+test(r_a2_switch_hints_are_linear_noop) :-
+    forall(r_a2_switch_token(Parts),
+           ( once(wam_parts_to_r(Parts, [], Lit)),
+             assertion(Lit == 'SwitchOnTerm()') )), !.
+
+test(r_a2_fallthrough_preserves_backtracking,
+     [condition(rscript_available)]) :-
+    maplist(retractall,
+            [user:r_a2_ft(_,_), user:r_a2_ft_backtracks,
+             user:r_a2_const(_,_), user:r_a2_const_ok,
+             user:r_a2_struct(_,_), user:r_a2_struct_ok]),
+    % Free A1 + constant/var A2 ⇒ switch_on_constant_a2_fallthrough.
+    assertz((user:r_a2_ft(Out, a) :- Out = first)),
+    assertz((user:r_a2_ft(Out, b) :- Out = specific)),
+    assertz((user:r_a2_ft(Out, _) :- Out = fallback)),
+    assertz((user:r_a2_ft_backtracks :-
+                user:r_a2_ft(Value, b), Value = fallback)),
+    % Free A1 + all-constant A2 ⇒ switch_on_constant_a2.
+    assertz((user:r_a2_const(Out, a) :- Out = ok)),
+    assertz((user:r_a2_const(Out, b) :- Out = ok)),
+    assertz((user:r_a2_const(Out, c) :- Out = ok)),
+    assertz((user:r_a2_const_ok :- user:r_a2_const(ok, b))),
+    % Free A1 + compound A2 ⇒ switch_on_structure_a2.
+    assertz((user:r_a2_struct(Out, f(_)) :- Out = ok)),
+    assertz((user:r_a2_struct(Out, g(_)) :- Out = ok)),
+    assertz((user:r_a2_struct(Out, h(_)) :- Out = ok)),
+    assertz((user:r_a2_struct_ok :- user:r_a2_struct(ok, g(1)))),
+    unique_r_tmp_dir('tmp_r_a2_ft', TmpDir),
+    call_cleanup(
+        ( write_wam_r_project(
+              [user:r_a2_ft/2, user:r_a2_ft_backtracks/0,
+               user:r_a2_const/2, user:r_a2_const_ok/0,
+               user:r_a2_struct/2, user:r_a2_struct_ok/0],
+              [emit_mode(interpreter), fact_table_layout(off)], TmpDir),
+          directory_file_path(TmpDir, 'R/generated_program.R', ProgPath),
+          read_file_to_string(ProgPath, Prog, []),
+          assertion(\+ sub_string(Prog, _, _, _, "Raw(\"switch_on_")),
+          assertion(sub_string(Prog, _, _, _, "SwitchOnTerm()")),
+          directory_file_path(TmpDir, 'R', RDir),
+          run_rscript_query(RDir, 'r_a2_ft_backtracks/0', FtOut),
+          assertion(once(sub_string(FtOut, _, _, _, "true"))),
+          run_rscript_query(RDir, 'r_a2_const_ok/0', ConstOut),
+          assertion(once(sub_string(ConstOut, _, _, _, "true"))),
+          run_rscript_query(RDir, 'r_a2_struct_ok/0', StructOut),
+          assertion(once(sub_string(StructOut, _, _, _, "true")))
+        ),
+        ( ( exists_directory(TmpDir)
+          -> delete_directory_and_contents(TmpDir) ; true ),
+          maplist(retractall,
+                  [user:r_a2_ft(_,_), user:r_a2_ft_backtracks,
+                    user:r_a2_const(_,_), user:r_a2_const_ok,
+                    user:r_a2_struct(_,_), user:r_a2_struct_ok])
+        )), !.
+
 :- end_tests(wam_r_generator).
 
 % ------------------------------------------------------------------

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -4895,6 +4895,12 @@ test(r_a2_fallthrough_preserves_backtracking,
     assertz((user:r_a2_struct(Out, g(_)) :- Out = ok)),
     assertz((user:r_a2_struct(Out, h(_)) :- Out = ok)),
     assertz((user:r_a2_struct_ok :- user:r_a2_struct(ok, g(1)))),
+    compile_predicate_to_wam_items(user:r_a2_ft/2, [], FtItems),
+    assertion(member(switch_on_constant_a2_fallthrough(_), FtItems)),
+    compile_predicate_to_wam_items(user:r_a2_const/2, [], ConstItems),
+    assertion(member(switch_on_constant_a2(_), ConstItems)),
+    compile_predicate_to_wam_items(user:r_a2_struct/2, [], StructItems),
+    assertion(member(switch_on_structure_a2(_), StructItems)),
     unique_r_tmp_dir('tmp_r_a2_ft', TmpDir),
     call_cleanup(
         ( write_wam_r_project(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Correctness-first handling for the three remaining R A2 switch-index opcodes that previously fell through to `Raw(...)`. All three lower to the existing linear `SwitchOnTerm()` no-op so the try/retry/trust clause chain remains authoritative. No new runtime instruction, dispatcher, or indexing algorithm.

## Preflight evidence

Generated predicates with free A1 and three A2 shapes:

| Opcode | Fixture shape | Previous R translation |
|---|---|---|
| `switch_on_constant_a2` | all-constant A2 clauses | `Raw(...)` |
| `switch_on_constant_a2_fallthrough` | constant A2 prefix plus trailing variable clause | `Raw(...)` |
| `switch_on_structure_a2` | all-compound A2 clauses with distinct functors | `Raw(...)` |

Each hint precedes a complete linear clause-choice chain. Per #3873, no fallthrough variant may reuse `SwitchOnConstant`: an indexed jump can bypass `TryMeElse` and lose later alternatives on backtracking.

## Implementation

Three compact `wam_parts_to_r/2` clauses map the remaining A2 hints to `SwitchOnTerm()`. This is an unindexed correctness fallback, not optimized A2 dispatch.

`templates/targets/r_wam/runtime.R.mustache` is unchanged; no new template machinery was needed.

## Tests and review corrections

`tests/test_wam_r_generator.pl` covers:

1. all three token translations produce `SwitchOnTerm()`;
2. compiler-generated WAM items for the fixtures contain their exact expected A2 opcodes;
3. generated R contains no `Raw("switch_on_...")`;
4. a bound-A2 query rejects the specific constant answer and successfully backtracks to the trailing variable clause;
5. all-constant and all-compound fixtures execute successfully.

Review found that the original hosted R job still named only #3873's tests. The existing `WAM R Conformance (interpreter + functions)` job now runs the two A2 regressions as well. No additional job or harness was added.

## Validation

Review head `c92635f`, Actions run #13728:

- all five A1+A2 switch-index regressions: **PASS**
- A2 Rscript backtracking fixture: **PASS**
- no PLUnit choicepoint warning
- full `r,r_functions` classic conformance: **PASS**
- all ten sampled fleet WAM jobs: **PASS**
- C# smoke: **PASS**
- repository-wide `test`: still running at last review poll

Local review checks:

- `git diff --check`: **PASS**
- workflow YAML parse: **PASS**
- SWI-Prolog/R unavailable locally; hosted R is the runtime authority

## Scope

| | |
|---|---:|
| Additions | **86** |
| Deletions | **8** |
| Net | **+78** |
| Files | **5** |

The fifth file is the existing workflow command needed to make the new runtime regression merge-gating; it does not introduce a new CI job.

## Documentation

- `docs/WAM_SWITCH_INDEXING_CROSS_TARGET.md`: R A2 cells marked as safe linear fallbacks
- `docs/WAM_R_STATUS.md`: remaining A2 hints documented as unoptimized `SwitchOnTerm()` mappings
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
