### PR TITLE
LMDB-R-0: versioned arg1-indexed on-demand fact source for hybrid WAM R

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,9 +229,9 @@ jobs:
       - name: Create smoke temp root
         run: mkdir -p "$UW_SMOKE_TMPDIR"
 
-      - name: Run R switch-index regressions (A1 + A2)
+      - name: Run R focused regressions (switch-index + LMDB)
         run: |
-          swipl -q -f init.pl -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:switch_on_constant_fallthrough_is_linear_noop,wam_r_generator:switch_on_term_a2_is_switch_on_term_noop,wam_r_generator:switch_on_constant_fallthrough_preserves_backtracking,wam_r_generator:r_a2_switch_hints_are_linear_noop,wam_r_generator:r_a2_fallthrough_preserves_backtracking])" -t halt
+          swipl -q -f init.pl -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:switch_on_constant_fallthrough_is_linear_noop,wam_r_generator:switch_on_term_a2_is_switch_on_term_noop,wam_r_generator:switch_on_constant_fallthrough_preserves_backtracking,wam_r_generator:r_a2_switch_hints_are_linear_noop,wam_r_generator:r_a2_fallthrough_preserves_backtracking,wam_r_generator:lmdb_r0_source_dispatch_selection,wam_r_generator:lmdb_arg1_v1_mock_adapter_lookup_and_stream,wam_r_generator:lmdb_arg1_v1_real_binding_e2e_rscript])" -t halt
 
       - name: Run full R classic conformance
         run: |

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -46,7 +46,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | LMDB-SCALA | LMDB policy tiers | Scala | M | — |
 | LMDB-C-0 | LMDB lookup source (prereq) | C | M | — |
 | LMDB-C | LMDB policy tiers | C | L | LMDB-C-0 |
-| LMDB-R-0 | LMDB lookup source (prereq) | R | M | — |
+| LMDB-R-0 ✅ | LMDB lookup source (prereq) | R | M | done (`lmdb_arg1_v1`) |
 | LMDB-R | LMDB policy tiers | R | L | LMDB-R-0 |
 | ISO-C | ISO three-form (new) | C | L | — |
 | ISO-GO | ISO three-form (new) | Go | L | — |
