### PR TITLE
mu_cosine: freeze outcome-blind no-solve HOP fidelity plan

### DIFF
--- a/prototypes/mu_cosine/DESIGN_pearltrees_hop_plan.md
+++ b/prototypes/mu_cosine/DESIGN_pearltrees_hop_plan.md
@@ -1,0 +1,215 @@
+# Pearltrees HOP fidelity no-solve plan
+
+**Status:** prospective implementation of the planning link between the
+accepted two-process snapshot-consensus receipt and the calibration lock in
+[`PROTOCOL_bounded_diffusion_fidelity.md`](PROTOCOL_bounded_diffusion_fidelity.md).
+This artifact performs topology bookkeeping only. It computes no diffusion
+response, leakage estimate, fidelity metric, filing metric, or judge result.
+
+## 1. Why planning is a separate transaction
+
+The snapshot receipt proves repeatable construction of one privacy-certified
+graph. It does not choose anchors or authorize an audit. The HOP plan freezes
+every outcome-blind choice that could otherwise move after calibration:
+
+- the degree-stratified anchors and calibration/audit split;
+- the four-anchor balanced batches and protected nodes;
+- one nested HOP ordering per batch, its strict candidate prefixes, and its
+  larger reference;
+- every real retained-to-omitted cut edge under exact Dirichlet grounding;
+- the radius-3 calibration shells;
+- the complete 9,999-replicate paired-bootstrap multiplicity schedule; and
+- the numerical, memory, and statistical contracts that later stages must use,
+  including reference adequacy, the 18-of-24 complete-audit-batch floor, and
+  the prospective `K_low`/`K_high` selection cases.
+
+An accepted plan authorizes only the registered calibration batches. It never
+authorizes audit solves. The later calibration-lock manifest must bind the
+complete plan-manifest content record, not only `plan_fingerprint`; freeze
+`alpha_top`, the selected contrast, and its actual path-free BLAS identity; and
+only then authorize the untouched audit.
+
+## 2. Full-chain verification and read boundary
+
+The planner requires the receipt, both snapshot attempts, source declaration,
+and relation policy. It reruns the full consensus verifier and accepts only
+`exact_consensus_ready`. Receipt-only verification is prohibited. The plan
+binds the receipt bytes and canonical attempt-A manifest bytes, plus the exact
+records for adjacency, eligibility, components, physical edges, source
+declaration, and relation policy. Attempt B remains repeatability evidence and
+is never pooled.
+
+Before invoking the upstream consensus verifier, the planner preflights fixed
+upper bounds for the receipt and both attempt manifests. It then rechecks every
+leaf in the three already-verified private bundles through bound directory
+descriptors: every leaf must remain a unique-link, mode-0600 regular file. This
+planner preflight does **not** bound the memory used inside the separate
+upstream snapshot-verifier subprocesses; those retain their own snapshot
+resource contract. Leaf descriptors are opened nonblocking and then checked as
+regular files, so a substituted FIFO or device fails rather than hanging or
+being consumed.
+
+After verification, attempt A is not reopened casually by pathname. The
+planner holds an `O_DIRECTORY|O_NOFOLLOW` descriptor, reads only
+`manifest.json`, `adjacency.jsonl`, and `anchor_eligibility.jsonl` through that
+descriptor, checks leaf identity/mode/link count, enforces the manifest-record
+size before reading, and operates on the captured bytes. The planner-input
+ceiling covers the receipt, both manifests, adjacency, eligibility, source
+specification, and relation policy that this planning transaction reads; it is
+not advertised as a bound on the upstream verifier. The planner reruns
+consensus and recaptures those bytes before atomic installation. The complete
+plan verifier repeats the full chain and derives every output byte again.
+
+The planning derivation never uses node titles, accounts, URLs, source IDs,
+embeddings, lineage exports, labels, judge outputs, filing results,
+calibration results, or caches. Account, source, and path declarations are
+inspected only to verify provenance and reject output/input overlap; they never
+enter anchor selection or graph construction. Reads performed by the required
+upstream verifier remain within that verifier's separately declared scope. The
+legacy DAG is not a graph input.
+
+## 3. Exact deterministic choices
+
+These details resolve ambiguities that prose alone left open:
+
+1. A typed node ID is ordered as `(namespace, positive decimal integer)`, so
+   `pt:2` precedes `pt:10`.
+2. For purpose `p` in `{select, split, batch}`, the random-looking key is
+   SHA-256 of newline-terminated canonical UTF-8 JSON
+   `[3882001,p,node_id]`. A hash collision is broken by the typed-ID order.
+3. If `N = 4q+r`, the first `r` degree quartiles receive `q+1` members and the
+   others receive `q`.
+4. Each batch has one continued multi-source ordinary-HOP order. Its first
+   256, 512, and 1,024 nodes are `S_256`, `S_512`, and `S_1024`; its first at
+   most 4,096 nodes are `R_top`. This guarantees a single nested chain rather
+   than restarting expansion from `S_1024`.
+5. A memoized revisit is path convergence or a cycle. Only a real edge with
+   one retained and one omitted endpoint enters the cut ledger.
+6. Bootstrap replicate `r`, draw `d`, and nonce `n` use SHA-256 of
+   newline-terminated canonical JSON
+   `[3882002,"paired_audit_batch_bootstrap",r,d,n]`. Interpret the digest as
+   an unsigned 256-bit integer and reject it when it is at least
+   `2^256 - (2^256 mod 24)`; map the first accepted value modulo 24. The
+   resulting 24-count multiplicity
+   vector is persisted for each of all 9,999 replicates; later runners consume
+   this artifact rather than calling a library PRNG.
+
+Later runners must consume the frozen node lists. They may not recompute a
+domain with a library comparator whose string ordering differs.
+
+## 4. Frozen design
+
+Eligible anchors are the snapshot verifier's public, non-isolated nodes in the
+largest component. The eligibility ledger legitimately also contains excluded
+private nodes that are absent from retained adjacency; those rows must be
+exactly `eligible=false` with reason `direct_private` or
+`private_descendant`, and they never enter the anchor population. Retained rows
+must cover adjacency and satisfy their complete retained-row schema. Eligible
+anchors are sorted by `(degree, typed-ID key)` and divided into four rank
+quartiles. Each quartile contributes 32 selected anchors: eight to calibration
+and 24 to untouched audit. Independent selection, split, and batch hash domains
+prevent one ordering from doing multiple jobs. Batch `j` contains the `j`th
+anchor from each quartile.
+
+For every anchor, a complete single-source HOP traversal freezes a traversal
+hash and reachable count. Its protected prefix is the anchor plus the first 16
+reachable non-anchor nodes. A batch protected set is their union. Missing
+protected coverage blocks the plan; there is no post-hoc intersection.
+
+Every domain is topology-only, uses unit conductance on policy-admitted graph
+edges, and retains exact Dirichlet grounding with no closure. The boundary
+artifact records every cut edge and integer `beta`. `R_top` is a bounded
+reference unless its boundary is empty, in which case it is the exact connected
+component.
+
+For each calibration anchor, the plan freezes all nodes at graph-hop radius 3.
+The shell must be nonempty, contained in that batch's `R_top`, and strictly
+interior (`beta=0`). The plan records the later target `exp(-1)` but leaves
+`alpha_status=unfrozen`; zero remains legal and no jitter is licensed.
+
+## 5. Resource and numeric contracts
+
+Three resource quantities are deliberately distinct:
+
+- the inherited snapshot compiler's raw/artifact byte ceiling;
+- a planner input-byte ceiling and deterministic edge-touch ceiling; and
+- the future study peak-RSS ceiling.
+
+The dense pre-workspace projection is `4 * 8 * n^2` bytes: four square
+float64 arrays, excluding factorization workspace. If the largest realized
+reference projection exceeds the registered study ceiling, the plan is an
+immutable scientific block. The later runner must measure peak RSS; the
+projection is not a claim that the workspace fits.
+
+The first phase freezes CPU `numpy.linalg.cholesky`, float64, one BLAS thread,
+no hidden jitter, reciprocal condition at least `sqrt(eps)`, and explicit
+symmetry/root/solve tolerances. A path-free actual BLAS identity is deferred to
+the calibration lock because the no-solve planner intentionally never loads
+BLAS. There is no automatic CPU/CUDA switch. A different backend requires a
+prospective amendment.
+
+The planner loads a bounded in-memory adjacency. This is suitable for the
+current bounded Pearltrees study, not a million-node scaling claim. A large
+snapshot that exceeds the explicit planner byte or edge-touch ceiling fails
+closed pending a disk-backed adjacency adapter; it does not silently consume
+unbounded memory.
+
+The structured statistical contract is complete rather than illustrative. It
+contains the absolute candidate gates, the stricter `S_1024`-versus-`R_top`
+reference gates, the minimum 18 complete balanced audit batches, conservative
+observed-order-statistic tails, all noninferiority margins, extended-real zero
+handling, and the calibration rule selecting the smallest adequate `K_low` and
+the next larger `K_high` (or the absolute-only `R_top` endpoint when
+`K_low=1024`). The paired-bootstrap contract binds the actual multiplicity
+artifact, identical multiplicities across endpoints, and the lower/upper
+order-statistic endpoint rules.
+
+## 6. Artifacts, privacy, and blocked outcomes
+
+The mode-0700 local-only directory contains mode-0600 canonical artifacts for
+quartiles, selected anchors, batches, anchor traversals, domains, boundaries,
+calibration shells, all 9,999 bootstrap multiplicity vectors, and the manifest.
+Every leaf is a unique-link regular file. Node-level material never appears in
+stdout. The CLI emits only acceptance, reason, batch counts, and `no_solve`.
+
+A structurally valid graph may produce an installed `accepted=false` plan for
+quartile coverage, protected coverage, calibration-shell adequacy, or study
+resource inadequacy. This is a complete no-solve scientific result, not an
+operational crash. Invalid provenance, privacy, artifact structure, path
+identity, or consensus aborts without installing a plan.
+
+The manifest states `solves_executed=0`,
+`structural_metrics_computed=true`,
+`diffusion_or_fidelity_metrics_computed=false`, and
+`audit_solve_authorized=false`; it contains no realized `K_low`, `K_high`, or
+measured `alpha_top`. `plan_fingerprint` hashes the scientific
+`fingerprint_core`. A separate `manifest_integrity_sha256` seals the complete
+manifest outside that field, including acceptance and authorization state.
+Neither unkeyed hash authenticates a malicious same-user replacement: the
+full upstream verification plus byte-for-byte re-derivation detects accidental
+or unsynchronized replacement, but a malicious same-user could replace an
+entire self-consistent declaration/receipt/plan/lock chain. Hostile
+authenticity requires an external signature or immutable trusted store. The
+calibration lock binds the complete manifest content record to prevent ordinary
+downstream drift; it is not authentication unless that lock is itself trusted
+externally.
+
+## 7. Output transaction and overlap boundary
+
+The plan target must be fresh, below the approved local root, and outside Git.
+It may not contain, be contained by, or equal the consensus receipt, either
+attempt, the source specification, the relation policy, the complete source
+declaration directory, any declared authoritative raw source, or the optional
+legacy parity input. This check is repeated during verification so a copied
+plan cannot be paired with an overlapping private input layout.
+
+Staging is a descriptor-bound transaction. Files are created relative to a
+bound mode-0700 staging-directory descriptor with no-follow, exclusive-create,
+mode-0600, unique-link, exact-size, per-file `fsync` checks. The staging
+directory is itself synchronized and fully verified, then renamed without
+replacement through the still-bound parent descriptor; the parent is
+synchronized before success is returned. On failure, cleanup removes only the
+known regular unique-link artifact inventory through the bound staging
+descriptor. If identity or inventory is no longer provable, cleanup fails
+closed and leaves the directory for manual inspection rather than recursively
+deleting a possibly substituted path.

--- a/prototypes/mu_cosine/PROTOCOL_bounded_diffusion_fidelity.md
+++ b/prototypes/mu_cosine/PROTOCOL_bounded_diffusion_fidelity.md
@@ -91,7 +91,10 @@ a receipt file alone. The source specification must be the complete private
 declaration bundle: a mode-0700 directory outside Git containing exactly the
 fixed mode-0600 local-only marker and canonical mode-0600 specification, with
 explicit RDF accounts and resolved absolute, non-symlink source paths of the
-declared types. Consensus binds the
+declared types. Before HOP planning, every leaf in that declaration, receipt,
+and snapshot-attempt bundle is rechecked through a bound directory descriptor
+with a nonblocking open as a mode-0600, unique-link regular file; a FIFO or
+device substitution fails closed. Consensus binds the
 declaration-validator implementation and runs exactly two fresh compiler
 attempts, with no third retry and no pooling. Its verifier must be supplied the
 receipt, source specification, relation policy, and both attempt directories;
@@ -138,6 +141,14 @@ sparse 1,504-row lineage/path export or to nodes for which one convenience path
 was materialized. Exclusions are determined from the frozen graph manifest
 before any metric is computed.
 
+The frozen eligibility ledger may also contain excluded-private rows whose
+nodes are intentionally absent from retained adjacency. Such a row is valid
+only with `eligible=false` and reason `direct_private` or
+`private_descendant`; it is evidence of exclusion, not a malformed missing
+adjacency row and never enters a degree quartile. Retained eligibility rows must
+cover every adjacency node and satisfy the retained-row degree/component
+contract.
+
 HOP consumes only the frozen reciprocal conductance adjacency. A memoized
 revisit during bounded traversal means path convergence or a cycle; it is not a
 cut point and must not create a ground shunt. Cuts are actual retained-to-omitted
@@ -146,8 +157,12 @@ edges. No parent direction, root, or depth is inferred in phase one.
 Construct exactly four deterministic rank-based degree quartiles. Sort all
 eligible anchors by `(undirected_conductance_degree, stable_typed_node_id)` and
 split that ordered population into four contiguous groups whose sizes differ by
-at most one. Within each quartile order nodes by
-`SHA-256(3882001, "select", typed_node_id)` and select exactly 32 anchors. If
+at most one. If `N=4q+r`, the first `r` quartiles receive `q+1` members. The
+typed-ID key is `(namespace, positive decimal integer)`, so `pt:2` precedes
+`pt:10`. Within each quartile order nodes by
+`SHA-256(3882001, "select", typed_node_id)` and select exactly 32 anchors. Each
+key is SHA-256 of newline-terminated canonical UTF-8 JSON
+`[3882001,purpose,typed_node_id]`, with the typed-ID key as a collision tie. If
 any quartile cannot supply 32, phase one is coverage-inadequate before solves.
 
 Within each quartile reorder the 32 selected anchors by the independent key
@@ -205,9 +220,11 @@ create fill and must never be mislabeled a scalar tree shunt.
 ## 5. Regime-specific larger-domain references and leakage
 
 For phase one, `U_top` is exactly the frozen HOP `S_1024` domain for that
-batch. Build its exact-Dirichlet model, then expand from `U_top` by the same
-frozen hop ordering to at most 4,096 retained nodes, preserving all of `U_top`,
-to obtain `R_top`. If `U_top` exceeds the resource contract or `R_top` cannot
+batch. Freeze one continued anchor-source multi-source HOP order through at
+most 4,096 nodes; `S_256`, `S_512`, `S_1024`, and `R_top` are its prefixes.
+This preserves all of `U_top` and makes reference expansion unambiguous. Build
+the exact-Dirichlet models only after the no-solve plan is accepted. If `U_top`
+exceeds the resource contract or `R_top` cannot
 be built, that batch is reference-inadequate and cannot support a convergence
 claim. If the connected component is exhausted, the whole component is an
 exact admissible reference.
