### PR TITLE
plawk: support redirected getline into the current record

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -47,7 +47,7 @@ only (runtime pending) · ❌ missing.
 | `delete arr[k]` | ◐ | `delete arr[$k]` removes the entry keyed by a field (parity with `arr[$k]++`); backward-shift deletion in the runtime (later colliding keys stay reachable), missing key is a no-op. String-literal / var keys are a follow-on |
 | `exit [n]` | ✅ | stops the record loop, runs END, returns N (default 0); `exit` in a rule body, an `if`/`else` branch, or a loop (propagates past the loop) — scalar state at the exit point flows into END |
 | `delete arr[k]` | ❌ | |
-| `getline` | ◐ | **`getline var < "file"` landed** (phase 1): reads the next line of a file into a scalar, returning 1/0/-1. `status = getline var < "file"` captures the return (dual-slot: `var` string, `status` i64); a bare `getline var < "file"` discards it. Handles are keyed by **filename** in a process-wide registry (`@wam_getline_file`), so every site reading the same file shares one advancing handle (as in awk); EOF preserves `var`. The **canonical in-condition idiom** works: `while ((getline var < "file") > 0) BODY` (normalised at parse to a priming read + a `while (status > 0)` loop whose body re-reads — reusing the phase-1 machinery, no new codegen). Follow-ons: plain `getline` / `getline < file` into `$0` (updates `NF`), `cmd | getline`, `getline` in BEGIN/END, and `var` as a strnum source. The multi-pass / `over` readers still cover the bulk-scan use |
+| `getline` | ◐ | **Redirected scalar and record getline landed.** `getline var < "file"` reads into a scalar; `getline < "file"` reads into `$0`, re-splits `$1…$NF` with the active FS (including regex FS), and updates `NF`. Their assignment forms capture the 1/0/-1 status (`status = getline …`), while bare statements discard it; EOF/error preserve the prior target. Handles are keyed by **filename** in the process-wide `@wam_getline_file` registry, so scalar- and record-target sites share one advancing handle. Both canonical conditions work: `while ((getline var < "file") > 0)` and `while ((getline < "file") > 0)`. Redirected record getline does **not** advance NR/FNR. Its v1 runtime sibling forces a physical newline record and preserves RS/RT while reusing the persistent reader; applying RS/RT to this form is a follow-on. Cleanly rejected follow-ons: plain main-input `getline`, bare main-input `getline var`, `cmd | getline`, dynamic filenames, and getline in BEGIN/END. The multi-pass / `over` readers still cover the bulk-scan use |
 
 ## Functions
 
