### PR TITLE
Add Rust WAM system name builtins

### DIFF
--- a/templates/targets/rust_wam/process_builtin.rs.mustache
+++ b/templates/targets/rust_wam/process_builtin.rs.mustache
@@ -45,6 +45,64 @@
     fn process_identity(_op: &str) -> Option<i64> {
         None
     }
+
+    #[cfg(unix)]
+    fn system_name(op: &str) -> Option<String> {
+        if op == "gethostname/1" {
+            extern "C" {
+                fn gethostname(
+                    name: *mut std::os::raw::c_char,
+                    len: usize,
+                ) -> std::os::raw::c_int;
+            }
+
+            let mut buffer = [0u8; 256];
+            if unsafe { gethostname(buffer.as_mut_ptr().cast(), buffer.len()) } != 0 {
+                return None;
+            }
+            let end = buffer.iter().position(|byte| *byte == 0)?;
+            return String::from_utf8(buffer[..end].to_vec()).ok();
+        }
+
+        let field_index = match op {
+            "uname_sysname/1" => 0usize,
+            "uname_machine/1" => 4usize,
+            _ => return None,
+        };
+        let field_width = if cfg!(any(target_os = "linux", target_os = "android")) {
+            65usize
+        } else if cfg!(any(
+            target_os = "macos", target_os = "ios", target_os = "tvos",
+            target_os = "watchos", target_os = "freebsd", target_os = "dragonfly",
+            target_os = "netbsd", target_os = "openbsd"
+        )) {
+            256usize
+        } else if cfg!(any(target_os = "solaris", target_os = "illumos")) {
+            257usize
+        } else {
+            return None;
+        };
+
+        #[repr(align(16))]
+        struct UnameBuffer([u8; 2048]);
+        extern "C" {
+            fn uname(name: *mut std::ffi::c_void) -> std::os::raw::c_int;
+        }
+
+        let mut buffer = UnameBuffer([0u8; 2048]);
+        if unsafe { uname(buffer.0.as_mut_ptr().cast()) } != 0 {
+            return None;
+        }
+        let start = field_index * field_width;
+        let field = &buffer.0[start..start + field_width];
+        let end = field.iter().position(|byte| *byte == 0)?;
+        String::from_utf8(field[..end].to_vec()).ok()
+    }
+
+    #[cfg(not(unix))]
+    fn system_name(_op: &str) -> Option<String> {
+        None
+    }
 {{case arms}}
             "getuid/1" | "geteuid/1" | "getgid/1" | "getegid/1"
             | "getppid/1" | "getpgrp/1" => {
@@ -55,6 +113,20 @@
                 let output = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
                 let mark = self.trail.len();
                 if self.unify(&output, &identity) {
+                    self.pc += 1; true
+                } else {
+                    self.unwind_trail_to(mark);
+                    false
+                }
+            }
+            "gethostname/1" | "uname_sysname/1" | "uname_machine/1" => {
+                let name = match Self::system_name(op) {
+                    Some(name) => Value::Atom(name),
+                    None => return false,
+                };
+                let output = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+                let mark = self.trail.len();
+                if self.unify(&output, &name) {
                     self.pc += 1; true
                 } else {
                     self.unwind_trail_to(mark);

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -114,6 +114,12 @@ t_process_identity(Uid, EUid, Gid, EGid, PPid, PGrp) :-
     getppid(PPid),
     getpgrp(PGrp).
 
+:- dynamic t_system_names/3.
+t_system_names(Host, Sysname, Machine) :-
+    gethostname(Host),
+    uname_sysname(Sysname),
+    uname_machine(Machine).
+
 :- dynamic t_process_commands/2.
 t_process_commands(Status, Output) :-
     shell('exit 0'),
@@ -409,6 +415,7 @@ test_builtin_parity_execution :-
              user:t_file_metadata/2,
              user:t_system_queries/3,
              user:t_process_identity/6,
+             user:t_system_names/3,
              user:t_process_commands/2,
              user:t_sleep/0,
              user:t_halt_zero/0,
@@ -454,6 +461,7 @@ use builtin_parity_test::{t_between_1, t_msort_1, t_sort_1, t_sort4_1, t_concat_
     t_file_metadata_2,
     t_system_queries_3,
     t_process_identity_6,
+    t_system_names_3,
     t_process_commands_2,
     t_sleep_0,
     t_environment_mutation_1,
@@ -501,6 +509,33 @@ fn native_process_identity() -> [i64; 6] {
             i64::from(getpgrp()),
         ]
     }
+}
+
+#[cfg(unix)]
+fn native_host_name() -> String {
+    extern "C" {
+        fn gethostname(
+            name: *mut std::os::raw::c_char,
+            len: usize,
+        ) -> std::os::raw::c_int;
+    }
+
+    let mut buffer = [0u8; 256];
+    assert_eq!(unsafe { gethostname(buffer.as_mut_ptr().cast(), buffer.len()) }, 0);
+    let end = buffer.iter().position(|byte| *byte == 0).unwrap();
+    String::from_utf8(buffer[..end].to_vec()).unwrap()
+}
+
+#[cfg(unix)]
+fn native_uname(flag: &str) -> String {
+    let output = std::process::Command::new("uname").arg(flag).output().unwrap();
+    assert!(output.status.success());
+    let mut value = String::from_utf8(output.stdout).unwrap();
+    while value.ends_with(char::from(10)) || value.ends_with(char::from(13)) {
+        value.pop();
+    }
+    assert!(!value.is_empty());
+    value
 }
 
 fn read_var(vm: &WamState, name: &str) -> Value {
@@ -713,6 +748,23 @@ fn test_process_identity_compiled() {
         ("PGrp", expected[5]),
     ] {
         assert_eq!(read_var(&vm, name), i(value), "unexpected {name}");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn test_system_names_compiled() {
+    let expected = [native_host_name(), native_uname("-s"), native_uname("-m")];
+    let mut vm = vmnew();
+    assert!(t_system_names_3(
+        &mut vm, ub("Host"), ub("Sysname"), ub("Machine")));
+
+    for (name, value) in [
+        ("Host", &expected[0]),
+        ("Sysname", &expected[1]),
+        ("Machine", &expected[2]),
+    ] {
+        assert_eq!(read_var(&vm, name), a(value), "unexpected {name}");
     }
 }
 
@@ -2447,6 +2499,32 @@ fn test_process_identity_direct() {
         assert!(!call1(op, i(value + 1)).0, "{op} must reject a mismatch");
         assert!(!call1(op, a("not_an_integer")).0);
         assert!(!vmnew().execute_builtin(op, 1));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn test_system_names_direct() {
+    for (op, value) in [
+        ("gethostname/1", native_host_name()),
+        ("uname_sysname/1", native_uname("-s")),
+        ("uname_machine/1", native_uname("-m")),
+    ] {
+        let (ok, vm) = call1(op, ub("Value"));
+        assert!(ok, "{op} must succeed");
+        assert_eq!(read_var(&vm, "Value"), a(&value));
+        assert!(call1(op, a(&value)).0, "{op} must accept its current value");
+        assert!(!call1(op, a(&format!("{value}-mismatch"))).0);
+        assert!(!call1(op, i(7)).0);
+        assert!(!vmnew().execute_builtin(op, 1));
+    }
+}
+
+#[cfg(not(unix))]
+#[test]
+fn test_system_names_unavailable_direct() {
+    for op in ["gethostname/1", "uname_sysname/1", "uname_machine/1"] {
+        assert!(!call1(op, ub("Value")).0);
     }
 }
 

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -472,6 +472,10 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, '"getegid/1"'),
         sub_string(S, _, _, _, '"getppid/1"'),
         sub_string(S, _, _, _, '"getpgrp/1"'),
+        sub_string(S, _, _, _, 'fn system_name'),
+        sub_string(S, _, _, _, '"gethostname/1"'),
+        sub_string(S, _, _, _, '"uname_sysname/1"'),
+        sub_string(S, _, _, _, '"uname_machine/1"'),
         sub_string(S, _, _, _, 'fn shell_process'),
         sub_string(S, _, _, _, '"shell/1"'),
         sub_string(S, _, _, _, '"shell/2"'),
@@ -1440,7 +1444,7 @@ test_compile_wam_runtime_output :-
         sub_string(S, _, _, _, 'collect_native_transitive_parent_distance_results'),
         sub_string(S, _, _, _, 'collect_native_transitive_step_parent_distance_results'),
         sub_string(S, _, _, _, 'collect_native_weighted_shortest_path_results'),
-        sub_string(S, _, _, _, 'collect_native_astar_shortest_path_results')
+        sub_string(S, _, _, _, 'collect_native_astar_shortest_path_cost')
     ->  pass(Test)
     ;   fail_test(Test, 'Runtime impl block incomplete')
     ).


### PR DESCRIPTION
## Summary

add Rust hybrid WAM support for gethostname/1, uname_sysname/1, and uname_machine/1

query libc directly using dependency-free, Unix-gated FFI

support common Linux, Darwin/BSD, and Solaris utsname layouts

fail cleanly on unsupported platforms

add compiled-predicate and direct-dispatch parity coverage

update the stale A* runtime assertion to expect collect_native_astar_shortest_path_cost


## Testing

swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl

swipl -q -s tests/test_wam_rust_target.pl

swipl -q -g run_tests -t halt tests/test_wam_rust_builtin_parity.pl

git diff --check :::


::git-create-branch ::git-stage ::git-commit ::git-push