@@ -444,9 +461,18 @@ HOP budget is adequate on calibration, phase one is right-censored and the audit
 reports diagnostics without a convergence claim. No audit result may change the
 chosen pair.
 
-Use 9,999 deterministic paired bootstrap resamples of the 24 audit four-anchor
-batches with seed `3882002`. Apply identical batch multiplicities to both
-budgets. Every resampled batch contains one anchor from each quartile, so
+Use the frozen `bootstrap_multiplicities.jsonl` artifact containing exactly
+9,999 deterministic paired resamples of the 24 audit four-anchor batches with
+seed `3882002`. For replicate `r`, draw `d`, and nonce `n`, hash
+newline-terminated canonical UTF-8 JSON
+`[3882002,"paired_audit_batch_bootstrap",r,d,n]`; interpret SHA-256 as an
+unsigned 256-bit integer, reject values at least
+`2^256 - (2^256 mod 24)`, and take the first accepted value modulo 24. Store
+the resulting 24-entry count vector, whose entries sum to 24. Later runners
+must consume these vectors and must not regenerate them with a library PRNG.
+Apply each vector's identical
+batch multiplicities to both budgets and every paired endpoint. Every
+resampled batch contains one anchor from each quartile, so
 recompute the four quartile means and average them equally; no replicate can omit a quartile
 and no redraw rule is needed. The one-sided 95% upper endpoint is the higher
 observed bootstrap order statistic at 0.95, and the lower endpoint is the lower
@@ -500,7 +526,13 @@ own prospective amendment and untouched audit data.
 
 ## 9. Reproducibility and fail-closed rules
 
-The run fingerprint covers content rather than machine-local paths. Before the
+The scientific `plan_fingerprint` covers the plan's `fingerprint_core` rather
+than machine-local paths. A separate full-manifest integrity seal covers the
+complete no-solve manifest, including accepted/blocked and authorization
+fields. These unkeyed records detect accidental or unsynchronized drift; they
+do not authenticate a wholly replaced self-consistent chain against a
+malicious same-user without an external signature or immutable trusted store.
+Before the
 no-solve plan is frozen, the full consensus verifier above must pass and the
 plan must bind both the receipt content record and canonical attempt-A manifest
 record; receipt-only verification is prohibited. The fingerprint includes:
@@ -514,10 +546,37 @@ record; receipt-only verification is prohibited. The fingerprint includes:
   prospective coverage gate;
 - `K`, shell, `alpha_top`, stable tie keys, and any future licensed selector or
   closure ledger;
-- metric definitions, tolerances, bootstrap seeds/resamples, and software SHA;
+- metric definitions, candidate and reference adequacy tolerances, the minimum
+  18-of-24 complete-audit-batch rule, prospective `K_low`/`K_high` selection
+  cases, noninferiority rules, the exact bootstrap multiplicity artifact, and
+  software SHA;
 - float dtype, numerical thresholds, backend/thread identity without absolute
   library paths; and
 - per-phase timings, peak RSS, cache keys, and deterministic-rerun hashes.
+
+Deterministic plan content and observational execution provenance are separate:
+elapsed times and measured peak RSS do not enter the no-solve plan fingerprint.
+The plan freezes their later measurement contract. The implementation and
+transaction details are specified in
+[`DESIGN_pearltrees_hop_plan.md`](DESIGN_pearltrees_hop_plan.md).
+
+The planner preflights bounded receipt and attempt-manifest reads, then enforces
+its own aggregate ceiling over the receipt, both manifests, adjacency,
+eligibility, source specification, and relation policy that it captures. This
+does not claim to cap memory inside the separately invoked upstream snapshot
+verifier; that verifier retains its own resource contract. The plan output may
+not overlap any receipt/attempt/policy input, the declaration bundle, any
+declared raw source, or the optional legacy parity source. Staging writes,
+verification, no-replace rename, directory synchronization, and conservative
+rollback are descriptor-relative; an unprovable replacement is leaked for
+manual inspection rather than recursively deleted.
+
+The no-solve manifest must state `structural_metrics_computed=true`,
+`diffusion_or_fidelity_metrics_computed=false`, and
+`audit_solve_authorized=false`. The calibration lock must bind the complete
+plan-manifest content record—not merely `plan_fingerprint`—before it records
+the actual path-free BLAS identity, freezes `alpha_top` and the selected
+contrast, and authorizes any audit solve.
 
 Fail closed on a missing or mismatched raw-source preparer manifest, unfrozen
 physical-edge policy, incomplete privacy propagation, incomplete or asymmetric