@@ -194,7 +194,8 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    family; larger, lower priority for the DSL's data-pipeline focus.
 
 Deferred by design (the DSL's model diverges here): `RS`/multi-char record
-separators, `getline` (the `over`/multi-pass readers subsume most uses),
+separators, main-input and pipeline `getline` (the `over`/multi-pass readers
+subsume most bulk-scan uses),
 multi-file `FILENAME`/`FNR` (`ARGV[N]`/`ARGC` themselves are landed for rule
 bodies — see the table), C-style `for(;;)` / `do-while` (the `while`
 runtime + for-in cover the loop needs).

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -156,6 +156,20 @@ plawk_dedupe_keep_order([PI | Rest0], [PI | Deduped]) :-
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
 %  the deterministic guard, and prints matching records.
+plawk_program_has_unsupported_getline(Program) :-
+    sub_term(Term, Program),
+    compound(Term),
+    functor(Term, unsupported_getline, _),
+    !.
+
+% Unsupported getline shapes are explicit parser nodes. Commit to rejection
+% before any specialized driver can ignore an unfamiliar BEGIN/END action or
+% accidentally route a main-input getline through an ordinary scalar path.
+plawk_program_native_driver_ir(Program, _InputPath, _DriverIR) :-
+    plawk_program_has_unsupported_getline(Program),
+    !,
+    fail.
+
 plawk_program_native_driver_ir(
     program(BeginClauses, [rule(Pattern, [Action0])], []),
     InputPath,
@@ -4133,6 +4147,11 @@ plawk_action_blob_field(if(_Pattern, ThenActions, ElseActions), Blob) :-
 %  bodies (no break/next); an `END { for (k in arr) print ... }`. The input
 %  must be a file argument (re-opened per pass); stdin is not re-openable
 %  (the design requires an explicit spool, a later phase).
+plawk_program_multipass_driver_ir(Program, _DriverIR) :-
+    plawk_program_has_unsupported_getline(Program),
+    !,
+    fail.
+
 plawk_program_multipass_driver_ir(
     program_passes(BeginClauses, Passes,
         [end([for_in(var(LoopVar), var(ArrayName), [print(PrintFields)])])]),
@@ -6767,7 +6786,10 @@ plawk_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
         ),
         ActionVars),
     plawk_rules_body_print_fields(Rules, BodyPrintFields),
-    ( ActionVars \== [] ; BodyPrintFields \== [] ),
+    ( ActionVars \== []
+    ; BodyPrintFields \== []
+    ; plawk_rules_have_record_getline(Rules)
+    ),
     findall(Name,
         ( member(Field, PrintFields),
           plawk_scalar_print_expr(Field, Name)
@@ -6776,6 +6798,33 @@ plawk_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
     append(ActionVars, PrintVars, Names0),
     sort(Names0, Names),
     plawk_scalar_typed_slots(Rules, Names, Slots).
+
+% A bare record-getline has an observable `$0` side effect but no scalar slot.
+% Keep the scalar action-chain driver active even when it is the only action in
+% the program. Walk nested control bodies too; the sequence walker supports the
+% same nodes there.
+plawk_rules_have_record_getline(Rules) :-
+    member(rule(_Pattern, Actions), Rules),
+    plawk_actions_have_record_getline(Actions),
+    !.
+
+plawk_actions_have_record_getline(Actions) :-
+    member(Action, Actions),
+    plawk_action_has_record_getline(Action),
+    !.
+
+plawk_action_has_record_getline(getline_file_record(_File)).
+plawk_action_has_record_getline(getline_file_record_capture(_Status, _File)).
+plawk_action_has_record_getline(if(_Pattern, ThenActions, ElseActions)) :-
+    ( plawk_actions_have_record_getline(ThenActions)
+    ; plawk_actions_have_record_getline(ElseActions)
+    ).
+plawk_action_has_record_getline(while_loop(_Cond, Body)) :-
+    plawk_actions_have_record_getline(Body).
+plawk_action_has_record_getline(do_while_loop(Body, _Cond)) :-
+    plawk_actions_have_record_getline(Body).
+plawk_action_has_record_getline(foreach_loop(_Layout, Body)) :-
+    plawk_actions_have_record_getline(Body).
 
 %% plawk_scalar_typed_slots(+Rules, +Names, -Slots)
 %
@@ -12220,6 +12269,11 @@ plawk_scalar_rule_body_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
 plawk_scalar_rule_body_action(Action) :-
     plawk_dynrec_bind_ok(Action).
+plawk_scalar_rule_body_action(getline_file_record(File)) :-
+    string(File).
+plawk_scalar_rule_body_action(getline_file_record_capture(Status, File)) :-
+    atom(Status),
+    string(File).
 % the store-only half of a rule-level `exit N` (terminal_exit split); it is a
 % plain store with no control, valid anywhere a plain body action is.
 plawk_scalar_rule_body_action(exit_store(_Code)).
@@ -12252,6 +12306,11 @@ plawk_scalar_branch_body_actions(Actions) :-
 
 plawk_scalar_rule_body_plain_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
+plawk_scalar_rule_body_plain_action(getline_file_record(File)) :-
+    string(File).
+plawk_scalar_rule_body_plain_action(getline_file_record_capture(Status, File)) :-
+    atom(Status),
+    string(File).
 % `exit [N]` inside a branch body (`if (c) exit`): the sequence walker lowers it
 % via branch_exit + plawk_branch_to_done_ir (branch to break_close_stream); the
 % store-only marker `exit_store` may appear when a branch ends the rule.
@@ -13040,6 +13099,9 @@ plawk_scalar_update_action_name(gsub_count(CountName, _Global, _Regex, _Repl, Ta
 % Status i64 slot; action_update reports Var, this surfaces Status too.
 plawk_scalar_update_action_name(getline_capture(Status, Var, _File), Name) :-
     ( Name = Var ; Name = Status ).
+% Record-target getline writes only its i64 status slot; `$0` lives in the
+% reserved transient record buffer rather than in the scalar state plan.
+plawk_scalar_update_action_name(getline_file_record_capture(Status, _File), Status).
 plawk_scalar_update_action_name(dynrec_bind(Vars, _Call, _Types), Name) :-
     plawk_dynrec_binding_names(Vars, Names),
     member(Name, Names).
@@ -13284,6 +13346,45 @@ plawk_getline_ir(Prefix, OpIndex, File, VarInput, VarNext, StNext, GlobalIR, IR)
          Base, Base,
          Base, StNext,
          VarNext, Base, Base, VarInput]).
+
+% Emit one `getline < "file"` site. The runtime sibling shares the scalar
+% getline filename registry, reads a physical newline record without changing
+% RS/RT, and replaces the reserved transient record buffer only on status 1.
+% The `%line` Value used throughout the action chain therefore remains the
+% current `$0`; fields and NF continue to project lazily from it.
+plawk_getline_record_ir(Prefix, OpIndex, File, StNext, GlobalIR, IR) :-
+    format(atom(Base), '~w_getline_record_~w', [Prefix, OpIndex]),
+    format(atom(PathName), '~w_path', [Base]),
+    llvm_emit_c_string_global(PathName, File, GlobalIR, PathLen, PathBytes),
+    format(atom(StNext), '%~w_status', [Base]),
+    format(atom(IR),
+'  %~w_pathp = getelementptr [~w x i8], [~w x i8]* @.~w, i64 0, i64 0
+  ~w = call i64 @wam_getline_file_record(i8* %~w_pathp, i64 ~w)',
+        [Base, PathBytes, PathBytes, PathName,
+         StNext, Base, PathLen]).
+
+% `status = getline < "file"`: update the current record and the status slot.
+plawk_scalar_action_sequence_pairs([getline_file_record_capture(Status, File) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { string(File),
+      nth0(StIndex, Slots, StSlot), plawk_slot_name(StSlot, Status),
+      plawk_getline_record_ir(Prefix, OpIndex, File, StNext, GlobalIR, IR),
+      replace_nth0(StIndex, Values0, StNext, Values1),
+      NextOpIndex is OpIndex + 1
+    },
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values1, Values, FinalOpIndex, ExitLabel, NextExits).
+% Bare `getline < "file"`: same record side effect, status discarded.
+plawk_scalar_action_sequence_pairs([getline_file_record(File) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { string(File),
+      plawk_getline_record_ir(Prefix, OpIndex, File, _StNext, GlobalIR, IR),
+      NextOpIndex is OpIndex + 1
+    },
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits).
 
 % `status = getline var < "file"`: read the next line into the Var string slot
 % and the 1/0/-1 status into the Status i64 slot (a dual-slot write). The file is
@@ -15879,21 +15980,28 @@ plawk_foreign_arg_ir(field(0), _FieldSeparator, ArgBase, ArgValueIR,
     % The record Value is the transient line atom whose buffer mutates
     % on the next read; Prolog-side atom identity (X == 'ERROR') and
     % anything the predicate might persist need a real atom, so $0
-    % interns the current line text. %line_s is the C string the
-    % driver's EOF check already resolved.
+    % interns the current line text. Resolve the pointer at this use site:
+    % record-getline can grow the transient buffer after the driver cached
+    % %line_s for its EOF check.
     SafeBase = ArgBase,
-    format(atom(LenIR),
-        '  %~w_len = call i64 @strlen(i8* %line_s)', [SafeBase]),
-    format(atom(InternIR),
-        '  %~w_id = call i64 @wam_intern_atom(i8* %line_s, i64 %~w_len)',
+    format(atom(PayloadIR),
+        '  %~w_line_id = call i64 @value_payload(%Value %line)', [SafeBase]),
+    format(atom(PtrIR),
+        '  %~w_line_ptr = call i8* @wam_atom_to_string(i64 %~w_line_id)',
         [SafeBase, SafeBase]),
+    format(atom(LenIR),
+        '  %~w_len = call i64 @strlen(i8* %~w_line_ptr)',
+        [SafeBase, SafeBase]),
+    format(atom(InternIR),
+        '  %~w_id = call i64 @wam_intern_atom(i8* %~w_line_ptr, i64 %~w_len)',
+        [SafeBase, SafeBase, SafeBase]),
     format(atom(Value0IR),
         '  %~w_v0 = insertvalue %Value undef, i32 0, 0', [SafeBase]),
     format(atom(ValueIR),
         '  %~w_v = insertvalue %Value %~w_v0, i64 %~w_id, 1',
         [SafeBase, SafeBase, SafeBase]),
     format(atom(ArgValueIR), '%~w_v', [SafeBase]),
-    SetupParts = [LenIR, InternIR, Value0IR, ValueIR].
+    SetupParts = [PayloadIR, PtrIR, LenIR, InternIR, Value0IR, ValueIR].
 plawk_foreign_arg_ir(field(FieldIndex), FieldSeparator, ArgBase, ArgValueIR,
         [EmptyGlobalIR], SetupParts) :-
     integer(FieldIndex),
@@ -16026,6 +16134,18 @@ plawk_expr_uses_nr(Expr) :-
     ; plawk_expr_uses_nr(Right)
     ).
 
+% Resolve the transient current-record pointer at the point of use. The driver
+% resolves `%line_s` before executing any rule actions, but `getline < file>`
+% may grow and relocate the shared transient buffer. `%line` keeps the reserved
+% transient atom id, so re-resolving it is both cheap and relocation-safe.
+plawk_fresh_record_ptr_ir(Base, PtrIR, [PayloadLine, PtrLine]) :-
+    format(atom(PayloadLine),
+        '  %~w_payload = call i64 @value_payload(%Value %line)', [Base]),
+    format(atom(PtrIR), '%~w_ptr', [Base]),
+    format(atom(PtrLine),
+        '  ~w = call i8* @wam_atom_to_string(i64 %~w_payload)',
+        [PtrIR, Base]).
+
 plawk_print_action_ir([field(0)], _FieldSeparator, _OutputSeparator, ''-IR) :-
     !,
     llvm_emit_printf_string(plawk_surface_print_line, 4, fmt, printed, '%line_s',
@@ -16061,9 +16181,12 @@ plawk_prefixed_print_action_ir([field(0)], _FieldSeparator, _OutputSeparator, Pr
     !,
     format(atom(FmtVar), '~w_line_fmt', [Prefix]),
     format(atom(PrintVar), '~w_printed_line', [Prefix]),
-    llvm_emit_printf_string(plawk_surface_print_line, 4, FmtVar, PrintVar, '%line_s',
+    format(atom(RecordBase), '~w_current_record', [Prefix]),
+    plawk_fresh_record_ptr_ir(RecordBase, RecordPtr, ResolveLines),
+    llvm_emit_printf_string(plawk_surface_print_line, 4, FmtVar, PrintVar, RecordPtr,
         [FmtPtr, PrintCall]),
-    atomic_list_concat([FmtPtr, PrintCall], '\n', IR).
+    append(ResolveLines, [FmtPtr, PrintCall], Lines),
+    atomic_list_concat(Lines, '\n', IR).
 plawk_prefixed_print_action_ir(Fields, FieldSeparator, OutputSeparator, Prefix, GlobalIR-IR) :-
     phrase(plawk_prefixed_print_fields_ir(Fields, FieldSeparator, OutputSeparator, Prefix, 0), Pairs),
     plawk_print_ir_parts(Pairs, GlobalParts, BodyParts),
@@ -16579,14 +16702,14 @@ plawk_emit_print_expr_for_context(index(field(FieldIndex), string(Needle)), Fiel
 plawk_emit_print_expr_for_context(tolower(field(FieldIndex)), FieldSeparator, Context,
         case_slice(lower, LowerBase, LenIR, PtrIR), [], SetupParts) :-
     plawk_print_expr_value_base(Context, tolower, LowerBase),
-    plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, LowerBase, LenIR, PtrIR,
-        SetupParts).
+    plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, Context, LowerBase,
+        LenIR, PtrIR, SetupParts).
 
 plawk_emit_print_expr_for_context(toupper(field(FieldIndex)), FieldSeparator, Context,
         case_slice(upper, UpperBase, LenIR, PtrIR), [], SetupParts) :-
     plawk_print_expr_value_base(Context, toupper, UpperBase),
-    plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, UpperBase, LenIR, PtrIR,
-        SetupParts).
+    plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, Context, UpperBase,
+        LenIR, PtrIR, SetupParts).
 
 plawk_emit_print_expr_for_context(field(FieldIndex), binfmt(Types), Context,
         PrintType, [], SetupLines) :-
@@ -16622,9 +16745,9 @@ plawk_emit_print_expr_for_context(field(FieldIndex), binfmt(Types), Context,
     ).
 
 plawk_emit_print_expr_for_context(field(0), _FieldSeparator, Context,
-        slice(FmtPrefix, PrintPrefix, LenIR, '%line_s'), [], [LineLen64, LineLen]) :-
+        slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), [], Lines) :-
     plawk_print_expr_output_names(Context, line, FmtPrefix, PrintPrefix),
-    plawk_emit_print_line_length_ir(Context, LenIR, LineLen64, LineLen).
+    plawk_emit_print_line_length_ir(Context, PtrIR, LenIR, Lines).
 
 plawk_emit_print_expr_for_context(field(FieldIndex), FieldSeparator, Context,
         slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), [], [SliceIR]) :-
@@ -16679,7 +16802,8 @@ plawk_normal_print_expr_value_base(field, Index, Base) :-
 plawk_normal_print_expr_value_base(string, Index, Base) :-
     format(atom(Base), 'plawk_string_~w', [Index]).
 
-plawk_emit_print_line_length_ir(print_context(normal, _Prefix, Index), LenIR, LineLen64, LineLen) :-
+plawk_emit_print_line_length_ir(print_context(normal, _Prefix, Index), '%line_s', LenIR,
+        [LineLen64, LineLen]) :-
     format(atom(LineLen64),
         '  %line_len64_~w = call i64 @strlen(i8* %line_s)',
         [Index]),
@@ -16687,15 +16811,17 @@ plawk_emit_print_line_length_ir(print_context(normal, _Prefix, Index), LenIR, Li
         '  %line_len_~w = trunc i64 %line_len64_~w to i32',
         [Index, Index]),
     format(atom(LenIR), '%line_len_~w', [Index]).
-plawk_emit_print_line_length_ir(print_context(prefixed, Prefix, Index), LenIR, LineLen64, LineLen) :-
+plawk_emit_print_line_length_ir(print_context(prefixed, Prefix, Index), PtrIR, LenIR, Lines) :-
     format(atom(Base), '~w_line_~w', [Prefix, Index]),
+    plawk_fresh_record_ptr_ir(Base, PtrIR, ResolveLines),
     format(atom(LineLen64),
-        '  %~w_len64 = call i64 @strlen(i8* %line_s)',
-        [Base]),
+        '  %~w_len64 = call i64 @strlen(i8* ~w)',
+        [Base, PtrIR]),
     format(atom(LineLen),
         '  %~w_len = trunc i64 %~w_len64 to i32',
         [Base, Base]),
-    format(atom(LenIR), '%~w_len', [Base]).
+    format(atom(LenIR), '%~w_len', [Base]),
+    append(ResolveLines, [LineLen64, LineLen], Lines).
 
 plawk_print_expr_output_names(print_context(normal, _Prefix, _Index), field, slice, slice) :-
     !.
@@ -16703,12 +16829,22 @@ plawk_print_expr_output_names(print_context(normal, _Prefix, _Index), Kind, Kind
 plawk_print_expr_output_names(print_context(prefixed, Prefix, Index), Kind, Base, Base) :-
     format(atom(Base), '~w_~w_~w', [Prefix, Kind, Index]).
 
-plawk_emit_case_source_slice_ir(0, _FieldSeparator, Base, LenIR, '%line_s', [LineLen64]) :-
+plawk_emit_case_source_slice_ir(0, _FieldSeparator, print_context(normal, _, _), Base,
+        LenIR, '%line_s', [LineLen64]) :-
     format(atom(LineLen64),
         '  %~w_len64 = call i64 @strlen(i8* %line_s)',
         [Base]),
     format(atom(LenIR), '%~w_len64', [Base]).
-plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, Base, LenIR, PtrIR, [SliceIR]) :-
+plawk_emit_case_source_slice_ir(0, _FieldSeparator, print_context(prefixed, _, _), Base,
+        LenIR, PtrIR, Lines) :-
+    plawk_fresh_record_ptr_ir(Base, PtrIR, ResolveLines),
+    format(atom(LineLen64),
+        '  %~w_len64 = call i64 @strlen(i8* ~w)',
+        [Base, PtrIR]),
+    format(atom(LenIR), '%~w_len64', [Base]),
+    append(ResolveLines, [LineLen64], Lines).
+plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, _Context, Base, LenIR, PtrIR,
+        [SliceIR]) :-
     FieldIndex > 0,
     llvm_emit_atom_field_slice('%line', FieldIndex, FieldSeparator, Base, SliceIR),
     format(atom(LenIR), '%~w_len64', [Base]),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -157,14 +157,14 @@ plawk_action_own_continue(if(_Pattern, Then, Else)) :-
 
 %% plawk_normalise_getline_loops(+Program0, -Program)
 %
-%  Desugar `while ((getline var < "file") > 0) BODY` (parsed to
-%  getline_loop(Var, File, Body)) into the phase-1 getline machinery: a priming
-%  read, then a `while (status > 0)` loop whose body is BODY plus a trailing
-%  re-read. `$getline_status` is a reserved i64 status slot (users cannot write a
-%  `$`-prefixed name). Applied once here so the rest of the pipeline (state plan,
-%  action sequence) only ever sees getline_capture + while_loop, both already
-%  supported. v1 rewrites rule bodies (and nested if/loop bodies); getline_loop
-%  in BEGIN/END/case blocks is a follow-on.
+%  Desugar the two supported in-condition forms into the existing while
+%  machinery. `while ((getline var < "file") > 0) BODY` becomes a priming
+%  getline_capture plus a `while (status > 0)` whose body ends in another read.
+%  The record form, `while ((getline < "file") > 0) BODY`, is identical except
+%  that its priming and trailing actions are getline_file_record_capture nodes.
+%  `$getline_status` is a reserved i64 slot (users cannot write a `$`-prefixed
+%  name). v1 rewrites rule bodies (and nested if/loop bodies); getline loops in
+%  BEGIN/END/case blocks remain explicit unsupported nodes.
 plawk_normalise_getline_loops(program(Begin, Rules0, End),
         program(Begin, Rules, End)) :-
     !,
@@ -186,6 +186,15 @@ plawk_norm_getline_rule(rule(Pattern, Actions0), rule(Pattern, Actions)) :-
 plawk_norm_getline_rule(Other, Other).
 
 plawk_norm_getline_actions([], []).
+plawk_norm_getline_actions([getline_file_record_loop(File, Body0) | Rest], Out) :-
+    !,
+    plawk_norm_getline_actions(Body0, Body),
+    Read = getline_file_record_capture('$getline_status', File),
+    append(Body, [Read], LoopBody),
+    plawk_norm_getline_actions(Rest, Rest1),
+    Out = [ Read,
+            while_loop(cmp(var('$getline_status'), gt, int(0)), LoopBody)
+          | Rest1 ].
 plawk_norm_getline_actions([getline_loop(Var, File, Body0) | Rest], Out) :-
     !,
     plawk_norm_getline_actions(Body0, Body),
@@ -1430,6 +1439,12 @@ begin_actions_rest([]) -->
 begin_action(Action) -->
     begin_assignment(Action),
     !.
+% getline is deliberately not executable in BEGIN in this phase. Preserve the
+% surface as an explicit node so codegen reports a compile error (exit 3)
+% instead of a parse error or an ignored BEGIN action.
+begin_action(unsupported_getline(begin(Action))) -->
+    getline_context_action(Action),
+    !.
 begin_action(Action) -->
     print_action(Action),
     !.
@@ -1559,6 +1574,10 @@ forin_accum_operand(_Array, _Key, int(Value)) -->
 
 end_action(Action) -->
     for_in_action(Action),
+    !.
+% As in BEGIN, retain getline syntax for a clean context rejection in codegen.
+end_action(unsupported_getline(end(Action))) -->
+    getline_context_action(Action),
     !.
 % a scalar-guarded print in END: `if (n > 1) print ...` [`else print ...`].
 % The condition is a scalar comparison (END has no current record), lowered
@@ -1786,6 +1805,8 @@ plawk_block_action(foreach(_Body)).
 plawk_block_action(while_loop(_Cond, _Body)).
 plawk_block_action(do_while_loop(_Body, _Cond)).
 plawk_block_action(getline_loop(_Var, _File, _Body)).
+plawk_block_action(getline_file_record_loop(_File, _Body)).
+plawk_block_action(unsupported_getline(while(_Getline, _Body))).
 
 %% action_sep//0
 %
@@ -1903,21 +1924,72 @@ action(Action) -->
 
 %% getline_action(-Action)//
 %
-%  `getline var < "file"` -- read the next line of a file into the scalar `var`,
-%  reusing the shared stream primitives (the file is opened once, then advanced
-%  one line per call). This bare statement form discards the 1/0/-1 status;
-%  `status = getline var < "file"` (an assignment) captures it (see
-%  assignment_action). v1: the file is a string literal, the target a scalar var;
-%  the canonical loop is `r = getline v < "f"; while (r > 0) { ...; r = getline v
-%  < "f" }` (getline inside a while CONDITION is a follow-on -- it needs the loop
-%  lowering to let the condition produce a slot update).
+%  `getline < "file"` reads a newline-delimited record into `$0`; codegen
+%  refreshes the current transient record so fields and NF re-split under the
+%  active FS. The sibling `getline var < "file"` reads into a scalar. Both use a
+%  filename-keyed shared handle. Unsupported main-input, pipeline, and dynamic
+%  filename shapes are retained as unsupported_getline nodes so they fail at
+%  compile time rather than being approximated.
+getline_action(getline_file_record(File)) -->
+    "getline",
+    identifier_boundary,
+    ws, "<", ws,
+    quoted_string(FCodes),
+    { string_codes(File, FCodes) },
+    !.
 getline_action(getline_read(Var, File)) -->
     "getline",
     required_ws,
     identifier(Var),
     ws, "<", ws,
     quoted_string(FCodes),
-    { string_codes(File, FCodes) }.
+    { string_codes(File, FCodes) },
+    !.
+getline_action(unsupported_getline(Reason)) -->
+    unsupported_getline_statement(Reason).
+
+% A context grammar used by BEGIN/END rejection. Assignment getline forms are
+% included so `BEGIN { r = getline < "f" }` is rejected at compile time too.
+getline_context_action(Action) -->
+    getline_action(Action).
+getline_context_action(Action) -->
+    getline_assignment_action(Action).
+
+% Unsupported statement forms. Longest shapes come first so the trailing
+% tokens cannot be left for the enclosing action grammar.
+unsupported_getline_statement(pipe(Command)) -->
+    getline_pipe_command(Command), ws,
+    "|", ws, "getline", identifier_boundary,
+    !.
+unsupported_getline_statement(file_var(Var, File)) -->
+    "getline", required_ws, identifier(Var), ws,
+    "<", ws, getline_dynamic_file_expr(File),
+    !.
+unsupported_getline_statement(file_record_dynamic(File)) -->
+    "getline", identifier_boundary, ws,
+    "<", ws, getline_dynamic_file_expr(File),
+    !.
+unsupported_getline_statement(main_var(Var)) -->
+    "getline", required_ws, identifier(Var),
+    !.
+unsupported_getline_statement(main_record) -->
+    "getline", identifier_boundary.
+
+getline_pipe_command(var(Command)) -->
+    identifier(Command).
+getline_pipe_command(string(Command)) -->
+    quoted_string(Codes),
+    { string_codes(Command, Codes) }.
+
+% Consume a non-string-literal filename expression solely so v1 can reject it
+% as an explicit unsupported node (build exit 3). Parenthesised scalar values
+% need their own clause because a bare `(name)` is not a general field_expr.
+getline_dynamic_file_expr(paren(Expr)) -->
+    "(", ws, scalar_value_expr(Expr), ws, ")",
+    !.
+getline_dynamic_file_expr(Expr) -->
+    scalar_value_expr(Expr),
+    { Expr \= string(_) }.
 
 %% subgsub_action(-Action)//
 %
@@ -2019,12 +2091,20 @@ delete_action(delete_assoc(var(Name), KeyExpr)) -->
 % the general action block, and the codegen (bin/plawk) rejects it with a clean
 % not-yet diagnostic until the loop runtime lands. The condition is a scalar
 % comparison for now; a general boolean condition is a follow-on.
-% `while ((getline var < "file") > 0) BODY` -- the canonical getline loop: read
-% successive lines of a file into `var`, running BODY per line until EOF/error.
-% Parses to getline_loop(Var, File, Body); the codegen desugars it into the
-% prime-then-re-read form (a getline assignment + a `while (status > 0)` over
-% BODY plus a trailing re-read), reusing the phase-1 getline machinery. Tried
-% before the generic while; the `((getline` prefix distinguishes it.
+% `while ((getline < "file") > 0) BODY` -- read successive newline-delimited
+% file records into `$0`. It normalises to a priming record read plus the same
+% status-slot while machinery used by scalar-target getline.
+while_action(getline_file_record_loop(File, Body)) -->
+    "while", identifier_boundary, ws,
+    "(", ws,
+    "(", ws, "getline", identifier_boundary, ws,
+    "<", ws, quoted_string(FCodes), ws, ")",
+    ws, ">", ws, "0", ws,
+    ")", ws,
+    body_block(Body),
+    { string_codes(File, FCodes) },
+    !.
+% `while ((getline var < "file") > 0) BODY` -- the scalar-target sibling.
 while_action(getline_loop(Var, File, Body)) -->
     "while", identifier_boundary, ws,
     "(", ws,
@@ -2034,6 +2114,17 @@ while_action(getline_loop(Var, File, Body)) -->
     ")", ws,
     body_block(Body),
     { string_codes(File, FCodes) }.
+% Other getline operands in the same while shape are deliberate v1
+% rejections: main-input reads and dynamic filenames must reach codegen as an
+% unsupported node rather than falling out of the parser with exit 2.
+while_action(unsupported_getline(while(Getline, Body))) -->
+    "while", identifier_boundary, ws,
+    "(", ws,
+    "(", ws, getline_action(Getline), ws, ")",
+    ws, ">", ws, "0", ws,
+    ")", ws,
+    body_block(Body),
+    !.
 while_action(while_loop(Cond, Body)) -->
     "while", identifier_boundary, ws,
     "(", ws,
@@ -2520,11 +2611,32 @@ assignment_action(gsub_count(CountName, Global, Regex, Repl, Target)) -->
     ws, ")",
     !.
 
-% `status = getline var < "file"` -- read the next line of the file into `var`
-% (a string scalar) and assign the 1/0/-1 status to `status` (an i64). A
-% dual-slot write. Tried before the generic scalar `set`; the `getline` keyword
-% after `=` is unambiguous.
-assignment_action(getline_capture(Status, Var, File)) -->
+% Getline assignments are tried before the generic scalar `set`. This is
+% essential for unsupported `status = getline`: without the dedicated fallback
+% it would be misparsed as a read of an ordinary variable named `getline`.
+assignment_action(Action) -->
+    getline_assignment_action(Action),
+    !.
+
+assignment_action(set(var(Name), Value)) -->
+    identifier(Name),
+    ws,
+    "=",
+    ws,
+    scalar_value_expr(Value).
+
+% `status = getline < "file"`: update `$0` and capture 1/0/-1 in status.
+getline_assignment_action(getline_file_record_capture(Status, File)) -->
+    identifier(Status),
+    ws, "=", ws,
+    "getline", identifier_boundary, ws,
+    "<", ws,
+    quoted_string(FCodes),
+    { string_codes(File, FCodes) },
+    !.
+
+% `status = getline var < "file"`: scalar-target form (a dual-slot write).
+getline_assignment_action(getline_capture(Status, Var, File)) -->
     identifier(Status),
     ws, "=", ws,
     "getline",
@@ -2535,12 +2647,24 @@ assignment_action(getline_capture(Status, Var, File)) -->
     { string_codes(File, FCodes) },
     !.
 
-assignment_action(set(var(Name), Value)) -->
-    identifier(Name),
-    ws,
-    "=",
-    ws,
-    scalar_value_expr(Value).
+getline_assignment_action(unsupported_getline(capture(Status, Reason))) -->
+    identifier(Status),
+    ws, "=", ws,
+    unsupported_getline_rhs(Reason).
+
+unsupported_getline_rhs(file_var(Var, File)) -->
+    "getline", required_ws, identifier(Var), ws,
+    "<", ws, getline_dynamic_file_expr(File),
+    !.
+unsupported_getline_rhs(file_record_dynamic(File)) -->
+    "getline", identifier_boundary, ws,
+    "<", ws, getline_dynamic_file_expr(File),
+    !.
+unsupported_getline_rhs(main_var(Var)) -->
+    "getline", required_ws, identifier(Var),
+    !.
+unsupported_getline_rhs(main_record) -->
+    "getline", identifier_boundary.
 
 % `x = sprintf("fmt", args...)`: format into a string scalar (the printf format
 % engine + string-valued scalars). Tried first -- the `sprintf(` keyword is

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -7333,15 +7333,29 @@ rsri.done:
 ; retained so streams with many records use only their high-water capacity.
 define void @wam_rt_clear() {
 entry:
+  %rtc.suppress = load i1, i1* @wam_rt_suppress
+  br i1 %rtc.suppress, label %rtc.done, label %rtc.write
+
+rtc.write:
   %rtc.empty = getelementptr [1 x i8], [1 x i8]* @.wam_rt_empty, i64 0, i64 0
   store i8* %rtc.empty, i8** @wam_rt_ptr
   store i64 0, i64* @wam_rt_len
+  br label %rtc.done
+
+rtc.done:
   ret void
 }
 
 ; Copy a matched record separator into stable process-owned RT storage.
 define i1 @wam_rt_set(i8* %src, i64 %len) {
 entry:
+  %rts.suppress = load i1, i1* @wam_rt_suppress
+  br i1 %rts.suppress, label %rts.suppressed, label %rts.dispatch
+
+rts.suppressed:
+  ret i1 true
+
+rts.dispatch:
   %rts.isempty = icmp eq i64 %len, 0
   br i1 %rts.isempty, label %rts.clear, label %rts.need
 
@@ -8345,6 +8359,54 @@ gl.eof:
 
 gl.err:
   ret i64 -1
+}
+
+; awk getline from a literal file into the current record. Reuse the shared
+; filename registry and persistent reader, but force a physical newline record
+; for this v1 form and suppress RT changes. On success, copy the persistent
+; atom text into the reserved transient record buffer so the existing %line
+; Value immediately exposes the new $0. EOF and errors leave that buffer
+; untouched. Returns the awk 1, 0, or -1 status.
+define i64 @wam_getline_file_record(i8* %pathptr, i64 %pathlen) {
+entry:
+  %gr.old_rs_ptr = load i8*, i8** @wam_rs_ptr
+  %gr.old_rs_len = load i64, i64* @wam_rs_len
+  %gr.old_rs_mode = load i8, i8* @wam_rs_mode
+  %gr.old_rt_suppress = load i1, i1* @wam_rt_suppress
+  %gr.newline = getelementptr [2 x i8], [2 x i8]* @.wam_rs_default, i64 0, i64 0
+  store i8* %gr.newline, i8** @wam_rs_ptr
+  store i64 1, i64* @wam_rs_len
+  store i8 0, i8* @wam_rs_mode
+  store i1 true, i1* @wam_rt_suppress
+  %gr.line_id_slot = alloca i64, align 8
+  %gr.status = call i64 @wam_getline_file(i8* %pathptr, i64 %pathlen, i64* %gr.line_id_slot)
+  store i8* %gr.old_rs_ptr, i8** @wam_rs_ptr
+  store i64 %gr.old_rs_len, i64* @wam_rs_len
+  store i8 %gr.old_rs_mode, i8* @wam_rs_mode
+  store i1 %gr.old_rt_suppress, i1* @wam_rt_suppress
+  %gr.got = icmp eq i64 %gr.status, 1
+  br i1 %gr.got, label %gr.copy, label %gr.return_status
+
+gr.copy:
+  %gr.line_id = load i64, i64* %gr.line_id_slot
+  %gr.line_ptr = call i8* @wam_atom_to_string(i64 %gr.line_id)
+  %gr.line_null = icmp eq i8* %gr.line_ptr, null
+  br i1 %gr.line_null, label %gr.copy_error, label %gr.copy_bytes
+
+gr.copy_bytes:
+  %gr.line_len = call i64 @strlen(i8* %gr.line_ptr)
+  %gr.transient_id = call i64 @wam_transient_atom_from_bytes(i8* %gr.line_ptr, i64 %gr.line_len)
+  %gr.copy_failed = icmp slt i64 %gr.transient_id, 0
+  br i1 %gr.copy_failed, label %gr.copy_error, label %gr.success
+
+gr.success:
+  ret i64 1
+
+gr.copy_error:
+  ret i64 -1
+
+gr.return_status:
+  ret i64 %gr.status
 }
 
 ; awk ENVIRON["NAME"]: look up an environment variable by its NUL-terminated
@@ -22330,6 +22392,7 @@ emit_atom_string_globals(IR) :-
 @wam_rt_len = global i64 0
 @wam_rt_buf = internal global i8* null
 @wam_rt_cap = internal global i64 0
+@wam_rt_suppress = internal global i1 false
 @.wam_rs_regex_error = private constant [38 x i8] c"plawk: invalid RS regular expression\\0A\\00"
 @.wam_subsep_default = private constant [2 x i8] c"\\1C\\00"
 @wam_subsep_ptr = global i8* getelementptr inbounds ([2 x i8], [2 x i8]* @.wam_subsep_default, i64 0, i64 0)
@@ -22473,6 +22536,7 @@ fail:
 @wam_rt_len = global i64 0
 @wam_rt_buf = internal global i8* null
 @wam_rt_cap = internal global i64 0
+@wam_rt_suppress = internal global i1 false
 @.wam_rs_regex_error = private constant [38 x i8] c"plawk: invalid RS regular expression\\0A\\00"
 @.wam_subsep_default = private constant [2 x i8] c"\\1C\\00"
 @wam_subsep_ptr = global i8* getelementptr inbounds ([2 x i8], [2 x i8]* @.wam_subsep_default, i64 0, i64 0)

--- a/tests/test_plawk_getline_record.pl
+++ b/tests/test_plawk_getline_record.pl
@@ -1,0 +1,204 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% File getline into the current record: `getline < "file"`. A successful read
+% replaces `$0` and fields are re-split lazily with the active FS; status is
+% 1/0/-1, while EOF/error preserve the prior record. This form shares the
+% filename registry with scalar-target getline, but v1 reads a physical newline
+% record without applying RS or changing RT. It never advances NR/FNR.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+
+:- begin_tests(plawk_getline_record).
+
+% --- parsing ---------------------------------------------------------------
+
+test(record_getline_bare_parses) :-
+    plawk_parse_string("{ getline < \"in.txt\" }\n",
+        program([], [rule(always, [getline_file_record("in.txt")])], [])),
+    !.
+
+test(record_getline_capture_parses) :-
+    plawk_parse_string("{ r = getline < \"in.txt\"; print r }\n",
+        program([], [rule(always,
+            [getline_file_record_capture(r, "in.txt"), print([var(r)])])], [])),
+    !.
+
+test(record_getline_while_normalises) :-
+    plawk_parse_string("{ while ((getline < \"f.txt\") > 0) print $0 }\n",
+        program(_, [rule(always, Actions)], _)),
+    Actions = [ getline_file_record_capture('$getline_status', "f.txt"),
+                while_loop(cmp(var('$getline_status'), gt, int(0)),
+                    [print([field(0)]),
+                     getline_file_record_capture('$getline_status', "f.txt")]) ],
+    !.
+
+% --- runtime ---------------------------------------------------------------
+
+% A successful read updates $0 and recomputes fields/NF through a regex FS.
+test(record_getline_resplits_regex_fs, [condition(clang_available)]) :-
+    rdir(Dir),
+    data_file(Dir, 'regex_fields.txt', "left::right,tail\n", Path),
+    format(atom(Src),
+        "BEGIN { FS = \"[,:]+\"; OFS = \"|\" } { r = getline < \"~w\"; print r, $0, $1, $2, $3, NF }\n",
+        [Path]),
+    build_run(Dir, 'regex_fields', Src, "trigger\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1|left::right,tail|left|right|tail|3\n"),
+    !.
+
+% EOF returns 0 and leaves $0, its fields, and NF at the last successful read.
+test(record_getline_eof_preserves_record, [condition(clang_available)]) :-
+    rdir(Dir),
+    data_file(Dir, 'one_record.txt', "one:two\n", Path),
+    format(atom(Src),
+        "BEGIN { FS = \":\"; OFS = \"|\" } { r = getline < \"~w\"; print r, $0, $1, $2, NF; r = getline < \"~w\"; print r, $0, $1, $2, NF }\n",
+        [Path, Path]),
+    build_run(Dir, 'eof_preserve', Src, "orig:main\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1|one:two|one|two|2\n0|one:two|one|two|2\n"),
+    !.
+
+% An open error returns -1 and preserves the main-input record and its fields.
+test(record_getline_open_error_preserves_record, [condition(clang_available)]) :-
+    rdir(Dir),
+    directory_file_path(Dir, 'record_getline_missing.txt', Missing),
+    format(atom(Src),
+        "BEGIN { FS = \":\"; OFS = \"|\" } { r = getline < \"~w\"; print r, $0, $1, $2, NF }\n",
+        [Missing]),
+    build_run(Dir, 'open_error', Src, "orig:main\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "-1|orig:main|orig|main|2\n"),
+    !.
+
+% The in-condition idiom drains the file. NR/FNR stay at the one main-input
+% record throughout; redirected getline never increments either counter.
+test(record_getline_while_keeps_nr_fnr, [condition(clang_available)]) :-
+    rdir(Dir),
+    data_file(Dir, 'drain.txt', "red green\nblue gold\n", Path),
+    format(atom(Src),
+        "BEGIN { OFS = \"|\" } { while ((getline < \"~w\") > 0) print NR, FNR, $0, NF }\n",
+        [Path]),
+    build_run(Dir, 'while_nr', Src, "trigger\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1|1|red green|2\n1|1|blue gold|2\n"),
+    !.
+
+% Record getline is newline-only in v1 even when the main reader has regex RS;
+% it also leaves the main reader's matched RT unchanged.
+test(record_getline_ignores_rs_and_preserves_rt, [condition(clang_available)]) :-
+    rdir(Dir),
+    data_file(Dir, 'physical_line.txt', "left45right\n", Path),
+    format(atom(Src),
+        "BEGIN { RS = \"[0-9]+\"; OFS = \"|\" } { r = getline < \"~w\"; print r, $0, RT }\n",
+        [Path]),
+    build_run(Dir, 'rs_rt', Src, "trigger123", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1|left45right|123\n"),
+    !.
+
+% Scalar-target and record-target sites use the same filename-keyed handle.
+test(record_getline_shares_scalar_registry, [condition(clang_available)]) :-
+    rdir(Dir),
+    data_file(Dir, 'shared.txt', "one\ntwo\n", Path),
+    format(atom(Src),
+        "{ r = getline v < \"~w\"; s = getline < \"~w\"; print r, v, s, $0 }\n",
+        [Path, Path]),
+    build_run(Dir, 'shared_registry', Src, "trigger\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1 one 1 two\n"),
+    !.
+
+% Growing the transient record buffer must not leave direct `$0` printers with
+% the driver's stale pre-getline pointer.
+test(record_getline_long_record_prints, [condition(clang_available)]) :-
+    rdir(Dir),
+    length(Codes, 5000),
+    maplist(=(0'x), Codes),
+    string_codes(Long, Codes),
+    string_concat(Long, "\n", Contents),
+    data_file(Dir, 'long.txt', Contents, Path),
+    format(atom(Src), "{ getline < \"~w\"; print $0 }\n", [Path]),
+    build_run(Dir, 'long_record', Src, "t\n", Out, St),
+    assertion(St == 0),
+    string_concat(Long, "\n", Expected),
+    assertion(Out == Expected),
+    !.
+
+% --- explicit v1 rejection boundary ---------------------------------------
+
+test(unsupported_getline_shapes_exit_3, [condition(clang_available)]) :-
+    rdir(Dir),
+    Cases = [ plain-"{ getline }\n",
+              main_var-"{ getline v }\n",
+              pipe-"{ cmd | getline }\n",
+              dynamic_file-"{ getline < filename }\n",
+              dynamic_field-"{ getline < $1 }\n",
+              dynamic_paren-"{ getline < (filename) }\n",
+              dynamic_scalar_target-"{ getline v < $1 }\n",
+              capture_main-"{ r = getline }\n",
+              capture_dynamic-"{ r = getline < $1 }\n",
+              while_main-"{ while ((getline) > 0) print $0 }\n",
+              while_main_var-"{ while ((getline v) > 0) print $0 }\n",
+              while_dynamic-"{ while ((getline < filename) > 0) print $0 }\n",
+              begin_ctx-"BEGIN { getline < \"x\" } { print $0 }\n",
+              begin_capture-"BEGIN { r = getline < \"x\" } { print $0 }\n",
+              end_ctx-"{ print $0 } END { getline < \"x\" }\n",
+              end_capture-"{ print $0 } END { r = getline < \"x\" }\n"
+            ],
+    forall(member(Name-Src, Cases),
+        ( build_status(Dir, Name, Src, Status),
+          assertion(Status == exit(3))
+        )),
+    !.
+
+:- end_tests(plawk_getline_record).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+rdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_getline_record', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+data_file(Dir, Name, Contents, Path) :-
+    directory_file_path(Dir, Name, Path),
+    setup_call_cleanup(open(Path, write, S, [encoding(utf8)]),
+        format(S, "~s", [Contents]), close(S)).
+
+write_prog(Dir, Name, Src, Bin-Prog) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        format(S, "~s", [Src]), close(S)),
+    atom_concat(Prog0, '_bin', Bin).
+
+build_status(Dir, Name, Src, Status) :-
+    write_prog(Dir, Name, Src, Bin-Prog),
+    process_create(path(swipl),
+        ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, Status).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    write_prog(Dir, Name, Src, Bin-Prog),
+    process_create(path(swipl),
+        ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~s", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
## Summary

- parse and lower `getline < "file"` into the current record, including status capture and the canonical while idiom
- re-split `$1` through `$NF` with the active FS while preserving `NR`/`FNR` and leaving `$0` unchanged on EOF or error
- reuse the filename-keyed getline registry and persistent reader while forcing newline-delimited records and preserving RS/RT for this v1 form
- reject unsupported main-input, pipeline, dynamic-filename, and BEGIN/END forms with compile exit 3
- document the supported surface and v1 boundary

## Tests

- `tests/test_plawk_getline_record.pl` — 11/11 passed
- `tests/test_plawk_getline.pl` — 10/10 passed
- `tests/test_plawk_rs_regex.pl` — 18/18 passed
- `tests/test_plawk_in_membership.pl` — 26/26 passed
- `tests/test_plawk_surface_prolog_calls.pl` — 16/16 passed
- `tests/test_plawk_print_literals.pl` — 11/11 passed
- `tests/test_plawk_surface_prefix_print.pl` — 217/221; the same four failures reproduce on the target branch

## Coordination

Reuses the `@wam_getline_file` handle registry and the persistent reader (shared with regex RS), and touches the `$0`/`NF` field path. No known conflict with in-flight work.

## Follow-up

RS/RT do not apply to redirected record getline in v1; it reads physical newline-delimited records.