### PR TITLE
mu_cosine: freeze explicit source declaration + two-process snapshot consensus

### DIFF
--- a/prototypes/mu_cosine/DESIGN_pearltrees_diffusion_consensus.md
+++ b/prototypes/mu_cosine/DESIGN_pearltrees_diffusion_consensus.md
@@ -1,0 +1,262 @@
+# Pearltrees diffusion source declaration and compilation consensus
+
+**Status:** prospective gate between the snapshot compiler and the bounded
+diffusion fidelity study. This gate declares the raw inputs explicitly and asks
+the same frozen compiler to reproduce one graph in two fresh processes. It does
+not run diffusion, select anchors, calibrate leakage, inspect filing labels, or
+claim that two executions are two independent graph observations. Detailed
+specifications, snapshots, and receipts remain local-only.
+
+This document complements
+[`DESIGN_pearltrees_diffusion_snapshot.md`](DESIGN_pearltrees_diffusion_snapshot.md)
+and satisfies the deterministic-recompilation prerequisite in
+[`PROTOCOL_bounded_diffusion_fidelity.md` Section 2](PROTOCOL_bounded_diffusion_fidelity.md#2-frozen-graph-and-conductance-regimes).
+
+## 1. Why there are two stages
+
+The snapshot compiler deliberately has no input discovery. The operator first
+creates one explicit source declaration, then independently executes the frozen
+compiler twice:
+
+```text
+human-reviewed explicit sources + relation policy
+  -> immutable local source specification
+  -> fresh compiler process A -> verify A
+  -> fresh compiler process B -> verify B
+  -> exact comparison -> immutable consensus receipt
+```
+
+Separating declaration from compilation prevents a second run from silently
+finding a newer export, a different API cache, or a filename-dependent account.
+Separating the executions into fresh processes tests deterministic repeatability
+and source stability. It does **not** protect against a parser defect shared by
+both executions, and it does not justify a two-sample uncertainty estimate.
+
+## 2. Explicit source declaration
+
+`declare_pearltrees_diffusion_sources.py` accepts only repeated, explicitly
+named source arguments. Each argument supplies a stable `source_id` and path;
+RDF additionally supplies its account. Supported kinds exactly match the frozen
+snapshot compiler: RDF, API SQLite, an API JSON directory, and path JSONL. A
+legacy assembled DAG may be named only as the optional parity diagnostic.
+
+```text
+declare_pearltrees_diffusion_sources.py \
+  --snapshot-label LABEL --local-root LOCAL_ROOT \
+  --output-dir NEW_DECLARATION_DIR --local-only \
+  [--rdf SOURCE_ID ACCOUNT PATH]... \
+  [--api-json-dir SOURCE_ID PATH]... \
+  [--api-sqlite SOURCE_ID PATH]... \
+  [--path-jsonl SOURCE_ID PATH]... \
+  [--legacy-dag PATH]
+```
+
+The declaration tool must never:
+
+- glob directories, choose the newest file, follow symlinks, or use an
+  environment-dependent default;
+- infer an RDF account from a filename or path;
+- harvest, repair, synthesize, or parse source content; or
+- treat the legacy DAG as an authoritative source.
+
+The canonical team-space RDF account is the literal `groups`, including for a
+historical source whose filename contains the misspelling `grous`. The account
+is a human-reviewed declaration, not a filename repair. Source IDs are unique,
+nonempty provenance labels; their ordering does not change the canonical
+specification.
+
+The tool checks only the declared filesystem type needed by the downstream
+adapter. Content validation and hashing remain the compiler's job. It writes a
+complete private declaration bundle into a new mode-0700 directory under an
+explicitly approved local root. The bundle contains exactly mode-0600
+`source_spec.json` (canonical `pearltrees-diffusion-source-spec-v1` JSON) and a
+mode-0600 `LOCAL_ONLY_DO_NOT_PUBLISH` marker with fixed bytes. It installs
+without replacement; the directory must be outside Git and no component may be
+a symlink. The local specification necessarily contains private source paths;
+standard output therefore reports only source-kind counts and success, never
+paths, IDs, labels, titles, or content hashes.
+
+Consensus accepts only this complete installed bundle, not an arbitrary
+schema-shaped JSON file. Before either child process it reruns the declaration
+validator over the directory/file modes, exact inventory and marker, canonical
+JSON, supported source kinds, explicit RDF accounts, canonical ordering,
+resolved absolute non-symlink paths of the declared types, unique IDs, and
+path/inode non-aliasing. The validator is repeated after each attempt, and its
+own content record is bound in the receipt.
+
+The relation policy is intentionally not generated here. It is a scientific
+choice and remains a separate, complete, human-reviewed input to the compiler.
+An installed declaration proves only an explicit deterministic inventory. It
+does not prove that the inventory is complete, current, authentic, or exhaustive
+of the user's account.
+
+## 3. Independent execution contract
+
+`prepare_pearltrees_diffusion_consensus.py` receives the immutable source
+specification, relation policy, approved local root, two new attempt directories,
+a new receipt directory, minimum-anchor threshold, and resource ceiling. It
+performs exactly these operations:
+
+```text
+prepare_pearltrees_diffusion_consensus.py prepare \
+  --source-spec SPEC --relation-policy POLICY \
+  --attempt-a-dir NEW_A --attempt-b-dir NEW_B --receipt-dir NEW_RECEIPT \
+  --local-root LOCAL_ROOT --local-only --minimum-anchors N \
+  --resource-ceiling-bytes N
+
+prepare_pearltrees_diffusion_consensus.py verify \
+  --receipt-dir RECEIPT --attempt-a-dir A --attempt-b-dir B \
+  --source-spec SPEC --relation-policy POLICY
+```
+
+1. verify the complete private declaration bundle, then reject path aliases,
+   symlinks, existing targets, in-repository outputs, and overlapping attempt
+   or receipt directories;
+2. invoke `prepare_pearltrees_diffusion_snapshot.py prepare` in a fresh process
+   for attempt A through the current Python executable in isolated mode,
+   accepting exit 0 or the documented scientific exit 2;
+3. invoke the compiler's independent `verify` command in another process;
+4. repeat the same pair of commands for attempt B without sharing artifacts;
+5. compare the verified manifests exactly on the consensus contract; and
+6. atomically install one local-only receipt and verify it against the frozen
+   inputs and both installed attempt directories. There is no third execution,
+   two-of-three rescue, or pooling of artifacts.
+
+Compiler exit 2 is a valid fail-closed scientific result: a verified snapshot
+may be privacy- or coverage-blocked. Operational failure, invalid output, or a
+failed verification is not consensus evidence and exits 1. A successfully
+written receipt exits 0 only when both snapshots are ready and exactly agree;
+an honest blocked receipt exits 2.
+
+Attempt A is the deterministic canonical downstream snapshot. Attempt B is
+repeatability evidence only. Artifacts are never pooled, averaged, or counted as
+two graphs. The compiler path is the fixed sibling implementation; an arbitrary
+compiler executable or `PATH` lookup is not allowed. Device/inode identities of
+the local root and every output parent are bound before execution and rechecked
+around child invocations and receipt installation, so a replaced parent fails
+closed.
+
+## 4. Exact agreement contract
+
+Both snapshots must independently verify. Consensus then requires equality of:
+
+- the exact source-specification and relation-policy content records observed
+  before attempt A and after attempt B;
+- the verified manifests after removing only the causally disconnected legacy
+  parity artifact record and aggregate status, while still requiring
+  `snapshot_label_hash`;
+- `snapshot_fingerprint` and the entire `fingerprint_core`;
+- scientific artifact records and their authoritative set hash (legacy parity
+  is excluded from the scientific fingerprint but its diagnostic status remains
+  recorded separately);
+- source-content and implementation records, repository commit, numeric
+  contract, privacy policy, and relation policy;
+- study-universe and largest-component hashes;
+- resource ceiling and observed byte contract;
+- aggregate counts, certification fields, and population hashes; and
+- the separately supplied minimum-anchor threshold, coverage decision,
+  `privacy_certified`, and `graph_asset_ready`.
+
+Exact fingerprint equality already binds most of these fields, but not the
+source-specification bytes, snapshot label, minimum-anchor threshold, or legacy
+parity. In particular, the v1 fingerprint records whether a source declared an
+account, not the declared account text itself. The exact specification content
+record therefore binds the human-reviewed RDF account declaration. The other
+explicit comparisons are retained as a defensive schema check and make
+readiness settings outside the fingerprint core impossible to overlook. Any
+scientific or readiness disagreement blocks; the gate does not select the more
+favorable run.
+
+Legacy parity remains causally disconnected. Its two artifact records and
+statuses are recorded and compared, but a legacy-only difference is a warning,
+not a graph-gate failure. It cannot make either a blocked graph ready or a ready
+graph blocked.
+
+## 5. Receipt and downstream chain
+
+The receipt is canonical JSON under a local-only marker and contains no paths,
+node IDs, titles, URLs, source IDs, or source labels. It records:
+
+- schema and algorithm identifiers;
+- exact source-specification and relation-policy content records;
+- the declaration validator, compiler entry point, and consensus-orchestrator
+  implementation records, plus the compiler-bound repository commit;
+- non-path runtime identity: Python implementation/version, SQLite runtime
+  version, Expat version, and Unicode-data version;
+- attempt labels A and B with each verified manifest's SHA-256, snapshot
+  fingerprint, observed byte contract, readiness fields, process exit codes,
+  legacy artifact record, and legacy status;
+- the common snapshot fingerprint and authoritative scientific artifact-set
+  hash, fingerprint-core hash, study-universe hash, largest-component hash,
+  compiler implementation records, numeric contract, and repository commit when
+  equal;
+- minimum anchors, resource ceiling, aggregate readiness/certification state,
+  and legacy-parity comparison/warning state;
+- an exact list of comparison gates and their Boolean results;
+- separate `repeatability_verified` and `graph_gate_pass` decisions, `accepted`,
+  one enumerated reason code, and the canonical-attempt label; and
+- enough canonical content for the downstream manifest to bind the receipt's
+  externally computed content record.
+
+Receipt verification is deliberately not receipt-only. The verifier requires
+the receipt directory, source specification, relation policy, and both attempt
+directories. It revalidates the complete declaration bundle, binds the actual
+input bytes, reruns the fixed snapshot verifier on both attempts, reloads both
+actual manifests, and re-derives every per-attempt record, comparison, common
+field, warning, and acceptance decision. It refuses extra fields, changed
+implementation/runtime identity, invalid modes, or a substituted artifact. The
+receipt's unkeyed self-hash detects accidental/internal mutation; it is an
+integrity aid, not proof of authenticity.
+
+The HOP study must run that full verification, then freeze the receipt hash and
+the canonical attempt-A manifest hash in its no-solve planning manifest. A
+path-free receipt alone cannot prove that a separately stored input or attempt
+directory has not been replaced.
+
+The intended immutable chain is:
+
+```text
+source specification + relation policy
+  -> attempt A manifest + attempt B manifest
+  -> snapshot consensus receipt
+  -> no-solve HOP planning manifest
+  -> calibration lock manifest
+  -> untouched audit result
+```
+
+Changing any bound input or record, or rebuilding from changed raw sources,
+policy, compiler commit, readiness threshold, resource ceiling, or receipt,
+invalidates every downstream link. Verification does not rehash raw files after
+their prepare-time transaction; calibration and audit may never silently rebuild
+the graph.
+
+## 6. Claims and non-claims
+
+An accepted receipt supports only this claim: on the recorded host runtime, the
+frozen compiler produced the same verified, privacy-certified, coverage-ready
+snapshot twice from the same explicit frozen inputs under the same resource and
+readiness contract.
+
+It does not establish parser correctness, corpus completeness, graph-physics
+validity, HOP convergence, selector quality, filing performance, covariance
+deployment, or CUDA value. An accepted receipt authorizes construction of the
+outcome-blind no-solve HOP plan; it does not by itself authorize calibration or
+audit solves. A blocked receipt is a complete scientific gate result and must
+not be repaired by changing inputs after inspecting which graph would pass.
+
+## 7. Rejected alternatives
+
+- **Automatic inventory discovery:** rejected because repeated runs could bind
+  different raw evidence while appearing deterministic.
+- **Inferring accounts from export names:** rejected because filenames are not
+  source evidence and the observed `grous` spelling is ambiguous.
+- **Two implementations as the required repeatability check:** rejected for this
+  gate because the snapshot fingerprint intentionally binds the frozen compiler
+  implementation. An orthogonal ledger validator is useful additional defense,
+  but is not a substitute for exact same-code reproduction.
+- **One process calling the compiler function twice:** rejected because module
+  state and shared resources weaken the fresh-execution claim.
+- **Two-of-three voting:** rejected because a nondeterministic compiler or moving
+  source is itself a failed prerequisite.
+- **Publishing detailed receipts:** rejected because hashes do not make private
+  corpus provenance automatically safe to disclose.

--- a/prototypes/mu_cosine/DESIGN_pearltrees_diffusion_snapshot.md
+++ b/prototypes/mu_cosine/DESIGN_pearltrees_diffusion_snapshot.md
@@ -7,8 +7,10 @@ It does not report a real-corpus result, authorize a solve, or authorize automat
 publication. `graph_asset_ready` means only that this compiled graph passed its
 declared privacy and anchor-coverage checks. It is **not** study readiness: the
 fidelity protocol still requires a second deterministic compilation with a
-matching fingerprint plus its separately frozen run manifest. All detailed
-artifacts are local-only.
+matching fingerprint plus its separately frozen run manifest. The explicit
+declaration and comparison contract is specified in
+[`DESIGN_pearltrees_diffusion_consensus.md`](DESIGN_pearltrees_diffusion_consensus.md).
+All detailed artifacts are local-only.
 
 ## 1. Why this is a compiler
 
@@ -86,9 +88,11 @@ shape (with `legacy_check` optional):
 ```
 
 Each source entry must contain a unique nonempty `source_id`, supported `kind`,
-and `path`; `account` is optional declared provenance. Relative paths resolve
-against the source-spec directory. Implicit globs, environment-dependent
-defaults, and “newest file” discovery are forbidden. An `api_json_dir` means
+and `path`; the compiler schema permits `account` as declared provenance, while
+the required consensus declaration contract makes it mandatory for RDF and
+forbids it on the other source kinds. Relative paths resolve against the
+source-spec directory. Implicit globs, environment-dependent defaults, and
+“newest file” discovery are forbidden. An `api_json_dir` means
 every regular non-symlink member of that explicitly named directory; an empty
 directory fails closed.
 
@@ -263,7 +267,10 @@ per newline. Records and adjacency neighbours use stable numeric `pt:` ordering.
 Artifacts are mode 0600 inside a mode-0700 run directory.
 
 `manifest.json` content-records every installed artifact so `verify` can detect
-local tampering. Its **scientific** `fingerprint_core` is narrower and contains:
+local tampering. It also records the exact source-specification and relation-policy
+bytes under `input_records` for consensus provenance. Those exact records are
+outside the scientific fingerprint because the source specification contains
+machine-local paths. Its **scientific** `fingerprint_core` is narrower and contains:
 
 - schema, compiler algorithm, and repository commit;
 - an implementation/parser content hash over the exact preparer contract bytes;
@@ -310,9 +317,10 @@ member paths, filenames, mtimes, inodes, user/host names, temporary names,
 minimum-anchor threshold, descriptive snapshot label, and legacy parity are
 excluded. The repository commit is included; `snapshot_label_hash` remains
 manifest provenance, while minimum-anchor coverage and `graph_asset_ready` are
-manifest-level decisions. Byte-identical declarations and authoritative sources
-under different local paths and the same commit produce the same graph artifacts
-and scientific fingerprint.
+manifest-level decisions. Relocating byte-identical authoritative sources changes
+the private manifest's exact source-specification record, because the declared path
+changed, but never the graph artifacts or scientific fingerprint when the logical
+declaration, source contents, policy, and commit are otherwise equivalent.
 
 ## 7. Atomicity, verification, and failure semantics
 
@@ -335,10 +343,13 @@ fingerprint mismatch, duplicate typed nodes or adjacency rows, excluded nodes in
 adjacency, duplicate/unsorted neighbours, asymmetric adjacency, components that do
 not partition retained adjacency nodes, or an eligible-anchor count mismatch.
 
-`verify` validates the immutable compiled run; it does not promise to revalidate
-raw sources that may later have moved. A future stronger verifier may replay the
-compiler from the private source declaration, but v1's source mutation check is a
-prepare-time transaction boundary.
+Snapshot `verify` validates one immutable compiled run; by itself it does not
+revalidate raw sources that may later have moved. The separate consensus
+verifier therefore requires the complete private declaration bundle, relation
+policy, receipt, and both attempt directories; it reruns this fixed snapshot
+verification on each attempt, reloads both manifests, and re-derives the
+cross-attempt decision. It still does not replay source parsing: v1's source
+mutation check remains the boundary of each prepare transaction.
 
 `privacy_certified=false` or fewer than `--minimum-anchors` yields a valid
 verified snapshot with `graph_asset_ready=false`; `prepare` returns exit 2. Exceeding
@@ -392,10 +403,12 @@ instruction or a reason to change the frozen graph.
 ## 10. What this unlocks—and what it does not
 
 A verified, privacy-certified snapshot with `graph_asset_ready=true` is only a
-candidate for the graph-input gate in protocol §2. A second independent compilation must reproduce the snapshot fingerprint, and
-that matching rerun hash must be frozen in the downstream run manifest. The
-protocol must still freeze anchor batches, protected sets, resources, backend,
-and downstream manifests before any real solve. The preparer
-does not compute diffusion, inspect placement labels or judge outcomes, generate
-embeddings, claim full-account coverage, or publish corpus artifacts. Until those
-separate gates pass, the honest result remains: **no real-corpus outcome yet**.
+candidate for the graph-input gate in protocol §2. The full consensus verifier
+must validate the declaration/policy inputs and both fresh-process attempts,
+then the downstream manifest must bind the receipt and canonical attempt-A
+manifest records. The protocol must still freeze anchor batches, protected
+sets, resources, backend, and downstream manifests before any real solve. The
+preparer does not compute diffusion, inspect placement labels or judge outcomes,
+generate embeddings, claim full-account coverage, or publish corpus artifacts.
+Until those separate gates pass, the honest result remains: **no real-corpus
+outcome yet**.

--- a/prototypes/mu_cosine/PROTOCOL_bounded_diffusion_fidelity.md
+++ b/prototypes/mu_cosine/PROTOCOL_bounded_diffusion_fidelity.md
@@ -12,7 +12,10 @@ only, and it is BLOCKED on a raw-source snapshot preparer. The current
 it loses relation type, privacy-propagation semantics, and visibility. The
 14,246-node scrubbed largest-component figure is an audit estimate, not the
 frozen study universe. Unknown visibility means `privacy_certified=false`. No real
-solve may start until the preparer contract in Section 2 is satisfied.
+solve may start until the preparer contract in Section 2 is satisfied. The
+same-code fresh-process reproduction and immutable receipt that close this gate
+are specified in
+[`DESIGN_pearltrees_diffusion_consensus.md`](DESIGN_pearltrees_diffusion_consensus.md).
 No node IDs, titles, paths, embeddings, or node-level manifests may be published; only
 aggregate summaries and content hashes approved for the local provenance store
 may leave the machine. Results must be labeled relative to this scrubbed
@@ -82,6 +85,21 @@ Before ANY real solve, a content-hashed raw-source snapshot preparer must:
   and
 - freeze the resulting study-universe and largest-component hashes, software
   commit, float64 backend, thread settings, and resource ceiling.
+
+The preparer gate closes only through the consensus contract, not by possessing
+a receipt file alone. The source specification must be the complete private
+declaration bundle: a mode-0700 directory outside Git containing exactly the
+fixed mode-0600 local-only marker and canonical mode-0600 specification, with
+explicit RDF accounts and resolved absolute, non-symlink source paths of the
+declared types. Consensus binds the
+declaration-validator implementation and runs exactly two fresh compiler
+attempts, with no third retry and no pooling. Its verifier must be supplied the
+receipt, source specification, relation policy, and both attempt directories;
+it reruns fixed snapshot verification on both, reloads the actual manifests,
+and re-derives all comparisons, common fields, warnings, and the decision.
+Legacy artifact records/statuses are retained per attempt, but legacy-only
+disagreement is warning-only. The receipt's unkeyed self-hash is an integrity
+aid, not an authenticity credential.
 
 The legacy assembled DAG may be compared only as a parity diagnostic; it cannot
 source the scientific adjacency, privacy decision, or study universe. Detailed
@@ -482,7 +500,10 @@ own prospective amendment and untouched audit data.
 
 ## 9. Reproducibility and fail-closed rules
 
-The run fingerprint covers content rather than machine-local paths:
+The run fingerprint covers content rather than machine-local paths. Before the
+no-solve plan is frozen, the full consensus verifier above must pass and the
+plan must bind both the receipt content record and canonical attempt-A manifest
+record; receipt-only verification is prohibited. The fingerprint includes:
 
 - raw-source and parser hashes, deterministic preparer hash, physical-edge
   policy, privacy-propagation and visibility-limitation manifests, frozen

--- a/prototypes/mu_cosine/declare_pearltrees_diffusion_sources.py
+++ b/prototypes/mu_cosine/declare_pearltrees_diffusion_sources.py
@@ -1,0 +1,620 @@
+#!/usr/bin/env python3
+"""Declare explicit local-only inputs for the Pearltrees diffusion compiler.
+
+This utility is intentionally only a declaration planner.  It never searches for
+inputs, chooses a newest file, opens source contents, or compiles a graph.  Its
+only output is a canonical ``pearltrees-diffusion-source-spec-v1`` in a newly
+installed local-only directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import ctypes
+import errno
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import sys
+import tempfile
+
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+SOURCE_SPEC_SCHEMA = "pearltrees-diffusion-source-spec-v1"
+SPEC_FILENAME = "source_spec.json"
+LOCAL_ONLY_MARKER = "LOCAL_ONLY_DO_NOT_PUBLISH"
+LOCAL_ONLY_MARKER_PAYLOAD = (
+    b"LOCAL ONLY - DO NOT PUBLISH SOURCE PATH DECLARATIONS\n"
+)
+SOURCE_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,199}")
+ACCOUNT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,199}")
+WILDCARD_CHARS = frozenset("*?[]{}")
+
+
+class DeclarationError(ValueError):
+    """Fail-closed source declaration or installation error."""
+
+
+def _canonical_json(value: object) -> bytes:
+    try:
+        text = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError, UnicodeError) as exc:
+        raise DeclarationError("source declaration is not canonical JSON") from exc
+    return (text + "\n").encode("utf-8")
+
+
+def _duplicate_checked_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DeclarationError("source declaration contains a duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_json(token: str) -> object:
+    del token
+    raise DeclarationError("source declaration contains a non-finite JSON number")
+
+
+def _strict_canonical_json(data: bytes) -> dict[str, object]:
+    """Decode one exact canonical JSON object, rejecting parser extensions."""
+
+    try:
+        text = data.decode("utf-8", errors="strict")
+        value = json.loads(
+            text,
+            object_pairs_hook=_duplicate_checked_object,
+            parse_constant=_reject_nonfinite_json,
+        )
+    except DeclarationError:
+        raise
+    except (json.JSONDecodeError, UnicodeError) as exc:
+        raise DeclarationError("source declaration is not strict UTF-8 JSON") from exc
+    if not isinstance(value, dict):
+        raise DeclarationError("source spec must be an object")
+    if _canonical_json(value) != data:
+        raise DeclarationError("source declaration bytes are not canonical JSON")
+    return value
+
+
+def _path_is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_git_worktree_marker(path: Path) -> bool:
+    """Recognize a real Git marker, not an unrelated empty ``.git`` path."""
+
+    try:
+        if path.is_file():
+            with open(path, "rb") as stream:
+                return stream.read(64).lstrip().startswith(b"gitdir:")
+        return path.is_dir() and (path / "HEAD").is_file()
+    except OSError:
+        # An unreadable candidate marker is treated conservatively as a marker.
+        return True
+
+
+def _absolute_lexical(path: str | os.PathLike[str]) -> Path:
+    try:
+        return Path(os.path.abspath(os.fspath(path)))
+    except (OSError, TypeError, ValueError) as exc:
+        raise DeclarationError("declared path is invalid") from exc
+
+
+def _reject_symlink_components(path: Path, label: str) -> None:
+    """Reject symlinks in every existing component without reading contents."""
+
+    if not path.is_absolute():
+        raise DeclarationError(f"{label} path is not absolute")
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        try:
+            mode = current.lstat().st_mode
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            raise DeclarationError(f"{label} path could not be validated") from exc
+        if stat.S_ISLNK(mode):
+            raise DeclarationError(f"{label} path cannot contain a symlink")
+
+
+def _resolved_declared_input(path_value: str, *, directory: bool) -> Path:
+    if not isinstance(path_value, str) or not path_value:
+        raise DeclarationError("declared source path must be nonempty text")
+    if any(character in path_value for character in WILDCARD_CHARS):
+        raise DeclarationError("wildcard-looking source paths are forbidden")
+    path = _absolute_lexical(path_value)
+    _reject_symlink_components(path, "declared source")
+    try:
+        mode = path.lstat().st_mode
+    except OSError as exc:
+        raise DeclarationError("declared source is unavailable") from exc
+    expected = stat.S_ISDIR(mode) if directory else stat.S_ISREG(mode)
+    if not expected:
+        kind = "directory" if directory else "regular file"
+        raise DeclarationError(f"declared source must be a non-symlink {kind}")
+    try:
+        return path.resolve(strict=True)
+    except OSError as exc:
+        raise DeclarationError("declared source could not be resolved") from exc
+
+
+def _path_identity(path: Path) -> tuple[int, int]:
+    try:
+        record = path.stat()
+    except OSError as exc:
+        raise DeclarationError("declared source identity could not be validated") from exc
+    return record.st_dev, record.st_ino
+
+
+def _source_id(value: str) -> str:
+    if not isinstance(value, str) or SOURCE_ID_RE.fullmatch(value) is None:
+        raise DeclarationError("source_id must use stable ASCII identifier syntax")
+    return value
+
+
+def _rdf_account(value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise DeclarationError("RDF account must be explicit nonempty text")
+    if value != value.strip() or ACCOUNT_RE.fullmatch(value) is None:
+        raise DeclarationError("RDF account must use canonical account syntax")
+    if value.casefold() == "grous":
+        raise DeclarationError("team RDF account typo is forbidden; use groups")
+    if value.casefold() == "groups" and value != "groups":
+        raise DeclarationError("team RDF account must be the literal groups")
+    return value
+
+
+def _source_entry(kind: str, values: tuple[str, ...]) -> dict[str, str]:
+    if kind == "rdf":
+        if len(values) != 3:
+            raise DeclarationError("RDF declaration fields mismatch")
+        source_id, account, path_value = values
+        return {
+            "account": _rdf_account(account),
+            "kind": kind,
+            "path": str(_resolved_declared_input(path_value, directory=False)),
+            "source_id": _source_id(source_id),
+        }
+    if len(values) != 2:
+        raise DeclarationError("source declaration fields mismatch")
+    source_id, path_value = values
+    return {
+        "kind": kind,
+        "path": str(
+            _resolved_declared_input(
+                path_value,
+                directory=(kind == "api_json_dir"),
+            )
+        ),
+        "source_id": _source_id(source_id),
+    }
+
+
+def build_source_spec(
+    *,
+    snapshot_label: str,
+    rdf: tuple[tuple[str, str, str], ...] = (),
+    api_json_dir: tuple[tuple[str, str], ...] = (),
+    api_sqlite: tuple[tuple[str, str], ...] = (),
+    path_jsonl: tuple[tuple[str, str], ...] = (),
+    legacy_dag: str | None = None,
+) -> dict[str, object]:
+    """Build a canonical source specification without reading source contents."""
+
+    if (
+        not isinstance(snapshot_label, str)
+        or not snapshot_label.strip()
+        or snapshot_label != snapshot_label.strip()
+    ):
+        raise DeclarationError("snapshot_label must be canonical nonempty text")
+    declarations: tuple[tuple[str, tuple[str, ...]], ...] = tuple(
+        [("rdf", tuple(item)) for item in rdf]
+        + [("api_json_dir", tuple(item)) for item in api_json_dir]
+        + [("api_sqlite", tuple(item)) for item in api_sqlite]
+        + [("path_jsonl", tuple(item)) for item in path_jsonl]
+    )
+    if not declarations:
+        raise DeclarationError("at least one explicit source is required")
+    sources = [_source_entry(kind, values) for kind, values in declarations]
+    source_ids = [entry["source_id"] for entry in sources]
+    if len(set(source_ids)) != len(source_ids):
+        raise DeclarationError("source_id values must be globally unique")
+    source_identities = [_path_identity(Path(entry["path"])) for entry in sources]
+    if len(set(source_identities)) != len(source_identities):
+        raise DeclarationError("authoritative source paths must not alias")
+    sources.sort(key=lambda entry: entry["source_id"])
+    spec: dict[str, object] = {
+        "schema": SOURCE_SPEC_SCHEMA,
+        "snapshot_label": snapshot_label,
+        "sources": sources,
+    }
+    if legacy_dag is not None:
+        legacy_path = _resolved_declared_input(legacy_dag, directory=False)
+        if _path_identity(legacy_path) in set(source_identities):
+            raise DeclarationError("legacy parity input cannot alias an authoritative source")
+        spec["legacy_check"] = {"dag_path": str(legacy_path)}
+    return spec
+
+
+def _validate_canonical_spec(spec: dict[str, object]) -> dict[str, object]:
+    if not isinstance(spec, dict):
+        raise DeclarationError("source spec must be an object")
+    allowed = {"schema", "snapshot_label", "sources", "legacy_check"}
+    if set(spec) - allowed or not {"schema", "snapshot_label", "sources"}.issubset(
+        spec
+    ):
+        raise DeclarationError("source spec fields mismatch")
+    if spec.get("schema") != SOURCE_SPEC_SCHEMA or not isinstance(
+        spec.get("sources"), list
+    ):
+        raise DeclarationError("source spec schema or sources mismatch")
+    grouped: dict[str, list[tuple[str, ...]]] = {
+        "rdf": [],
+        "api_json_dir": [],
+        "api_sqlite": [],
+        "path_jsonl": [],
+    }
+    for entry in spec["sources"]:
+        if not isinstance(entry, dict) or entry.get("kind") not in grouped:
+            raise DeclarationError("source entry is unsupported")
+        kind = entry["kind"]
+        expected = (
+            {"account", "kind", "path", "source_id"}
+            if kind == "rdf"
+            else {"kind", "path", "source_id"}
+        )
+        if set(entry) != expected:
+            raise DeclarationError("source entry fields mismatch")
+        if kind == "rdf":
+            grouped[kind].append(
+                (entry["source_id"], entry["account"], entry["path"])
+            )
+        else:
+            grouped[kind].append((entry["source_id"], entry["path"]))
+    legacy = spec.get("legacy_check")
+    if legacy is not None and (
+        not isinstance(legacy, dict) or set(legacy) != {"dag_path"}
+    ):
+        raise DeclarationError("legacy_check fields mismatch")
+    rebuilt = build_source_spec(
+        snapshot_label=spec["snapshot_label"],
+        rdf=tuple(grouped["rdf"]),
+        api_json_dir=tuple(grouped["api_json_dir"]),
+        api_sqlite=tuple(grouped["api_sqlite"]),
+        path_jsonl=tuple(grouped["path_jsonl"]),
+        legacy_dag=legacy["dag_path"] if legacy is not None else None,
+    )
+    if rebuilt != spec:
+        raise DeclarationError("source spec is not in canonical declaration order")
+    return rebuilt
+
+
+def _output_parent_identity(parent: Path) -> tuple[int, int]:
+    """Return the identity of one resolved, non-symlink output parent."""
+
+    _reject_symlink_components(parent, "output parent")
+    try:
+        record = parent.lstat()
+        resolved = parent.resolve(strict=True)
+    except OSError as exc:
+        raise DeclarationError("output parent identity could not be validated") from exc
+    if not stat.S_ISDIR(record.st_mode) or resolved != parent:
+        raise DeclarationError("output parent must remain a resolved directory")
+    return record.st_dev, record.st_ino
+
+
+def _recheck_output_parent(parent: Path, expected: tuple[int, int]) -> None:
+    if _output_parent_identity(parent) != expected:
+        raise DeclarationError("output parent identity changed during installation")
+
+
+def _validate_output_paths(
+    output_dir: str | os.PathLike[str],
+    local_root: str | os.PathLike[str],
+    spec: dict[str, object],
+) -> tuple[Path, Path, tuple[int, int]]:
+    root_input = _absolute_lexical(local_root)
+    output_input = _absolute_lexical(output_dir)
+    _reject_symlink_components(root_input, "local root")
+    _reject_symlink_components(output_input.parent, "output parent")
+    if output_input.is_symlink():
+        raise DeclarationError("output directory cannot be a symlink")
+    try:
+        root_mode = root_input.lstat().st_mode
+        parent_mode = output_input.parent.lstat().st_mode
+    except OSError as exc:
+        raise DeclarationError("output root or parent is unavailable") from exc
+    if not stat.S_ISDIR(root_mode) or not stat.S_ISDIR(parent_mode):
+        raise DeclarationError("local root and output parent must be directories")
+    local_root_resolved = root_input.resolve(strict=True)
+    output_parent = output_input.parent.resolve(strict=True)
+    output_parent_identity = _output_parent_identity(output_parent)
+    output_resolved = output_parent / output_input.name
+    if output_resolved.exists() or output_resolved.is_symlink():
+        raise DeclarationError("output directory already exists")
+    if (
+        output_resolved == local_root_resolved
+        or not _path_is_within(output_resolved, local_root_resolved)
+    ):
+        raise DeclarationError("output directory must be below the explicit local root")
+    repo = REPO_ROOT.resolve()
+    if _path_is_within(output_resolved, repo) or any(
+        _is_git_worktree_marker(ancestor / ".git")
+        for ancestor in (output_parent, *output_parent.parents)
+    ):
+        raise DeclarationError("output directory cannot be inside a Git worktree")
+
+    input_paths = [Path(entry["path"]) for entry in spec["sources"]]
+    legacy = spec.get("legacy_check")
+    if isinstance(legacy, dict):
+        input_paths.append(Path(legacy["dag_path"]))
+    for input_path in input_paths:
+        if (
+            input_path == output_resolved
+            or _path_is_within(input_path, output_resolved)
+            or _path_is_within(output_resolved, input_path)
+        ):
+            raise DeclarationError("declared input and output paths cannot overlap")
+        try:
+            input_stat = input_path.stat()
+            root_stat = local_root_resolved.stat()
+        except OSError as exc:
+            raise DeclarationError("input/output alias check failed") from exc
+        if (input_stat.st_dev, input_stat.st_ino) == (
+            root_stat.st_dev,
+            root_stat.st_ino,
+        ):
+            raise DeclarationError("local root cannot alias an input")
+    return output_resolved, local_root_resolved, output_parent_identity
+
+
+def _rename_directory_noreplace(source: Path, target: Path) -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    renameat2 = getattr(libc, "renameat2", None)
+    if renameat2 is None:
+        raise DeclarationError("atomic no-replace rename is unavailable")
+    renameat2.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    renameat2.restype = ctypes.c_int
+    result = renameat2(
+        -100,
+        os.fsencode(source),
+        -100,
+        os.fsencode(target),
+        1,
+    )
+    if result == 0:
+        return
+    error_number = ctypes.get_errno()
+    if error_number in {errno.EEXIST, errno.ENOTEMPTY}:
+        raise DeclarationError("output appeared during atomic installation")
+    raise DeclarationError("atomic no-replace installation failed") from OSError(
+        error_number, os.strerror(error_number)
+    )
+
+
+def _write_private(path: Path, data: bytes) -> None:
+    try:
+        with open(path, "xb") as stream:
+            os.chmod(path, 0o600)
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+    except OSError as exc:
+        raise DeclarationError("local-only declaration could not be written") from exc
+
+
+def verify_installed_source_spec(
+    source_spec: str | os.PathLike[str],
+) -> dict[str, object]:
+    """Verify and return one complete, private source-declaration bundle.
+
+    Verification deliberately covers both the semantic declaration and its local-only
+    installation envelope.  A caller cannot bypass explicit account/path/type checks by
+    hand-writing a merely schema-shaped JSON file.
+    """
+
+    source_path = _absolute_lexical(source_spec)
+    if source_path.name != SPEC_FILENAME:
+        raise DeclarationError(f"installed source spec must be named {SPEC_FILENAME}")
+    _reject_symlink_components(source_path, "installed source declaration")
+    directory = source_path.parent
+    marker_path = directory / LOCAL_ONLY_MARKER
+    try:
+        directory_record = directory.lstat()
+        source_record = source_path.lstat()
+        marker_record = marker_path.lstat()
+        installed_names = {entry.name for entry in directory.iterdir()}
+    except OSError as exc:
+        raise DeclarationError("installed source declaration cannot be inspected") from exc
+
+    if not stat.S_ISDIR(directory_record.st_mode):
+        raise DeclarationError("source declaration bundle must be a directory")
+    if stat.S_IMODE(directory_record.st_mode) != 0o700:
+        raise DeclarationError("source declaration directory mode must be 0700")
+    if installed_names != {SPEC_FILENAME, LOCAL_ONLY_MARKER}:
+        raise DeclarationError("source declaration bundle file set mismatch")
+    if not stat.S_ISREG(source_record.st_mode) or not stat.S_ISREG(
+        marker_record.st_mode
+    ):
+        raise DeclarationError("source declaration bundle files must be regular files")
+    if stat.S_IMODE(source_record.st_mode) != 0o600 or stat.S_IMODE(
+        marker_record.st_mode
+    ) != 0o600:
+        raise DeclarationError("source declaration bundle file modes must be 0600")
+
+    directory_resolved = directory.resolve(strict=True)
+    repo = REPO_ROOT.resolve()
+    if _path_is_within(directory_resolved, repo) or any(
+        _is_git_worktree_marker(ancestor / ".git")
+        for ancestor in (directory_resolved, *directory_resolved.parents)
+    ):
+        raise DeclarationError("source declaration bundle cannot be inside a Git worktree")
+
+    try:
+        payload = source_path.read_bytes()
+        marker_payload = marker_path.read_bytes()
+    except OSError as exc:
+        raise DeclarationError("installed source declaration cannot be read") from exc
+    if marker_payload != LOCAL_ONLY_MARKER_PAYLOAD:
+        raise DeclarationError("source declaration local-only marker mismatch")
+    return _validate_canonical_spec(_strict_canonical_json(payload))
+
+
+def install_source_spec(
+    spec: dict[str, object],
+    *,
+    output_dir: str | os.PathLike[str],
+    local_root: str | os.PathLike[str],
+) -> dict[str, object]:
+    """Atomically install a canonical source spec in a new private directory."""
+
+    spec = _validate_canonical_spec(spec)
+    output, _root, output_parent_identity = _validate_output_paths(
+        output_dir, local_root, spec
+    )
+    payload = _canonical_json(spec)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=output.parent))
+    os.chmod(temporary, 0o700)
+    installed = False
+    try:
+        _write_private(temporary / SPEC_FILENAME, payload)
+        _write_private(
+            temporary / LOCAL_ONLY_MARKER,
+            LOCAL_ONLY_MARKER_PAYLOAD,
+        )
+        directory_fd = os.open(temporary, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+        _recheck_output_parent(output.parent, output_parent_identity)
+        _rename_directory_noreplace(temporary, output)
+        installed = True
+        _recheck_output_parent(output.parent, output_parent_identity)
+        parent_open_flags = (
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        parent_fd = os.open(
+            output.parent,
+            parent_open_flags,
+        )
+        try:
+            parent_record = os.fstat(parent_fd)
+            if (parent_record.st_dev, parent_record.st_ino) != output_parent_identity:
+                raise DeclarationError(
+                    "output parent identity changed before directory synchronization"
+                )
+            os.fsync(parent_fd)
+        finally:
+            os.close(parent_fd)
+    except OSError as exc:
+        raise DeclarationError("local-only declaration installation failed") from exc
+    finally:
+        if not installed and temporary.exists():
+            shutil.rmtree(temporary)
+
+    installed_spec = verify_installed_source_spec(output / SPEC_FILENAME)
+    if installed_spec != spec:
+        raise DeclarationError("installed source declaration verification failed")
+    counts = Counter(entry["kind"] for entry in installed_spec["sources"])
+    return {
+        "legacy_check_declared": "legacy_check" in installed_spec,
+        "local_only": True,
+        "source_count": len(installed_spec["sources"]),
+        "source_kind_counts": dict(sorted(counts.items())),
+        "spec_written": True,
+    }
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot-label", required=True)
+    parser.add_argument("--local-root", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--local-only", action="store_true", required=True)
+    parser.add_argument(
+        "--rdf",
+        action="append",
+        nargs=3,
+        default=[],
+        metavar=("SOURCE_ID", "ACCOUNT", "PATH"),
+    )
+    parser.add_argument(
+        "--api-json-dir",
+        action="append",
+        nargs=2,
+        default=[],
+        metavar=("SOURCE_ID", "PATH"),
+    )
+    parser.add_argument(
+        "--api-sqlite",
+        action="append",
+        nargs=2,
+        default=[],
+        metavar=("SOURCE_ID", "PATH"),
+    )
+    parser.add_argument(
+        "--path-jsonl",
+        action="append",
+        nargs=2,
+        default=[],
+        metavar=("SOURCE_ID", "PATH"),
+    )
+    parser.add_argument("--legacy-dag")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        spec = build_source_spec(
+            snapshot_label=args.snapshot_label,
+            rdf=tuple(tuple(item) for item in args.rdf),
+            api_json_dir=tuple(tuple(item) for item in args.api_json_dir),
+            api_sqlite=tuple(tuple(item) for item in args.api_sqlite),
+            path_jsonl=tuple(tuple(item) for item in args.path_jsonl),
+            legacy_dag=args.legacy_dag,
+        )
+        summary = install_source_spec(
+            spec,
+            output_dir=args.output_dir,
+            local_root=args.local_root,
+        )
+        print(json.dumps(summary, sort_keys=True, separators=(",", ":")))
+        return 0
+    except Exception:
+        print(
+            json.dumps({"error": "source declaration failed closed"}, sort_keys=True),
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/prepare_pearltrees_diffusion_consensus.py
+++ b/prototypes/mu_cosine/prepare_pearltrees_diffusion_consensus.py
@@ -1,0 +1,1315 @@
+#!/usr/bin/env python3
+"""Require exact two-process consensus before using a Pearltrees snapshot.
+
+The two snapshot compilations are repeatability evidence for one frozen graph,
+not two independent graph observations.  This gate never pools artifacts and
+never retries a disagreement.  Detailed artifacts and the consensus receipt
+are local-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import errno
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import sqlite3
+import stat
+import subprocess
+import sys
+import tempfile
+import unicodedata
+import xml.parsers.expat
+
+import declare_pearltrees_diffusion_sources as declaration
+
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+SNAPSHOT_PREPARER = HERE / "prepare_pearltrees_diffusion_snapshot.py"
+PRIVACY_RULE = HERE / "privacy.py"
+SCHEMA = "pearltrees-diffusion-consensus-v1"
+ALGORITHM = "two-fresh-process-exact-consensus-v1"
+RECEIPT_NAME = "consensus_receipt.json"
+MARKER_NAME = "LOCAL_ONLY_DO_NOT_PUBLISH"
+MARKER_BYTES = b"LOCAL ONLY - DO NOT PUBLISH SNAPSHOT CONSENSUS ARTIFACTS\n"
+RECEIPT_FILES = frozenset((RECEIPT_NAME, MARKER_NAME))
+EVIDENCE_INTERPRETATION = (
+    "same-code, same-runtime repeatability for one frozen graph; not independent replication"
+)
+DOWNSTREAM_REQUIREMENT = (
+    "re-verify canonical attempt_a and bind its manifest record before any solve"
+)
+LEGACY_PARITY_ROLE = "diagnostic_only_not_readiness"
+CRITICAL_COMPARISON_CHECKS = frozenset(
+    (
+        "aggregate_nonlegacy_equal",
+        "fingerprint_core_equal",
+        "implementation_records_equal",
+        "nonlegacy_manifest_equal",
+        "policy_records_equal",
+        "population_records_equal",
+        "readiness_equal",
+        "resource_records_equal",
+        "scientific_artifact_records_equal",
+        "snapshot_fingerprint_equal",
+        "snapshot_label_hash_equal",
+        "source_records_equal",
+    )
+)
+
+
+class ConsensusError(ValueError):
+    """Fail-closed operational or contract error in consensus preparation."""
+
+
+def _duplicate_checked_object(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise ConsensusError("duplicate JSON key")
+        value[key] = item
+    return value
+
+
+def _reject_nonfinite(_value):
+    raise ConsensusError("non-finite JSON constant")
+
+
+def _canonical_json(value):
+    try:
+        text = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ConsensusError("value is not canonical finite JSON") from exc
+    return (text + "\n").encode("utf-8")
+
+
+def _strict_json_bytes(data, label):
+    try:
+        value = json.loads(
+            data.decode("utf-8"),
+            object_pairs_hook=_duplicate_checked_object,
+            parse_constant=_reject_nonfinite,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ConsensusError(f"invalid UTF-8 JSON in {label}") from exc
+    if _canonical_json(value) != data:
+        raise ConsensusError(f"{label} is not canonical JSON")
+    return value
+
+
+def _content_record(data):
+    return {"sha256": hashlib.sha256(data).hexdigest(), "size_bytes": len(data)}
+
+
+def _hex_string_is_valid(value, length):
+    return (
+        isinstance(value, str)
+        and len(value) == length
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _content_record_is_valid(value):
+    return (
+        isinstance(value, dict)
+        and set(value) == {"sha256", "size_bytes"}
+        and _hex_string_is_valid(value["sha256"], 64)
+        and isinstance(value["size_bytes"], int)
+        and not isinstance(value["size_bytes"], bool)
+        and value["size_bytes"] >= 0
+    )
+
+
+def _regular_file_record(path, label):
+    path = Path(path)
+    if path.is_symlink() or not path.is_file():
+        raise ConsensusError(f"{label} must be a regular non-symlink file")
+    try:
+        return _content_record(path.read_bytes())
+    except OSError as exc:
+        raise ConsensusError(f"{label} could not be read") from exc
+
+
+def _path_is_within(path, root):
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _has_symlink_ancestor(path):
+    absolute = Path(os.path.abspath(os.fspath(path)))
+    return any(item.is_symlink() for item in (absolute, *absolute.parents))
+
+
+def _is_git_worktree_marker(path):
+    """Recognize an actual Git marker, not an unrelated empty `.git` path."""
+
+    try:
+        if path.is_symlink():
+            return True
+        if path.is_file():
+            with open(path, "rb") as stream:
+                return stream.read(256).lstrip().startswith(b"gitdir:")
+        return path.is_dir() and (path / "HEAD").is_file()
+    except OSError:
+        # An unreadable candidate marker is conservatively treated as Git.
+        return True
+
+
+def _has_git_ancestor(path):
+    return any(
+        _is_git_worktree_marker(ancestor / ".git") for ancestor in (path, *path.parents)
+    )
+
+
+def _bind_directory_identities(paths):
+    bindings = []
+    for path in sorted({Path(item).resolve() for item in paths}, key=str):
+        if _has_symlink_ancestor(path) or not path.is_dir():
+            raise ConsensusError("bound output parent must be a non-symlink directory")
+        try:
+            record = path.stat()
+        except OSError as exc:
+            raise ConsensusError("output parent identity could not be bound") from exc
+        bindings.append((path, record.st_dev, record.st_ino))
+    return tuple(bindings)
+
+
+def _assert_directory_identities(bindings):
+    for path, expected_device, expected_inode in bindings:
+        if _has_symlink_ancestor(path):
+            raise ConsensusError("output parent path changed to a symlink")
+        try:
+            record = path.stat()
+        except OSError as exc:
+            raise ConsensusError("output parent identity became unavailable") from exc
+        if (
+            not stat.S_ISDIR(record.st_mode)
+            or record.st_dev != expected_device
+            or record.st_ino != expected_inode
+        ):
+            raise ConsensusError("output parent identity changed during consensus")
+
+
+def _bind_existing_directory(path, label):
+    path_input = Path(path)
+    if _has_symlink_ancestor(path_input):
+        raise ConsensusError(f"{label} path cannot contain a symlink")
+    try:
+        resolved = path_input.resolve(strict=True)
+        record = resolved.stat()
+    except OSError as exc:
+        raise ConsensusError(f"{label} identity could not be bound") from exc
+    if not stat.S_ISDIR(record.st_mode):
+        raise ConsensusError(f"{label} must be a directory")
+    return resolved, record.st_dev, record.st_ino
+
+
+def _assert_bound_directory(binding, label):
+    path, expected_device, expected_inode = binding
+    if _has_symlink_ancestor(path):
+        raise ConsensusError(f"{label} path changed to a symlink")
+    try:
+        record = path.stat()
+    except OSError as exc:
+        raise ConsensusError(f"{label} identity became unavailable") from exc
+    if (
+        not stat.S_ISDIR(record.st_mode)
+        or record.st_dev != expected_device
+        or record.st_ino != expected_inode
+    ):
+        raise ConsensusError(f"{label} identity changed during verification")
+    return path
+
+
+def _validate_output_paths(
+    local_root,
+    attempt_a_dir,
+    attempt_b_dir,
+    receipt_dir,
+    source_spec,
+    relation_policy,
+):
+    root_input = Path(local_root)
+    raw_outputs = [Path(attempt_a_dir), Path(attempt_b_dir), Path(receipt_dir)]
+    if _has_symlink_ancestor(root_input) or any(
+        _has_symlink_ancestor(path) for path in raw_outputs
+    ):
+        raise ConsensusError("local-only output paths cannot be symlinks")
+    root = root_input.resolve()
+    if not root.is_dir():
+        raise ConsensusError("local root must be an existing non-symlink directory")
+    outputs = [path.resolve() for path in raw_outputs]
+    if len(set(outputs)) != len(outputs):
+        raise ConsensusError("attempt and receipt directories must not alias")
+    for output in outputs:
+        if output == root or not _path_is_within(output, root):
+            raise ConsensusError("all output directories must be children of the local root")
+        if _path_is_within(output, REPO_ROOT.resolve()) or _has_git_ancestor(output.parent):
+            raise ConsensusError("local-only output cannot be inside a Git worktree")
+        if output.exists():
+            raise ConsensusError("attempt and receipt directories must be fresh")
+        if not output.parent.is_dir():
+            raise ConsensusError("output-directory parents must already exist")
+    for index, first in enumerate(outputs):
+        for second in outputs[index + 1 :]:
+            if _path_is_within(first, second) or _path_is_within(second, first):
+                raise ConsensusError("attempt and receipt directories cannot be nested")
+
+    inputs = [Path(source_spec), Path(relation_policy)]
+    for item in inputs:
+        if _has_symlink_ancestor(item) or not item.is_file():
+            raise ConsensusError("consensus inputs must be regular non-symlink files")
+        resolved = item.resolve()
+        try:
+            if (
+                resolved.stat().st_dev == root.stat().st_dev
+                and resolved.stat().st_ino == root.stat().st_ino
+            ):
+                raise ConsensusError("local root aliases an input")
+        except OSError as exc:
+            raise ConsensusError("consensus input could not be validated") from exc
+        for output in outputs:
+            if (
+                resolved == output
+                or _path_is_within(resolved, output)
+                or _path_is_within(output, resolved)
+            ):
+                raise ConsensusError("input and output paths overlap")
+    return root, tuple(outputs)
+
+
+def _positive_int(value):
+    try:
+        result = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if result < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return result
+
+
+def _run_snapshot_cli(arguments):
+    try:
+        return subprocess.run(
+            [
+                sys.executable,
+                "-I",
+                "-B",
+                str(SNAPSHOT_PREPARER),
+                *map(str, arguments),
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+        ).returncode
+    except OSError as exc:
+        raise ConsensusError("snapshot compiler subprocess could not be started") from exc
+
+
+def _assert_inputs_unchanged(expected, source_spec, relation_policy):
+    observed = {
+        "relation_policy": _regular_file_record(relation_policy, "relation policy"),
+        "source_spec": _regular_file_record(source_spec, "source spec"),
+    }
+    if observed != expected:
+        raise ConsensusError("source spec or relation policy changed across attempts")
+
+
+def _run_attempt(
+    run_dir,
+    *,
+    source_spec,
+    relation_policy,
+    local_root,
+    minimum_anchors,
+    resource_ceiling_bytes,
+    expected_inputs,
+    output_parent_bindings,
+):
+    _assert_directory_identities(output_parent_bindings)
+    prepare_code = _run_snapshot_cli(
+        (
+            "prepare",
+            "--source-spec",
+            source_spec,
+            "--relation-policy",
+            relation_policy,
+            "--run-dir",
+            run_dir,
+            "--local-root",
+            local_root,
+            "--local-only",
+            "--minimum-anchors",
+            minimum_anchors,
+            "--resource-ceiling-bytes",
+            resource_ceiling_bytes,
+        )
+    )
+    _assert_inputs_unchanged(expected_inputs, source_spec, relation_policy)
+    if prepare_code not in {0, 2}:
+        raise ConsensusError("snapshot preparation had an operational failure")
+    if not Path(run_dir).is_dir():
+        raise ConsensusError("snapshot preparation did not install its run directory")
+
+    attempt_binding = _bind_existing_directory(run_dir, "snapshot attempt")
+    _assert_directory_identities(output_parent_bindings)
+    verified_run_dir = _assert_bound_directory(attempt_binding, "snapshot attempt")
+    verify_code = _run_snapshot_cli(("verify", "--run-dir", verified_run_dir))
+    _assert_inputs_unchanged(expected_inputs, source_spec, relation_policy)
+    if verify_code != 0:
+        raise ConsensusError("snapshot verification had an operational failure")
+    _assert_directory_identities(output_parent_bindings)
+    verified_run_dir = _assert_bound_directory(attempt_binding, "snapshot attempt")
+    manifest_path = verified_run_dir / "manifest.json"
+    try:
+        manifest_bytes = manifest_path.read_bytes()
+    except OSError as exc:
+        raise ConsensusError("verified snapshot manifest could not be read") from exc
+    _assert_bound_directory(attempt_binding, "snapshot attempt")
+    manifest = _strict_json_bytes(manifest_bytes, "verified snapshot manifest")
+    if not isinstance(manifest, dict):
+        raise ConsensusError("verified snapshot manifest is not an object")
+    return {
+        "manifest": manifest,
+        "manifest_record": _content_record(manifest_bytes),
+        "prepare_exit_code": prepare_code,
+        "verify_exit_code": verify_code,
+    }
+
+
+def _scientific_artifact_records(manifest):
+    records = manifest.get("artifact_records")
+    if not isinstance(records, dict):
+        raise ConsensusError("verified manifest artifact records are malformed")
+    return {name: record for name, record in records.items() if name != "legacy_parity.json"}
+
+
+def _without_legacy_parity(manifest):
+    normalized = dict(manifest)
+    artifacts = dict(normalized.get("artifact_records", {}))
+    artifacts.pop("legacy_parity.json", None)
+    normalized["artifact_records"] = artifacts
+    aggregate = dict(normalized.get("aggregate", {}))
+    aggregate.pop("legacy_parity_status", None)
+    normalized["aggregate"] = aggregate
+    return normalized
+
+
+def _named_comparisons(first, second):
+    try:
+        first_core = first["fingerprint_core"]
+        second_core = second["fingerprint_core"]
+        first_readiness = {
+            "graph_asset_ready": first["graph_asset_ready"],
+            "minimum_anchor_count": first["aggregate"]["minimum_anchor_count"],
+            "minimum_anchor_coverage_pass": first["aggregate"]["minimum_anchor_coverage_pass"],
+            "privacy_certified": first["aggregate"]["privacy_certified"],
+        }
+        second_readiness = {
+            "graph_asset_ready": second["graph_asset_ready"],
+            "minimum_anchor_count": second["aggregate"]["minimum_anchor_count"],
+            "minimum_anchor_coverage_pass": second["aggregate"]["minimum_anchor_coverage_pass"],
+            "privacy_certified": second["aggregate"]["privacy_certified"],
+        }
+        first_population = {
+            "largest_component_sha256": first_core["largest_component_sha256"],
+            "study_universe_sha256": first_core["study_universe_sha256"],
+        }
+        second_population = {
+            "largest_component_sha256": second_core["largest_component_sha256"],
+            "study_universe_sha256": second_core["study_universe_sha256"],
+        }
+        first_resources = {
+            "observed_contract_bytes": first_core["observed_contract_bytes"],
+            "resource_ceiling_bytes": first_core["resource_ceiling_bytes"],
+        }
+        second_resources = {
+            "observed_contract_bytes": second_core["observed_contract_bytes"],
+            "resource_ceiling_bytes": second_core["resource_ceiling_bytes"],
+        }
+    except (KeyError, TypeError) as exc:
+        raise ConsensusError("verified snapshot manifest is missing consensus fields") from exc
+    first_legacy_record = first.get("artifact_records", {}).get("legacy_parity.json")
+    second_legacy_record = second.get("artifact_records", {}).get("legacy_parity.json")
+    first_nonlegacy_aggregate = dict(first.get("aggregate", {}))
+    second_nonlegacy_aggregate = dict(second.get("aggregate", {}))
+    first_legacy_status = first_nonlegacy_aggregate.pop("legacy_parity_status", None)
+    second_legacy_status = second_nonlegacy_aggregate.pop("legacy_parity_status", None)
+    return {
+        "aggregate_nonlegacy_equal": first_nonlegacy_aggregate == second_nonlegacy_aggregate,
+        "fingerprint_core_equal": first_core == second_core,
+        "full_manifest_equal": first == second,
+        "implementation_records_equal": first_core.get("implementation_records")
+        == second_core.get("implementation_records"),
+        "legacy_parity_artifact_record_equal": first_legacy_record == second_legacy_record,
+        "legacy_parity_status_equal": first_legacy_status == second_legacy_status,
+        "nonlegacy_manifest_equal": _without_legacy_parity(first)
+        == _without_legacy_parity(second),
+        "policy_records_equal": {
+            "privacy_policy": first.get("privacy_policy"),
+            "relation_policy": first.get("relation_policy"),
+        }
+        == {
+            "privacy_policy": second.get("privacy_policy"),
+            "relation_policy": second.get("relation_policy"),
+        },
+        "population_records_equal": first_population == second_population,
+        "readiness_equal": first_readiness == second_readiness,
+        "resource_records_equal": first_resources == second_resources,
+        "scientific_artifact_records_equal": _scientific_artifact_records(first)
+        == _scientific_artifact_records(second),
+        "snapshot_fingerprint_equal": first.get("snapshot_fingerprint")
+        == second.get("snapshot_fingerprint"),
+        "snapshot_label_hash_equal": first.get("snapshot_label_hash")
+        == second.get("snapshot_label_hash"),
+        "source_records_equal": first_core.get("source_records")
+        == second_core.get("source_records"),
+    }
+
+
+def _critical_comparisons_pass(checks):
+    if set(checks) != CRITICAL_COMPARISON_CHECKS | {
+        "full_manifest_equal",
+        "legacy_parity_artifact_record_equal",
+        "legacy_parity_status_equal",
+    }:
+        raise ConsensusError("consensus comparison inventory mismatch")
+    return all(checks[name] for name in CRITICAL_COMPARISON_CHECKS)
+
+
+def _validate_invocation_contract(attempt, minimum_anchors, resource_ceiling_bytes):
+    manifest = attempt["manifest"]
+    try:
+        aggregate = manifest["aggregate"]
+        core = manifest["fingerprint_core"]
+        graph_ready = manifest["graph_asset_ready"]
+        privacy_certified = aggregate["privacy_certified"]
+        coverage = aggregate["minimum_anchor_coverage_pass"]
+    except (KeyError, TypeError) as exc:
+        raise ConsensusError("verified manifest is missing invocation fields") from exc
+    if aggregate.get("minimum_anchor_count") != minimum_anchors:
+        raise ConsensusError("snapshot compiler did not bind the requested minimum anchors")
+    if core.get("resource_ceiling_bytes") != resource_ceiling_bytes:
+        raise ConsensusError("snapshot compiler did not bind the requested resource ceiling")
+    if any(not isinstance(value, bool) for value in (graph_ready, privacy_certified, coverage)):
+        raise ConsensusError("snapshot readiness fields are not Boolean")
+    expected_prepare_code = 0 if graph_ready else 2
+    if attempt["prepare_exit_code"] != expected_prepare_code:
+        raise ConsensusError("prepare exit code disagrees with verified readiness")
+
+
+def _validate_attempt_input_records(attempt, expected_inputs):
+    try:
+        observed = attempt["manifest"]["input_records"]
+    except (KeyError, TypeError) as exc:
+        raise ConsensusError("snapshot manifest is missing exact input records") from exc
+    if observed != expected_inputs:
+        raise ConsensusError("snapshot attempt does not bind the supplied input records")
+
+
+def _readiness_from_manifest(manifest):
+    return {
+        "graph_asset_ready": manifest["graph_asset_ready"],
+        "minimum_anchor_count": manifest["aggregate"]["minimum_anchor_count"],
+        "minimum_anchor_coverage_pass": manifest["aggregate"][
+            "minimum_anchor_coverage_pass"
+        ],
+        "privacy_certified": manifest["aggregate"]["privacy_certified"],
+        "resource_ceiling_bytes": manifest["fingerprint_core"]["resource_ceiling_bytes"],
+    }
+
+
+def _summary_from_manifest(manifest):
+    aggregate = manifest["aggregate"]
+    return {
+        "eligible_anchor_count": aggregate["eligible_anchor_count"],
+        "largest_component_node_count": aggregate["largest_component_node_count"],
+        "physical_edge_count": aggregate["physical_edge_count"],
+        "retained_node_count": aggregate["retained_node_count"],
+    }
+
+
+def _common_records_from_manifest(manifest):
+    core = manifest["fingerprint_core"]
+    return {
+        "authoritative_artifact_set_sha256": core[
+            "authoritative_artifact_set_sha256"
+        ],
+        "compiler_implementation_records": core["implementation_records"],
+        "fingerprint_core_sha256": hashlib.sha256(_canonical_json(core)).hexdigest(),
+        "largest_component_sha256": core["largest_component_sha256"],
+        "numeric_contract": core["numeric_contract"],
+        "repository_commit": core["repository_commit"],
+        "study_universe_sha256": core["study_universe_sha256"],
+    }
+
+
+def _attempt_receipt_record(label, attempt):
+    manifest = attempt["manifest"]
+    return {
+        "attempt_label": label,
+        "legacy_parity_artifact_record": manifest.get("artifact_records", {}).get(
+            "legacy_parity.json"
+        ),
+        "legacy_parity_status": manifest.get("aggregate", {}).get(
+            "legacy_parity_status"
+        ),
+        "manifest_record": attempt["manifest_record"],
+        "observed_contract_bytes": manifest["fingerprint_core"][
+            "observed_contract_bytes"
+        ],
+        "prepare_exit_code": attempt["prepare_exit_code"],
+        "readiness": _readiness_from_manifest(manifest),
+        "snapshot_fingerprint": manifest["snapshot_fingerprint"],
+        "verify_exit_code": attempt["verify_exit_code"],
+    }
+
+
+def _derive_consensus(manifest_a, manifest_b):
+    checks = _named_comparisons(manifest_a, manifest_b)
+    exact = _critical_comparisons_pass(checks)
+    legacy_warning = not (
+        checks["legacy_parity_artifact_record_equal"]
+        and checks["legacy_parity_status_equal"]
+    )
+    if exact:
+        common_fingerprint = manifest_a["snapshot_fingerprint"]
+        common_records = _common_records_from_manifest(manifest_a)
+        readiness = _readiness_from_manifest(manifest_a)
+        aggregate_summary = _summary_from_manifest(manifest_a)
+        accepted = readiness["privacy_certified"] and readiness["graph_asset_ready"]
+        if accepted:
+            reason = "exact_consensus_ready"
+        elif not readiness["privacy_certified"]:
+            reason = "privacy_not_certified"
+        else:
+            reason = "graph_asset_not_ready"
+    else:
+        common_fingerprint = None
+        common_records = None
+        readiness = None
+        aggregate_summary = None
+        accepted = False
+        reason = "exact_consensus_mismatch"
+    return {
+        "accepted": accepted,
+        "aggregate_summary": aggregate_summary,
+        "common_records": common_records,
+        "common_snapshot_fingerprint": common_fingerprint,
+        "comparison_checks": checks,
+        "readiness": readiness,
+        "reason": reason,
+        "repeatability_verified": exact,
+        "warnings": ["legacy_parity_disagreement"] if legacy_warning else [],
+    }
+
+
+def _seal_receipt(receipt):
+    sealed = dict(receipt)
+    sealed["repeatability_contract_sha256"] = hashlib.sha256(
+        _canonical_json(receipt)
+    ).hexdigest()
+    return sealed
+
+
+def _write_bytes(path, data):
+    with open(path, "xb") as stream:
+        os.chmod(path, 0o600)
+        stream.write(data)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def _rename_directory_noreplace(source, target):
+    libc = ctypes.CDLL(None, use_errno=True)
+    renameat2 = getattr(libc, "renameat2", None)
+    if renameat2 is None:
+        raise ConsensusError("atomic no-replace rename is unavailable")
+    renameat2.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    renameat2.restype = ctypes.c_int
+    result = renameat2(
+        -100,
+        os.fsencode(source),
+        -100,
+        os.fsencode(target),
+        1,
+    )
+    if result == 0:
+        return
+    error_number = ctypes.get_errno()
+    if error_number in {errno.EEXIST, errno.ENOTEMPTY}:
+        raise ConsensusError("receipt directory appeared during atomic installation")
+    raise ConsensusError("atomic no-replace receipt installation failed") from OSError(
+        error_number, os.strerror(error_number)
+    )
+
+
+def _install_receipt(receipt_dir, receipt):
+    receipt_dir = Path(receipt_dir)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{receipt_dir.name}.", dir=receipt_dir.parent))
+    os.chmod(temporary, 0o700)
+    installed = False
+    try:
+        _write_bytes(temporary / RECEIPT_NAME, _canonical_json(receipt))
+        _write_bytes(temporary / MARKER_NAME, MARKER_BYTES)
+        directory_fd = os.open(temporary, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+        _rename_directory_noreplace(temporary, receipt_dir)
+        installed = True
+        parent_fd = os.open(receipt_dir.parent, os.O_RDONLY)
+        try:
+            os.fsync(parent_fd)
+        finally:
+            os.close(parent_fd)
+    finally:
+        if not installed and temporary.exists():
+            shutil.rmtree(temporary)
+
+
+def _validate_consensus_receipt_structure(receipt_dir):
+    receipt_input = Path(receipt_dir)
+    receipt_binding = _bind_existing_directory(receipt_input, "consensus receipt")
+    receipt_dir = _assert_bound_directory(receipt_binding, "consensus receipt")
+    if _path_is_within(receipt_dir, REPO_ROOT.resolve()) or _has_git_ancestor(
+        receipt_dir.parent
+    ):
+        raise ConsensusError("consensus receipt directory cannot be inside a Git worktree")
+    if not receipt_dir.is_dir() or stat.S_IMODE(receipt_dir.stat().st_mode) != 0o700:
+        raise ConsensusError("consensus receipt directory is unavailable or not mode 0700")
+    entries = list(receipt_dir.iterdir())
+    if any(item.is_symlink() or not item.is_file() for item in entries):
+        raise ConsensusError("consensus receipt contains a nonregular entry")
+    if {item.name for item in entries} != RECEIPT_FILES:
+        raise ConsensusError("consensus receipt file set mismatch")
+    if any(stat.S_IMODE(item.stat().st_mode) != 0o600 for item in entries):
+        raise ConsensusError("consensus receipt artifact mode is not 0600")
+    if (receipt_dir / MARKER_NAME).read_bytes() != MARKER_BYTES:
+        raise ConsensusError("consensus local-only marker mismatch")
+    data = (receipt_dir / RECEIPT_NAME).read_bytes()
+    _assert_bound_directory(receipt_binding, "consensus receipt")
+    receipt = _strict_json_bytes(data, "consensus receipt")
+    expected_keys = {
+        "accepted",
+        "aggregate_summary",
+        "algorithm",
+        "attempt_count",
+        "attempts",
+        "canonical_attempt",
+        "common_records",
+        "common_snapshot_fingerprint",
+        "comparison_checks",
+        "downstream_requirement",
+        "evidence_interpretation",
+        "graph_observation_count",
+        "graph_gate_pass",
+        "implementation_records",
+        "input_records",
+        "legacy_parity_role",
+        "no_pooling",
+        "readiness",
+        "reason",
+        "repeatability_contract_sha256",
+        "repeatability_verified",
+        "schema",
+        "warnings",
+    }
+    if not isinstance(receipt, dict) or set(receipt) != expected_keys:
+        raise ConsensusError("consensus receipt fields mismatch")
+    if receipt.get("schema") != SCHEMA:
+        raise ConsensusError("consensus receipt schema mismatch")
+    if receipt.get("algorithm") != ALGORITHM:
+        raise ConsensusError("consensus receipt algorithm mismatch")
+    expected_repeatability_hash = receipt["repeatability_contract_sha256"]
+    unsealed = dict(receipt)
+    del unsealed["repeatability_contract_sha256"]
+    if (
+        not isinstance(expected_repeatability_hash, str)
+        or len(expected_repeatability_hash) != 64
+        or hashlib.sha256(_canonical_json(unsealed)).hexdigest()
+        != expected_repeatability_hash
+    ):
+        raise ConsensusError("consensus repeatability-contract hash mismatch")
+    if (
+        receipt["attempt_count"] != 2
+        or receipt["graph_observation_count"] != 1
+        or receipt["no_pooling"] is not True
+        or receipt["canonical_attempt"] != "attempt_a"
+        or receipt["evidence_interpretation"] != EVIDENCE_INTERPRETATION
+        or receipt["downstream_requirement"] != DOWNSTREAM_REQUIREMENT
+        or receipt["legacy_parity_role"] != LEGACY_PARITY_ROLE
+    ):
+        raise ConsensusError("consensus interpretation contract mismatch")
+
+    input_records = receipt["input_records"]
+    if (
+        not isinstance(input_records, dict)
+        or set(input_records) != {"relation_policy", "source_spec"}
+        or any(not _content_record_is_valid(value) for value in input_records.values())
+    ):
+        raise ConsensusError("consensus input records are malformed")
+    expected_runtime = {
+        "expat_version": xml.parsers.expat.EXPAT_VERSION,
+        "python_implementation": sys.implementation.name,
+        "python_version": ".".join(map(str, sys.version_info[:3])),
+        "sqlite_version": sqlite3.sqlite_version,
+        "unicode_data_version": unicodedata.unidata_version,
+    }
+    implementation = receipt["implementation_records"]
+    if (
+        not isinstance(implementation, dict)
+        or set(implementation)
+        != {
+            "consensus_preparer",
+            "runtime_identity",
+            "snapshot_preparer_entrypoint",
+            "source_declaration_validator",
+        }
+        or not _content_record_is_valid(implementation["consensus_preparer"])
+        or not _content_record_is_valid(implementation["snapshot_preparer_entrypoint"])
+        or not _content_record_is_valid(implementation["source_declaration_validator"])
+        or implementation["consensus_preparer"]
+        != _regular_file_record(Path(__file__).resolve(), "consensus preparer")
+        or implementation["snapshot_preparer_entrypoint"]
+        != _regular_file_record(SNAPSHOT_PREPARER, "snapshot preparer entrypoint")
+        or implementation["source_declaration_validator"]
+        != _regular_file_record(
+            Path(declaration.__file__).resolve(), "source declaration validator"
+        )
+        or implementation["runtime_identity"] != expected_runtime
+    ):
+        raise ConsensusError("consensus implementation provenance mismatch")
+
+    attempts = receipt["attempts"]
+    if not isinstance(attempts, list) or len(attempts) != 2:
+        raise ConsensusError("consensus attempts must contain exactly two records")
+    for expected_label, attempt in zip(("attempt_a", "attempt_b"), attempts):
+        if (
+            not isinstance(attempt, dict)
+            or set(attempt)
+            != {
+                "attempt_label",
+                "legacy_parity_artifact_record",
+                "legacy_parity_status",
+                "manifest_record",
+                "observed_contract_bytes",
+                "prepare_exit_code",
+                "readiness",
+                "snapshot_fingerprint",
+                "verify_exit_code",
+            }
+            or attempt["attempt_label"] != expected_label
+            or not _content_record_is_valid(
+                attempt["legacy_parity_artifact_record"]
+            )
+            or not isinstance(attempt["legacy_parity_status"], str)
+            or not attempt["legacy_parity_status"]
+            or not _content_record_is_valid(attempt["manifest_record"])
+            or not isinstance(attempt["observed_contract_bytes"], int)
+            or isinstance(attempt["observed_contract_bytes"], bool)
+            or attempt["observed_contract_bytes"] < 0
+            or attempt["prepare_exit_code"] not in {0, 2}
+            or not _hex_string_is_valid(attempt["snapshot_fingerprint"], 64)
+            or attempt["verify_exit_code"] != 0
+        ):
+            raise ConsensusError("consensus attempt record is malformed")
+        readiness = attempt["readiness"]
+        if (
+            not isinstance(readiness, dict)
+            or set(readiness)
+            != {
+                "graph_asset_ready",
+                "minimum_anchor_count",
+                "minimum_anchor_coverage_pass",
+                "privacy_certified",
+                "resource_ceiling_bytes",
+            }
+            or any(
+                not isinstance(readiness[key], bool)
+                for key in (
+                    "graph_asset_ready",
+                    "minimum_anchor_coverage_pass",
+                    "privacy_certified",
+                )
+            )
+            or not isinstance(readiness["minimum_anchor_count"], int)
+            or isinstance(readiness["minimum_anchor_count"], bool)
+            or readiness["minimum_anchor_count"] < 1
+            or not isinstance(readiness["resource_ceiling_bytes"], int)
+            or isinstance(readiness["resource_ceiling_bytes"], bool)
+            or readiness["resource_ceiling_bytes"] < 1
+            or readiness["graph_asset_ready"]
+            is not (
+                readiness["privacy_certified"]
+                and readiness["minimum_anchor_coverage_pass"]
+            )
+            or attempt["prepare_exit_code"]
+            != (0 if readiness["graph_asset_ready"] else 2)
+        ):
+            raise ConsensusError("consensus attempt readiness is malformed")
+
+    checks = receipt["comparison_checks"]
+    expected_check_keys = CRITICAL_COMPARISON_CHECKS | {
+        "full_manifest_equal",
+        "legacy_parity_artifact_record_equal",
+        "legacy_parity_status_equal",
+    }
+    if (
+        not isinstance(checks, dict)
+        or set(checks) != expected_check_keys
+        or any(not isinstance(value, bool) for value in checks.values())
+    ):
+        raise ConsensusError("consensus comparison checks are malformed")
+    scientific_exact = all(checks[name] for name in CRITICAL_COMPARISON_CHECKS)
+    if receipt["repeatability_verified"] is not scientific_exact:
+        raise ConsensusError("repeatability decision disagrees with scientific checks")
+    legacy_warning = not (
+        checks["legacy_parity_artifact_record_equal"]
+        and checks["legacy_parity_status_equal"]
+    )
+    expected_warnings = ["legacy_parity_disagreement"] if legacy_warning else []
+    if receipt["warnings"] != expected_warnings:
+        raise ConsensusError("consensus warning state mismatch")
+    if scientific_exact and not legacy_warning and not checks["full_manifest_equal"]:
+        raise ConsensusError("full manifest equality disagrees with component checks")
+    if checks["full_manifest_equal"] and legacy_warning:
+        raise ConsensusError("legacy warning contradicts full manifest equality")
+    if checks["full_manifest_equal"] is not (
+        attempts[0]["manifest_record"] == attempts[1]["manifest_record"]
+    ):
+        raise ConsensusError("full manifest equality disagrees with content records")
+    if checks["legacy_parity_artifact_record_equal"] is not (
+        attempts[0]["legacy_parity_artifact_record"]
+        == attempts[1]["legacy_parity_artifact_record"]
+    ):
+        raise ConsensusError("legacy artifact equality disagrees with attempt records")
+    if checks["legacy_parity_status_equal"] is not (
+        attempts[0]["legacy_parity_status"]
+        == attempts[1]["legacy_parity_status"]
+    ):
+        raise ConsensusError("legacy status equality disagrees with attempt records")
+
+    if scientific_exact:
+        readiness = receipt["readiness"]
+        if readiness != attempts[0]["readiness"] or readiness != attempts[1]["readiness"]:
+            raise ConsensusError("common readiness disagrees with attempts")
+        fingerprint = receipt["common_snapshot_fingerprint"]
+        if not _hex_string_is_valid(fingerprint, 64):
+            raise ConsensusError("common snapshot fingerprint is malformed")
+        if any(attempt["snapshot_fingerprint"] != fingerprint for attempt in attempts):
+            raise ConsensusError("attempt fingerprints disagree with common fingerprint")
+        if attempts[0]["observed_contract_bytes"] != attempts[1]["observed_contract_bytes"]:
+            raise ConsensusError("repeatable attempts disagree on observed contract bytes")
+        common_records = receipt["common_records"]
+        if (
+            not isinstance(common_records, dict)
+            or set(common_records)
+            != {
+                "authoritative_artifact_set_sha256",
+                "compiler_implementation_records",
+                "fingerprint_core_sha256",
+                "largest_component_sha256",
+                "numeric_contract",
+                "repository_commit",
+                "study_universe_sha256",
+            }
+            or any(
+                not _hex_string_is_valid(common_records[key], 64)
+                for key in (
+                    "authoritative_artifact_set_sha256",
+                    "fingerprint_core_sha256",
+                    "largest_component_sha256",
+                    "study_universe_sha256",
+                )
+            )
+            or common_records["fingerprint_core_sha256"] != fingerprint
+            or not _hex_string_is_valid(common_records["repository_commit"], 40)
+            or common_records["numeric_contract"]
+            != {
+                "downstream_decision_dtype": "float64",
+                "preparer_arithmetic": "exact_integer_graph",
+                "preparer_threads": 1,
+            }
+            or not isinstance(common_records["compiler_implementation_records"], dict)
+            or set(common_records["compiler_implementation_records"])
+            != {"preparer", "privacy_rule"}
+            or any(
+                not _content_record_is_valid(value)
+                for value in common_records["compiler_implementation_records"].values()
+            )
+            or common_records["compiler_implementation_records"]["preparer"]
+            != implementation["snapshot_preparer_entrypoint"]
+            or common_records["compiler_implementation_records"]["privacy_rule"]
+            != _regular_file_record(PRIVACY_RULE, "snapshot privacy rule")
+        ):
+            raise ConsensusError("common repeatability records are malformed")
+        summary = receipt["aggregate_summary"]
+        if (
+            not isinstance(summary, dict)
+            or set(summary)
+            != {
+                "eligible_anchor_count",
+                "largest_component_node_count",
+                "physical_edge_count",
+                "retained_node_count",
+            }
+            or any(
+                not isinstance(value, int) or isinstance(value, bool) or value < 0
+                for value in summary.values()
+            )
+        ):
+            raise ConsensusError("consensus aggregate summary is malformed")
+        expected_accepted = readiness["privacy_certified"] and readiness["graph_asset_ready"]
+        if expected_accepted:
+            expected_reason = "exact_consensus_ready"
+        elif not readiness["privacy_certified"]:
+            expected_reason = "privacy_not_certified"
+        else:
+            expected_reason = "graph_asset_not_ready"
+    else:
+        expected_accepted = False
+        expected_reason = "exact_consensus_mismatch"
+        if (
+            receipt["readiness"] is not None
+            or receipt["aggregate_summary"] is not None
+            or receipt["common_records"] is not None
+            or receipt["common_snapshot_fingerprint"] is not None
+        ):
+            raise ConsensusError("mismatched consensus exposes invalid common fields")
+    if (
+        receipt["accepted"] is not expected_accepted
+        or receipt["graph_gate_pass"] is not expected_accepted
+        or receipt["reason"] != expected_reason
+    ):
+        raise ConsensusError("consensus decision does not follow verified checks")
+    return receipt
+
+
+def _load_reverified_attempt(run_dir, prepare_exit_code, *, binding=None):
+    run_input = Path(run_dir)
+    attempt_binding = binding or _bind_existing_directory(
+        run_input, "snapshot attempt"
+    )
+    run_resolved = _assert_bound_directory(attempt_binding, "snapshot attempt")
+    if _path_is_within(run_resolved, REPO_ROOT.resolve()) or _has_git_ancestor(
+        run_resolved.parent
+    ):
+        raise ConsensusError("snapshot attempt cannot be inside a Git worktree")
+    verify_code = _run_snapshot_cli(("verify", "--run-dir", run_resolved))
+    if verify_code != 0:
+        raise ConsensusError("snapshot attempt failed independent verification")
+    run_resolved = _assert_bound_directory(attempt_binding, "snapshot attempt")
+    manifest_path = run_resolved / "manifest.json"
+    try:
+        manifest_bytes = manifest_path.read_bytes()
+    except OSError as exc:
+        raise ConsensusError("reverified snapshot manifest could not be read") from exc
+    _assert_bound_directory(attempt_binding, "snapshot attempt")
+    manifest = _strict_json_bytes(manifest_bytes, "reverified snapshot manifest")
+    if not isinstance(manifest, dict):
+        raise ConsensusError("reverified snapshot manifest is not an object")
+    return {
+        "manifest": manifest,
+        "manifest_record": _content_record(manifest_bytes),
+        "prepare_exit_code": prepare_exit_code,
+        "verify_exit_code": verify_code,
+    }
+
+
+def verify_consensus_receipt(
+    receipt_dir,
+    *,
+    attempt_a_dir,
+    attempt_b_dir,
+    source_spec,
+    relation_policy,
+):
+    """Verify a receipt against both installed attempts and frozen inputs."""
+
+    try:
+        declaration.verify_installed_source_spec(source_spec)
+    except declaration.DeclarationError as exc:
+        raise ConsensusError("source declaration bundle failed verification") from exc
+    if _has_symlink_ancestor(Path(relation_policy)):
+        raise ConsensusError("relation policy path cannot contain a symlink")
+    receipt = _validate_consensus_receipt_structure(receipt_dir)
+    observed_inputs = {
+        "relation_policy": _regular_file_record(relation_policy, "relation policy"),
+        "source_spec": _regular_file_record(source_spec, "source spec"),
+    }
+    if receipt["input_records"] != observed_inputs:
+        raise ConsensusError("consensus receipt input records do not match supplied inputs")
+
+    recorded_attempts = receipt["attempts"]
+    attempt_a_binding = _bind_existing_directory(attempt_a_dir, "attempt A")
+    attempt_b_binding = _bind_existing_directory(attempt_b_dir, "attempt B")
+    attempt_a_path = attempt_a_binding[0]
+    attempt_b_path = attempt_b_binding[0]
+    if (
+        attempt_a_path == attempt_b_path
+        or attempt_a_binding[1:] == attempt_b_binding[1:]
+        or _path_is_within(attempt_a_path, attempt_b_path)
+        or _path_is_within(attempt_b_path, attempt_a_path)
+    ):
+        raise ConsensusError("consensus requires two distinct nonnested attempt directories")
+    actual_a = _load_reverified_attempt(
+        attempt_a_path,
+        recorded_attempts[0]["prepare_exit_code"],
+        binding=attempt_a_binding,
+    )
+    actual_b = _load_reverified_attempt(
+        attempt_b_path,
+        recorded_attempts[1]["prepare_exit_code"],
+        binding=attempt_b_binding,
+    )
+    _validate_attempt_input_records(actual_a, observed_inputs)
+    _validate_attempt_input_records(actual_b, observed_inputs)
+    _validate_invocation_contract(
+        actual_a,
+        recorded_attempts[0]["readiness"]["minimum_anchor_count"],
+        recorded_attempts[0]["readiness"]["resource_ceiling_bytes"],
+    )
+    _validate_invocation_contract(
+        actual_b,
+        recorded_attempts[1]["readiness"]["minimum_anchor_count"],
+        recorded_attempts[1]["readiness"]["resource_ceiling_bytes"],
+    )
+    actual_attempt_records = [
+        _attempt_receipt_record("attempt_a", actual_a),
+        _attempt_receipt_record("attempt_b", actual_b),
+    ]
+    if recorded_attempts != actual_attempt_records:
+        raise ConsensusError("consensus attempt records do not match installed attempts")
+
+    derived = _derive_consensus(actual_a["manifest"], actual_b["manifest"])
+    for key, value in derived.items():
+        if receipt[key] != value:
+            raise ConsensusError(f"consensus receipt {key} is not derived from attempts")
+    if receipt["graph_gate_pass"] is not derived["accepted"]:
+        raise ConsensusError("consensus graph gate is not derived from attempts")
+    return receipt
+
+
+def prepare_consensus(
+    source_spec,
+    relation_policy,
+    attempt_a_dir,
+    attempt_b_dir,
+    receipt_dir,
+    local_root,
+    *,
+    minimum_anchors=128,
+    resource_ceiling_bytes,
+):
+    if isinstance(minimum_anchors, bool) or minimum_anchors < 1:
+        raise ConsensusError("minimum_anchors must be positive")
+    if isinstance(resource_ceiling_bytes, bool) or resource_ceiling_bytes < 1:
+        raise ConsensusError("resource ceiling must be positive")
+    try:
+        declaration.verify_installed_source_spec(source_spec)
+    except declaration.DeclarationError as exc:
+        raise ConsensusError("source declaration bundle failed verification") from exc
+    local_root, outputs = _validate_output_paths(
+        local_root,
+        attempt_a_dir,
+        attempt_b_dir,
+        receipt_dir,
+        source_spec,
+        relation_policy,
+    )
+    attempt_a_dir, attempt_b_dir, receipt_dir = outputs
+    output_parent_bindings = _bind_directory_identities(
+        (local_root, *(path.parent for path in outputs))
+    )
+    declaration_dir = Path(source_spec).resolve().parent
+    if declaration_dir == local_root or not _path_is_within(
+        declaration_dir, local_root
+    ):
+        raise ConsensusError("source declaration bundle must be below the local root")
+    input_records = {
+        "relation_policy": _regular_file_record(relation_policy, "relation policy"),
+        "source_spec": _regular_file_record(source_spec, "source spec"),
+    }
+    implementation_records = {
+        "consensus_preparer": _regular_file_record(Path(__file__).resolve(), "consensus preparer"),
+        "runtime_identity": {
+            "expat_version": xml.parsers.expat.EXPAT_VERSION,
+            "python_implementation": sys.implementation.name,
+            "python_version": ".".join(map(str, sys.version_info[:3])),
+            "sqlite_version": sqlite3.sqlite_version,
+            "unicode_data_version": unicodedata.unidata_version,
+        },
+        "snapshot_preparer_entrypoint": _regular_file_record(
+            SNAPSHOT_PREPARER, "snapshot preparer entrypoint"
+        ),
+        "source_declaration_validator": _regular_file_record(
+            Path(declaration.__file__).resolve(), "source declaration validator"
+        ),
+    }
+
+    common = {
+        "source_spec": Path(source_spec).resolve(),
+        "relation_policy": Path(relation_policy).resolve(),
+        "local_root": local_root,
+        "minimum_anchors": minimum_anchors,
+        "resource_ceiling_bytes": resource_ceiling_bytes,
+        "expected_inputs": input_records,
+        "output_parent_bindings": output_parent_bindings,
+    }
+    attempt_a = _run_attempt(attempt_a_dir, **common)
+    try:
+        declaration.verify_installed_source_spec(source_spec)
+    except declaration.DeclarationError as exc:
+        raise ConsensusError("source declaration changed after attempt A") from exc
+    attempt_b = _run_attempt(attempt_b_dir, **common)
+    try:
+        declaration.verify_installed_source_spec(source_spec)
+    except declaration.DeclarationError as exc:
+        raise ConsensusError("source declaration changed after attempt B") from exc
+    _assert_inputs_unchanged(input_records, source_spec, relation_policy)
+    _validate_invocation_contract(attempt_a, minimum_anchors, resource_ceiling_bytes)
+    _validate_invocation_contract(attempt_b, minimum_anchors, resource_ceiling_bytes)
+    _validate_attempt_input_records(attempt_a, input_records)
+    _validate_attempt_input_records(attempt_b, input_records)
+
+    manifest_a = attempt_a["manifest"]
+    manifest_b = attempt_b["manifest"]
+    derived = _derive_consensus(manifest_a, manifest_b)
+    accepted = derived["accepted"]
+
+    receipt = {
+        "accepted": accepted,
+        "aggregate_summary": derived["aggregate_summary"],
+        "algorithm": ALGORITHM,
+        "attempt_count": 2,
+        "attempts": [
+            _attempt_receipt_record("attempt_a", attempt_a),
+            _attempt_receipt_record("attempt_b", attempt_b),
+        ],
+        "canonical_attempt": "attempt_a",
+        "common_records": derived["common_records"],
+        "common_snapshot_fingerprint": derived["common_snapshot_fingerprint"],
+        "comparison_checks": derived["comparison_checks"],
+        "downstream_requirement": DOWNSTREAM_REQUIREMENT,
+        "evidence_interpretation": EVIDENCE_INTERPRETATION,
+        "graph_observation_count": 1,
+        "graph_gate_pass": accepted,
+        "implementation_records": implementation_records,
+        "input_records": input_records,
+        "legacy_parity_role": LEGACY_PARITY_ROLE,
+        "no_pooling": True,
+        "readiness": derived["readiness"],
+        "reason": derived["reason"],
+        "repeatability_verified": derived["repeatability_verified"],
+        "schema": SCHEMA,
+        "warnings": derived["warnings"],
+    }
+    receipt = _seal_receipt(receipt)
+    _assert_directory_identities(output_parent_bindings)
+    _install_receipt(receipt_dir, receipt)
+    _assert_directory_identities(output_parent_bindings)
+    verified = verify_consensus_receipt(
+        receipt_dir,
+        attempt_a_dir=attempt_a_dir,
+        attempt_b_dir=attempt_b_dir,
+        source_spec=source_spec,
+        relation_policy=relation_policy,
+    )
+    if verified != receipt:
+        raise ConsensusError("installed consensus receipt changed during verification")
+    return receipt, (0 if accepted else 2)
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("--source-spec", required=True)
+    prepare.add_argument("--relation-policy", required=True)
+    prepare.add_argument("--attempt-a-dir", required=True)
+    prepare.add_argument("--attempt-b-dir", required=True)
+    prepare.add_argument("--receipt-dir", required=True)
+    prepare.add_argument("--local-root", required=True)
+    prepare.add_argument("--local-only", action="store_true", required=True)
+    prepare.add_argument("--minimum-anchors", type=_positive_int, default=128)
+    prepare.add_argument("--resource-ceiling-bytes", type=_positive_int, required=True)
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--receipt-dir", required=True)
+    verify.add_argument("--attempt-a-dir", required=True)
+    verify.add_argument("--attempt-b-dir", required=True)
+    verify.add_argument("--source-spec", required=True)
+    verify.add_argument("--relation-policy", required=True)
+    return parser
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
+    try:
+        if args.command == "prepare":
+            receipt, exit_code = prepare_consensus(
+                args.source_spec,
+                args.relation_policy,
+                args.attempt_a_dir,
+                args.attempt_b_dir,
+                args.receipt_dir,
+                args.local_root,
+                minimum_anchors=args.minimum_anchors,
+                resource_ceiling_bytes=args.resource_ceiling_bytes,
+            )
+            output = {
+                "accepted": receipt["accepted"],
+                "graph_asset_ready": (
+                    receipt["readiness"]["graph_asset_ready"]
+                    if receipt["readiness"] is not None
+                    else False
+                ),
+                "reason": receipt["reason"],
+            }
+        else:
+            receipt = verify_consensus_receipt(
+                args.receipt_dir,
+                attempt_a_dir=args.attempt_a_dir,
+                attempt_b_dir=args.attempt_b_dir,
+                source_spec=args.source_spec,
+                relation_policy=args.relation_policy,
+            )
+            exit_code = 0 if receipt["accepted"] else 2
+            output = {
+                "accepted": receipt["accepted"],
+                "reason": receipt["reason"],
+                "verified": True,
+            }
+        print(json.dumps(output, sort_keys=True))
+        return exit_code
+    except Exception:
+        print(
+            json.dumps({"error": "snapshot consensus failed closed"}, sort_keys=True),
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/prepare_pearltrees_diffusion_snapshot.py
+++ b/prototypes/mu_cosine/prepare_pearltrees_diffusion_snapshot.py
@@ -1557,6 +1557,21 @@ def _path_is_within(path, root):
         return False
 
 
+def _is_git_worktree_marker(path):
+    """Recognize an actual Git marker, not an unrelated empty `.git` path."""
+
+    try:
+        if path.is_symlink():
+            return True
+        if path.is_file():
+            with open(path, "rb") as stream:
+                return stream.read(256).lstrip().startswith(b"gitdir:")
+        return path.is_dir() and (path / "HEAD").is_file()
+    except OSError:
+        # An unreadable candidate marker is conservatively treated as Git.
+        return True
+
+
 def _validate_output_paths(run_dir, local_root, inputs):
     run_input = Path(run_dir)
     local_input = Path(local_root)
@@ -1570,7 +1585,10 @@ def _validate_output_paths(run_dir, local_root, inputs):
         raise SnapshotError("run directory must be a child of the approved local root")
     if _path_is_within(run_dir, REPO_ROOT.resolve()):
         raise SnapshotError("run directory cannot be inside the Git repository")
-    if any((ancestor / ".git").exists() for ancestor in (run_dir.parent, *run_dir.parents)):
+    if any(
+        _is_git_worktree_marker(ancestor / ".git")
+        for ancestor in (run_dir.parent, *run_dir.parents)
+    ):
         raise SnapshotError("run directory cannot be inside a Git worktree")
     if run_dir.exists():
         raise SnapshotError("run directory already exists")
@@ -2209,6 +2227,7 @@ def verify_snapshot(run_dir):
         "snapshot_fingerprint",
         "snapshot_label_hash",
         "graph_asset_ready",
+        "input_records",
     }
     if not isinstance(manifest, dict) or set(manifest) != expected_keys:
         raise SnapshotError("manifest fields mismatch")
@@ -2275,6 +2294,21 @@ def verify_snapshot(run_dir):
     }
     if core["numeric_contract"] != expected_numeric:
         raise SnapshotError("numeric contract mismatch")
+    input_records = manifest["input_records"]
+    if (
+        not isinstance(input_records, dict)
+        or set(input_records) != {"source_spec", "relation_policy"}
+        or any(
+            not isinstance(record, dict)
+            or set(record) != {"sha256", "size_bytes"}
+            or re.fullmatch(r"[0-9a-f]{64}", record.get("sha256", "")) is None
+            or not isinstance(record.get("size_bytes"), int)
+            or isinstance(record.get("size_bytes"), bool)
+            or record["size_bytes"] < 0
+            for record in input_records.values()
+        )
+    ):
+        raise SnapshotError("snapshot input content record is malformed")
     expected_privacy_policy = _expected_privacy_policy()
     if (
         manifest["privacy_policy"] != expected_privacy_policy
@@ -2438,6 +2472,10 @@ def prepare_snapshot(
             spec["snapshot_label"].encode("utf-8")
         ).hexdigest(),
         "graph_asset_ready": graph_asset_ready,
+        "input_records": {
+            "relation_policy": policy_before,
+            "source_spec": spec_before,
+        },
     }
     manifest_bytes = _canonical_json(manifest)
 

--- a/prototypes/mu_cosine/test_declare_pearltrees_diffusion_sources.py
+++ b/prototypes/mu_cosine/test_declare_pearltrees_diffusion_sources.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+"""Focused tests for the explicit Pearltrees diffusion source planner."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import stat
+
+import pytest
+
+import declare_pearltrees_diffusion_sources as declare
+import prepare_pearltrees_diffusion_snapshot as snapshot
+
+
+def _declared_inputs(tmp_path: Path) -> dict[str, Path]:
+    inputs = tmp_path / "private-inputs"
+    inputs.mkdir()
+    paths = {
+        "rdf_groups": inputs / "groups.rdf",
+        "rdf_primary": inputs / "primary.rdf",
+        "api_json_dir": inputs / "trees",
+        "api_sqlite": inputs / "api.db",
+        "path_jsonl": inputs / "paths.jsonl",
+        "legacy": inputs / "assembled_dag.tsv",
+    }
+    paths["rdf_groups"].write_bytes(
+        b"private team RDF contents are deliberately not parsed"
+    )
+    paths["rdf_primary"].write_bytes(
+        b"private primary RDF contents are deliberately not parsed"
+    )
+    paths["api_json_dir"].mkdir()
+    paths["api_sqlite"].write_bytes(b"not opened by the declaration planner")
+    paths["path_jsonl"].write_bytes(b"not read by the declaration planner\n")
+    paths["legacy"].write_bytes(b"not read by the declaration planner\n")
+    return paths
+
+
+def _full_spec(tmp_path: Path, *, reverse: bool = False) -> tuple[dict, dict[str, Path]]:
+    paths = _declared_inputs(tmp_path)
+    rdf = (
+        ("rdf-groups", "groups", str(paths["rdf_groups"])),
+        ("rdf-primary", "s243a", str(paths["rdf_primary"])),
+    )
+    if reverse:
+        rdf = tuple(reversed(rdf))
+    spec = declare.build_source_spec(
+        snapshot_label="frozen-local-snapshot",
+        rdf=rdf,
+        api_json_dir=(("api-files", str(paths["api_json_dir"])),),
+        api_sqlite=(("api-db", str(paths["api_sqlite"])),),
+        path_jsonl=(("paths", str(paths["path_jsonl"])),),
+        legacy_dag=str(paths["legacy"]),
+    )
+    return spec, paths
+
+
+def test_exact_compiler_shape_is_deterministic_and_private(tmp_path: Path) -> None:
+    spec, paths = _full_spec(tmp_path)
+    local_root = tmp_path / "local-only"
+    local_root.mkdir()
+    first = local_root / "declaration-a"
+    second = local_root / "declaration-b"
+
+    summary_a = declare.install_source_spec(
+        spec, output_dir=first, local_root=local_root
+    )
+    reverse_spec = declare.build_source_spec(
+        snapshot_label="frozen-local-snapshot",
+        rdf=(
+            ("rdf-primary", "s243a", str(paths["rdf_primary"])),
+            ("rdf-groups", "groups", str(paths["rdf_groups"])),
+        ),
+        path_jsonl=(("paths", str(paths["path_jsonl"])),),
+        api_sqlite=(("api-db", str(paths["api_sqlite"])),),
+        api_json_dir=(("api-files", str(paths["api_json_dir"])),),
+        legacy_dag=str(paths["legacy"]),
+    )
+    summary_b = declare.install_source_spec(
+        reverse_spec, output_dir=second, local_root=local_root
+    )
+
+    assert (first / declare.SPEC_FILENAME).read_bytes() == (
+        second / declare.SPEC_FILENAME
+    ).read_bytes()
+    installed = json.loads((first / declare.SPEC_FILENAME).read_text(encoding="utf-8"))
+    assert installed == spec == reverse_spec
+    assert declare.verify_installed_source_spec(first / declare.SPEC_FILENAME) == spec
+    assert set(installed) == {"legacy_check", "schema", "snapshot_label", "sources"}
+    assert [row["source_id"] for row in installed["sources"]] == sorted(
+        row["source_id"] for row in installed["sources"]
+    )
+    assert all(Path(row["path"]).is_absolute() for row in installed["sources"])
+    assert [set(row) for row in installed["sources"] if row["kind"] == "rdf"] == [
+        {"account", "kind", "path", "source_id"},
+        {"account", "kind", "path", "source_id"},
+    ]
+    assert all(
+        "account" not in row for row in installed["sources"] if row["kind"] != "rdf"
+    )
+    assert installed["legacy_check"] == {"dag_path": str(paths["legacy"].resolve())}
+    resolved_sources, resolved_legacy = snapshot._resolve_source_paths(
+        first / declare.SPEC_FILENAME, installed
+    )
+    assert len(resolved_sources) == 5
+    assert resolved_legacy == paths["legacy"].resolve()
+    assert stat.S_IMODE(first.stat().st_mode) == 0o700
+    assert stat.S_IMODE((first / declare.SPEC_FILENAME).stat().st_mode) == 0o600
+    assert stat.S_IMODE((first / declare.LOCAL_ONLY_MARKER).stat().st_mode) == 0o600
+    assert summary_a == summary_b == {
+        "legacy_check_declared": True,
+        "local_only": True,
+        "source_count": 5,
+        "source_kind_counts": {
+            "api_json_dir": 1,
+            "api_sqlite": 1,
+            "path_jsonl": 1,
+            "rdf": 2,
+        },
+        "spec_written": True,
+    }
+
+
+def test_cli_prints_only_aggregate_counts(tmp_path: Path, capsys) -> None:
+    private = tmp_path / "private-title-never-print.rdf"
+    private.write_bytes(b"private")
+    local_root = tmp_path / "local"
+    local_root.mkdir()
+
+    status = declare.main(
+        [
+            "--snapshot-label",
+            "secret-label-never-print",
+            "--local-root",
+            str(local_root),
+            "--output-dir",
+            str(local_root / "declaration"),
+            "--local-only",
+            "--rdf",
+            "secret-source-id-never-print",
+            "groups",
+            str(private),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 0
+    assert captured.err == ""
+    public = json.loads(captured.out)
+    assert public == {
+        "legacy_check_declared": False,
+        "local_only": True,
+        "source_count": 1,
+        "source_kind_counts": {"rdf": 1},
+        "spec_written": True,
+    }
+    for private_value in (
+        str(private),
+        "private-title-never-print",
+        "secret-label-never-print",
+        "secret-source-id-never-print",
+    ):
+        assert private_value not in captured.out
+
+
+def test_api_directory_contents_are_not_scanned(tmp_path: Path) -> None:
+    api_dir = tmp_path / "explicit-api-dir"
+    api_dir.mkdir()
+    (api_dir / "malformed-private.json").write_bytes(b"not JSON")
+    (api_dir / "nested-source-link").symlink_to(tmp_path / "missing-private-target")
+
+    spec = declare.build_source_spec(
+        snapshot_label="no-scan",
+        api_json_dir=(("api-files", str(api_dir)),),
+    )
+
+    assert spec["sources"] == [
+        {
+            "kind": "api_json_dir",
+            "path": str(api_dir.resolve()),
+            "source_id": "api-files",
+        }
+    ]
+
+
+def test_source_ids_are_globally_unique(tmp_path: Path) -> None:
+    paths = _declared_inputs(tmp_path)
+
+    with pytest.raises(declare.DeclarationError, match="globally unique"):
+        declare.build_source_spec(
+            snapshot_label="duplicates",
+            rdf=(("duplicate", "groups", str(paths["rdf_groups"])),),
+            api_sqlite=(("duplicate", str(paths["api_sqlite"])),),
+        )
+
+
+@pytest.mark.parametrize("hardlink", (False, True), ids=("same-path", "hardlink"))
+def test_authoritative_source_path_aliases_are_rejected(
+    tmp_path: Path, hardlink: bool
+) -> None:
+    source = tmp_path / "source.rdf"
+    source.write_bytes(b"not read")
+    alias = source
+    if hardlink:
+        alias = tmp_path / "source-hardlink.rdf"
+        os.link(source, alias)
+
+    with pytest.raises(declare.DeclarationError, match="source paths must not alias"):
+        declare.build_source_spec(
+            snapshot_label="no-source-aliases",
+            rdf=(("rdf-a", "groups", str(source)), ("rdf-b", "s243a", str(alias))),
+        )
+
+
+def test_legacy_input_cannot_alias_authoritative_source(tmp_path: Path) -> None:
+    source = tmp_path / "source.rdf"
+    source.write_bytes(b"not read")
+
+    with pytest.raises(declare.DeclarationError, match="legacy parity input cannot alias"):
+        declare.build_source_spec(
+            snapshot_label="no-legacy-alias",
+            rdf=(("rdf", "groups", str(source)),),
+            legacy_dag=str(source),
+        )
+
+
+def test_installer_rejects_noncanonical_or_extended_specs(tmp_path: Path) -> None:
+    source = tmp_path / "source.rdf"
+    source.write_bytes(b"not read")
+    second_source = tmp_path / "paths.jsonl"
+    second_source.write_bytes(b"not read\n")
+    local_root = tmp_path / "local"
+    local_root.mkdir()
+    spec = declare.build_source_spec(
+        snapshot_label="canonical",
+        rdf=(("z-source", "groups", str(source)),),
+        path_jsonl=(("a-source", str(second_source)),),
+    )
+    spec["sources"] = list(reversed(spec["sources"]))
+
+    with pytest.raises(declare.DeclarationError, match="canonical declaration order"):
+        declare.install_source_spec(
+            spec, output_dir=local_root / "noncanonical", local_root=local_root
+        )
+
+    extended = declare.build_source_spec(
+        snapshot_label="canonical",
+        rdf=(("source", "groups", str(source)),),
+    )
+    extended["publishable"] = False
+    with pytest.raises(declare.DeclarationError, match="fields mismatch"):
+        declare.install_source_spec(
+            extended, output_dir=local_root / "extended", local_root=local_root
+        )
+
+    assert list(local_root.iterdir()) == []
+
+
+@pytest.mark.parametrize("account", ("", " ", "grous", "GROUS", "GROUPS"))
+def test_noncanonical_team_accounts_fail_closed(tmp_path: Path, account: str) -> None:
+    source = tmp_path / "team.rdf"
+    source.write_bytes(b"not read")
+
+    with pytest.raises(declare.DeclarationError, match="account|typo|groups"):
+        declare.build_source_spec(
+            snapshot_label="account-check",
+            rdf=(("team-rdf", account, str(source)),),
+        )
+
+
+def test_filename_never_infers_or_changes_explicit_account(tmp_path: Path) -> None:
+    misleading = tmp_path / "grous-and-s243a.rdf"
+    misleading.write_bytes(b"not read")
+
+    spec = declare.build_source_spec(
+        snapshot_label="explicit-account",
+        rdf=(("team-rdf", "groups", str(misleading)),),
+    )
+
+    assert spec["sources"][0]["account"] == "groups"
+
+
+@pytest.mark.parametrize("wildcard", ("*.rdf", "tree?.json", "[12].db", "{a,b}.jsonl"))
+def test_wildcard_looking_paths_are_rejected(tmp_path: Path, wildcard: str) -> None:
+    wildcard_path = tmp_path / wildcard
+    wildcard_path.write_bytes(b"exists but remains forbidden")
+
+    with pytest.raises(declare.DeclarationError, match="wildcard-looking"):
+        declare.build_source_spec(
+            snapshot_label="no-globs",
+            path_jsonl=(("paths", str(wildcard_path)),),
+        )
+
+
+@pytest.mark.parametrize("symlink_parent", (False, True), ids=("leaf", "parent"))
+def test_declared_input_symlinks_are_rejected(
+    tmp_path: Path, symlink_parent: bool
+) -> None:
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    real_file = real_dir / "source.rdf"
+    real_file.write_bytes(b"not read")
+    if symlink_parent:
+        linked_dir = tmp_path / "linked-dir"
+        linked_dir.symlink_to(real_dir, target_is_directory=True)
+        declared = linked_dir / "source.rdf"
+    else:
+        declared = tmp_path / "linked.rdf"
+        declared.symlink_to(real_file)
+
+    with pytest.raises(declare.DeclarationError, match="symlink"):
+        declare.build_source_spec(
+            snapshot_label="no-symlinks",
+            rdf=(("rdf", "groups", str(declared)),),
+        )
+
+
+@pytest.mark.parametrize(
+    ("kind", "make_directory"),
+    (("api_json_dir", False), ("rdf", True), ("api_sqlite", True), ("path_jsonl", True)),
+)
+def test_declared_input_types_are_checked_only_by_type(
+    tmp_path: Path, kind: str, make_directory: bool
+) -> None:
+    source = tmp_path / "wrong-type"
+    source.mkdir() if make_directory else source.write_bytes(b"file")
+    kwargs = {kind: (("source", str(source)),)}
+    if kind == "rdf":
+        kwargs = {kind: (("source", "groups", str(source)),)}
+
+    with pytest.raises(declare.DeclarationError, match="directory|regular file"):
+        declare.build_source_spec(snapshot_label="type-check", **kwargs)
+
+
+def test_output_must_be_new_private_external_directory(tmp_path: Path) -> None:
+    source = tmp_path / "source.rdf"
+    source.write_bytes(b"not read")
+    spec = declare.build_source_spec(
+        snapshot_label="output-check",
+        rdf=(("rdf", "groups", str(source)),),
+    )
+    local_root = tmp_path / "local"
+    local_root.mkdir()
+    existing = local_root / "existing"
+    existing.mkdir()
+    with pytest.raises(declare.DeclarationError, match="already exists"):
+        declare.install_source_spec(spec, output_dir=existing, local_root=local_root)
+
+    target = local_root / "target"
+    target.mkdir()
+    linked = local_root / "linked-output"
+    linked.symlink_to(target, target_is_directory=True)
+    with pytest.raises(declare.DeclarationError, match="symlink"):
+        declare.install_source_spec(spec, output_dir=linked, local_root=local_root)
+
+    forbidden = declare.REPO_ROOT / "prototypes" / "mu_cosine" / "forbidden-output"
+    with pytest.raises(declare.DeclarationError, match="Git worktree"):
+        declare.install_source_spec(
+            spec,
+            output_dir=forbidden,
+            local_root=declare.REPO_ROOT,
+        )
+    assert not forbidden.exists()
+
+
+def test_atomic_install_never_replaces_a_racing_target(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source = tmp_path / "source.rdf"
+    source.write_bytes(b"not read")
+    spec = declare.build_source_spec(
+        snapshot_label="race-check",
+        rdf=(("rdf", "groups", str(source)),),
+    )
+    local_root = tmp_path / "local"
+    local_root.mkdir()
+    output = local_root / "declaration"
+    original = declare._rename_directory_noreplace
+
+    def race(source_dir: Path, target_dir: Path) -> None:
+        target_dir.mkdir()
+        (target_dir / "winner").write_text("concurrent", encoding="utf-8")
+        original(source_dir, target_dir)
+
+    monkeypatch.setattr(declare, "_rename_directory_noreplace", race)
+
+    with pytest.raises(declare.DeclarationError, match="appeared"):
+        declare.install_source_spec(spec, output_dir=output, local_root=local_root)
+
+    assert (output / "winner").read_text(encoding="utf-8") == "concurrent"
+    assert not (output / declare.SPEC_FILENAME).exists()
+    assert not any(path.name.startswith(".declaration.") for path in local_root.iterdir())
+
+
+def test_output_parent_identity_is_rechecked_before_atomic_promotion(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source = tmp_path / "source.rdf"
+    source.write_bytes(b"not read")
+    spec = declare.build_source_spec(
+        snapshot_label="parent-race-check",
+        rdf=(("rdf", "groups", str(source)),),
+    )
+    local_root = tmp_path / "local"
+    local_root.mkdir()
+    output = local_root / "declaration"
+    rename_called = False
+
+    def fail_parent_recheck(parent: Path, expected: tuple[int, int]) -> None:
+        del parent, expected
+        raise declare.DeclarationError(
+            "output parent identity changed during installation"
+        )
+
+    def record_rename(source_dir: Path, target_dir: Path) -> None:
+        del source_dir, target_dir
+        nonlocal rename_called
+        rename_called = True
+
+    monkeypatch.setattr(declare, "_recheck_output_parent", fail_parent_recheck)
+    monkeypatch.setattr(declare, "_rename_directory_noreplace", record_rename)
+
+    with pytest.raises(declare.DeclarationError, match="parent identity changed"):
+        declare.install_source_spec(
+            spec,
+            output_dir=output,
+            local_root=local_root,
+        )
+
+    assert rename_called is False
+    assert not output.exists()
+    assert not any(path.name.startswith(".declaration.") for path in local_root.iterdir())
+
+
+def test_cli_failure_is_generic_and_does_not_disclose_input(
+    tmp_path: Path, capsys
+) -> None:
+    missing = tmp_path / "very-private-missing-source.rdf"
+    local_root = tmp_path / "local"
+    local_root.mkdir()
+
+    status = declare.main(
+        [
+            "--snapshot-label",
+            "private-label",
+            "--local-root",
+            str(local_root),
+            "--output-dir",
+            str(local_root / "declaration"),
+            "--local-only",
+            "--rdf",
+            "private-source-id",
+            "groups",
+            str(missing),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert status == 1
+    assert captured.out == ""
+    assert json.loads(captured.err) == {"error": "source declaration failed closed"}
+    assert str(missing) not in captured.err
+    assert "private-source-id" not in captured.err
+    assert "private-label" not in captured.err
+
+
+def test_empty_declaration_has_no_implicit_default() -> None:
+    with pytest.raises(declare.DeclarationError, match="explicit source"):
+        declare.build_source_spec(snapshot_label="no-defaults")
+
+
+def _installed_full_spec(tmp_path: Path) -> tuple[dict, Path]:
+    spec, _paths = _full_spec(tmp_path)
+    local_root = tmp_path / "local-only"
+    local_root.mkdir()
+    output = local_root / "declaration"
+    declare.install_source_spec(spec, output_dir=output, local_root=local_root)
+    return spec, output
+
+
+def test_verifier_rejects_handwritten_rdf_without_explicit_account(
+    tmp_path: Path,
+) -> None:
+    spec, output = _installed_full_spec(tmp_path)
+    malformed = json.loads(json.dumps(spec))
+    rdf = next(row for row in malformed["sources"] if row["kind"] == "rdf")
+    del rdf["account"]
+    (output / declare.SPEC_FILENAME).write_bytes(declare._canonical_json(malformed))
+
+    with pytest.raises(declare.DeclarationError, match="source entry fields mismatch"):
+        declare.verify_installed_source_spec(output / declare.SPEC_FILENAME)
+
+
+def test_verifier_rejects_noncanonical_json_key_order(tmp_path: Path) -> None:
+    spec, output = _installed_full_spec(tmp_path)
+    reversed_top_level = dict(reversed(tuple(spec.items())))
+    payload = (
+        json.dumps(
+            reversed_top_level,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+    assert payload != declare._canonical_json(spec)
+    (output / declare.SPEC_FILENAME).write_bytes(payload)
+
+    with pytest.raises(declare.DeclarationError, match="not canonical JSON"):
+        declare.verify_installed_source_spec(output / declare.SPEC_FILENAME)
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    (
+        (b'{"schema":"a","schema":"b"}\n', "duplicate JSON key"),
+        (b'{"schema":NaN}\n', "non-finite JSON number"),
+        (b'{"schema":"\xff"}\n', "strict UTF-8 JSON"),
+    ),
+    ids=("duplicate-key", "nonfinite", "invalid-utf8"),
+)
+def test_verifier_uses_strict_json_parser(
+    tmp_path: Path, payload: bytes, error: str
+) -> None:
+    _spec, output = _installed_full_spec(tmp_path)
+    (output / declare.SPEC_FILENAME).write_bytes(payload)
+
+    with pytest.raises(declare.DeclarationError, match=error):
+        declare.verify_installed_source_spec(output / declare.SPEC_FILENAME)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ("directory-mode", "spec-mode", "marker-mode", "extra-file", "marker-bytes"),
+)
+def test_verifier_rejects_unsafe_bundle_envelope(
+    tmp_path: Path, mutation: str
+) -> None:
+    _spec, output = _installed_full_spec(tmp_path)
+    if mutation == "directory-mode":
+        os.chmod(output, 0o755)
+    elif mutation == "spec-mode":
+        os.chmod(output / declare.SPEC_FILENAME, 0o644)
+    elif mutation == "marker-mode":
+        os.chmod(output / declare.LOCAL_ONLY_MARKER, 0o644)
+    elif mutation == "extra-file":
+        (output / "unexpected").write_bytes(b"not allowed")
+    elif mutation == "marker-bytes":
+        (output / declare.LOCAL_ONLY_MARKER).write_bytes(b"not the marker\n")
+    else:  # pragma: no cover - parameter exhaustiveness
+        raise AssertionError(mutation)
+
+    with pytest.raises(declare.DeclarationError):
+        declare.verify_installed_source_spec(output / declare.SPEC_FILENAME)
+
+
+@pytest.mark.parametrize("symlink_kind", ("spec", "marker", "parent"))
+def test_verifier_rejects_symlinked_bundle_paths(
+    tmp_path: Path, symlink_kind: str
+) -> None:
+    _spec, output = _installed_full_spec(tmp_path)
+    source_spec = output / declare.SPEC_FILENAME
+    if symlink_kind == "spec":
+        replacement = tmp_path / "replacement-spec.json"
+        replacement.write_bytes(source_spec.read_bytes())
+        source_spec.unlink()
+        source_spec.symlink_to(replacement)
+    elif symlink_kind == "marker":
+        marker = output / declare.LOCAL_ONLY_MARKER
+        replacement = tmp_path / "replacement-marker"
+        replacement.write_bytes(marker.read_bytes())
+        marker.unlink()
+        marker.symlink_to(replacement)
+    elif symlink_kind == "parent":
+        linked = tmp_path / "linked-declaration"
+        linked.symlink_to(output, target_is_directory=True)
+        source_spec = linked / declare.SPEC_FILENAME
+    else:  # pragma: no cover - parameter exhaustiveness
+        raise AssertionError(symlink_kind)
+
+    with pytest.raises(declare.DeclarationError, match="symlink|regular files"):
+        declare.verify_installed_source_spec(source_spec)
+
+
+def test_verifier_requires_exact_spec_filename(tmp_path: Path) -> None:
+    _spec, output = _installed_full_spec(tmp_path)
+
+    with pytest.raises(declare.DeclarationError, match="must be named"):
+        declare.verify_installed_source_spec(output / declare.LOCAL_ONLY_MARKER)
+
+
+def test_verifier_rejects_bundle_inside_real_git_worktree(tmp_path: Path) -> None:
+    spec, _paths = _full_spec(tmp_path)
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    git_marker = checkout / ".git"
+    git_marker.mkdir()
+    (git_marker / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    output = checkout / "declaration"
+    output.mkdir(mode=0o700)
+    source_spec = output / declare.SPEC_FILENAME
+    source_spec.write_bytes(declare._canonical_json(spec))
+    marker = output / declare.LOCAL_ONLY_MARKER
+    marker.write_bytes(declare.LOCAL_ONLY_MARKER_PAYLOAD)
+    os.chmod(source_spec, 0o600)
+    os.chmod(marker, 0o600)
+
+    with pytest.raises(declare.DeclarationError, match="Git worktree"):
+        declare.verify_installed_source_spec(source_spec)

--- a/prototypes/mu_cosine/test_prepare_pearltrees_diffusion_consensus.py
+++ b/prototypes/mu_cosine/test_prepare_pearltrees_diffusion_consensus.py
@@ -1,0 +1,732 @@
+#!/usr/bin/env python3
+"""Focused tests for the two-process Pearltrees snapshot consensus gate."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+
+import pytest
+
+import declare_pearltrees_diffusion_sources as declaration
+import prepare_pearltrees_diffusion_consensus as consensus
+
+
+RESOURCE_CEILING = 1_000_000
+PHYSICAL_RELATIONS = {
+    "alias": True,
+    "collection": True,
+    "cross_link": False,
+    "path": True,
+    "ref": True,
+    "shortcut": True,
+}
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _public_rdf() -> bytes:
+    return b"""<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:pt="https://www.pearltrees.com/rdf/0.1/#">
+  <pt:Tree rdf:about="https://www.pearltrees.com/synthetic/id1">
+    <pt:treeId>1</pt:treeId><pt:title>Public root</pt:title><pt:privacy>0</pt:privacy>
+  </pt:Tree>
+  <pt:Tree rdf:about="https://www.pearltrees.com/synthetic/id2">
+    <pt:treeId>2</pt:treeId><pt:title>Public child</pt:title><pt:privacy>0</pt:privacy>
+  </pt:Tree>
+  <pt:RefPearl>
+    <pt:parentTree rdf:resource="https://www.pearltrees.com/synthetic/id1" />
+    <pt:seeAlso rdf:resource="https://www.pearltrees.com/synthetic/id2" />
+    <pt:title>Public child</pt:title><pt:privacy>0</pt:privacy>
+  </pt:RefPearl>
+</rdf:RDF>
+"""
+
+
+def _case(tmp_path: Path, *, with_legacy: bool = False) -> dict[str, Path]:
+    inputs = tmp_path / "inputs"
+    local_root = tmp_path / "local"
+    inputs.mkdir()
+    local_root.mkdir()
+    rdf_path = inputs / "evidence.rdf"
+    rdf_path.write_bytes(_public_rdf())
+    legacy_path = inputs / "legacy.tsv"
+    if with_legacy:
+        legacy_path.write_bytes(b"")
+    policy_path = inputs / "policy.json"
+    declaration_dir = local_root / "declaration"
+    spec = declaration.build_source_spec(
+        snapshot_label="synthetic-consensus-test",
+        rdf=(("explicit-rdf", "synthetic", str(rdf_path)),),
+        legacy_dag=str(legacy_path) if with_legacy else None,
+    )
+    declaration.install_source_spec(
+        spec,
+        output_dir=declaration_dir,
+        local_root=local_root,
+    )
+    _write_json(
+        policy_path,
+        {
+            "physical_edges": PHYSICAL_RELATIONS,
+            "schema": "pearltrees-diffusion-relation-policy-v1",
+        },
+    )
+    return {
+        "attempt_a": local_root / "attempt-a",
+        "attempt_b": local_root / "attempt-b",
+        "local_root": local_root,
+        "policy": policy_path,
+        "receipt": local_root / "consensus",
+        "rdf": rdf_path,
+        "legacy": legacy_path,
+        "source_spec": declaration_dir / declaration.SPEC_FILENAME,
+    }
+
+
+def _prepare(case: dict[str, Path], *, minimum_anchors: int = 1):
+    return consensus.prepare_consensus(
+        case["source_spec"],
+        case["policy"],
+        case["attempt_a"],
+        case["attempt_b"],
+        case["receipt"],
+        case["local_root"],
+        minimum_anchors=minimum_anchors,
+        resource_ceiling_bytes=RESOURCE_CEILING,
+    )
+
+
+def _verify(case: dict[str, Path]):
+    return consensus.verify_consensus_receipt(
+        case["receipt"],
+        attempt_a_dir=case["attempt_a"],
+        attempt_b_dir=case["attempt_b"],
+        source_spec=case["source_spec"],
+        relation_policy=case["policy"],
+    )
+
+
+def test_exact_ready_consensus_runs_two_compilers_and_never_pools(tmp_path: Path) -> None:
+    case = _case(tmp_path)
+
+    receipt, exit_code = _prepare(case)
+
+    assert exit_code == 0
+    assert receipt["accepted"] is True
+    assert receipt["reason"] == "exact_consensus_ready"
+    assert receipt["canonical_attempt"] == "attempt_a"
+    assert receipt["graph_observation_count"] == 1
+    assert receipt["repeatability_verified"] is True
+    assert receipt["graph_gate_pass"] is True
+    assert receipt["no_pooling"] is True
+    assert receipt["readiness"] == {
+        "graph_asset_ready": True,
+        "minimum_anchor_count": 1,
+        "minimum_anchor_coverage_pass": True,
+        "privacy_certified": True,
+        "resource_ceiling_bytes": RESOURCE_CEILING,
+    }
+    assert all(receipt["comparison_checks"].values())
+    assert [row["prepare_exit_code"] for row in receipt["attempts"]] == [0, 0]
+    assert [row["verify_exit_code"] for row in receipt["attempts"]] == [0, 0]
+    assert receipt["attempts"][0]["manifest_record"] == receipt["attempts"][1][
+        "manifest_record"
+    ]
+    assert receipt["attempts"][0]["snapshot_fingerprint"] == receipt[
+        "common_snapshot_fingerprint"
+    ]
+    assert receipt["attempts"][0]["observed_contract_bytes"] == receipt["attempts"][
+        1
+    ]["observed_contract_bytes"]
+    assert receipt["common_records"]["fingerprint_core_sha256"] == receipt[
+        "common_snapshot_fingerprint"
+    ]
+    assert set(receipt["input_records"]) == {"relation_policy", "source_spec"}
+    assert set(receipt["implementation_records"]) == {
+        "consensus_preparer",
+        "runtime_identity",
+        "snapshot_preparer_entrypoint",
+        "source_declaration_validator",
+    }
+    assert len(receipt["repeatability_contract_sha256"]) == 64
+    assert case["attempt_a"].is_dir() and case["attempt_b"].is_dir()
+    assert stat.S_IMODE(case["receipt"].stat().st_mode) == 0o700
+    assert all(
+        stat.S_IMODE(path.stat().st_mode) == 0o600
+        for path in case["receipt"].iterdir()
+    )
+    assert _verify(case) == receipt
+    receipt_text = (case["receipt"] / consensus.RECEIPT_NAME).read_text(encoding="utf-8")
+    assert str(tmp_path) not in receipt_text
+    assert "Public root" not in receipt_text
+    assert "explicit-rdf" not in receipt_text
+
+
+def test_exact_but_undercovered_runs_are_recorded_as_scientifically_blocked(
+    tmp_path: Path,
+) -> None:
+    case = _case(tmp_path)
+
+    receipt, exit_code = _prepare(case, minimum_anchors=3)
+
+    assert exit_code == 2
+    assert receipt["accepted"] is False
+    assert receipt["repeatability_verified"] is True
+    assert receipt["graph_gate_pass"] is False
+    assert receipt["reason"] == "graph_asset_not_ready"
+    assert receipt["common_snapshot_fingerprint"] is not None
+    assert receipt["readiness"]["privacy_certified"] is True
+    assert receipt["readiness"]["minimum_anchor_coverage_pass"] is False
+    assert receipt["readiness"]["graph_asset_ready"] is False
+    assert [row["prepare_exit_code"] for row in receipt["attempts"]] == [2, 2]
+    assert all(receipt["comparison_checks"].values())
+
+
+def test_privacy_block_takes_reason_precedence_over_undercoverage(tmp_path: Path) -> None:
+    case = _case(tmp_path)
+    case["rdf"].write_bytes(
+        _public_rdf().replace(b"<pt:privacy>0</pt:privacy>", b"")
+    )
+
+    receipt, exit_code = _prepare(case, minimum_anchors=3)
+
+    assert exit_code == 2
+    assert receipt["repeatability_verified"] is True
+    assert receipt["readiness"]["privacy_certified"] is False
+    assert receipt["readiness"]["minimum_anchor_coverage_pass"] is False
+    assert receipt["reason"] == "privacy_not_certified"
+
+
+def test_handwritten_spec_without_rdf_account_is_rejected_before_subprocess(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    case = _case(tmp_path)
+    value = json.loads(case["source_spec"].read_text(encoding="utf-8"))
+    del value["sources"][0]["account"]
+    _write_json(case["source_spec"], value)
+    invoked = False
+
+    def should_not_run(_arguments):
+        nonlocal invoked
+        invoked = True
+        return 1
+
+    monkeypatch.setattr(consensus, "_run_snapshot_cli", should_not_run)
+
+    with pytest.raises(consensus.ConsensusError, match="declaration bundle"):
+        _prepare(case)
+
+    assert invoked is False
+    assert not case["attempt_a"].exists()
+    assert not case["receipt"].exists()
+
+
+def test_verified_manifest_disagreement_has_no_retry_and_installs_block_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    case = _case(tmp_path)
+    original = consensus._run_attempt
+    calls = 0
+
+    def divergent_attempt(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        result = original(*args, **kwargs)
+        if calls == 1:
+            case["rdf"].write_bytes(
+                _public_rdf().replace(b"Public child", b"Changed child")
+            )
+        return result
+
+    monkeypatch.setattr(consensus, "_run_attempt", divergent_attempt)
+
+    receipt, exit_code = _prepare(case)
+
+    assert calls == 2
+    assert exit_code == 2
+    assert receipt["accepted"] is False
+    assert receipt["repeatability_verified"] is False
+    assert receipt["graph_gate_pass"] is False
+    assert receipt["reason"] == "exact_consensus_mismatch"
+    assert receipt["common_snapshot_fingerprint"] is None
+    assert receipt["common_records"] is None
+    assert receipt["readiness"] is None
+    assert receipt["comparison_checks"]["source_records_equal"] is False
+    assert receipt["comparison_checks"]["full_manifest_equal"] is False
+    assert case["receipt"].is_dir()
+
+
+def test_legacy_only_disagreement_is_recorded_but_does_not_block_science(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    case = _case(tmp_path, with_legacy=True)
+    original = consensus._run_attempt
+    calls = 0
+
+    def legacy_divergence(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        result = original(*args, **kwargs)
+        if calls == 1:
+            case["legacy"].write_bytes(b"1\t2\n")
+        return result
+
+    monkeypatch.setattr(consensus, "_run_attempt", legacy_divergence)
+
+    receipt, exit_code = _prepare(case)
+
+    assert calls == 2
+    assert exit_code == 0
+    assert receipt["accepted"] is True
+    assert receipt["repeatability_verified"] is True
+    assert receipt["graph_gate_pass"] is True
+    assert receipt["reason"] == "exact_consensus_ready"
+    assert receipt["comparison_checks"]["nonlegacy_manifest_equal"] is True
+    assert receipt["comparison_checks"]["full_manifest_equal"] is False
+    assert receipt["comparison_checks"]["legacy_parity_artifact_record_equal"] is False
+    assert receipt["warnings"] == ["legacy_parity_disagreement"]
+
+
+@pytest.mark.parametrize("bad_output", ("alias", "existing", "symlink"))
+def test_nonfresh_or_aliased_outputs_fail_before_any_compile(
+    tmp_path: Path, bad_output: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    case = _case(tmp_path)
+    if bad_output == "alias":
+        case["attempt_b"] = case["attempt_a"]
+    elif bad_output == "existing":
+        case["attempt_a"].mkdir()
+    else:
+        target = case["local_root"] / "target"
+        target.mkdir()
+        case["attempt_a"].symlink_to(target, target_is_directory=True)
+    invoked = False
+
+    def should_not_run(_arguments):
+        nonlocal invoked
+        invoked = True
+        return 1
+
+    monkeypatch.setattr(consensus, "_run_snapshot_cli", should_not_run)
+
+    with pytest.raises(consensus.ConsensusError):
+        _prepare(case)
+
+    assert invoked is False
+    assert not case["receipt"].exists()
+
+
+def test_symlinked_ancestor_is_rejected_before_any_compile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    _case(real)
+    linked = tmp_path / "linked"
+    linked.symlink_to(real, target_is_directory=True)
+    case = {
+        "attempt_a": linked / "local" / "attempt-a",
+        "attempt_b": linked / "local" / "attempt-b",
+        "local_root": linked / "local",
+        "policy": linked / "inputs" / "policy.json",
+        "receipt": linked / "local" / "consensus",
+        "source_spec": linked
+        / "local"
+        / "declaration"
+        / declaration.SPEC_FILENAME,
+    }
+    invoked = False
+
+    def should_not_run(_arguments):
+        nonlocal invoked
+        invoked = True
+        return 1
+
+    monkeypatch.setattr(consensus, "_run_snapshot_cli", should_not_run)
+
+    with pytest.raises(consensus.ConsensusError, match="declaration bundle"):
+        _prepare(case)
+
+    assert invoked is False
+
+
+def test_empty_git_named_ancestor_is_not_a_worktree(tmp_path: Path) -> None:
+    neutral = tmp_path / "neutral"
+    neutral.mkdir()
+    (neutral / ".git").mkdir()
+    case = _case(neutral)
+
+    receipt, exit_code = _prepare(case)
+
+    assert exit_code == 0
+    assert receipt["graph_gate_pass"] is True
+
+
+def test_real_git_marker_ancestor_fails_before_compile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    case = _case(worktree)
+    marker = worktree / ".git"
+    marker.mkdir()
+    (marker / "HEAD").write_text("ref: refs/heads/test\n", encoding="utf-8")
+    invoked = False
+
+    def should_not_run(_arguments):
+        nonlocal invoked
+        invoked = True
+        return 1
+
+    monkeypatch.setattr(consensus, "_run_snapshot_cli", should_not_run)
+
+    with pytest.raises(consensus.ConsensusError, match="declaration bundle"):
+        _prepare(case)
+
+    assert invoked is False
+
+
+@pytest.mark.parametrize("mutated_input", ("policy", "rdf-account"))
+def test_source_spec_or_policy_mutation_is_an_operational_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mutated_input: str
+) -> None:
+    case = _case(tmp_path)
+
+    def mutate_before_return(_arguments):
+        if mutated_input == "policy":
+            case["policy"].write_text("{}\n", encoding="utf-8")
+        else:
+            source_spec = json.loads(case["source_spec"].read_text(encoding="utf-8"))
+            source_spec["sources"][0]["account"] = "different-explicit-account"
+            _write_json(case["source_spec"], source_spec)
+        return 1
+
+    monkeypatch.setattr(consensus, "_run_snapshot_cli", mutate_before_return)
+
+    with pytest.raises(consensus.ConsensusError, match="changed across attempts"):
+        _prepare(case)
+
+    assert not case["receipt"].exists()
+    assert not case["attempt_b"].exists()
+
+
+def test_operational_subprocess_failure_does_not_create_scientific_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    case = _case(tmp_path)
+    monkeypatch.setattr(consensus, "_run_snapshot_cli", lambda _arguments: 1)
+
+    with pytest.raises(consensus.ConsensusError, match="operational failure"):
+        _prepare(case)
+
+    assert not case["receipt"].exists()
+
+
+def test_output_parent_identity_is_rechecked_before_receipt_install(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    case = _case(tmp_path)
+    original_check = consensus._assert_directory_identities
+    checks = 0
+    installed = False
+
+    def fail_before_receipt(bindings):
+        nonlocal checks
+        checks += 1
+        if checks == 7:
+            raise consensus.ConsensusError("simulated output parent replacement")
+        original_check(bindings)
+
+    def should_not_install(_receipt_dir, _receipt):
+        nonlocal installed
+        installed = True
+
+    monkeypatch.setattr(consensus, "_assert_directory_identities", fail_before_receipt)
+    monkeypatch.setattr(consensus, "_install_receipt", should_not_install)
+
+    with pytest.raises(consensus.ConsensusError, match="parent replacement"):
+        _prepare(case)
+
+    assert checks == 7
+    assert installed is False
+    assert case["attempt_a"].is_dir() and case["attempt_b"].is_dir()
+    assert not case["receipt"].exists()
+
+
+def test_cli_stdout_is_aggregate_only_and_verify_preserves_scientific_exit_code(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    case = _case(tmp_path)
+    arguments = [
+        "prepare",
+        "--source-spec",
+        str(case["source_spec"]),
+        "--relation-policy",
+        str(case["policy"]),
+        "--attempt-a-dir",
+        str(case["attempt_a"]),
+        "--attempt-b-dir",
+        str(case["attempt_b"]),
+        "--receipt-dir",
+        str(case["receipt"]),
+        "--local-root",
+        str(case["local_root"]),
+        "--local-only",
+        "--minimum-anchors",
+        "3",
+        "--resource-ceiling-bytes",
+        str(RESOURCE_CEILING),
+    ]
+
+    assert consensus.main(arguments) == 2
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert output == {
+        "accepted": False,
+        "graph_asset_ready": False,
+        "reason": "graph_asset_not_ready",
+    }
+    assert captured.err == ""
+    assert str(tmp_path) not in captured.out
+    assert "Public root" not in captured.out
+    assert consensus.main(
+        [
+            "verify",
+            "--receipt-dir",
+            str(case["receipt"]),
+            "--attempt-a-dir",
+            str(case["attempt_a"]),
+            "--attempt-b-dir",
+            str(case["attempt_b"]),
+            "--source-spec",
+            str(case["source_spec"]),
+            "--relation-policy",
+            str(case["policy"]),
+        ]
+    ) == 2
+    verified_output = json.loads(capsys.readouterr().out)
+    assert verified_output == {
+        "accepted": False,
+        "reason": "graph_asset_not_ready",
+        "verified": True,
+    }
+
+
+def test_receipt_verification_rejects_extra_file_and_wrong_modes(tmp_path: Path) -> None:
+    case = _case(tmp_path)
+    _prepare(case)
+    extra = case["receipt"] / "extra"
+    extra.write_text("not allowed", encoding="utf-8")
+
+    with pytest.raises(consensus.ConsensusError, match="file set mismatch"):
+        _verify(case)
+
+    extra.unlink()
+    os.chmod(case["receipt"] / consensus.RECEIPT_NAME, 0o644)
+    with pytest.raises(consensus.ConsensusError, match="mode is not 0600"):
+        _verify(case)
+
+
+def test_verifier_rejects_copied_attempt_inside_git_worktree(tmp_path: Path) -> None:
+    case = _case(tmp_path)
+    _prepare(case)
+    worktree = tmp_path / "copied-worktree"
+    worktree.mkdir()
+    marker = worktree / ".git"
+    marker.mkdir()
+    (marker / "HEAD").write_text("ref: refs/heads/test\n", encoding="utf-8")
+    copied_attempt = worktree / "attempt-a"
+    shutil.copytree(case["attempt_a"], copied_attempt)
+
+    with pytest.raises(consensus.ConsensusError, match="snapshot attempt.*Git worktree"):
+        consensus.verify_consensus_receipt(
+            case["receipt"],
+            attempt_a_dir=copied_attempt,
+            attempt_b_dir=case["attempt_b"],
+            source_spec=case["source_spec"],
+            relation_policy=case["policy"],
+        )
+
+
+def test_receipt_verification_rederives_decision_after_valid_reseal(tmp_path: Path) -> None:
+    case = _case(tmp_path)
+    receipt, _exit_code = _prepare(case)
+    tampered = dict(receipt)
+    del tampered["repeatability_contract_sha256"]
+    tampered["accepted"] = False
+    tampered["reason"] = "exact_consensus_mismatch"
+    tampered = consensus._seal_receipt(tampered)
+    (case["receipt"] / consensus.RECEIPT_NAME).write_bytes(
+        consensus._canonical_json(tampered)
+    )
+
+    with pytest.raises(consensus.ConsensusError, match="decision does not follow"):
+        _verify(case)
+
+
+def test_receipt_verification_rejects_malformed_common_provenance_after_reseal(
+    tmp_path: Path,
+) -> None:
+    case = _case(tmp_path)
+    receipt, _exit_code = _prepare(case)
+    tampered = copy.deepcopy(receipt)
+    del tampered["repeatability_contract_sha256"]
+    tampered["common_records"]["repository_commit"] = "0" * 39
+    tampered = consensus._seal_receipt(tampered)
+    (case["receipt"] / consensus.RECEIPT_NAME).write_bytes(
+        consensus._canonical_json(tampered)
+    )
+
+    with pytest.raises(consensus.ConsensusError, match="common repeatability records"):
+        _verify(case)
+
+
+@pytest.mark.parametrize("target", ("privacy-rule", "aggregate-summary"))
+def test_receipt_verification_rejects_coherent_resealed_forgery_against_attempts(
+    tmp_path: Path, target: str
+) -> None:
+    case = _case(tmp_path)
+    receipt, _exit_code = _prepare(case)
+    tampered = copy.deepcopy(receipt)
+    del tampered["repeatability_contract_sha256"]
+    if target == "privacy-rule":
+        tampered["common_records"]["compiler_implementation_records"][
+            "privacy_rule"
+        ] = {"sha256": "0" * 64, "size_bytes": 1}
+    else:
+        tampered["aggregate_summary"]["eligible_anchor_count"] += 10
+    tampered = consensus._seal_receipt(tampered)
+    (case["receipt"] / consensus.RECEIPT_NAME).write_bytes(
+        consensus._canonical_json(tampered)
+    )
+
+    with pytest.raises(consensus.ConsensusError):
+        _verify(case)
+
+
+@pytest.mark.parametrize("substitution", ("source-spec", "relation-policy"))
+def test_verifier_binds_supplied_inputs_to_both_attempt_manifests(
+    tmp_path: Path, substitution: str
+) -> None:
+    case = _case(tmp_path)
+    receipt, _exit_code = _prepare(case)
+    tampered = copy.deepcopy(receipt)
+    del tampered["repeatability_contract_sha256"]
+    if substitution == "source-spec":
+        alternate_dir = case["local_root"] / "alternate-declaration"
+        alternate = declaration.build_source_spec(
+            snapshot_label="different-valid-label",
+            rdf=(("explicit-rdf", "groups", str(case["rdf"])),),
+        )
+        declaration.install_source_spec(
+            alternate,
+            output_dir=alternate_dir,
+            local_root=case["local_root"],
+        )
+        supplied = alternate_dir / declaration.SPEC_FILENAME
+        tampered["input_records"]["source_spec"] = consensus._regular_file_record(
+            supplied, "alternate source spec"
+        )
+        source_spec = supplied
+        relation_policy = case["policy"]
+    else:
+        supplied = case["policy"].parent / "alternate-policy.json"
+        alternate_policy = {
+            "physical_edges": {**PHYSICAL_RELATIONS, "cross_link": True},
+            "schema": "pearltrees-diffusion-relation-policy-v1",
+        }
+        _write_json(supplied, alternate_policy)
+        tampered["input_records"]["relation_policy"] = consensus._regular_file_record(
+            supplied, "alternate relation policy"
+        )
+        source_spec = case["source_spec"]
+        relation_policy = supplied
+    tampered = consensus._seal_receipt(tampered)
+    (case["receipt"] / consensus.RECEIPT_NAME).write_bytes(
+        consensus._canonical_json(tampered)
+    )
+
+    with pytest.raises(consensus.ConsensusError, match="bind the supplied input records"):
+        consensus.verify_consensus_receipt(
+            case["receipt"],
+            attempt_a_dir=case["attempt_a"],
+            attempt_b_dir=case["attempt_b"],
+            source_spec=source_spec,
+            relation_policy=relation_policy,
+        )
+
+
+def test_verifier_rejects_one_attempt_directory_supplied_twice(tmp_path: Path) -> None:
+    case = _case(tmp_path)
+    _prepare(case)
+
+    with pytest.raises(consensus.ConsensusError, match="two distinct nonnested"):
+        consensus.verify_consensus_receipt(
+            case["receipt"],
+            attempt_a_dir=case["attempt_a"],
+            attempt_b_dir=case["attempt_a"],
+            source_spec=case["source_spec"],
+            relation_policy=case["policy"],
+        )
+
+
+def test_verifier_detects_attempt_leaf_replacement_after_child_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    case = _case(tmp_path)
+    _prepare(case)
+    original_run = consensus._run_snapshot_cli
+    calls = 0
+
+    def replace_after_verification(arguments):
+        nonlocal calls
+        result = original_run(arguments)
+        calls += 1
+        if calls == 1:
+            case["attempt_a"].rename(case["local_root"] / "verified-attempt-a")
+            shutil.copytree(case["attempt_b"], case["attempt_a"])
+        return result
+
+    monkeypatch.setattr(consensus, "_run_snapshot_cli", replace_after_verification)
+
+    with pytest.raises(consensus.ConsensusError, match="identity changed"):
+        _verify(case)
+
+
+def test_compiler_launch_is_fixed_sibling_path_and_isolated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed = None
+
+    class Completed:
+        returncode = 1
+
+    def fake_run(command, **kwargs):
+        nonlocal observed
+        observed = (command, kwargs)
+        return Completed()
+
+    monkeypatch.setattr(consensus.subprocess, "run", fake_run)
+
+    assert consensus._run_snapshot_cli(("verify", "--run-dir", "/not-used")) == 1
+    command, kwargs = observed
+    assert command[:4] == [
+        consensus.sys.executable,
+        "-I",
+        "-B",
+        str(consensus.SNAPSHOT_PREPARER),
+    ]
+    assert kwargs["cwd"] == consensus.REPO_ROOT
+    assert kwargs["capture_output"] is True

--- a/prototypes/mu_cosine/test_prepare_pearltrees_diffusion_snapshot.py
+++ b/prototypes/mu_cosine/test_prepare_pearltrees_diffusion_snapshot.py
@@ -280,8 +280,20 @@ def test_relocation_and_source_declaration_order_do_not_change_snapshot(
     (first_manifest, first_run), (second_manifest, second_run) = prepared
     assert first_manifest["snapshot_fingerprint"] == second_manifest["snapshot_fingerprint"]
     assert {
-        name: (first_run / name).read_bytes() for name in snapshot.ALL_RUN_FILES
-    } == {name: (second_run / name).read_bytes() for name in snapshot.ALL_RUN_FILES}
+        name: (first_run / name).read_bytes()
+        for name in snapshot.ALL_RUN_FILES
+        if name != "manifest.json"
+    } == {
+        name: (second_run / name).read_bytes()
+        for name in snapshot.ALL_RUN_FILES
+        if name != "manifest.json"
+    }
+    first_without_inputs = dict(first_manifest)
+    second_without_inputs = dict(second_manifest)
+    first_without_inputs.pop("input_records")
+    second_without_inputs.pop("input_records")
+    assert first_without_inputs == second_without_inputs
+    assert first_manifest["input_records"] != second_manifest["input_records"]
 
 
 def test_sqlite_wal_sidecar_is_rejected_without_output(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add an explicit-only Pearltrees source declaration planner that installs a canonical private bundle with required RDF accounts, absolute non-symlink paths, exact file modes, and no discovery or filename inference
- add a two-fresh-process snapshot consensus gate with no pooling, retry, or majority rescue; attempt A remains the sole canonical downstream graph
- make receipt verification revalidate the declaration and policy, rerun the fixed snapshot verifier on both installed attempts, and rederive every comparison, common field, warning, and decision
- bind exact source-specification and relation-policy records in the private snapshot manifest without changing the path-invariant scientific fingerprint
- harden parent/attempt/receipt identity checks, Git-worktree rejection, implementation provenance, privacy-rule binding, and local-only installation
- document the immutable declaration → attempts → receipt → no-solve HOP-plan chain and its non-claims

## Why

PR #3902 supplied the fail-closed snapshot compiler, but the preregistered fidelity study still needed a reproducible way to declare private raw evidence and prove that one frozen graph can be reproduced by two fresh compiler processes. This PR closes that gate without running diffusion or claiming a real-corpus result.

The receipt self-hash is deliberately described only as an integrity aid. Verification requires the actual declaration, policy, and two attempt directories; it does not treat a receipt alone as authenticity evidence.

## Scientific scope

This PR does **not** run the Pearltrees HOP study, select anchors, calibrate leakage, use filing labels, deploy covariance, or unlock CUDA claims. Legacy parity remains diagnostic and causally disconnected: a legacy-only difference is recorded as a warning but cannot change graph readiness.

Relocating byte-identical source content can change the private manifest's exact input record because the declared path changed. It does not change graph artifacts or the scientific snapshot fingerprint.

## Validation

- `219 passed`: declaration, consensus, snapshot, bounded-diffusion fidelity, leaky-diffusion, and local-grounded-diffusion suites
- Python syntax compilation for all three entry points
- `git diff --check`
- independent science/statistical review: approved
- independent security/privacy/provenance review: approved