@@ -345,15 +345,14 @@ path, not the reverse index.
   3. Dispatch on Mode at fact-source construction; gate all under `#ifdef WAM_C_ENABLE_LMDB`.
 - **Acceptance:** `swipl -q -g run_tests -t halt -l tests/test_wam_c_target.pl` passes new assertions that generated C emits eager (`wam_fact_source_load_lmdb`), lazy (cursor find, no cache), and cached (cursor + L2 capacity) code per mode; C still compiles with `-DWAM_C_ENABLE_LMDB` (verify: repo's C-build smoke, e.g. `test_wam_c_target.pl` build step).
 
-### LMDB-R-0 (prerequisite): On-demand LMDB lookup source in the R runtime
-- **Lever:** LMDB policy tiers  **Target:** R  **Size:** M  **Depends on:** —
-- **Goal:** R currently only has `read_facts_lmdb` (load-everything, `wam_r_target.pl:1458`); add a per-key LMDB query function to `runtime.R.mustache` so lazy/cached tiers are possible.
-- **Files to touch:** `templates/targets/r_wam/runtime.R.mustache` (add `WamRuntime$lookup_facts_lmdb`/`stream_facts_lmdb`); `src/unifyweaver/targets/wam_r_target.pl` (`fact_source_loader_call` line 1458, `emit_external_fact_source` 1414); `tests/test_wam_r_generator.pl`.
-- **Reference to copy from:** Scala `LmdbFactSource.lookupByArg1`/`streamAll` (`runtime.scala.mustache:339,327`) and Go `lmdbAtomFact2Source.LookupArg1` (`wam_go_target.pl:2932`) for the lookup-by-arg1 + stream-all contract; existing R `read_facts_lmdb` for the LMDB-open/intern-table conventions.
-- **Steps:**
-  1. Add an R function opening the LMDB env and returning tuples for a given ground arg1 key (arity ≥ 2, split the tab-joined value into registers 2..N as F#/Scala do), plus a streaming full-scan variant.
-  2. Expose both via `WamRuntime$` alongside `read_facts_lmdb` and make the fact-source loader able to select the on-demand path.
-- **Acceptance:** `swipl -q -g run_tests -t halt -l tests/test_wam_r_generator.pl` passes a case asserting the generated R runtime defines the per-key lookup + stream functions and they are selectable as a fact-source backend.
+### LMDB-R-0 ✅ (prerequisite): On-demand LMDB lookup source in the R runtime
+- **Status:** Landed. Selectable `lmdb_arg1_v1(Path)` fact source with
+  versioned schema (`__uw_schema__=lmdb_arg1_v1`), exact-key ground-arg1
+  lookup via `WamRuntime$lmdb_arg1_v1_lookup` / `lmdb_arg1_v1_dispatch`,
+  and explicit `lmdb_arg1_v1_stream` for unbound arg1. Legacy `lmdb(Path)`
+  remains eager `read_facts_lmdb`. Injectable `lmdb_kv_adapter` proves
+  get-without-list; thor/lmdbr e2e is conditional.
+- **Open follow-up:** LMDB-R eager/lazy/cached/auto policy tiers.
 
 ### LMDB-R: Add eager/lazy/cached tiers to R LMDB fact source
 - **Lever:** LMDB policy tiers  **Target:** R  **Size:** L  **Depends on:** LMDB-R-0

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -39,8 +39,10 @@ native(parse_term))` — R is one of only two backends (with C++) whose
 runtime-parser default is native, with the compiled
 `prolog_term_parser` available as an opt-in fallback.
 
-**Optional LMDB.** Load-everything LMDB fact path (not the
-lazy/cached tiers of F#/Haskell).
+**Optional LMDB.** Legacy `lmdb(Path)` remains load-everything.
+Versioned `lmdb_arg1_v1(Path)` adds on-demand exact-key arg1 lookup
+(plus explicit stream-all for unbound arg1). Lazy/cached L1/L2 tiers
+remain open (LMDB-R).
 
 ## Gaps (relative to Rust / Haskell / F#)
 
@@ -49,14 +51,15 @@ lazy/cached tiers of F#/Haskell).
   forms (`switch_on_constant_a2`, `_a2_fallthrough`, `switch_on_structure_a2`)
   — map to the existing `SwitchOnTerm()` linear no-op (not optimized A2
   dispatch), preserving the full try/retry/trust chain.
-- **LMDB is load-everything** — no lazy/cached two-level policies.
+- **LMDB-R policy tiers** (eager/lazy/cached/auto) still open; LMDB-R-0
+  on-demand lookup source is landed.
 - **ISO error support** is `tryCatch`-level only, not the three-form
   contract.
 - No dedicated effective-distance cross-target bench row.
 
 ## Path forward
 
-1. Lazy/cached LMDB policies over the load-everything path.
+1. LMDB-R eager/lazy/cached tiers over `lmdb_arg1_v1` lookup/stream.
 2. ISO three-form adoption if R joins the error-fidelity set.
 3. Effective-distance cross-target matrix row.
 

--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -342,7 +342,9 @@ supported today:
 - `lmdb_arg1_v1('path.lmdb')` -- versioned on-demand arg1 index
   (arity ≥ 2): ground arg1 → exact-key get; unbound → stream-all.
   Schema key `__uw_schema__=lmdb_arg1_v1`; values are NL-buckets of
-  TAB-tagged args 2..N. Writer: `lmdb_write_facts_arg1_v1`.
+  TAB-tagged args 2..N. Atom payloads use URL percent-encoding so tabs,
+  newlines, percent signs, and other reserved bytes remain unambiguous.
+  Writer: `lmdb_write_facts_arg1_v1`.
 
 ```prolog
 :- write_wam_r_project(

--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -337,12 +337,12 @@ supported today:
 - `grouped_by_first('data.tsv')` -- tab-separated rows shaped as
   `key<TAB>v1<TAB>v2<TAB>...`; the loader explodes each row into
   separate `(key, vK)` tuples. Arity-2 only.
-- `lmdb('path.lmdb')` -- on-disk LMDB env containing one fact per
-  key, value encoded as TAB-separated `tag:payload` fields. Any
-  arity. Requires an R LMDB binding (see *LMDB install* below);
-  loader returns an empty fact table with a warning if the binding
-  is absent. Step-1 semantics: load-everything (treats LMDB as a
-  serialization format); step-2 probe-on-demand is a follow-up.
+- `lmdb('path.lmdb')` -- legacy load-everything LMDB (opaque keys,
+  full-tuple values). Requires thor/lmdbr; empty table if absent.
+- `lmdb_arg1_v1('path.lmdb')` -- versioned on-demand arg1 index
+  (arity ≥ 2): ground arg1 → exact-key get; unbound → stream-all.
+  Schema key `__uw_schema__=lmdb_arg1_v1`; values are NL-buckets of
+  TAB-tagged args 2..N. Writer: `lmdb_write_facts_arg1_v1`.
 
 ```prolog
 :- write_wam_r_project(

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -1428,6 +1428,32 @@ fact_source_pi_match(Name/Ar, P, Arity) :-
 %  generated loader output feeds the same build_fact_indexes +
 %  fact_table_dispatch pipeline used by inline fact tables, so
 %  per-arg indexing and dispatch are unchanged across backends.
+%
+%  lmdb_arg1_v1(Path) is the versioned on-demand exception: no eager
+%  load / build_fact_indexes; the iterator probes LMDB per call.
+emit_external_fact_source(Pred, Arity, lmdb_arg1_v1(Path),
+                          DataDecl, LoweredFunc, FuncName) :- !,
+    (   Arity >= 2
+    ->  true
+    ;   throw(error(domain_error(arity_ge_2_for_lmdb_arg1_v1, Arity), _))
+    ),
+    r_pred_name(Pred, RName),
+    format(atom(PathVar), '~w_lmdb_path', [RName]),
+    format(atom(FuncName), '~w_fact_iter', [RName]),
+    atom_string(Path, PathStr),
+    r_string_literal(PathStr, PathLit),
+    format(string(DataDecl),
+'# External fact source for ~w/~w (lmdb_arg1_v1 on-demand: ~w)
+~w <- ~w',
+        [Pred, Arity, PathStr, PathVar, PathLit]),
+    fact_args_collect(Arity, ArgsCollect),
+    format(string(LoweredFunc),
+'~w <- function(program, state) {
+  args <- ~w
+  WamRuntime$lmdb_arg1_v1_dispatch(program, state, ~w, ~wL, args,
+                                    state$pc + 1L)
+}',
+        [FuncName, ArgsCollect, PathVar, Arity]).
 emit_external_fact_source(Pred, Arity, Spec,
                           DataDecl, LoweredFunc, FuncName) :-
     r_pred_name(Pred, RName),

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3659,7 +3659,7 @@ WamRuntime$lmdb_arg1_v1_id <- "lmdb_arg1_v1"
 WamRuntime$lmdb_parse_tagged_field <- function(p, intern_table) {
   if (nchar(p) < 2L || substr(p, 2L, 2L) != ":") return(Atom(WamRuntime$intern(intern_table, p)))
   tag <- substr(p, 1L, 1L); payload <- substr(p, 3L, nchar(p))
-  if (tag == "a") Atom(WamRuntime$intern(intern_table, payload))
+  if (tag == "a") Atom(WamRuntime$intern(intern_table, URLdecode(payload)))
   else if (tag == "i") IntTerm(as.integer(payload))
   else if (tag == "f") FloatTerm(as.numeric(payload))
   else Atom(WamRuntime$intern(intern_table, p))
@@ -3673,7 +3673,7 @@ WamRuntime$lmdb_parse_tagged_tuple <- function(raw, intern_table) {
 }
 WamRuntime$lmdb_encode_tagged_field <- function(v, intern_table) {
   if (is.null(v) || !is.list(v) || is.null(v$tag)) return("a:?")
-  if (v$tag == "atom") paste0("a:", WamRuntime$string_of(intern_table, v$id))
+  if (v$tag == "atom") paste0("a:", URLencode(WamRuntime$string_of(intern_table, v$id), reserved = TRUE))
   else if (v$tag == "int") paste0("i:", as.character(v$val))
   else if (v$tag == "float") paste0("f:", format(v$val, digits = 17))
   else paste0("a:?", v$tag)
@@ -3726,8 +3726,12 @@ WamRuntime$lmdb_kv_put_all <- function(path, pairs) {
   }
   FALSE
 }
-WamRuntime$lmdb_arg1_v1_ok <- function(path)
-  identical(WamRuntime$lmdb_kv_get(path, WamRuntime$lmdb_schema_key), WamRuntime$lmdb_arg1_v1_id)
+WamRuntime$lmdb_arg1_v1_ok <- function(path) {
+  raw <- WamRuntime$lmdb_kv_get(path, WamRuntime$lmdb_schema_key)
+  if (is.null(raw)) return(FALSE)
+  value <- if (is.raw(raw)) rawToChar(raw) else as.character(raw)
+  length(value) == 1L && identical(value[[1]], WamRuntime$lmdb_arg1_v1_id)
+}
 WamRuntime$lmdb_arg1_v1_expand <- function(key_str, raw, intern_table, arity) {
   a1 <- WamRuntime$lmdb_parse_tagged_field(key_str, intern_table)
   s <- if (is.raw(raw)) rawToChar(raw) else as.character(raw); out <- list()

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3650,6 +3650,133 @@ WamRuntime$lmdb_pick_pkg <- function() {
   NULL
 }
 
+# --- lmdb_arg1_v1: versioned on-demand arg1 index (not legacy numeric keys) ---
+# Schema: "__uw_schema__"="lmdb_arg1_v1"; key=tagged arg1; value=NL-rows of TAB args2..N
+# Adapter (tests): lmdb_kv_adapter=list(get=, list=, put_all=)
+WamRuntime$lmdb_kv_adapter <- NULL
+WamRuntime$lmdb_schema_key <- "__uw_schema__"
+WamRuntime$lmdb_arg1_v1_id <- "lmdb_arg1_v1"
+WamRuntime$lmdb_parse_tagged_field <- function(p, intern_table) {
+  if (nchar(p) < 2L || substr(p, 2L, 2L) != ":") return(Atom(WamRuntime$intern(intern_table, p)))
+  tag <- substr(p, 1L, 1L); payload <- substr(p, 3L, nchar(p))
+  if (tag == "a") Atom(WamRuntime$intern(intern_table, payload))
+  else if (tag == "i") IntTerm(as.integer(payload))
+  else if (tag == "f") FloatTerm(as.numeric(payload))
+  else Atom(WamRuntime$intern(intern_table, p))
+}
+WamRuntime$lmdb_parse_tagged_tuple <- function(raw, intern_table) {
+  if (is.null(raw)) return(NULL)
+  s <- if (is.raw(raw)) rawToChar(raw) else as.character(raw)
+  parts <- strsplit(s, "\t", fixed = TRUE)[[1]]
+  if (!length(parts)) return(NULL)
+  lapply(parts, function(p) WamRuntime$lmdb_parse_tagged_field(p, intern_table))
+}
+WamRuntime$lmdb_encode_tagged_field <- function(v, intern_table) {
+  if (is.null(v) || !is.list(v) || is.null(v$tag)) return("a:?")
+  if (v$tag == "atom") paste0("a:", WamRuntime$string_of(intern_table, v$id))
+  else if (v$tag == "int") paste0("i:", as.character(v$val))
+  else if (v$tag == "float") paste0("f:", format(v$val, digits = 17))
+  else paste0("a:?", v$tag)
+}
+WamRuntime$lmdb_kv_get <- function(path, key) {
+  ad <- WamRuntime$lmdb_kv_adapter; if (!is.null(ad)) return(ad$get(path, key))
+  pkg <- WamRuntime$lmdb_pick_pkg(); if (is.null(pkg)) return(NULL)
+  if (pkg == "thor") {
+    env <- tryCatch(thor::mdb_env(path, create = FALSE), error = function(e) NULL)
+    if (is.null(env)) return(NULL); on.exit(try(env$close(), silent = TRUE), add = TRUE)
+    return(tryCatch(env$get(key, missing_is_error = FALSE), error = function(e) NULL))
+  }
+  if (pkg == "lmdbr") {
+    env <- tryCatch(lmdbr::mdb_env(path), error = function(e) NULL)
+    if (is.null(env)) return(NULL); on.exit(try(lmdbr::mdb_env_close(env), silent = TRUE), add = TRUE)
+    return(tryCatch(lmdbr::mdb_get(env, key), error = function(e) NULL))
+  }
+  NULL
+}
+WamRuntime$lmdb_kv_list <- function(path) {
+  ad <- WamRuntime$lmdb_kv_adapter; if (!is.null(ad)) return(ad$list(path))
+  pkg <- WamRuntime$lmdb_pick_pkg(); if (is.null(pkg)) return(character(0))
+  if (pkg == "thor") {
+    env <- tryCatch(thor::mdb_env(path, create = FALSE), error = function(e) NULL)
+    if (is.null(env)) return(character(0)); on.exit(try(env$close(), silent = TRUE), add = TRUE)
+    keys <- tryCatch(env$list(), error = function(e) NULL)
+    return(if (is.null(keys)) character(0) else as.character(keys))
+  }
+  if (pkg == "lmdbr") {
+    env <- tryCatch(lmdbr::mdb_env(path), error = function(e) NULL)
+    if (is.null(env)) return(character(0)); on.exit(try(lmdbr::mdb_env_close(env), silent = TRUE), add = TRUE)
+    keys <- tryCatch(lmdbr::mdb_list(env), error = function(e) NULL)
+    return(if (is.null(keys)) character(0) else as.character(keys))
+  }
+  character(0)
+}
+WamRuntime$lmdb_kv_put_all <- function(path, pairs) {
+  ad <- WamRuntime$lmdb_kv_adapter; if (!is.null(ad)) return(isTRUE(ad$put_all(path, pairs)))
+  pkg <- WamRuntime$lmdb_pick_pkg(); if (is.null(pkg)) return(FALSE)
+  keys <- names(pairs)
+  if (pkg == "thor") {
+    env <- tryCatch(thor::mdb_env(path, create = TRUE), error = function(e) NULL)
+    if (is.null(env)) return(FALSE); on.exit(try(env$close(), silent = TRUE), add = TRUE)
+    return(tryCatch({ for (k in keys) env$put(k, pairs[[k]]); TRUE }, error = function(e) FALSE))
+  }
+  if (pkg == "lmdbr") {
+    env <- tryCatch(lmdbr::mdb_env(path, create = TRUE), error = function(e) NULL)
+    if (is.null(env)) return(FALSE); on.exit(try(lmdbr::mdb_env_close(env), silent = TRUE), add = TRUE)
+    return(tryCatch({ for (k in keys) lmdbr::mdb_put(env, k, pairs[[k]]); TRUE }, error = function(e) FALSE))
+  }
+  FALSE
+}
+WamRuntime$lmdb_arg1_v1_ok <- function(path)
+  identical(WamRuntime$lmdb_kv_get(path, WamRuntime$lmdb_schema_key), WamRuntime$lmdb_arg1_v1_id)
+WamRuntime$lmdb_arg1_v1_expand <- function(key_str, raw, intern_table, arity) {
+  a1 <- WamRuntime$lmdb_parse_tagged_field(key_str, intern_table)
+  s <- if (is.raw(raw)) rawToChar(raw) else as.character(raw); out <- list()
+  for (row in strsplit(s, "\n", fixed = TRUE)[[1]]) {
+    if (!nzchar(row)) next
+    tail <- WamRuntime$lmdb_parse_tagged_tuple(row, intern_table)
+    if (!is.null(tail) && length(tail) == arity - 1L) out <- c(out, list(c(list(a1), tail)))
+  }
+  out
+}
+WamRuntime$lmdb_arg1_v1_lookup <- function(path, key_term, arity, intern_table) {
+  if (!WamRuntime$lmdb_arg1_v1_ok(path)) return(list())
+  key <- WamRuntime$lmdb_encode_tagged_field(key_term, intern_table)
+  raw <- WamRuntime$lmdb_kv_get(path, key)
+  if (is.null(raw)) list() else WamRuntime$lmdb_arg1_v1_expand(key, raw, intern_table, arity)
+}
+WamRuntime$lmdb_arg1_v1_stream <- function(path, arity, intern_table) {
+  if (!WamRuntime$lmdb_arg1_v1_ok(path)) return(list()); out <- list()
+  for (k in WamRuntime$lmdb_kv_list(path)) {
+    if (identical(k, WamRuntime$lmdb_schema_key)) next
+    raw <- WamRuntime$lmdb_kv_get(path, k)
+    if (!is.null(raw)) out <- c(out, WamRuntime$lmdb_arg1_v1_expand(k, raw, intern_table, arity))
+  }
+  out
+}
+WamRuntime$lmdb_arg1_v1_dispatch <- function(program, state, path, arity, args, resume_pc) {
+  table <- program$intern_table
+  if (!WamRuntime$lmdb_arg1_v1_ok(path)) return(FALSE)
+  a1 <- WamRuntime$deref(state, args[[1]])
+  ground <- !is.null(a1) && !is.null(a1$tag) && a1$tag %in% c("atom", "int", "float")
+  tuples <- if (ground) WamRuntime$lmdb_arg1_v1_lookup(path, a1, arity, table)
+            else WamRuntime$lmdb_arg1_v1_stream(path, arity, table)
+  if (!length(tuples)) return(FALSE)
+  WamRuntime$fact_table_iter(program, state, path, tuples, args, 1L, resume_pc)
+}
+WamRuntime$lmdb_write_facts_arg1_v1 <- function(path, facts, intern_table) {
+  buckets <- new.env(parent = emptyenv())
+  for (tup in facts) {
+    if (length(tup) < 2L) next
+    key <- WamRuntime$lmdb_encode_tagged_field(tup[[1]], intern_table)
+    tail <- paste(vapply(tup[-1], function(v) WamRuntime$lmdb_encode_tagged_field(v, intern_table), character(1)), collapse = "\t")
+    prev <- if (exists(key, envir = buckets, inherits = FALSE)) get(key, envir = buckets) else character(0)
+    assign(key, c(prev, tail), envir = buckets)
+  }
+  pairs <- list(); pairs[[WamRuntime$lmdb_schema_key]] <- WamRuntime$lmdb_arg1_v1_id
+  for (k in ls(envir = buckets, all.names = TRUE)) pairs[[k]] <- paste(get(k, envir = buckets), collapse = "\n")
+  WamRuntime$lmdb_kv_put_all(path, pairs)
+}
+
 # Build per-arg hash indexes for a runtime-loaded fact table.
 # Returns a list of N envs (one per arg position, where N = arity).
 # Each env follows the same shape as the codegen-emitted

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -4531,6 +4531,108 @@ r_escape_chars([C | Rest], Out) :-
     r_escape_chars(Rest, OutRest).
 
 % ------------------------------------------------------------------
+% LMDB-R-0: legacy lmdb/1 eager; lmdb_arg1_v1 on-demand + mock proof.
+% ------------------------------------------------------------------
+test(lmdb_r0_source_dispatch_selection) :-
+    once((
+        unique_r_tmp_dir('tmp_r_lmdb_r0_sel', Tmp),
+        write_wam_r_project([user:legedge/2],
+            [r_fact_sources([source(legedge/2, lmdb('/tmp/leg.lmdb'))])], Tmp),
+        directory_file_path(Tmp, 'R/generated_program.R', P1),
+        read_file_to_string(P1, C1, []),
+        assertion(sub_string(C1,_,_,_,'WamRuntime$read_facts_lmdb(')),
+        assertion(\+ sub_string(C1,_,_,_,'lmdb_arg1_v1_dispatch')),
+        delete_directory_and_contents(Tmp),
+        unique_r_tmp_dir('tmp_r_lmdb_r0_v1', Tmp2),
+        write_wam_r_project([user:ixedge/2],
+            [r_fact_sources([source(ixedge/2, lmdb_arg1_v1('/tmp/ix.lmdb'))])], Tmp2),
+        directory_file_path(Tmp2, 'R/generated_program.R', P2),
+        read_file_to_string(P2, C2, []),
+        assertion(sub_string(C2,_,_,_,'WamRuntime$lmdb_arg1_v1_dispatch(')),
+        assertion(\+ sub_string(C2,_,_,_,'WamRuntime$read_facts_lmdb(')),
+        assertion(\+ sub_string(C2,_,_,_,'build_fact_indexes')),
+        delete_directory_and_contents(Tmp2)
+    )).
+
+% Authoritative mock adapter (no thor required). Conditional real e2e below.
+test(lmdb_arg1_v1_mock_adapter_lookup_and_stream) :-
+    once((rscript_available -> lmdb_arg1_v1_mock_adapter_proof ; true)).
+
+lmdb_arg1_v1_mock_adapter_proof :-
+    unique_r_tmp_dir('tmp_r_lmdb_v1_mock', TmpDir),
+    write_wam_r_project([user:medge/2],
+        [intern_atoms([alice,bob,carol,eve,p,q,r]),
+         r_fact_sources([source(medge/2, lmdb_arg1_v1('mock.lmdb'))])], TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    directory_file_path(RDir, 'lmdb_arg1_v1_mock_proof.R', Script),
+    setup_call_cleanup(open(Script, write, S), write(S,
+'source("wam_runtime.R"); source("generated_program.R")
+store <- new.env(parent=emptyenv())
+assign("__uw_schema__","lmdb_arg1_v1",envir=store)
+assign("a:alice","a:bob\na:eve",envir=store); assign("a:bob","a:carol",envir=store)
+listed <<- 0L
+WamRuntime$lmdb_kv_adapter <- list(
+  get=function(path,key) if (exists(key,envir=store,inherits=FALSE)) get(key,envir=store) else NULL,
+  list=function(path){ listed <<- listed+1L; ls(envir=store,all.names=TRUE) },
+  put_all=function(path,pairs) TRUE)
+it <- intern_table
+rows <- WamRuntime$lmdb_arg1_v1_lookup("mock.lmdb", Atom(WamRuntime$intern(it,"alice")), 2L, it)
+stopifnot(length(rows)==2L, listed==0L)
+ys <- vapply(rows, function(t) WamRuntime$string_of(it,t[[2]]$id), character(1))
+stopifnot(setequal(ys,c("bob","eve")))
+stopifnot(length(WamRuntime$lmdb_arg1_v1_lookup("mock.lmdb", Atom(WamRuntime$intern(it,"zzz")), 2L, it))==0L, listed==0L)
+stopifnot(length(WamRuntime$lmdb_arg1_v1_stream("mock.lmdb", 2L, it))==3L, listed>=1L)
+assign("a:p","a:q\ti:3\na:r\ti:4",envir=store)
+t3 <- WamRuntime$lmdb_arg1_v1_lookup("mock.lmdb", Atom(WamRuntime$intern(it,"p")), 3L, it)
+stopifnot(length(t3)==2L, t3[[1]][[3]]$val==3L)
+st <- WamRuntime$new_state(); st$regs2[[1]] <- Atom(WamRuntime$intern(it,"alice"))
+st$regs2[[2]] <- Unbound("V0"); args <- list(st$regs2[[1]], st$regs2[[2]])
+stopifnot(isTRUE(WamRuntime$fact_table_iter(shared_program, st, "medge/2", rows, args, 1L, 0L)), length(st$cps)>=1L)
+cat("OK\n")
+'), close(S)),
+    process_create(path('Rscript'), [Script],
+                   [cwd(RDir), stdout(pipe(O)), stderr(pipe(E)), process(PID)]),
+    read_string(O, _, Out), close(O), read_string(E, _, Err), close(E),
+    process_wait(PID, Status),
+    assertion(Status == exit(0)), assertion(sub_string(Out,_,_,_,"OK")),
+    assertion(\+ sub_string(Err,_,_,_,"Error")),
+    delete_directory_and_contents(TmpDir).
+
+test(lmdb_arg1_v1_real_binding_e2e_rscript) :-
+    once((rscript_available, r_lmdb_pkg_available -> lmdb_arg1_v1_real_binding_e2e ; true)).
+
+lmdb_arg1_v1_real_binding_e2e :-
+    retractall(user:redge(_,_)), retractall(user:r_hit), retractall(user:r_miss), retractall(user:r_findall),
+    unique_r_tmp_dir('tmp_r_lmdb_v1_real', TmpDir), make_directory_path(TmpDir),
+    directory_file_path(TmpDir, 'redge.lmdb', LmdbPath), atom_string(LmdbPath, LmdbPathStr),
+    r_double_quoted_literal(LmdbPathStr, LmdbPathLit),
+    assertz((user:r_hit :- redge(alice, bob))),
+    assertz((user:r_miss :- redge(zzz, bob))),
+    assertz((user:r_findall :- findall(Y, redge(alice, Y), L), msort(L, S), S == [bob, eve])),
+    write_wam_r_project(
+        [user:redge/2, user:r_hit/0, user:r_miss/0, user:r_findall/0],
+        [intern_atoms([alice,bob,eve,zzz]),
+         r_fact_sources([source(redge/2, lmdb_arg1_v1(LmdbPathStr))])], TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    directory_file_path(RDir, 'seed_arg1_v1.R', Seed),
+    format(string(SeedSrc),
+'source("wam_runtime.R"); source("generated_program.R")
+facts <- list(
+  list(Atom(WamRuntime$intern(intern_table,"alice")), Atom(WamRuntime$intern(intern_table,"bob"))),
+  list(Atom(WamRuntime$intern(intern_table,"alice")), Atom(WamRuntime$intern(intern_table,"eve"))),
+  list(Atom(WamRuntime$intern(intern_table,"bob")), Atom(WamRuntime$intern(intern_table,"eve"))))
+stopifnot(WamRuntime$lmdb_write_facts_arg1_v1(~w, facts, intern_table))
+', [LmdbPathLit]),
+    setup_call_cleanup(open(Seed, write, S), write(S, SeedSrc), close(S)),
+    process_create(path('Rscript'), [Seed], [cwd(RDir), stdout(null), stderr(null), process(PID0)]),
+    process_wait(PID0, exit(0)),
+    run_rscript_query(RDir, 'r_hit/0', Hit), run_rscript_query(RDir, 'r_miss/0', Miss),
+    run_rscript_query(RDir, 'r_findall/0', FA),
+    assertion(sub_string(Hit,_,_,_,"true")), assertion(sub_string(Miss,_,_,_,"false")),
+    assertion(sub_string(FA,_,_,_,"true")),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
 % End-to-end: cut barrier truncates state$cps back to the depth at the
 % predicate's call site, so a `!` in a clause body that has just
 % returned from a multi-clause helper drops both the helper's leftover

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -4568,13 +4568,13 @@ lmdb_arg1_v1_mock_adapter_proof :-
     setup_call_cleanup(open(Script, write, S), write(S,
 'source("wam_runtime.R"); source("generated_program.R")
 store <- new.env(parent=emptyenv())
-assign("__uw_schema__","lmdb_arg1_v1",envir=store)
-assign("a:alice","a:bob\na:eve",envir=store); assign("a:bob","a:carol",envir=store)
+assign("__uw_schema__",charToRaw("lmdb_arg1_v1"),envir=store)
+assign("a:alice",charToRaw("a:bob\na:eve"),envir=store); assign("a:bob",charToRaw("a:carol"),envir=store)
 listed <<- 0L
 WamRuntime$lmdb_kv_adapter <- list(
   get=function(path,key) if (exists(key,envir=store,inherits=FALSE)) get(key,envir=store) else NULL,
   list=function(path){ listed <<- listed+1L; ls(envir=store,all.names=TRUE) },
-  put_all=function(path,pairs) TRUE)
+  put_all=function(path,pairs){ for(k in names(pairs)) assign(k,charToRaw(pairs[[k]]),envir=store); TRUE })
 it <- intern_table
 rows <- WamRuntime$lmdb_arg1_v1_lookup("mock.lmdb", Atom(WamRuntime$intern(it,"alice")), 2L, it)
 stopifnot(length(rows)==2L, listed==0L)
@@ -4582,9 +4582,14 @@ ys <- vapply(rows, function(t) WamRuntime$string_of(it,t[[2]]$id), character(1))
 stopifnot(setequal(ys,c("bob","eve")))
 stopifnot(length(WamRuntime$lmdb_arg1_v1_lookup("mock.lmdb", Atom(WamRuntime$intern(it,"zzz")), 2L, it))==0L, listed==0L)
 stopifnot(length(WamRuntime$lmdb_arg1_v1_stream("mock.lmdb", 2L, it))==3L, listed>=1L)
-assign("a:p","a:q\ti:3\na:r\ti:4",envir=store)
+assign("a:p",charToRaw("a:q\ti:3\na:r\ti:4"),envir=store)
 t3 <- WamRuntime$lmdb_arg1_v1_lookup("mock.lmdb", Atom(WamRuntime$intern(it,"p")), 3L, it)
 stopifnot(length(t3)==2L, t3[[1]][[3]]$val==3L)
+special <- "tab\tline\npercent%"
+special_fact <- list(list(Atom(WamRuntime$intern(it,special)), Atom(WamRuntime$intern(it,"value"))))
+stopifnot(WamRuntime$lmdb_write_facts_arg1_v1("mock.lmdb", special_fact, it))
+special_rows <- WamRuntime$lmdb_arg1_v1_lookup("mock.lmdb", Atom(WamRuntime$intern(it,special)), 2L, it)
+stopifnot(length(special_rows)==1L, WamRuntime$string_of(it,special_rows[[1]][[1]]$id)==special)
 st <- WamRuntime$new_state(); st$regs2[[1]] <- Atom(WamRuntime$intern(it,"alice"))
 st$regs2[[2]] <- Unbound("V0"); args <- list(st$regs2[[1]], st$regs2[[2]])
 stopifnot(isTRUE(WamRuntime$fact_table_iter(shared_program, st, "medge/2", rows, args, 1L, 0L)), length(st$cps)>=1L)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a genuine, versioned on-demand LMDB fact source for hybrid WAM R while preserving legacy `lmdb(Path)` load-everything behavior.

New source: `r_fact_sources([source(P/A, lmdb_arg1_v1(Path))])` for arity ≥ 2.

## Schema and dispatch

The legacy database uses opaque numeric keys and full-tuple values, so it cannot support exact arg1 lookup. `lmdb_arg1_v1` is intentionally distinct:

- metadata: `__uw_schema__=lmdb_arg1_v1`;
- data key: tagged, URL-percent-encoded arg1;
- data value: newline-separated buckets of tab-separated tagged args 2..N;
- ground scalar arg1: exact-key `get`, without `list()`;
- unbound arg1: explicit stream-all;
- multiple rows per arg1: one deterministic bucket, exposed through the existing fact iterator and choice-point protocol.

A specialized generated iterator calls `lmdb_arg1_v1_dispatch` directly. It does not call `read_facts_lmdb` or `build_fact_indexes`. Legacy `lmdb(Path)` remains unchanged and eager.

## Implementation

- **Mustache runtime:** shared tagged codec; thor/lmdbr KV adapters; schema validation; exact lookup, stream, dispatch, and writer.
- **Code generation:** selectable `lmdb_arg1_v1(Path)` fact-source clause.
- **Tests:** injectable mock adapter plus conditional real-binding e2e.
- No cached/L1/L2/auto policy was added; LMDB-R remains open.

## Review corrections

Review found and fixed three issues on head `574263e`:

1. thor/lmdbr may return raw byte vectors, but the schema marker was compared directly with a character string. The runtime now normalizes raw/character marker values.
2. v1 used tab/newline delimiters without escaping atom payloads. Atom payloads now use URL percent-encoding; the writer/reader round-trip tabs, newlines, percent signs, and reserved bytes.
3. The new LMDB tests were absent from hosted CI. The existing R job now runs the three LMDB-R-0 tests alongside the five switch-index regressions; no new job or harness was added.

## Validation

Actions run #13748 on `574263e`:

- eight focused R regressions, including raw-byte mock and delimiter round-trip: **PASS**
- no PLUnit choicepoint warnings
- full `r` and `r_functions` classic conformance: **PASS**
- all ten sampled fleet WAM jobs: **PASS**
- repository-wide `test` and C# smoke: still running at last review poll

The real thor/lmdbr e2e remains conditional because hosted CI installs base R without either binding. It is not counted as authoritative hosted binding proof; the raw-byte injectable adapter is the deterministic merge gate.

Local review checks:

- `git diff --check`: **PASS**
- workflow YAML parse: **PASS**
- SWI-Prolog/R unavailable locally; hosted R is the runtime authority

## Scope

| | |
|---|---:|
| Additions | **290** |
| Deletions | **22** |
| Net | **+268** |
| Files | **7** |

The size is justified by one reusable Mustache runtime implementation, two backend adapters, generated dispatch, focused tests, existing-CI wiring, and user-facing schema documentation. No duplicate runtime or parity harness was introduced.

## Documentation

- `docs/WAM_FLEET_GAP_TASKS.md`: LMDB-R-0 complete; LMDB-R tiers remain open
- `docs/WAM_R_STATUS.md`: on-demand lookup landed
- `docs/WAM_R_TARGET.md`: versioned schema and escaping contract
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