--- a/prototypes/mu_cosine/prepare_pearltrees_hop_plan.py
+++ b/prototypes/mu_cosine/prepare_pearltrees_hop_plan.py
@@ -1,0 +1,2123 @@
+#!/usr/bin/env python3
+"""Freeze the outcome-blind, no-solve Pearltrees HOP fidelity plan.
+
+This tool consumes only the verified structural artifacts from canonical
+snapshot attempt A.  It selects anchors, protected sets, strict HOP prefixes,
+exact cut ledgers, references, and calibration shells.  It never imports a
+numerical array package, builds a precision matrix, calibrates leakage, or
+executes a solve.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+from dataclasses import dataclass
+import errno
+from functools import lru_cache
+import hashlib
+from importlib import metadata
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+
+import declare_pearltrees_diffusion_sources as declaration
+import prepare_pearltrees_diffusion_consensus as consensus
+
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+PROTOCOL_PATH = HERE / "PROTOCOL_bounded_diffusion_fidelity.md"
+DESIGN_PATH = HERE / "DESIGN_pearltrees_hop_plan.md"
+
+SCHEMA = "pearltrees-hop-fidelity-plan-v1"
+ALGORITHM = "outcome-blind-nested-hop-plan-v1"
+MARKER_NAME = "LOCAL_ONLY_DO_NOT_PUBLISH"
+MARKER_BYTES = b"LOCAL ONLY - DO NOT PUBLISH HOP PLAN NODE ARTIFACTS\n"
+MANIFEST_NAME = "manifest.json"
+ARTIFACT_NAMES = (
+    "quartiles.jsonl",
+    "selected_anchors.jsonl",
+    "batches.jsonl",
+    "anchor_traversals.jsonl",
+    "domains.jsonl",
+    "boundaries.jsonl",
+    "calibration_shells.jsonl",
+    "bootstrap_multiplicities.jsonl",
+)
+ALL_PLAN_FILES = frozenset(ARTIFACT_NAMES + (MANIFEST_NAME, MARKER_NAME))
+
+SELECTION_SEED = 3_882_001
+BOOTSTRAP_SEED = 3_882_002
+QUARTILE_COUNT = 4
+ANCHORS_PER_QUARTILE = 32
+CALIBRATION_PER_QUARTILE = 8
+AUDIT_PER_QUARTILE = 24
+ANCHORS_PER_BATCH = 4
+PROTECTED_NONANCHORS = 16
+CANDIDATE_BUDGETS = (256, 512, 1024)
+REFERENCE_BUDGET = 4096
+CALIBRATION_SHELL_RADIUS = 3
+CALIBRATION_TARGET = "exp(-1)"
+DENSE_ARRAY_COUNT = 4
+FLOAT64_BYTES = 8
+MINIMUM_RECIPROCAL_CONDITION_HEX = "0x1.0000000000000p-26"
+MAXIMUM_PLAN_MANIFEST_BYTES = 4 * 1024 * 1024
+MAXIMUM_CONSENSUS_RECEIPT_BYTES = 4 * 1024 * 1024
+MAXIMUM_ATTEMPT_MANIFEST_BYTES = 16 * 1024 * 1024
+MAXIMUM_SOURCE_SPEC_BYTES = 16 * 1024 * 1024
+MAXIMUM_PRIVATE_BUNDLE_FILES = 256
+
+HASH_KEY_ENCODING = "sha256-canonical-json-line-[3882001,purpose,typed_id]-v1"
+TYPED_ID_ORDER = "namespace-then-positive-decimal-integer-v1"
+REFERENCE_RULE = "continue-anchor-multisource-hop-order-through-4096-v1"
+
+
+class HopPlanError(ValueError):
+    """Fail-closed plan integrity or operational error."""
+
+
+@dataclass
+class _TouchBudget:
+    ceiling: int
+    observed: int = 0
+
+    def add(self, amount):
+        self.observed += int(amount)
+        if self.observed > self.ceiling:
+            raise HopPlanError("planner edge-touch ceiling exceeded")
+
+
+def _duplicate_checked_object(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise HopPlanError("duplicate JSON key")
+        value[key] = item
+    return value
+
+
+def _reject_nonfinite(_value):
+    raise HopPlanError("non-finite JSON constant")
+
+
+def _canonical_json(value):
+    try:
+        text = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise HopPlanError("value is not canonical finite JSON") from exc
+    return (text + "\n").encode("utf-8")
+
+
+def _strict_json_bytes(data, label):
+    try:
+        value = json.loads(
+            data.decode("utf-8"),
+            object_pairs_hook=_duplicate_checked_object,
+            parse_constant=_reject_nonfinite,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise HopPlanError(f"invalid canonical JSON in {label}") from exc
+    if _canonical_json(value) != data:
+        raise HopPlanError(f"noncanonical JSON in {label}")
+    return value
+
+
+def _jsonl_bytes(records):
+    return b"".join(_canonical_json(record) for record in records)
+
+
+def _strict_jsonl_bytes(data, label):
+    if data and not data.endswith(b"\n"):
+        raise HopPlanError(f"noncanonical JSONL in {label}")
+    records = []
+    for line in data.splitlines(keepends=True):
+        records.append(_strict_json_bytes(line, label))
+    return records
+
+
+def _content_record(data):
+    return {"sha256": hashlib.sha256(data).hexdigest(), "size_bytes": len(data)}
+
+
+def _content_record_is_valid(value):
+    return (
+        isinstance(value, dict)
+        and set(value) == {"sha256", "size_bytes"}
+        and isinstance(value["sha256"], str)
+        and re.fullmatch(r"[0-9a-f]{64}", value["sha256"]) is not None
+        and isinstance(value["size_bytes"], int)
+        and not isinstance(value["size_bytes"], bool)
+        and value["size_bytes"] >= 0
+    )
+
+
+def _file_record(path):
+    try:
+        return _content_record(Path(path).read_bytes())
+    except OSError as exc:
+        raise HopPlanError("required implementation artifact is unavailable") from exc
+
+
+def _typed_id_key(value):
+    if not isinstance(value, str):
+        raise HopPlanError("structural artifact contains an invalid typed node ID")
+    match = re.fullmatch(r"([a-z][a-z0-9_-]*):([1-9][0-9]*)", value)
+    if match is None:
+        raise HopPlanError("structural artifact contains an invalid typed node ID")
+    return match.group(1), int(match.group(2))
+
+
+def _selection_key(purpose, node_id):
+    if purpose not in {"select", "split", "batch"}:
+        raise HopPlanError("unknown selection-key purpose")
+    digest = hashlib.sha256(
+        _canonical_json([SELECTION_SEED, purpose, node_id])
+    ).hexdigest()
+    return digest, _typed_id_key(node_id)
+
+
+def _path_is_within(path, root):
+    try:
+        Path(path).relative_to(Path(root))
+        return True
+    except ValueError:
+        return False
+
+
+def _is_git_worktree_marker(path):
+    try:
+        path = Path(path)
+        if path.is_symlink():
+            return True
+        if path.is_file():
+            with open(path, "rb") as stream:
+                return stream.read(256).lstrip().startswith(b"gitdir:")
+        return path.is_dir() and (path / "HEAD").is_file()
+    except OSError:
+        return True
+
+
+def _has_git_ancestor(path):
+    resolved = Path(path).resolve()
+    return any(
+        _is_git_worktree_marker(ancestor / ".git")
+        for ancestor in (resolved, *resolved.parents)
+    )
+
+
+def _has_symlink_ancestor(path):
+    path = Path(path).absolute()
+    for candidate in (path, *path.parents):
+        try:
+            if candidate.is_symlink():
+                return True
+        except OSError:
+            return True
+    return False
+
+
+@dataclass
+class _BoundDirectory:
+    path: Path
+    fd: int
+    device: int
+    inode: int
+
+    def close(self):
+        if self.fd >= 0:
+            os.close(self.fd)
+            self.fd = -1
+
+
+def _bind_directory(path, label):
+    raw = Path(path)
+    if _has_symlink_ancestor(raw):
+        raise HopPlanError(f"{label} cannot contain a symlink")
+    resolved = raw.resolve()
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        fd = os.open(resolved, flags)
+        observed = os.fstat(fd)
+        current = os.stat(resolved, follow_symlinks=False)
+    except OSError as exc:
+        try:
+            os.close(fd)
+        except (OSError, UnboundLocalError):
+            pass
+        raise HopPlanError(f"{label} is unavailable") from exc
+    if not stat.S_ISDIR(observed.st_mode) or (
+        observed.st_dev,
+        observed.st_ino,
+    ) != (current.st_dev, current.st_ino):
+        os.close(fd)
+        raise HopPlanError(f"{label} identity mismatch")
+    return _BoundDirectory(resolved, fd, observed.st_dev, observed.st_ino)
+
+
+def _assert_bound_directory(binding, label):
+    if binding.fd < 0:
+        raise HopPlanError(f"{label} binding is closed")
+    try:
+        observed = os.fstat(binding.fd)
+        current = os.stat(binding.path, follow_symlinks=False)
+    except OSError as exc:
+        raise HopPlanError(f"{label} changed during planning") from exc
+    if (
+        observed.st_dev,
+        observed.st_ino,
+        current.st_dev,
+        current.st_ino,
+    ) != (binding.device, binding.inode, binding.device, binding.inode):
+        raise HopPlanError(f"{label} changed during planning")
+
+
+def _bind_child_directory(parent_binding, leaf, label):
+    if (
+        not isinstance(leaf, str)
+        or leaf in {"", ".", ".."}
+        or Path(leaf).name != leaf
+    ):
+        raise HopPlanError(f"{label} leaf is malformed")
+    _assert_bound_directory(parent_binding, "plan output parent")
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        fd = os.open(leaf, flags, dir_fd=parent_binding.fd)
+        observed = os.fstat(fd)
+        current = os.stat(leaf, dir_fd=parent_binding.fd, follow_symlinks=False)
+    except OSError as exc:
+        try:
+            os.close(fd)
+        except (OSError, UnboundLocalError):
+            pass
+        raise HopPlanError(f"{label} is unavailable") from exc
+    if (
+        not stat.S_ISDIR(observed.st_mode)
+        or (observed.st_dev, observed.st_ino) != (current.st_dev, current.st_ino)
+    ):
+        os.close(fd)
+        raise HopPlanError(f"{label} identity mismatch")
+    return _BoundDirectory(
+        parent_binding.path / leaf, fd, observed.st_dev, observed.st_ino
+    )
+
+
+def _create_bound_staging(parent_binding, target_leaf):
+    _assert_bound_directory(parent_binding, "plan output parent")
+    for _attempt in range(100):
+        leaf = f".{target_leaf}.staging-{os.urandom(16).hex()}"
+        try:
+            os.mkdir(leaf, 0o700, dir_fd=parent_binding.fd)
+        except FileExistsError:
+            continue
+        except OSError as exc:
+            raise HopPlanError("HOP plan staging directory could not be created") from exc
+        binding = _bind_child_directory(
+            parent_binding, leaf, "HOP plan staging directory"
+        )
+        try:
+            os.fchmod(binding.fd, 0o700)
+            if stat.S_IMODE(os.fstat(binding.fd).st_mode) != 0o700:
+                raise HopPlanError("HOP plan staging mode could not be fixed")
+            _assert_bound_directory(binding, "HOP plan staging directory")
+            return leaf, binding
+        except Exception:
+            binding.close()
+            raise
+    raise HopPlanError("HOP plan staging name allocation failed")
+
+
+def _read_at_most(fd, maximum_size, label):
+    if (
+        not isinstance(maximum_size, int)
+        or isinstance(maximum_size, bool)
+        or maximum_size < 0
+    ):
+        raise HopPlanError(f"{label} read ceiling is malformed")
+    chunks = []
+    remaining = maximum_size + 1
+    while remaining:
+        chunk = os.read(fd, min(1024 * 1024, remaining))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    data = b"".join(chunks)
+    if len(data) > maximum_size:
+        raise HopPlanError(f"{label} artifact exceeds its bound")
+    return data
+
+
+def _read_bound_file(
+    binding, name, expected_record, label, *, maximum_size=None
+):
+    if expected_record is not None and not _content_record_is_valid(expected_record):
+        raise HopPlanError(f"{label} expected content record is malformed")
+    if expected_record is None and maximum_size is None:
+        raise HopPlanError(f"{label} requires a read ceiling")
+    read_ceiling = (
+        expected_record["size_bytes"]
+        if expected_record is not None
+        else maximum_size
+    )
+    if maximum_size is not None:
+        read_ceiling = min(read_ceiling, maximum_size)
+    _assert_bound_directory(binding, label)
+    flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC | os.O_NONBLOCK
+    try:
+        fd = os.open(name, flags, dir_fd=binding.fd)
+        before = os.fstat(fd)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or stat.S_IMODE(before.st_mode) != 0o600
+        ):
+            raise HopPlanError(f"{label} artifact contract mismatch")
+        if expected_record is not None and before.st_size != expected_record["size_bytes"]:
+            raise HopPlanError(f"{label} artifact size mismatch")
+        if before.st_size > read_ceiling:
+            raise HopPlanError(f"{label} artifact exceeds its bound")
+        data = _read_at_most(fd, read_ceiling, label)
+        after = os.fstat(fd)
+    except OSError as exc:
+        raise HopPlanError(f"{label} artifact is unavailable") from exc
+    finally:
+        try:
+            os.close(fd)
+        except (OSError, UnboundLocalError):
+            pass
+    if (
+        (before.st_dev, before.st_ino, before.st_size)
+        != (after.st_dev, after.st_ino, after.st_size)
+        or after.st_nlink != 1
+        or stat.S_IMODE(after.st_mode) != 0o600
+    ):
+        raise HopPlanError(f"{label} artifact changed during read")
+    if expected_record is not None and _content_record(data) != expected_record:
+        raise HopPlanError(f"{label} artifact content mismatch")
+    _assert_bound_directory(binding, label)
+    return data
+
+
+def _read_regular_path(path, expected_record, label):
+    if not _content_record_is_valid(expected_record):
+        raise HopPlanError(f"{label} expected content record is malformed")
+    raw = Path(path)
+    if _has_symlink_ancestor(raw):
+        raise HopPlanError(f"{label} cannot contain a symlink")
+    flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC | os.O_NONBLOCK
+    try:
+        fd = os.open(raw, flags)
+        before = os.fstat(fd)
+        if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+            raise HopPlanError(f"{label} must be a unique regular file")
+        if before.st_size != expected_record["size_bytes"]:
+            raise HopPlanError(f"{label} size mismatch")
+        data = _read_at_most(fd, expected_record["size_bytes"], label)
+        after = os.fstat(fd)
+    except OSError as exc:
+        raise HopPlanError(f"{label} is unavailable") from exc
+    finally:
+        try:
+            os.close(fd)
+        except (OSError, UnboundLocalError):
+            pass
+    if (
+        (before.st_dev, before.st_ino, before.st_size)
+        != (after.st_dev, after.st_ino, after.st_size)
+        or after.st_nlink != 1
+    ):
+        raise HopPlanError(f"{label} changed during read")
+    if _content_record(data) != expected_record:
+        raise HopPlanError(f"{label} content mismatch")
+    return data
+
+
+def _bounded_directory_names(binding, maximum_count, label):
+    if (
+        not isinstance(maximum_count, int)
+        or isinstance(maximum_count, bool)
+        or maximum_count < 0
+    ):
+        raise HopPlanError(f"{label} inventory ceiling is malformed")
+    _assert_bound_directory(binding, label)
+    names = []
+    try:
+        with os.scandir(binding.fd) as entries:
+            for entry in entries:
+                names.append(entry.name)
+                if len(names) > maximum_count:
+                    raise HopPlanError(f"{label} artifact inventory exceeds its bound")
+    except OSError as exc:
+        raise HopPlanError(f"{label} artifact inventory is unavailable") from exc
+    _assert_bound_directory(binding, label)
+    return tuple(names)
+
+
+def _assert_private_directory_files(
+    binding, label, *, maximum_count=MAXIMUM_PRIVATE_BUNDLE_FILES
+):
+    """Recheck the already-verified private bundle's leaf envelope by dirfd."""
+
+    _assert_bound_directory(binding, label)
+    try:
+        names = _bounded_directory_names(binding, maximum_count, label)
+        for name in names:
+            fd = os.open(
+                name,
+                os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC | os.O_NONBLOCK,
+                dir_fd=binding.fd,
+            )
+            try:
+                observed = os.fstat(fd)
+            finally:
+                os.close(fd)
+            if (
+                not stat.S_ISREG(observed.st_mode)
+                or observed.st_nlink != 1
+                or stat.S_IMODE(observed.st_mode) != 0o600
+            ):
+                raise HopPlanError(f"{label} artifact contract mismatch")
+    except OSError as exc:
+        raise HopPlanError(f"{label} artifact inventory is unavailable") from exc
+    _assert_bound_directory(binding, label)
+
+
+def _git_commit():
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_")
+    }
+    environment["LC_ALL"] = "C"
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT,
+            env=environment,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise HopPlanError("repository commit is unavailable") from exc
+    commit = result.stdout.strip()
+    if re.fullmatch(r"[0-9a-f]{40}", commit) is None:
+        raise HopPlanError("repository commit is malformed")
+    return commit
+
+
+def _hop_order(anchors, adjacency, maximum_nodes=None, *, touch_budget=None):
+    anchors = tuple(sorted(set(anchors), key=_typed_id_key))
+    if not anchors:
+        raise HopPlanError("HOP traversal requires anchors")
+    if any(anchor not in adjacency for anchor in anchors):
+        raise HopPlanError("HOP traversal anchor is absent from adjacency")
+    limit = len(adjacency) if maximum_nodes is None else int(maximum_nodes)
+    if isinstance(maximum_nodes, bool) or limit < len(anchors):
+        raise HopPlanError("HOP traversal limit is invalid")
+    order = list(anchors)
+    distance = {anchor: 0 for anchor in anchors}
+    seen = set(anchors)
+    layer = list(anchors)
+    truncated_tie_count = 0
+    while layer and len(order) < limit:
+        candidates = set()
+        for node in layer:
+            if touch_budget is not None:
+                touch_budget.add(len(adjacency[node]))
+            for neighbor in adjacency[node]:
+                if neighbor not in seen:
+                    candidates.add(neighbor)
+        ordered = tuple(sorted(candidates, key=_typed_id_key))
+        if not ordered:
+            break
+        remaining = limit - len(order)
+        chosen = ordered[:remaining]
+        if len(chosen) < len(ordered):
+            truncated_tie_count = len(ordered) - len(chosen)
+        next_distance = distance[layer[0]] + 1
+        order.extend(chosen)
+        for node in chosen:
+            distance[node] = next_distance
+        seen.update(chosen)
+        layer = list(chosen)
+        if truncated_tie_count:
+            break
+    return tuple(order), distance, truncated_tie_count
+
+
+def _boundary_record(
+    batch_id, role, requested_nodes, nodes, adjacency, *, touch_budget=None
+):
+    retained = set(nodes)
+    cut_edges = []
+    beta = {}
+    boundary_nodes = []
+    for node in sorted(retained, key=_typed_id_key):
+        if touch_budget is not None:
+            touch_budget.add(len(adjacency[node]))
+        omitted = [
+            neighbor for neighbor in adjacency[node] if neighbor not in retained
+        ]
+        if omitted:
+            omitted.sort(key=_typed_id_key)
+            boundary_nodes.append(node)
+            beta[node] = len(omitted)
+            cut_edges.extend([[node, neighbor] for neighbor in omitted])
+    cut_edges.sort(key=lambda edge: (_typed_id_key(edge[0]), _typed_id_key(edge[1])))
+    return {
+        "batch_id": batch_id,
+        "beta": [
+            {"cut_conductance": beta[node], "node_id": node}
+            for node in boundary_nodes
+        ],
+        "boundary_node_count": len(boundary_nodes),
+        "closure_policy": "exact_dirichlet_no_closure",
+        "cut_edge_count": len(cut_edges),
+        "cut_edges": cut_edges,
+        "cut_mass": len(cut_edges),
+        "requested_nodes": requested_nodes,
+        "role": role,
+        "unit_conductance": 1,
+    }
+
+
+def _quartile_slices(size):
+    base, remainder = divmod(size, QUARTILE_COUNT)
+    result = []
+    start = 0
+    for index in range(QUARTILE_COUNT):
+        width = base + (1 if index < remainder else 0)
+        result.append((start, start + width))
+        start += width
+    if start != size:
+        raise HopPlanError("quartile allocation failed")
+    return tuple(result)
+
+
+def _load_graph(manifest_data, adjacency_data, eligibility_data):
+    manifest = _strict_json_bytes(manifest_data, "attempt manifest")
+    if not isinstance(manifest, dict):
+        raise HopPlanError("attempt manifest is malformed")
+    adjacency_rows = _strict_jsonl_bytes(adjacency_data, "adjacency")
+    eligibility_rows = _strict_jsonl_bytes(eligibility_data, "anchor eligibility")
+    adjacency = {}
+    for row in adjacency_rows:
+        if not isinstance(row, dict) or set(row) != {"neighbors", "node_id"}:
+            raise HopPlanError("adjacency row is malformed")
+        node = row["node_id"]
+        _typed_id_key(node)
+        if node in adjacency or not isinstance(row["neighbors"], list):
+            raise HopPlanError("adjacency row is malformed")
+        neighbors = tuple(row["neighbors"])
+        if len(neighbors) != len(set(neighbors)):
+            raise HopPlanError("adjacency row contains duplicate neighbors")
+        if node in neighbors:
+            raise HopPlanError("adjacency contains a self edge")
+        for neighbor in neighbors:
+            _typed_id_key(neighbor)
+        adjacency[node] = tuple(sorted(neighbors, key=_typed_id_key))
+    for node, neighbors in adjacency.items():
+        if any(neighbor not in adjacency or node not in adjacency[neighbor] for neighbor in neighbors):
+            raise HopPlanError("adjacency is incomplete or asymmetric")
+    eligible = []
+    seen_eligibility = set()
+    for row in eligibility_rows:
+        if not isinstance(row, dict) or "node_id" not in row or "eligible" not in row:
+            raise HopPlanError("anchor eligibility row is malformed")
+        node = row["node_id"]
+        _typed_id_key(node)
+        if node in seen_eligibility:
+            raise HopPlanError("anchor eligibility row is malformed")
+        seen_eligibility.add(node)
+        if node not in adjacency:
+            if (
+                set(row) != {"eligible", "node_id", "reason"}
+                or row["eligible"] is not False
+                or row["reason"] not in {"direct_private", "private_descendant"}
+            ):
+                raise HopPlanError("excluded-private eligibility row is malformed")
+            continue
+        if set(row) != {
+            "component_id",
+            "degree",
+            "eligible",
+            "node_id",
+            "reason",
+        }:
+            raise HopPlanError("retained eligibility row is malformed")
+        if row["eligible"] is True:
+            if row.get("reason") != "eligible" or row.get("degree") != len(adjacency[node]):
+                raise HopPlanError("eligible-anchor degree contract mismatch")
+            eligible.append((node, len(adjacency[node])))
+        elif row["eligible"] is not False:
+            raise HopPlanError("anchor eligibility flag is malformed")
+    if not set(adjacency).issubset(seen_eligibility):
+        raise HopPlanError("anchor eligibility does not cover adjacency")
+    eligible.sort(key=lambda item: (item[1], _typed_id_key(item[0])))
+    return manifest, adjacency, tuple(eligible)
+
+
+def _freeze_anchor_design(eligible):
+    quartile_records = []
+    selected_records = []
+    selected_by_split = {"calibration": [[] for _ in range(4)], "audit": [[] for _ in range(4)]}
+    block_reasons = []
+    slices = _quartile_slices(len(eligible))
+    for quartile_index, (start, stop) in enumerate(slices):
+        quartile_id = f"q{quartile_index + 1}"
+        members = eligible[start:stop]
+        selection_order = sorted(
+            members, key=lambda item: _selection_key("select", item[0])
+        )
+        quartile_records.append(
+            {
+                "degree_rank_members": [
+                    {"degree": degree, "node_id": node}
+                    for node, degree in members
+                ],
+                "degree_rank_start": start,
+                "degree_rank_stop_exclusive": stop,
+                "maximum_degree": members[-1][1] if members else None,
+                "member_count": len(members),
+                "minimum_degree": members[0][1] if members else None,
+                "quartile_id": quartile_id,
+                "remainder_allocation": "first-r-quartiles-receive-one-v1",
+                "selection_order": [node for node, _degree in selection_order],
+            }
+        )
+        if len(selection_order) < ANCHORS_PER_QUARTILE:
+            block_reasons.append("quartile_coverage_inadequate")
+            continue
+        chosen = selection_order[:ANCHORS_PER_QUARTILE]
+        split_order = sorted(
+            chosen, key=lambda item: _selection_key("split", item[0])
+        )
+        split_parts = {
+            "calibration": split_order[:CALIBRATION_PER_QUARTILE],
+            "audit": split_order[CALIBRATION_PER_QUARTILE:],
+        }
+        for split, values in split_parts.items():
+            batch_order = sorted(
+                values, key=lambda item: _selection_key("batch", item[0])
+            )
+            selected_by_split[split][quartile_index] = [node for node, _ in batch_order]
+            selection_rank = {node: rank for rank, (node, _degree) in enumerate(selection_order)}
+            split_rank = {node: rank for rank, (node, _degree) in enumerate(split_order)}
+            batch_rank = {node: rank for rank, (node, _degree) in enumerate(batch_order)}
+            for node, degree in batch_order:
+                selected_records.append(
+                    {
+                        "batch_key_sha256": _selection_key("batch", node)[0],
+                        "batch_rank_within_split_quartile": batch_rank[node],
+                        "degree": degree,
+                        "node_id": node,
+                        "quartile_id": quartile_id,
+                        "selection_key_sha256": _selection_key("select", node)[0],
+                        "selection_rank_within_quartile": selection_rank[node],
+                        "split": split,
+                        "split_key_sha256": _selection_key("split", node)[0],
+                        "split_rank_within_quartile": split_rank[node],
+                    }
+                )
+    if block_reasons:
+        return quartile_records, [], [], sorted(set(block_reasons))
+
+    selected_records.sort(
+        key=lambda row: (
+            0 if row["split"] == "calibration" else 1,
+            row["batch_rank_within_split_quartile"],
+            row["quartile_id"],
+        )
+    )
+    selected_ids = [row["node_id"] for row in selected_records]
+    if len(selected_ids) != 128 or len(set(selected_ids)) != 128:
+        raise HopPlanError("selected-anchor assignment is not unique")
+
+    batches = []
+    for split, batch_count in (
+        ("calibration", CALIBRATION_PER_QUARTILE),
+        ("audit", AUDIT_PER_QUARTILE),
+    ):
+        for batch_index in range(batch_count):
+            anchors = [
+                selected_by_split[split][quartile_index][batch_index]
+                for quartile_index in range(QUARTILE_COUNT)
+            ]
+            if len(set(anchors)) != ANCHORS_PER_BATCH:
+                raise HopPlanError("balanced batch contains duplicate anchors")
+            batches.append(
+                {
+                    "anchors_by_quartile": [
+                        {"node_id": node, "quartile_id": f"q{index + 1}"}
+                        for index, node in enumerate(anchors)
+                    ],
+                    "batch_id": f"{split}-{batch_index:02d}",
+                    "batch_index": batch_index,
+                    "split": split,
+                }
+            )
+    return quartile_records, selected_records, batches, []
+
+
+def _hop_order_fingerprint(order, distance):
+    digest = hashlib.sha256()
+    for node in order:
+        digest.update(_canonical_json({"distance": distance[node], "node_id": node}))
+    return digest.hexdigest()
+
+
+def _freeze_anchor_traversals(selected_records, adjacency, touch_budget):
+    selected_ids = {row["node_id"] for row in selected_records}
+    records = []
+    internal = {}
+    block_reasons = []
+    for selected in sorted(selected_records, key=lambda row: _typed_id_key(row["node_id"])):
+        node = selected["node_id"]
+        order, distance, truncated = _hop_order(
+            (node,), adjacency, touch_budget=touch_budget
+        )
+        if truncated != 0:
+            raise HopPlanError("full anchor traversal was unexpectedly truncated")
+        protected = order[: PROTECTED_NONANCHORS + 1]
+        if len(protected) != PROTECTED_NONANCHORS + 1:
+            block_reasons.append("protected_coverage_inadequate")
+        pair_distances = {
+            other: distance[other]
+            for other in selected_ids
+            if other in distance
+        }
+        shell = tuple(
+            candidate
+            for candidate in order
+            if distance[candidate] == CALIBRATION_SHELL_RADIUS
+        )
+        record = {
+            "full_hop_order_sha256": _hop_order_fingerprint(order, distance),
+            "node_id": node,
+            "protected_nodes": [
+                {"hop_distance": distance[candidate], "node_id": candidate}
+                for candidate in protected
+            ],
+            "reachable_node_count": len(order),
+            "split": selected["split"],
+        }
+        records.append(record)
+        internal[node] = {
+            "pair_distances": pair_distances,
+            "protected": tuple(protected),
+            "shell": shell,
+        }
+    return records, internal, sorted(set(block_reasons))
+
+
+def _freeze_domains(batches, anchor_internal, adjacency, touch_budget):
+    batch_records = []
+    domain_records = []
+    boundary_records = []
+    shell_records = []
+    block_reasons = []
+    maximum_projected_bytes = 0
+    for batch in batches:
+        batch_id = batch["batch_id"]
+        anchors = tuple(row["node_id"] for row in batch["anchors_by_quartile"])
+        protected = tuple(
+            sorted(
+                {
+                    node
+                    for anchor in anchors
+                    for node in anchor_internal[anchor]["protected"]
+                },
+                key=_typed_id_key,
+            )
+        )
+        pair_rows = []
+        for source in anchors:
+            distances = anchor_internal[source]["pair_distances"]
+            if any(target not in distances for target in anchors):
+                raise HopPlanError("batch anchors are not mutually reachable")
+            pair_rows.append(
+                {
+                    "distances_by_quartile": [distances[target] for target in anchors],
+                    "source_node_id": source,
+                }
+            )
+        full_order, full_distance, reference_truncated = _hop_order(
+            anchors,
+            adjacency,
+            REFERENCE_BUDGET,
+            touch_budget=touch_budget,
+        )
+        if tuple(full_order[: len(anchors)]) != tuple(sorted(anchors, key=_typed_id_key)):
+            raise HopPlanError("multi-source HOP order does not begin with its anchors")
+        batch_record = dict(batch)
+        batch_record.update(
+            {
+                "protected_node_count": len(protected),
+                "protected_nodes": list(protected),
+                "source_to_source_hop_distances": pair_rows,
+            }
+        )
+        batch_records.append(batch_record)
+
+        boundary_by_role = {}
+        roles = [(f"S_{budget}", budget) for budget in CANDIDATE_BUDGETS]
+        roles.append(("R_top", REFERENCE_BUDGET))
+        previous_nodes = set()
+        for role, requested in roles:
+            realized = min(requested, len(full_order))
+            nodes = full_order[:realized]
+            node_set = set(nodes)
+            if previous_nodes and not previous_nodes < node_set:
+                # A component with fewer than the requested nodes is exact, but then
+                # later nominal budgets may be equal.  Equality is recorded and is
+                # not misrepresented as strict finite-budget nesting.
+                if previous_nodes != node_set:
+                    raise HopPlanError("HOP prefixes are not nested")
+            previous_nodes = node_set
+            coverage = set(protected).issubset(node_set)
+            if not coverage:
+                block_reasons.append("protected_coverage_inadequate")
+            cutoff_distance = full_distance[nodes[-1]]
+            trailing_same_shell = sum(
+                1
+                for candidate in full_order[realized:]
+                if full_distance[candidate] == cutoff_distance
+            )
+            if (
+                reference_truncated
+                and cutoff_distance == full_distance[full_order[-1]]
+            ):
+                trailing_same_shell += reference_truncated
+            node_rows = [
+                {"hop_distance": full_distance[node], "node_id": node}
+                for node in nodes
+            ]
+            projected = DENSE_ARRAY_COUNT * FLOAT64_BYTES * realized * realized
+            maximum_projected_bytes = max(maximum_projected_bytes, projected)
+            domain_records.append(
+                {
+                    "batch_id": batch_id,
+                    "component_exhausted": False,
+                    "cutoff_distance": cutoff_distance,
+                    "dense_preworkspace_projection_bytes": projected,
+                    "hop_order_sha256": hashlib.sha256(
+                        _jsonl_bytes(node_rows)
+                    ).hexdigest(),
+                    "nodes": node_rows,
+                    "protected_coverage": coverage,
+                    "realized_nodes": realized,
+                    "requested_nodes": requested,
+                    "role": role,
+                    "truncated_final_shell_nodes": trailing_same_shell,
+                }
+            )
+            boundary = _boundary_record(
+                batch_id,
+                role,
+                requested,
+                nodes,
+                adjacency,
+                touch_budget=touch_budget,
+            )
+            boundary_by_role[role] = boundary
+            boundary_records.append(boundary)
+            domain_records[-1]["component_exhausted"] = boundary["cut_edge_count"] == 0
+
+        if batch["split"] == "calibration":
+            reference_nodes = {
+                row["node_id"]
+                for row in domain_records[-1]["nodes"]
+            }
+            reference_beta = {
+                row["node_id"]: row["cut_conductance"]
+                for row in boundary_by_role["R_top"]["beta"]
+            }
+            for anchor in anchors:
+                shell = anchor_internal[anchor]["shell"]
+                reasons = []
+                if not shell:
+                    reasons.append("empty_radius_3_shell")
+                if any(node not in reference_nodes for node in shell):
+                    reasons.append("shell_outside_reference")
+                if any(reference_beta.get(node, 0) != 0 for node in shell):
+                    reasons.append("shell_not_strictly_interior")
+                if reasons:
+                    block_reasons.append("calibration_shell_inadequate")
+                shell_records.append(
+                    {
+                        "anchor_node_id": anchor,
+                        "batch_id": batch_id,
+                        "hop_radius": CALIBRATION_SHELL_RADIUS,
+                        "reasons": sorted(set(reasons)),
+                        "shell_nodes": list(shell),
+                        "strictly_interior_pass": not reasons,
+                        "target_attenuation": CALIBRATION_TARGET,
+                    }
+                )
+    return (
+        batch_records,
+        domain_records,
+        boundary_records,
+        shell_records,
+        maximum_projected_bytes,
+        sorted(set(block_reasons)),
+    )
+
+
+def _positive_integer(name, value):
+    if isinstance(value, bool):
+        raise HopPlanError(f"{name} must be a positive integer")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise HopPlanError(f"{name} must be a positive integer") from exc
+    if parsed != value or parsed < 1:
+        raise HopPlanError(f"{name} must be a positive integer")
+    return parsed
+
+
+def _validated_config(config):
+    if not isinstance(config, dict) or set(config) != {
+        "effective_resistance_arm",
+        "planner_edge_touch_ceiling",
+        "planner_input_ceiling_bytes",
+        "study_peak_rss_ceiling_bytes",
+    }:
+        raise HopPlanError("planning configuration fields mismatch")
+    resistance = config["effective_resistance_arm"]
+    if resistance not in {"enabled", "omitted"}:
+        raise HopPlanError("effective-resistance arm must be enabled or omitted")
+    return {
+        "effective_resistance_arm": resistance,
+        "planner_edge_touch_ceiling": _positive_integer(
+            "planner_edge_touch_ceiling", config["planner_edge_touch_ceiling"]
+        ),
+        "planner_input_ceiling_bytes": _positive_integer(
+            "planner_input_ceiling_bytes", config["planner_input_ceiling_bytes"]
+        ),
+        "study_peak_rss_ceiling_bytes": _positive_integer(
+            "study_peak_rss_ceiling_bytes", config["study_peak_rss_ceiling_bytes"]
+        ),
+    }
+
+
+def _capture_verified_inputs(
+    receipt,
+    receipt_binding,
+    attempt_a_binding,
+    attempt_b_binding,
+    source_spec,
+    relation_policy,
+    *,
+    planner_input_ceiling_bytes,
+):
+    receipt_expected = _content_record(_canonical_json(receipt))
+    receipt_data = _read_bound_file(
+        receipt_binding,
+        consensus.RECEIPT_NAME,
+        receipt_expected,
+        "consensus receipt",
+    )
+    if _strict_json_bytes(receipt_data, "consensus receipt") != receipt:
+        raise HopPlanError("consensus receipt changed after verification")
+    receipt_record = _content_record(receipt_data)
+    expected_a = receipt["attempts"][0]["manifest_record"]
+    expected_b = receipt["attempts"][1]["manifest_record"]
+    manifest_a_data = _read_bound_file(
+        attempt_a_binding, "manifest.json", expected_a, "canonical attempt A"
+    )
+    manifest_b_data = _read_bound_file(
+        attempt_b_binding, "manifest.json", expected_b, "attempt B"
+    )
+    manifest_a = _strict_json_bytes(manifest_a_data, "attempt A manifest")
+    _strict_json_bytes(manifest_b_data, "attempt B manifest")
+    try:
+        artifact_records = manifest_a["artifact_records"]
+        adjacency_record = artifact_records["adjacency.jsonl"]
+        eligibility_record = artifact_records["anchor_eligibility.jsonl"]
+        planning_artifact_records = {
+            name: artifact_records[name]
+            for name in (
+                "adjacency.jsonl",
+                "anchor_eligibility.jsonl",
+                "components.jsonl",
+                "physical_edges.tsv",
+            )
+        }
+    except (KeyError, TypeError) as exc:
+        raise HopPlanError("attempt A manifest lacks planning artifacts") from exc
+    if any(not _content_record_is_valid(value) for value in planning_artifact_records.values()):
+        raise HopPlanError("planning artifact content record is malformed")
+    source_record = receipt["input_records"]["source_spec"]
+    policy_record = receipt["input_records"]["relation_policy"]
+    planned_input_bytes = (
+        len(receipt_data)
+        + len(manifest_a_data)
+        + len(manifest_b_data)
+        + adjacency_record["size_bytes"]
+        + eligibility_record["size_bytes"]
+        + source_record["size_bytes"]
+        + policy_record["size_bytes"]
+    )
+    if planned_input_bytes > planner_input_ceiling_bytes:
+        raise HopPlanError("planner input ceiling exceeded")
+    adjacency_data = _read_bound_file(
+        attempt_a_binding,
+        "adjacency.jsonl",
+        adjacency_record,
+        "canonical attempt A",
+    )
+    eligibility_data = _read_bound_file(
+        attempt_a_binding,
+        "anchor_eligibility.jsonl",
+        eligibility_record,
+        "canonical attempt A",
+    )
+    _read_regular_path(source_spec, source_record, "source specification")
+    _read_regular_path(relation_policy, policy_record, "relation policy")
+    return {
+        "adjacency_data": adjacency_data,
+        "eligibility_data": eligibility_data,
+        "input_bindings": {
+            "canonical_attempt_a_manifest": expected_a,
+            "consensus_receipt": receipt_record,
+            "planning_graph_artifacts": planning_artifact_records,
+            "relation_policy": policy_record,
+            "source_spec": source_record,
+        },
+        "manifest_a_data": manifest_a_data,
+        "planned_input_bytes": planned_input_bytes,
+    }
+
+
+def _numeric_backend_contract():
+    try:
+        numpy_version = metadata.version("numpy")
+    except metadata.PackageNotFoundError as exc:
+        raise HopPlanError("frozen NumPy backend is unavailable") from exc
+    return {
+        "actual_blas_identity": "required_in_calibration_lock_without_library_paths",
+        "backend": "numpy.linalg.cholesky",
+        "blas_threads": 1,
+        "cholesky_reconstruction_atol_hex": float(1e-12).hex(),
+        "cholesky_reconstruction_rtol_hex": float(1e-11).hex(),
+        "decision_dtype": "float64",
+        "device_class": "cpu",
+        "hidden_jitter": False,
+        "minimum_reciprocal_condition_hex": MINIMUM_RECIPROCAL_CONDITION_HEX,
+        "numpy_version": numpy_version,
+        "python_implementation": sys.implementation.name,
+        "python_version": ".".join(map(str, sys.version_info[:3])),
+        "solve_residual_relative_tolerance_hex": float(1e-10).hex(),
+        "symmetry_absolute_tolerance_hex": float(1e-12).hex(),
+    }
+
+
+def _statistical_contract():
+    return {
+        "absolute_adequacy": {
+            "boundary_harmonic_q90_max": 0.10,
+            "effective_resistance_relative_error_q90_max": 0.05,
+            "maximum_h_absolute_error_q90_max": 0.025,
+            "rank_inversion_fraction_q90_max": 0.05,
+            "raw_relative_l2_error_q90_max": 0.05,
+            "top8_overlap_q10_min": 0.90,
+        },
+        "bootstrap": {
+            "audit_batch_resamples": 9999,
+            "draws_per_resample": AUDIT_PER_QUARTILE,
+            "endpoint_rule": {
+                "lower_0.05": "lower-observed-order-statistic",
+                "upper_0.95": "higher-observed-order-statistic",
+            },
+            "identical_multiplicities_across_endpoints": True,
+            "multiplicity_schedule_artifact": "bootstrap_multiplicities.jsonl",
+            "sampler": (
+                "sha256-rejection-canonical-json-line-"
+                "[3882002,paired_audit_batch_bootstrap,replicate,draw,nonce]-mod-24-v1"
+            ),
+            "seed": BOOTSTRAP_SEED,
+            "unit": "balanced_four-anchor_batch",
+        },
+        "calibration_selection": {
+            "candidate_order": list(CANDIDATE_BUDGETS),
+            "if_k_low_1024": (
+                "K_high=R_top; report absolute adequacy only; no finite-budget efficacy claim"
+            ),
+            "k_high_rule": "next-larger-candidate-after-smallest-adequate-k-low",
+            "k_low_rule": "smallest-calibration-adequate-candidate",
+            "no_adequate_candidate": "right-censored-no-convergence-claim",
+        },
+        "efficacy_log_ratio_threshold": "log(0.9)",
+        "estimand": "equal-degree-quartile-macro-mean",
+        "extended_real_zero_handling": True,
+        "minimum_complete_audit_batches": 18,
+        "noninferiority_intersection_margins": {
+            "boundary_harmonic_absolute_harm": 0.01,
+            "effective_resistance_relative_error_harm": 0.01,
+            "maximum_h_absolute_error_harm": 0.01,
+            "primary_log_error_ratio": "log(1.10)",
+            "rank_inversion_absolute_harm": 0.01,
+            "source_diagonal_relative_error_harm": 0.01,
+            "top8_overlap_loss": 0.01,
+        },
+        "reference_adequacy": {
+            "maximum_h_absolute_error_q90_max": 0.005,
+            "raw_relative_l2_error_q90_max": 0.01,
+            "top8_overlap_q10_min": 0.98,
+        },
+        "tail_rule": "observed-order-statistic-conservative-no-interpolation",
+    }
+
+
+@lru_cache(maxsize=1)
+def _bootstrap_multiplicity_records():
+    """Freeze the paired 24-batch bootstrap without a library PRNG."""
+
+    modulus = AUDIT_PER_QUARTILE
+    rejection_limit = (1 << 256) - ((1 << 256) % modulus)
+    records = []
+    for replicate in range(9999):
+        counts = [0] * modulus
+        for draw in range(modulus):
+            nonce = 0
+            while True:
+                digest = hashlib.sha256(
+                    _canonical_json(
+                        [
+                            BOOTSTRAP_SEED,
+                            "paired_audit_batch_bootstrap",
+                            replicate,
+                            draw,
+                            nonce,
+                        ]
+                    )
+                ).digest()
+                value = int.from_bytes(digest, "big")
+                if value < rejection_limit:
+                    counts[value % modulus] += 1
+                    break
+                nonce += 1
+        records.append(
+            {"multiplicities": counts, "replicate_index": replicate}
+        )
+    return tuple(records)
+
+
+def _operator_contract():
+    return {
+        "boundary": "exact_dirichlet",
+        "closure": "disabled",
+        "conductance": "unit_on_policy_admitted_reciprocal_edges",
+        "embeddings": "prohibited",
+        "operator": "topology_only_hop",
+        "resistance_selector": "prohibited",
+        "skeleton_selector": "prohibited",
+    }
+
+
+def _selection_contract():
+    return {
+        "anchor_selection_seed": SELECTION_SEED,
+        "anchors_per_batch": ANCHORS_PER_BATCH,
+        "anchors_per_quartile": ANCHORS_PER_QUARTILE,
+        "audit_per_quartile": AUDIT_PER_QUARTILE,
+        "batch_key_purpose": "batch",
+        "calibration_per_quartile": CALIBRATION_PER_QUARTILE,
+        "hash_key_encoding": HASH_KEY_ENCODING,
+        "protected_nonanchors_per_anchor": PROTECTED_NONANCHORS,
+        "quartile_count": QUARTILE_COUNT,
+        "quartile_remainder_allocation": "first-r-quartiles-receive-one-v1",
+        "selection_key_purpose": "select",
+        "split_key_purpose": "split",
+        "typed_id_order": TYPED_ID_ORDER,
+    }
+
+
+def _derive_plan(capture, receipt, config):
+    config = _validated_config(config)
+    manifest_a, adjacency, eligible = _load_graph(
+        capture["manifest_a_data"],
+        capture["adjacency_data"],
+        capture["eligibility_data"],
+    )
+    quartiles, selected, batches, block_reasons = _freeze_anchor_design(eligible)
+    touch_budget = _TouchBudget(config["planner_edge_touch_ceiling"])
+    anchor_traversals = []
+    batch_records = []
+    domain_records = []
+    boundary_records = []
+    shell_records = []
+    maximum_projected_bytes = 0
+    if not block_reasons:
+        anchor_traversals, anchor_internal, traversal_blocks = _freeze_anchor_traversals(
+            selected, adjacency, touch_budget
+        )
+        block_reasons.extend(traversal_blocks)
+        if not traversal_blocks:
+            (
+                batch_records,
+                domain_records,
+                boundary_records,
+                shell_records,
+                maximum_projected_bytes,
+                domain_blocks,
+            ) = _freeze_domains(batches, anchor_internal, adjacency, touch_budget)
+            block_reasons.extend(domain_blocks)
+    if maximum_projected_bytes > config["study_peak_rss_ceiling_bytes"]:
+        block_reasons.append("study_resource_inadequate")
+    block_reasons = sorted(set(block_reasons))
+    priority = (
+        "quartile_coverage_inadequate",
+        "protected_coverage_inadequate",
+        "calibration_shell_inadequate",
+        "study_resource_inadequate",
+    )
+    reason = "hop_plan_frozen"
+    if block_reasons:
+        reason = next(item for item in priority if item in block_reasons)
+    accepted = not block_reasons
+
+    payloads = {
+        "quartiles.jsonl": _jsonl_bytes(quartiles),
+        "selected_anchors.jsonl": _jsonl_bytes(selected),
+        "batches.jsonl": _jsonl_bytes(batch_records),
+        "anchor_traversals.jsonl": _jsonl_bytes(anchor_traversals),
+        "domains.jsonl": _jsonl_bytes(domain_records),
+        "boundaries.jsonl": _jsonl_bytes(boundary_records),
+        "calibration_shells.jsonl": _jsonl_bytes(shell_records),
+        "bootstrap_multiplicities.jsonl": _jsonl_bytes(
+            _bootstrap_multiplicity_records()
+        ),
+    }
+    artifact_records = {name: _content_record(data) for name, data in payloads.items()}
+    numeric_contract = _numeric_backend_contract()
+    implementation_records = {
+        "design": _file_record(DESIGN_PATH),
+        "planner": _file_record(Path(__file__).resolve()),
+        "protocol": _file_record(PROTOCOL_PATH),
+    }
+    resource_contract = {
+        "automatic_resource_downgrade": False,
+        "cache_key_contract": "plan_fingerprint+calibration_lock+batch_id+role+backend",
+        "cache_policy": "content_addressed_local_only_no_cross_plan_reuse",
+        "candidate_budgets": list(CANDIDATE_BUDGETS),
+        "dense_array_count_before_workspace": DENSE_ARRAY_COUNT,
+        "dense_projection_formula": "4*8*n*n",
+        "effective_resistance_arm": config["effective_resistance_arm"],
+        "float64_bytes": FLOAT64_BYTES,
+        "maximum_projected_dense_preworkspace_bytes": maximum_projected_bytes,
+        "maximum_reference_nodes": REFERENCE_BUDGET,
+        "planner_edge_touch_ceiling": config["planner_edge_touch_ceiling"],
+        "planner_edge_touches_observed": touch_budget.observed,
+        "planner_input_ceiling_bytes": config["planner_input_ceiling_bytes"],
+        "planner_input_bytes_observed": capture["planned_input_bytes"],
+        "study_peak_rss_ceiling_bytes": config["study_peak_rss_ceiling_bytes"],
+        "solve_timeout_seconds": 3600,
+    }
+    calibration_contract = {
+        "alpha_status": "unfrozen",
+        "calibration_split_only": True,
+        "global_alpha_rule": "maximum-anchor-required-added-leakage",
+        "hidden_floor_or_jitter": False,
+        "radius": CALIBRATION_SHELL_RADIUS,
+        "target_attenuation": CALIBRATION_TARGET,
+        "zero_alpha_allowed": True,
+    }
+    reference_contract = {
+        "candidate_union": "S_1024",
+        "maximum_nodes": REFERENCE_BUDGET,
+        "reference_rule": REFERENCE_RULE,
+        "whole_component_when_exhausted": True,
+    }
+    receipt_common = receipt["common_records"]
+    fingerprint_core = {
+        "algorithm": ALGORITHM,
+        "artifact_records": artifact_records,
+        "calibration_contract": calibration_contract,
+        "implementation_records": implementation_records,
+        "input_bindings": capture["input_bindings"],
+        "numeric_backend_contract": numeric_contract,
+        "operator_contract": _operator_contract(),
+        "reference_contract": reference_contract,
+        "repository_commit": _git_commit(),
+        "resource_contract": resource_contract,
+        "schema": SCHEMA,
+        "selection_contract": _selection_contract(),
+        "snapshot_common_records": receipt_common,
+        "statistical_contract": _statistical_contract(),
+    }
+    plan_fingerprint = hashlib.sha256(_canonical_json(fingerprint_core)).hexdigest()
+    manifest = {
+        "accepted": accepted,
+        "aggregate": {
+            "audit_batches": sum(row["split"] == "audit" for row in batch_records),
+            "calibration_batches": sum(
+                row["split"] == "calibration" for row in batch_records
+            ),
+            "eligible_anchor_count": len(eligible),
+            "publishable": False,
+            "selected_anchor_count": len(selected),
+        },
+        "algorithm": ALGORITHM,
+        "audit_solve_authorized": False,
+        "block_reasons": block_reasons,
+        "calibration_solve_authorized": accepted,
+        "diffusion_or_fidelity_metrics_computed": False,
+        "fingerprint_core": fingerprint_core,
+        "no_solve": True,
+        "plan_fingerprint": plan_fingerprint,
+        "reason": reason,
+        "schema": SCHEMA,
+        "solves_executed": 0,
+        "structural_metrics_computed": True,
+    }
+    manifest["manifest_integrity_sha256"] = hashlib.sha256(
+        _canonical_json(manifest)
+    ).hexdigest()
+    return payloads, manifest
+
+
+def _declared_source_inputs(
+    source_spec, *, maximum_size=MAXIMUM_SOURCE_SPEC_BYTES
+):
+    maximum_size = min(
+        MAXIMUM_SOURCE_SPEC_BYTES,
+        _positive_integer("source_specification_read_ceiling", maximum_size),
+    )
+    source_input = Path(source_spec)
+    if _has_symlink_ancestor(source_input):
+        raise HopPlanError("source declaration bundle cannot contain a symlink")
+    declaration_dir = source_input.resolve().parent
+    declaration_binding = _bind_directory(
+        declaration_dir, "source declaration bundle"
+    )
+    try:
+        if stat.S_IMODE(os.fstat(declaration_binding.fd).st_mode) != 0o700:
+            raise HopPlanError("source declaration bundle mode mismatch")
+        names = set(
+            _bounded_directory_names(
+                declaration_binding, 2, "source declaration bundle"
+            )
+        )
+        if names != {declaration.SPEC_FILENAME, declaration.LOCAL_ONLY_MARKER}:
+            raise HopPlanError("source declaration bundle inventory mismatch")
+        _assert_private_directory_files(
+            declaration_binding, "source declaration bundle", maximum_count=2
+        )
+        source_data = _read_bound_file(
+            declaration_binding,
+            declaration.SPEC_FILENAME,
+            None,
+            "source declaration bundle",
+            maximum_size=maximum_size,
+        )
+        marker_data = _read_bound_file(
+            declaration_binding,
+            declaration.LOCAL_ONLY_MARKER,
+            _content_record(declaration.LOCAL_ONLY_MARKER_PAYLOAD),
+            "source declaration bundle",
+        )
+        if marker_data != declaration.LOCAL_ONLY_MARKER_PAYLOAD:
+            raise HopPlanError("source declaration marker mismatch")
+        try:
+            verified = declaration._validate_canonical_spec(
+                declaration._strict_canonical_json(source_data)
+            )
+        except declaration.DeclarationError as exc:
+            raise HopPlanError("source declaration verification failed") from exc
+    finally:
+        declaration_binding.close()
+    paths = {declaration_dir}
+    for entry in verified["sources"]:
+        paths.add(Path(entry["path"]).resolve())
+    legacy = verified.get("legacy_check")
+    if isinstance(legacy, dict):
+        paths.add(Path(legacy["dag_path"]).resolve())
+    return tuple(sorted(paths, key=os.fspath))
+
+
+def _assert_no_output_input_overlap(
+    target,
+    input_dirs,
+    input_files,
+    source_spec,
+    *,
+    source_spec_maximum_size=MAXIMUM_SOURCE_SPEC_BYTES,
+):
+    inputs = {
+        *(Path(value).resolve() for value in input_dirs),
+        *(Path(value).resolve() for value in input_files),
+        *_declared_source_inputs(
+            source_spec, maximum_size=source_spec_maximum_size
+        ),
+    }
+    for item in inputs:
+        if (
+            item == target
+            or _path_is_within(item, target)
+            or _path_is_within(target, item)
+        ):
+            raise HopPlanError("plan output overlaps a verified input")
+
+
+def _validate_output_paths(
+    plan_dir,
+    local_root,
+    input_dirs,
+    input_files,
+    source_spec,
+    source_spec_maximum_size,
+):
+    raw_plan = Path(plan_dir)
+    raw_root = Path(local_root)
+    if _has_symlink_ancestor(raw_plan) or _has_symlink_ancestor(raw_root):
+        raise HopPlanError("local-only output paths cannot contain symlinks")
+    root = raw_root.resolve()
+    target = raw_plan.resolve()
+    if not root.is_dir():
+        raise HopPlanError("local root must be an existing directory")
+    if target == root or not _path_is_within(target, root):
+        raise HopPlanError("plan directory must be a child of the local root")
+    if _path_is_within(target, REPO_ROOT.resolve()) or _has_git_ancestor(target.parent):
+        raise HopPlanError("plan directory cannot be inside a Git worktree")
+    if target.exists() or not target.parent.is_dir():
+        raise HopPlanError("plan directory must be fresh with an existing parent")
+    _assert_no_output_input_overlap(
+        target,
+        input_dirs,
+        input_files,
+        source_spec,
+        source_spec_maximum_size=source_spec_maximum_size,
+    )
+    parent_binding = _bind_directory(target.parent, "plan output parent")
+    return target, parent_binding
+
+
+def _write_bound_bytes(binding, name, data):
+    if (
+        not isinstance(name, str)
+        or name in {"", ".", ".."}
+        or Path(name).name != name
+    ):
+        raise HopPlanError("local-only plan artifact name is malformed")
+    _assert_bound_directory(binding, "HOP plan staging directory")
+    try:
+        fd = os.open(
+            name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=binding.fd,
+        )
+        os.fchmod(fd, 0o600)
+        offset = 0
+        while offset < len(data):
+            offset += os.write(fd, data[offset:])
+        os.fsync(fd)
+        observed = os.fstat(fd)
+        if (
+            not stat.S_ISREG(observed.st_mode)
+            or observed.st_nlink != 1
+            or stat.S_IMODE(observed.st_mode) != 0o600
+            or observed.st_size != len(data)
+        ):
+            raise HopPlanError("local-only plan artifact contract mismatch")
+    except OSError as exc:
+        raise HopPlanError("local-only plan artifact could not be written") from exc
+    finally:
+        try:
+            os.close(fd)
+        except (OSError, UnboundLocalError):
+            pass
+    _assert_bound_directory(binding, "HOP plan staging directory")
+
+
+def _rename_directory_noreplace(parent_binding, source_leaf, target_leaf):
+    for leaf in (source_leaf, target_leaf):
+        if (
+            not isinstance(leaf, str)
+            or leaf in {"", ".", ".."}
+            or Path(leaf).name != leaf
+        ):
+            raise HopPlanError("atomic installation leaf is malformed")
+    _assert_bound_directory(parent_binding, "plan output parent")
+    libc = ctypes.CDLL(None, use_errno=True)
+    renameat2 = getattr(libc, "renameat2", None)
+    if renameat2 is None:
+        raise HopPlanError("atomic no-replace installation is unavailable")
+    renameat2.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    renameat2.restype = ctypes.c_int
+    result = renameat2(
+        parent_binding.fd,
+        os.fsencode(source_leaf),
+        parent_binding.fd,
+        os.fsencode(target_leaf),
+        1,
+    )
+    if result == 0:
+        return
+    error_number = ctypes.get_errno()
+    if error_number in {errno.EEXIST, errno.ENOTEMPTY}:
+        raise HopPlanError("plan directory appeared during atomic installation")
+    raise HopPlanError("atomic no-replace installation failed") from OSError(
+        error_number, os.strerror(error_number)
+    )
+
+
+def _cleanup_bound_staging(parent_binding, staging_binding, staging_leaf):
+    """Remove only our known, still-bound staging leaves; otherwise leak safely."""
+
+    _assert_bound_directory(parent_binding, "plan output parent")
+    _assert_bound_directory(staging_binding, "HOP plan staging directory")
+    entries = set(
+        _bounded_directory_names(
+            staging_binding, len(ALL_PLAN_FILES), "HOP plan staging directory"
+        )
+    )
+    if not entries.issubset(ALL_PLAN_FILES):
+        raise HopPlanError("HOP plan staging inventory changed during cleanup")
+    for name in sorted(entries):
+        try:
+            observed = os.stat(name, dir_fd=staging_binding.fd, follow_symlinks=False)
+            if not stat.S_ISREG(observed.st_mode) or observed.st_nlink != 1:
+                raise HopPlanError("HOP plan staging artifact changed during cleanup")
+            os.unlink(name, dir_fd=staging_binding.fd)
+        except OSError as exc:
+            raise HopPlanError("HOP plan staging cleanup failed") from exc
+    os.fsync(staging_binding.fd)
+    _assert_bound_directory(staging_binding, "HOP plan staging directory")
+    _assert_bound_directory(parent_binding, "plan output parent")
+    try:
+        os.rmdir(staging_leaf, dir_fd=parent_binding.fd)
+        os.fsync(parent_binding.fd)
+    except OSError as exc:
+        raise HopPlanError("HOP plan staging cleanup failed") from exc
+    _assert_bound_directory(parent_binding, "plan output parent")
+
+
+def _plan_manifest_from_binding(plan_binding):
+    _assert_bound_directory(plan_binding, "HOP plan")
+    try:
+        observed = os.fstat(plan_binding.fd)
+    except OSError as exc:
+        raise HopPlanError("HOP plan directory is unavailable") from exc
+    entries = set(
+        _bounded_directory_names(
+            plan_binding, len(ALL_PLAN_FILES), "HOP plan"
+        )
+    )
+    if stat.S_IMODE(observed.st_mode) != 0o700 or entries != ALL_PLAN_FILES:
+        raise HopPlanError("HOP plan directory contract mismatch")
+    marker = _read_bound_file(
+        plan_binding,
+        MARKER_NAME,
+        _content_record(MARKER_BYTES),
+        "HOP plan",
+    )
+    if marker != MARKER_BYTES:
+        raise HopPlanError("HOP plan local-only marker mismatch")
+    manifest_data = _read_bound_file(
+        plan_binding,
+        MANIFEST_NAME,
+        None,
+        "HOP plan",
+        maximum_size=MAXIMUM_PLAN_MANIFEST_BYTES,
+    )
+    manifest = _strict_json_bytes(manifest_data, "HOP plan manifest")
+    expected_keys = {
+        "accepted",
+        "aggregate",
+        "algorithm",
+        "audit_solve_authorized",
+        "block_reasons",
+        "calibration_solve_authorized",
+        "diffusion_or_fidelity_metrics_computed",
+        "fingerprint_core",
+        "manifest_integrity_sha256",
+        "no_solve",
+        "plan_fingerprint",
+        "reason",
+        "schema",
+        "solves_executed",
+        "structural_metrics_computed",
+    }
+    if not isinstance(manifest, dict) or set(manifest) != expected_keys:
+        raise HopPlanError("HOP plan manifest fields mismatch")
+    if (
+        manifest["schema"] != SCHEMA
+        or manifest["algorithm"] != ALGORITHM
+        or manifest["no_solve"] is not True
+        or manifest["solves_executed"] != 0
+        or manifest["structural_metrics_computed"] is not True
+        or manifest["diffusion_or_fidelity_metrics_computed"] is not False
+        or manifest["audit_solve_authorized"] is not False
+        or manifest["calibration_solve_authorized"] is not manifest["accepted"]
+    ):
+        raise HopPlanError("HOP plan interpretation contract mismatch")
+    unsealed = dict(manifest)
+    integrity = unsealed.pop("manifest_integrity_sha256")
+    if (
+        not isinstance(integrity, str)
+        or re.fullmatch(r"[0-9a-f]{64}", integrity) is None
+        or hashlib.sha256(_canonical_json(unsealed)).hexdigest() != integrity
+    ):
+        raise HopPlanError("HOP plan manifest integrity mismatch")
+    core = manifest["fingerprint_core"]
+    if not isinstance(core, dict) or hashlib.sha256(_canonical_json(core)).hexdigest() != manifest["plan_fingerprint"]:
+        raise HopPlanError("HOP plan fingerprint mismatch")
+    return manifest
+
+
+def _config_from_manifest(manifest):
+    try:
+        resource = manifest["fingerprint_core"]["resource_contract"]
+        return _validated_config(
+            {
+                "effective_resistance_arm": resource["effective_resistance_arm"],
+                "planner_edge_touch_ceiling": resource["planner_edge_touch_ceiling"],
+                "planner_input_ceiling_bytes": resource["planner_input_ceiling_bytes"],
+                "study_peak_rss_ceiling_bytes": resource["study_peak_rss_ceiling_bytes"],
+            }
+        )
+    except (KeyError, TypeError) as exc:
+        raise HopPlanError("HOP plan resource contract is malformed") from exc
+
+
+def _verify_or_prepare_inputs(
+    receipt_dir,
+    attempt_a_dir,
+    attempt_b_dir,
+    source_spec,
+    relation_policy,
+    config,
+):
+    receipt_binding = _bind_directory(receipt_dir, "consensus receipt")
+    attempt_a_binding = _bind_directory(attempt_a_dir, "canonical attempt A")
+    attempt_b_binding = _bind_directory(attempt_b_dir, "attempt B")
+    bindings = (receipt_binding, attempt_a_binding, attempt_b_binding)
+    try:
+        if len({(item.device, item.inode) for item in bindings}) != 3:
+            raise HopPlanError("consensus directories must be distinct")
+        for binding, label in zip(
+            bindings, ("consensus receipt", "canonical attempt A", "attempt B")
+        ):
+            _assert_private_directory_files(binding, label)
+        receipt_preflight_data = _read_bound_file(
+            receipt_binding,
+            consensus.RECEIPT_NAME,
+            None,
+            "consensus receipt",
+            maximum_size=min(
+                MAXIMUM_CONSENSUS_RECEIPT_BYTES,
+                config["planner_input_ceiling_bytes"],
+            ),
+        )
+        receipt_preflight = _strict_json_bytes(
+            receipt_preflight_data, "consensus receipt"
+        )
+        try:
+            source_record = receipt_preflight["input_records"]["source_spec"]
+            policy_record = receipt_preflight["input_records"]["relation_policy"]
+        except (KeyError, TypeError) as exc:
+            raise HopPlanError("consensus receipt lacks input records") from exc
+        if not _content_record_is_valid(source_record) or not _content_record_is_valid(
+            policy_record
+        ):
+            raise HopPlanError("consensus receipt input record is malformed")
+        manifest_preflight_bytes = 0
+        for binding, label in (
+            (attempt_a_binding, "canonical attempt A"),
+            (attempt_b_binding, "attempt B"),
+        ):
+            manifest_preflight_bytes += len(
+                _read_bound_file(
+                    binding,
+                    "manifest.json",
+                    None,
+                    label,
+                    maximum_size=min(
+                        MAXIMUM_ATTEMPT_MANIFEST_BYTES,
+                        config["planner_input_ceiling_bytes"],
+                    ),
+                )
+            )
+        preliminary_bytes = (
+            len(receipt_preflight_data)
+            + manifest_preflight_bytes
+            + source_record["size_bytes"]
+            + policy_record["size_bytes"]
+        )
+        if preliminary_bytes > config["planner_input_ceiling_bytes"]:
+            raise HopPlanError("planner input ceiling exceeded")
+        _read_regular_path(source_spec, source_record, "source specification")
+        _read_regular_path(relation_policy, policy_record, "relation policy")
+        try:
+            receipt = consensus.verify_consensus_receipt(
+                receipt_dir,
+                attempt_a_dir=attempt_a_dir,
+                attempt_b_dir=attempt_b_dir,
+                source_spec=source_spec,
+                relation_policy=relation_policy,
+            )
+        except consensus.ConsensusError as exc:
+            raise HopPlanError("full snapshot consensus verification failed") from exc
+        if (
+            receipt.get("accepted") is not True
+            or receipt.get("graph_gate_pass") is not True
+            or receipt.get("repeatability_verified") is not True
+            or receipt.get("reason") != "exact_consensus_ready"
+            or receipt.get("canonical_attempt") != "attempt_a"
+            or receipt.get("attempt_count") != 2
+            or receipt.get("graph_observation_count") != 1
+            or receipt.get("no_pooling") is not True
+        ):
+            raise HopPlanError("snapshot consensus does not authorize HOP planning")
+        for binding, label in zip(
+            bindings, ("consensus receipt", "canonical attempt A", "attempt B")
+        ):
+            _assert_bound_directory(binding, label)
+            _assert_private_directory_files(binding, label)
+        capture = _capture_verified_inputs(
+            receipt,
+            receipt_binding,
+            attempt_a_binding,
+            attempt_b_binding,
+            source_spec,
+            relation_policy,
+            planner_input_ceiling_bytes=config["planner_input_ceiling_bytes"],
+        )
+        for binding, label in zip(
+            bindings, ("consensus receipt", "canonical attempt A", "attempt B")
+        ):
+            _assert_private_directory_files(binding, label)
+        return receipt, capture, bindings
+    except Exception:
+        for binding in bindings:
+            binding.close()
+        raise
+
+
+def verify_plan(
+    plan_dir,
+    *,
+    receipt_dir,
+    attempt_a_dir,
+    attempt_b_dir,
+    source_spec,
+    relation_policy,
+):
+    plan_input = Path(plan_dir)
+    if _has_symlink_ancestor(plan_input):
+        raise HopPlanError("HOP plan path cannot contain a symlink")
+    resolved = plan_input.resolve()
+    if _path_is_within(resolved, REPO_ROOT.resolve()) or _has_git_ancestor(resolved.parent):
+        raise HopPlanError("HOP plan cannot be inside a Git worktree")
+    plan_binding = _bind_directory(resolved, "HOP plan")
+    bindings = ()
+    try:
+        manifest = _plan_manifest_from_binding(plan_binding)
+        config = _config_from_manifest(manifest)
+        _assert_no_output_input_overlap(
+            resolved,
+            (receipt_dir, attempt_a_dir, attempt_b_dir),
+            (source_spec, relation_policy),
+            source_spec,
+            source_spec_maximum_size=config["planner_input_ceiling_bytes"],
+        )
+        receipt, capture, bindings = _verify_or_prepare_inputs(
+            receipt_dir,
+            attempt_a_dir,
+            attempt_b_dir,
+            source_spec,
+            relation_policy,
+            config,
+        )
+        expected_payloads, expected_manifest = _derive_plan(capture, receipt, config)
+        if manifest != expected_manifest:
+            raise HopPlanError("HOP plan manifest does not match re-derived plan")
+        artifact_records = manifest["fingerprint_core"]["artifact_records"]
+        if set(artifact_records) != set(ARTIFACT_NAMES):
+            raise HopPlanError("HOP plan artifact inventory mismatch")
+        for name in ARTIFACT_NAMES:
+            expected_data = expected_payloads[name]
+            observed_data = _read_bound_file(
+                plan_binding, name, artifact_records[name], "HOP plan"
+            )
+            if observed_data != expected_data:
+                raise HopPlanError("HOP plan artifact does not match re-derived plan")
+        final_receipt = consensus.verify_consensus_receipt(
+            receipt_dir,
+            attempt_a_dir=attempt_a_dir,
+            attempt_b_dir=attempt_b_dir,
+            source_spec=source_spec,
+            relation_policy=relation_policy,
+        )
+        if final_receipt != receipt:
+            raise HopPlanError("consensus changed during HOP plan verification")
+        final_capture = _capture_verified_inputs(
+            receipt,
+            bindings[0],
+            bindings[1],
+            bindings[2],
+            source_spec,
+            relation_policy,
+            planner_input_ceiling_bytes=config["planner_input_ceiling_bytes"],
+        )
+        if final_capture != capture:
+            raise HopPlanError("planning inputs changed during HOP plan verification")
+        if _plan_manifest_from_binding(plan_binding) != manifest:
+            raise HopPlanError("HOP plan manifest changed during verification")
+        for name in ARTIFACT_NAMES:
+            if _read_bound_file(
+                plan_binding, name, artifact_records[name], "HOP plan"
+            ) != expected_payloads[name]:
+                raise HopPlanError("HOP plan artifact changed during verification")
+        _assert_private_directory_files(plan_binding, "HOP plan")
+        for binding, label in zip(
+            bindings, ("consensus receipt", "canonical attempt A", "attempt B")
+        ):
+            _assert_private_directory_files(binding, label)
+        return manifest
+    finally:
+        plan_binding.close()
+        for binding in bindings:
+            binding.close()
+
+
+def prepare_plan(
+    *,
+    receipt_dir,
+    attempt_a_dir,
+    attempt_b_dir,
+    source_spec,
+    relation_policy,
+    plan_dir,
+    local_root,
+    planner_input_ceiling_bytes,
+    planner_edge_touch_ceiling,
+    study_peak_rss_ceiling_bytes,
+    effective_resistance_arm,
+):
+    config = _validated_config(
+        {
+            "effective_resistance_arm": effective_resistance_arm,
+            "planner_edge_touch_ceiling": planner_edge_touch_ceiling,
+            "planner_input_ceiling_bytes": planner_input_ceiling_bytes,
+            "study_peak_rss_ceiling_bytes": study_peak_rss_ceiling_bytes,
+        }
+    )
+    target, parent_binding = _validate_output_paths(
+        plan_dir,
+        local_root,
+        (receipt_dir, attempt_a_dir, attempt_b_dir),
+        (source_spec, relation_policy),
+        source_spec,
+        config["planner_input_ceiling_bytes"],
+    )
+    bindings = ()
+    staging = None
+    staging_binding = None
+    staging_leaf = None
+    committed = False
+    try:
+        receipt, capture, bindings = _verify_or_prepare_inputs(
+            receipt_dir,
+            attempt_a_dir,
+            attempt_b_dir,
+            source_spec,
+            relation_policy,
+            config,
+        )
+        payloads, manifest = _derive_plan(capture, receipt, config)
+
+        # Re-run the complete verifier and recapture bound leaf bytes before the
+        # transaction is installed.  This closes the ordinary verify-then-reopen
+        # gap; downstream verification repeats the same derivation again.
+        receipt_again = consensus.verify_consensus_receipt(
+            receipt_dir,
+            attempt_a_dir=attempt_a_dir,
+            attempt_b_dir=attempt_b_dir,
+            source_spec=source_spec,
+            relation_policy=relation_policy,
+        )
+        if receipt_again != receipt:
+            raise HopPlanError("consensus changed during HOP planning")
+        capture_again = _capture_verified_inputs(
+            receipt,
+            bindings[0],
+            bindings[1],
+            bindings[2],
+            source_spec,
+            relation_policy,
+            planner_input_ceiling_bytes=config["planner_input_ceiling_bytes"],
+        )
+        if capture_again != capture:
+            raise HopPlanError("verified planning inputs changed during HOP planning")
+
+        _assert_bound_directory(parent_binding, "plan output parent")
+        staging_leaf, staging_binding = _create_bound_staging(
+            parent_binding, target.name
+        )
+        staging = staging_binding.path
+        for name in ARTIFACT_NAMES:
+            _write_bound_bytes(staging_binding, name, payloads[name])
+        _write_bound_bytes(staging_binding, MARKER_NAME, MARKER_BYTES)
+        _write_bound_bytes(staging_binding, MANIFEST_NAME, _canonical_json(manifest))
+        os.fsync(staging_binding.fd)
+
+        verified_staging = verify_plan(
+            staging,
+            receipt_dir=receipt_dir,
+            attempt_a_dir=attempt_a_dir,
+            attempt_b_dir=attempt_b_dir,
+            source_spec=source_spec,
+            relation_policy=relation_policy,
+        )
+        if verified_staging != manifest:
+            raise HopPlanError("staged HOP plan changed during verification")
+        _assert_bound_directory(parent_binding, "plan output parent")
+        _assert_bound_directory(staging_binding, "HOP plan staging directory")
+        _rename_directory_noreplace(parent_binding, staging_leaf, target.name)
+        staging_binding.path = target
+        staging = target
+        staging_leaf = target.name
+        _assert_bound_directory(staging_binding, "installed HOP plan")
+        _assert_bound_directory(parent_binding, "plan output parent")
+        os.fsync(parent_binding.fd)
+        _assert_bound_directory(parent_binding, "plan output parent")
+        verified = verify_plan(
+            target,
+            receipt_dir=receipt_dir,
+            attempt_a_dir=attempt_a_dir,
+            attempt_b_dir=attempt_b_dir,
+            source_spec=source_spec,
+            relation_policy=relation_policy,
+        )
+        if verified != manifest:
+            raise HopPlanError("installed HOP plan changed during verification")
+        _assert_bound_directory(staging_binding, "installed HOP plan")
+        _assert_bound_directory(parent_binding, "plan output parent")
+        os.fsync(parent_binding.fd)
+        _assert_bound_directory(parent_binding, "plan output parent")
+        committed = True
+        return manifest, (0 if manifest["accepted"] else 2)
+    finally:
+        try:
+            if not committed and staging_binding is not None:
+                _cleanup_bound_staging(parent_binding, staging_binding, staging_leaf)
+        finally:
+            if staging_binding is not None:
+                staging_binding.close()
+            for binding in bindings:
+                binding.close()
+            parent_binding.close()
+
+
+def _arg_positive_int(value):
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("--receipt-dir", required=True)
+    prepare.add_argument("--attempt-a-dir", required=True)
+    prepare.add_argument("--attempt-b-dir", required=True)
+    prepare.add_argument("--source-spec", required=True)
+    prepare.add_argument("--relation-policy", required=True)
+    prepare.add_argument("--plan-dir", required=True)
+    prepare.add_argument("--local-root", required=True)
+    prepare.add_argument("--local-only", action="store_true", required=True)
+    prepare.add_argument("--planner-input-ceiling-bytes", type=_arg_positive_int, required=True)
+    prepare.add_argument("--planner-edge-touch-ceiling", type=_arg_positive_int, required=True)
+    prepare.add_argument("--study-peak-rss-ceiling-bytes", type=_arg_positive_int, required=True)
+    prepare.add_argument(
+        "--effective-resistance-arm", choices=("enabled", "omitted"), required=True
+    )
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--receipt-dir", required=True)
+    verify.add_argument("--attempt-a-dir", required=True)
+    verify.add_argument("--attempt-b-dir", required=True)
+    verify.add_argument("--source-spec", required=True)
+    verify.add_argument("--relation-policy", required=True)
+    verify.add_argument("--plan-dir", required=True)
+    return parser
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
+    try:
+        if args.command == "prepare":
+            manifest, exit_code = prepare_plan(
+                receipt_dir=args.receipt_dir,
+                attempt_a_dir=args.attempt_a_dir,
+                attempt_b_dir=args.attempt_b_dir,
+                source_spec=args.source_spec,
+                relation_policy=args.relation_policy,
+                plan_dir=args.plan_dir,
+                local_root=args.local_root,
+                planner_input_ceiling_bytes=args.planner_input_ceiling_bytes,
+                planner_edge_touch_ceiling=args.planner_edge_touch_ceiling,
+                study_peak_rss_ceiling_bytes=args.study_peak_rss_ceiling_bytes,
+                effective_resistance_arm=args.effective_resistance_arm,
+            )
+            output = {
+                "accepted": manifest["accepted"],
+                "audit_batches": manifest["aggregate"]["audit_batches"],
+                "calibration_batches": manifest["aggregate"]["calibration_batches"],
+                "no_solve": True,
+                "reason": manifest["reason"],
+            }
+        else:
+            manifest = verify_plan(
+                args.plan_dir,
+                receipt_dir=args.receipt_dir,
+                attempt_a_dir=args.attempt_a_dir,
+                attempt_b_dir=args.attempt_b_dir,
+                source_spec=args.source_spec,
+                relation_policy=args.relation_policy,
+            )
+            exit_code = 0 if manifest["accepted"] else 2
+            output = {
+                "accepted": manifest["accepted"],
+                "no_solve": True,
+                "reason": manifest["reason"],
+                "verified": True,
+            }
+        print(json.dumps(output, sort_keys=True))
+        return exit_code
+    except Exception:
+        print(
+            json.dumps({"error": "HOP plan failed closed"}, sort_keys=True),
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/test_prepare_pearltrees_hop_plan.py
+++ b/prototypes/mu_cosine/test_prepare_pearltrees_hop_plan.py
@@ -1,0 +1,621 @@
+#!/usr/bin/env python3
+"""Contract tests for the outcome-blind Pearltrees no-solve HOP plan."""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+
+import pytest
+
+import declare_pearltrees_diffusion_sources as declaration
+import prepare_pearltrees_diffusion_consensus as consensus
+import prepare_pearltrees_hop_plan as plan
+
+
+SNAPSHOT_RESOURCE_CEILING = 200_000_000
+PLANNER_INPUT_CEILING = 200_000_000
+PLANNER_TOUCH_CEILING = 200_000_000
+STUDY_RSS_CEILING = 200_000_000
+PHYSICAL_RELATIONS = {
+    "alias": True,
+    "collection": True,
+    "cross_link": False,
+    "path": True,
+    "ref": True,
+    "shortcut": True,
+}
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _chain_rdf(node_count: int, *, private_isolated: bool = False) -> bytes:
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" '
+        'xmlns:pt="https://www.pearltrees.com/rdf/0.1/#">',
+    ]
+    final_node = node_count + (1 if private_isolated else 0)
+    for node in range(1, final_node + 1):
+        privacy = 1 if private_isolated and node == final_node else 0
+        lines.extend(
+            [
+                f'  <pt:Tree rdf:about="https://www.pearltrees.com/synthetic/id{node}">',
+                f"    <pt:treeId>{node}</pt:treeId>",
+                f"    <pt:title>Synthetic title {node}</pt:title>",
+                f"    <pt:privacy>{privacy}</pt:privacy>",
+                "  </pt:Tree>",
+            ]
+        )
+    for child in range(2, node_count + 1):
+        parent = child - 1
+        lines.extend(
+            [
+                "  <pt:RefPearl>",
+                "    <pt:parentTree "
+                f'rdf:resource="https://www.pearltrees.com/synthetic/id{parent}" />',
+                "    <pt:seeAlso "
+                f'rdf:resource="https://www.pearltrees.com/synthetic/id{child}" />',
+                f"    <pt:title>Synthetic title {child}</pt:title>",
+                "    <pt:privacy>0</pt:privacy>",
+                "  </pt:RefPearl>",
+            ]
+        )
+    lines.append("</rdf:RDF>")
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def _make_case(
+    root: Path,
+    *,
+    node_count: int,
+    minimum_anchors: int,
+    private_isolated: bool = False,
+) -> dict[str, Path]:
+    inputs = root / "inputs"
+    local = root / "local"
+    inputs.mkdir(parents=True)
+    local.mkdir()
+    rdf = inputs / "private-structural-source.rdf"
+    rdf.write_bytes(_chain_rdf(node_count, private_isolated=private_isolated))
+    policy = inputs / "policy.json"
+    _write_json(
+        policy,
+        {
+            "physical_edges": PHYSICAL_RELATIONS,
+            "schema": "pearltrees-diffusion-relation-policy-v1",
+        },
+    )
+    declaration_dir = local / "declaration"
+    spec = declaration.build_source_spec(
+        snapshot_label="private-synthetic-hop-plan",
+        rdf=(("private-source-id", "synthetic", str(rdf)),),
+    )
+    declaration.install_source_spec(
+        spec, output_dir=declaration_dir, local_root=local
+    )
+    case = {
+        "attempt_a": local / "attempt-a",
+        "attempt_b": local / "attempt-b",
+        "local": local,
+        "policy": policy,
+        "receipt": local / "consensus",
+        "source_spec": declaration_dir / declaration.SPEC_FILENAME,
+    }
+    receipt, exit_code = consensus.prepare_consensus(
+        case["source_spec"],
+        case["policy"],
+        case["attempt_a"],
+        case["attempt_b"],
+        case["receipt"],
+        case["local"],
+        minimum_anchors=minimum_anchors,
+        resource_ceiling_bytes=SNAPSHOT_RESOURCE_CEILING,
+    )
+    assert exit_code == 0
+    assert receipt["accepted"] is True
+    return case
+
+
+def _prepare_plan(case: dict[str, Path], name: str, **overrides):
+    values = {
+        "planner_input_ceiling_bytes": PLANNER_INPUT_CEILING,
+        "planner_edge_touch_ceiling": PLANNER_TOUCH_CEILING,
+        "study_peak_rss_ceiling_bytes": STUDY_RSS_CEILING,
+        "effective_resistance_arm": "enabled",
+    }
+    values.update(overrides)
+    output = case["local"] / name
+    manifest, exit_code = plan.prepare_plan(
+        receipt_dir=case["receipt"],
+        attempt_a_dir=case["attempt_a"],
+        attempt_b_dir=case["attempt_b"],
+        source_spec=case["source_spec"],
+        relation_policy=case["policy"],
+        plan_dir=output,
+        local_root=case["local"],
+        **values,
+    )
+    return output, manifest, exit_code
+
+
+def _verify(case: dict[str, Path], output: Path):
+    return plan.verify_plan(
+        output,
+        receipt_dir=case["receipt"],
+        attempt_a_dir=case["attempt_a"],
+        attempt_b_dir=case["attempt_b"],
+        source_spec=case["source_spec"],
+        relation_policy=case["policy"],
+    )
+
+
+def _jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+@pytest.fixture(scope="module")
+def ready_case(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
+    return _make_case(
+        tmp_path_factory.mktemp("pearltrees-hop-ready"),
+        node_count=1100,
+        minimum_anchors=128,
+        private_isolated=True,
+    )
+
+
+def test_numeric_typed_id_order_and_hash_preimage_are_frozen() -> None:
+    assert plan._typed_id_key("pt:2") < plan._typed_id_key("pt:10")
+    assert plan._typed_id_key("pt:10") < plan._typed_id_key("zz:1")
+    expected = plan.hashlib.sha256(
+        b'[3882001,"select","pt:2"]\n'
+    ).hexdigest()
+    assert plan._selection_key("select", "pt:2")[0] == expected
+    with pytest.raises(plan.HopPlanError):
+        plan._typed_id_key("pt:02")
+
+
+def test_quartile_remainder_allocation_is_frozen() -> None:
+    assert plan._quartile_slices(130) == (
+        (0, 33),
+        (33, 66),
+        (66, 98),
+        (98, 130),
+    )
+
+
+def test_cycle_convergence_is_not_a_cut() -> None:
+    adjacency = {
+        "pt:1": ("pt:2", "pt:3"),
+        "pt:2": ("pt:1", "pt:4"),
+        "pt:3": ("pt:1", "pt:4"),
+        "pt:4": ("pt:2", "pt:3", "pt:5"),
+        "pt:5": ("pt:4",),
+    }
+    order, distances, truncated = plan._hop_order(("pt:1",), adjacency)
+    assert order == ("pt:1", "pt:2", "pt:3", "pt:4", "pt:5")
+    assert distances["pt:4"] == 2
+    assert truncated == 0
+    boundary = plan._boundary_record(
+        "audit-001", "S_4", 4, order[:4], adjacency
+    )
+    assert boundary["cut_edges"] == [["pt:4", "pt:5"]]
+    assert boundary["beta"] == [{"cut_conductance": 1, "node_id": "pt:4"}]
+
+
+def test_reference_truncation_counts_the_omitted_final_shell() -> None:
+    leaf_count = 4100
+    center = "pt:1"
+    leaves = tuple(f"pt:{index}" for index in range(2, leaf_count + 2))
+    adjacency = {center: leaves}
+    adjacency.update({leaf: (center,) for leaf in leaves})
+    anchors = leaves[:4]
+    batch = {
+        "anchors_by_quartile": [
+            {"node_id": anchor, "quartile_id": f"q{index + 1}"}
+            for index, anchor in enumerate(anchors)
+        ],
+        "batch_id": "audit-001",
+        "split": "audit",
+    }
+    internal = {
+        anchor: {
+            "pair_distances": {other: (0 if other == anchor else 2) for other in anchors},
+            "protected": (anchor,),
+            "shell": (),
+        }
+        for anchor in anchors
+    }
+    _batches, domains, _boundaries, _shells, _maximum, blocks = plan._freeze_domains(
+        (batch,), internal, adjacency, plan._TouchBudget(100_000)
+    )
+    assert blocks == []
+    reference = next(row for row in domains if row["role"] == "R_top")
+    assert reference["realized_nodes"] == 4096
+    assert reference["truncated_final_shell_nodes"] == 5
+
+
+def test_planner_source_has_a_static_no_solve_import_and_call_boundary() -> None:
+    source = Path(plan.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_modules = {"numpy", "scipy", "torch", "unifyweaver.graph"}
+    forbidden_calls = {"solve", "cholesky", "eig", "eigh", "eigvalsh", "qr", "inv"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            assert all(
+                not any(alias.name == name or alias.name.startswith(name + ".") for name in forbidden_modules)
+                for alias in node.names
+            )
+        elif isinstance(node, ast.ImportFrom):
+            assert node.module is None or not any(
+                node.module == name or node.module.startswith(name + ".")
+                for name in forbidden_modules
+            )
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in forbidden_calls
+            elif isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in forbidden_calls
+
+
+def test_private_bundle_fifo_fails_without_a_blocking_open(tmp_path: Path) -> None:
+    bundle = tmp_path / "private-bundle"
+    bundle.mkdir(mode=0o700)
+    fifo = bundle / "corrupt-leaf"
+    os.mkfifo(fifo, mode=0o600)
+    binding = plan._bind_directory(bundle, "synthetic private bundle")
+    try:
+        with pytest.raises(plan.HopPlanError, match="artifact contract mismatch"):
+            plan._assert_private_directory_files(
+                binding, "synthetic private bundle"
+            )
+    finally:
+        binding.close()
+
+
+def test_private_bundle_inventory_scan_is_bounded(tmp_path: Path) -> None:
+    bundle = tmp_path / "oversized-private-bundle"
+    bundle.mkdir(mode=0o700)
+    for index in range(4):
+        leaf = bundle / f"leaf-{index}"
+        leaf.write_bytes(b"")
+        os.chmod(leaf, 0o600)
+    binding = plan._bind_directory(bundle, "synthetic private bundle")
+    try:
+        with pytest.raises(plan.HopPlanError, match="inventory exceeds its bound"):
+            plan._bounded_directory_names(
+                binding, 3, "synthetic private bundle"
+            )
+    finally:
+        binding.close()
+
+
+def test_ready_plan_is_balanced_nested_local_only_and_byte_deterministic(
+    ready_case: dict[str, Path],
+) -> None:
+    first, manifest, exit_code = _prepare_plan(ready_case, "plan-one")
+    second, second_manifest, second_exit = _prepare_plan(ready_case, "plan-two")
+
+    assert exit_code == second_exit == 0
+    assert manifest == second_manifest
+    assert manifest["accepted"] is True
+    assert manifest["reason"] == "hop_plan_frozen"
+    assert manifest["solves_executed"] == 0
+    assert manifest["structural_metrics_computed"] is True
+    assert manifest["diffusion_or_fidelity_metrics_computed"] is False
+    assert manifest["calibration_solve_authorized"] is True
+    assert manifest["audit_solve_authorized"] is False
+    assert manifest["aggregate"] == {
+        "audit_batches": 24,
+        "calibration_batches": 8,
+        "eligible_anchor_count": 1100,
+        "publishable": False,
+        "selected_anchor_count": 128,
+    }
+    assert _verify(ready_case, first) == manifest
+    assert {item.name for item in first.iterdir()} == plan.ALL_PLAN_FILES
+    assert stat.S_IMODE(first.stat().st_mode) == 0o700
+    assert all(stat.S_IMODE(item.stat().st_mode) == 0o600 for item in first.iterdir())
+    assert all(
+        (first / name).read_bytes() == (second / name).read_bytes()
+        for name in plan.ALL_PLAN_FILES
+    )
+
+    quartiles = _jsonl(first / "quartiles.jsonl")
+    assert [row["member_count"] for row in quartiles] == [275, 275, 275, 275]
+    anchors = _jsonl(first / "selected_anchors.jsonl")
+    assert len(anchors) == len({row["node_id"] for row in anchors}) == 128
+    assert sum(row["split"] == "calibration" for row in anchors) == 32
+    assert sum(row["split"] == "audit" for row in anchors) == 96
+    batches = _jsonl(first / "batches.jsonl")
+    assert len(batches) == 32
+    assert all(
+        [row["quartile_id"] for row in batch["anchors_by_quartile"]]
+        == ["q1", "q2", "q3", "q4"]
+        for batch in batches
+    )
+    domains = _jsonl(first / "domains.jsonl")
+    by_batch = {}
+    for row in domains:
+        by_batch.setdefault(row["batch_id"], {})[row["role"]] = row
+    assert len(by_batch) == 32
+    for roles in by_batch.values():
+        s256 = [row["node_id"] for row in roles["S_256"]["nodes"]]
+        s512 = [row["node_id"] for row in roles["S_512"]["nodes"]]
+        s1024 = [row["node_id"] for row in roles["S_1024"]["nodes"]]
+        reference = [row["node_id"] for row in roles["R_top"]["nodes"]]
+        assert s256 == s512[:256]
+        assert s512 == s1024[:512]
+        assert s1024 == reference[:1024]
+        assert [len(s256), len(s512), len(s1024), len(reference)] == [
+            256,
+            512,
+            1024,
+            1100,
+        ]
+    boundaries = _jsonl(first / "boundaries.jsonl")
+    assert all(row["closure_policy"] == "exact_dirichlet_no_closure" for row in boundaries)
+    assert all(row["cut_mass"] == row["cut_edge_count"] for row in boundaries)
+    shells = _jsonl(first / "calibration_shells.jsonl")
+    assert len(shells) == 32
+    assert all(row["strictly_interior_pass"] is True for row in shells)
+    bootstrap = _jsonl(first / "bootstrap_multiplicities.jsonl")
+    assert len(bootstrap) == 9999
+    assert bootstrap[0] == {
+        "multiplicities": [
+            4,
+            1,
+            1,
+            0,
+            0,
+            1,
+            1,
+            0,
+            1,
+            1,
+            1,
+            0,
+            1,
+            1,
+            1,
+            0,
+            4,
+            0,
+            2,
+            1,
+            1,
+            1,
+            0,
+            1,
+        ],
+        "replicate_index": 0,
+    }
+    assert all(sum(row["multiplicities"]) == 24 for row in bootstrap)
+    statistical = manifest["fingerprint_core"]["statistical_contract"]
+    assert statistical["minimum_complete_audit_batches"] == 18
+    assert statistical["reference_adequacy"] == {
+        "maximum_h_absolute_error_q90_max": 0.005,
+        "raw_relative_l2_error_q90_max": 0.01,
+        "top8_overlap_q10_min": 0.98,
+    }
+
+    eligibility = _jsonl(ready_case["attempt_a"] / "anchor_eligibility.jsonl")
+    private = next(row for row in eligibility if row["node_id"] == "pt:1101")
+    assert private == {
+        "eligible": False,
+        "node_id": "pt:1101",
+        "reason": "direct_private",
+    }
+    adjacency_ids = {
+        row["node_id"] for row in _jsonl(ready_case["attempt_a"] / "adjacency.jsonl")
+    }
+    assert "pt:1101" not in adjacency_ids
+
+    manifest_text = (first / "manifest.json").read_text(encoding="utf-8")
+    assert "Synthetic title" not in manifest_text
+    assert "private-source-id" not in manifest_text
+    assert str(ready_case["local"].parent) not in manifest_text
+    assert '"K_low"' not in manifest_text and '"K_high"' not in manifest_text
+
+
+def test_small_valid_snapshot_installs_an_immutable_coverage_block(
+    tmp_path: Path,
+) -> None:
+    case = _make_case(tmp_path / "small", node_count=20, minimum_anchors=1)
+    output, manifest, exit_code = _prepare_plan(case, "blocked-plan")
+
+    assert exit_code == 2
+    assert manifest["accepted"] is False
+    assert manifest["reason"] == "quartile_coverage_inadequate"
+    assert manifest["block_reasons"] == ["quartile_coverage_inadequate"]
+    assert manifest["calibration_solve_authorized"] is False
+    assert manifest["audit_solve_authorized"] is False
+    assert _verify(case, output) == manifest
+    assert (output / "batches.jsonl").read_bytes() == b""
+
+
+def test_tiny_study_ceiling_records_resource_block(
+    ready_case: dict[str, Path],
+) -> None:
+    output, manifest, exit_code = _prepare_plan(
+        ready_case,
+        "resource-block",
+        study_peak_rss_ceiling_bytes=1,
+    )
+
+    assert exit_code == 2
+    assert manifest["accepted"] is False
+    assert "study_resource_inadequate" in manifest["block_reasons"]
+    assert _verify(ready_case, output) == manifest
+
+
+def test_plan_verifier_rejects_changed_node_artifact(
+    ready_case: dict[str, Path], tmp_path: Path
+) -> None:
+    source = ready_case["local"] / "plan-one"
+    changed = tmp_path / "changed-plan"
+    shutil.copytree(source, changed)
+    path = changed / "batches.jsonl"
+    path.write_bytes(path.read_bytes() + b'{}\n')
+    os.chmod(path, 0o600)
+
+    with pytest.raises(plan.HopPlanError):
+        _verify(ready_case, changed)
+
+
+def test_full_chain_rejects_changed_attempt_a_leaf_before_plan_install(
+    ready_case: dict[str, Path], tmp_path: Path
+) -> None:
+    changed_attempt = tmp_path / "attempt-a"
+    shutil.copytree(ready_case["attempt_a"], changed_attempt)
+    adjacency = changed_attempt / "adjacency.jsonl"
+    adjacency.write_bytes(adjacency.read_bytes() + b'{}\n')
+    os.chmod(adjacency, 0o600)
+
+    with pytest.raises(plan.HopPlanError):
+        plan.prepare_plan(
+            receipt_dir=ready_case["receipt"],
+            attempt_a_dir=changed_attempt,
+            attempt_b_dir=ready_case["attempt_b"],
+            source_spec=ready_case["source_spec"],
+            relation_policy=ready_case["policy"],
+            plan_dir=ready_case["local"] / "must-not-install",
+            local_root=ready_case["local"],
+            planner_input_ceiling_bytes=PLANNER_INPUT_CEILING,
+            planner_edge_touch_ceiling=PLANNER_TOUCH_CEILING,
+            study_peak_rss_ceiling_bytes=STUDY_RSS_CEILING,
+            effective_resistance_arm="enabled",
+        )
+    assert not (ready_case["local"] / "must-not-install").exists()
+
+
+def test_plan_target_cannot_nest_inside_the_source_declaration(
+    ready_case: dict[str, Path],
+) -> None:
+    target = ready_case["source_spec"].parent / "must-not-install"
+    with pytest.raises(plan.HopPlanError):
+        plan.prepare_plan(
+            receipt_dir=ready_case["receipt"],
+            attempt_a_dir=ready_case["attempt_a"],
+            attempt_b_dir=ready_case["attempt_b"],
+            source_spec=ready_case["source_spec"],
+            relation_policy=ready_case["policy"],
+            plan_dir=target,
+            local_root=ready_case["local"],
+            planner_input_ceiling_bytes=PLANNER_INPUT_CEILING,
+            planner_edge_touch_ceiling=PLANNER_TOUCH_CEILING,
+            study_peak_rss_ceiling_bytes=STUDY_RSS_CEILING,
+            effective_resistance_arm="enabled",
+        )
+    assert not target.exists()
+    declaration.verify_installed_source_spec(ready_case["source_spec"])
+
+
+def test_source_declaration_hardlink_fails_before_plan_install(
+    ready_case: dict[str, Path],
+) -> None:
+    marker = ready_case["source_spec"].parent / declaration.LOCAL_ONLY_MARKER
+    extra_link = ready_case["local"] / "temporary-declaration-marker-hardlink"
+    target = ready_case["local"] / "hardlink-must-not-install"
+    os.link(marker, extra_link)
+    try:
+        with pytest.raises(plan.HopPlanError):
+            plan.prepare_plan(
+                receipt_dir=ready_case["receipt"],
+                attempt_a_dir=ready_case["attempt_a"],
+                attempt_b_dir=ready_case["attempt_b"],
+                source_spec=ready_case["source_spec"],
+                relation_policy=ready_case["policy"],
+                plan_dir=target,
+                local_root=ready_case["local"],
+                planner_input_ceiling_bytes=PLANNER_INPUT_CEILING,
+                planner_edge_touch_ceiling=PLANNER_TOUCH_CEILING,
+                study_peak_rss_ceiling_bytes=STUDY_RSS_CEILING,
+                effective_resistance_arm="enabled",
+            )
+        assert not target.exists()
+    finally:
+        extra_link.unlink()
+
+
+def test_unused_attempt_leaf_hardlink_is_rejected(
+    ready_case: dict[str, Path],
+) -> None:
+    source = ready_case["attempt_a"] / "nodes.jsonl"
+    extra_link = ready_case["local"] / "temporary-unused-attempt-hardlink"
+    os.link(source, extra_link)
+    try:
+        with pytest.raises(plan.HopPlanError, match="artifact contract mismatch"):
+            _verify(ready_case, ready_case["local"] / "plan-one")
+    finally:
+        extra_link.unlink()
+
+
+def test_plan_target_cannot_nest_inside_authoritative_api_directory(
+    ready_case: dict[str, Path],
+) -> None:
+    api_dir = ready_case["local"] / "authoritative-api-json"
+    api_dir.mkdir()
+    _write_json(api_dir / "page.json", {"synthetic": True})
+    alternate_dir = ready_case["local"] / "api-source-declaration"
+    alternate = declaration.build_source_spec(
+        snapshot_label="private-api-overlap-regression",
+        api_json_dir=(("api-source", str(api_dir)),),
+    )
+    declaration.install_source_spec(
+        alternate, output_dir=alternate_dir, local_root=ready_case["local"]
+    )
+    target = api_dir / "must-not-install"
+    with pytest.raises(plan.HopPlanError, match="overlaps a verified input"):
+        plan.prepare_plan(
+            receipt_dir=ready_case["receipt"],
+            attempt_a_dir=ready_case["attempt_a"],
+            attempt_b_dir=ready_case["attempt_b"],
+            source_spec=alternate_dir / declaration.SPEC_FILENAME,
+            relation_policy=ready_case["policy"],
+            plan_dir=target,
+            local_root=ready_case["local"],
+            planner_input_ceiling_bytes=PLANNER_INPUT_CEILING,
+            planner_edge_touch_ceiling=PLANNER_TOUCH_CEILING,
+            study_peak_rss_ceiling_bytes=STUDY_RSS_CEILING,
+            effective_resistance_arm="enabled",
+        )
+    assert not target.exists()
+
+
+def test_cli_failure_is_generic_and_does_not_echo_private_paths(
+    ready_case: dict[str, Path], capsys: pytest.CaptureFixture[str]
+) -> None:
+    private_missing = ready_case["local"] / "private-missing-plan"
+    exit_code = plan.main(
+        [
+            "verify",
+            "--receipt-dir",
+            str(ready_case["receipt"]),
+            "--attempt-a-dir",
+            str(ready_case["attempt_a"]),
+            "--attempt-b-dir",
+            str(ready_case["attempt_b"]),
+            "--source-spec",
+            str(ready_case["source_spec"]),
+            "--relation-policy",
+            str(ready_case["policy"]),
+            "--plan-dir",
+            str(private_missing),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert json.loads(captured.err) == {"error": "HOP plan failed closed"}
+    assert str(private_missing) not in captured.err


### PR DESCRIPTION
## Summary

- add a fully verified, outcome-blind no-solve HOP planner downstream of the two-process Pearltrees snapshot consensus
- freeze degree-stratified anchors, calibration/audit batches, protected sets, nested HOP domains, exact Dirichlet cut ledgers, and radius-3 calibration shells
- bind an exact 9,999-resample paired-bootstrap multiplicity schedule and the complete reference-adequacy/noninferiority decision contract
- harden local-only provenance with bounded nonblocking reads, complete link/mode checks, raw-source overlap rejection, full-manifest sealing, and descriptor-relative atomic installation
- document the calibration-lock handoff, scale limits, same-user authenticity boundary, and explicit no-solve/non-claims

## Why

PR #3906 established a repeatable, privacy-certified structural snapshot and consensus receipt. The study still needed a prospective planning transaction that freezes every outcome-blind design choice before leakage calibration or audit data can be inspected. Without that link, anchor selection, domain construction, bootstrap resampling, or resource choices could drift after outcomes were visible.

## Scientific scope

This PR performs topology bookkeeping only. It runs no diffusion solve, computes no fidelity or filing metric, does not calibrate `alpha_top`, does not select `K_low`/`K_high`, and does not authorize audit execution. An accepted plan authorizes only the registered calibration stage. The later calibration lock must bind the complete plan-manifest content record before any untouched audit solve.

The in-memory planner is intended for the current bounded Pearltrees study, not million-node deployment. Larger graphs fail closed pending a disk-backed adapter. Unkeyed hashes and byte re-derivation detect drift but do not authenticate a wholly replaced self-consistent chain against a hostile same-user without an external trust anchor.

## Validation

- `181 passed`: source declaration, snapshot, consensus, HOP planner, and bounded-diffusion fidelity suites
- focused HOP planner suite: `17 passed`
- Python syntax compilation
- `git diff --check`
- independent science/statistical review: approved
- independent security/privacy/provenance review: approved
