### PR TITLE
LMDB-R-2A: bounded cached materialisation for versioned arg1 source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run R focused regressions (switch-index + LMDB)
         run: |
-          swipl -q -f init.pl -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:switch_on_constant_fallthrough_is_linear_noop,wam_r_generator:switch_on_term_a2_is_switch_on_term_noop,wam_r_generator:switch_on_constant_fallthrough_preserves_backtracking,wam_r_generator:r_a2_switch_hints_are_linear_noop,wam_r_generator:r_a2_fallthrough_preserves_backtracking,wam_r_generator:lmdb_r0_source_dispatch_selection,wam_r_generator:lmdb_arg1_v1_mock_adapter_lookup_and_stream,wam_r_generator:lmdb_arg1_v1_real_binding_e2e_rscript,wam_r_generator:lmdb_r1_materialisation_codegen,wam_r_generator:lmdb_r1_eager_lazy_runtime_parity])" -t halt
+          swipl -q -f init.pl -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:switch_on_constant_fallthrough_is_linear_noop,wam_r_generator:switch_on_term_a2_is_switch_on_term_noop,wam_r_generator:switch_on_constant_fallthrough_preserves_backtracking,wam_r_generator:r_a2_switch_hints_are_linear_noop,wam_r_generator:r_a2_fallthrough_preserves_backtracking,wam_r_generator:lmdb_r0_source_dispatch_selection,wam_r_generator:lmdb_arg1_v1_mock_adapter_lookup_and_stream,wam_r_generator:lmdb_arg1_v1_real_binding_e2e_rscript,wam_r_generator:lmdb_r1_materialisation_codegen,wam_r_generator:lmdb_r1_eager_lazy_runtime_parity,wam_r_generator:lmdb_r2a_cached_codegen,wam_r_generator:lmdb_r2a_cached_runtime])" -t halt
 
       - name: Run full R classic conformance
         run: |

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -48,7 +48,8 @@ self-contained so a single coding agent can pick it up in isolation.
 | LMDB-C | LMDB policy tiers | C | L | LMDB-C-0 |
 | LMDB-R-0 ✅ | LMDB lookup source (prereq) | R | M | done (`lmdb_arg1_v1`) |
 | LMDB-R-1 ✅ | eager/lazy materialisation | R | S | done (`lmdb_materialisation`) |
-| LMDB-R-2 | cached/auto policy tiers | R | M | LMDB-R-1 |
+| LMDB-R-2A ✅ | bounded cached materialisation | R | S | done (`cached` + L2) |
+| LMDB-R-2B | auto materialisation resolution | R | S | LMDB-R-2A |
 | ISO-C | ISO three-form (new) | C | L | — |
 | ISO-GO | ISO three-form (new) | Go | L | — |
 | ISO-SCALA | ISO three-form (new) | Scala | L | — |
@@ -358,12 +359,19 @@ path, not the reverse index.
 - **Status:** Landed. `lmdb_materialisation(lazy|eager)` (default **lazy**)
   over the same v1 schema: lazy → on-demand dispatch; eager → init
   `lmdb_arg1_v1_stream` + `build_fact_indexes` + `fact_table_dispatch`
-  (not `read_facts_lmdb`). `cached`/`auto` → domain_error.
-- **Open:** LMDB-R-2 cached/auto (+ `lmdb_l2_capacity`).
+  (not `read_facts_lmdb`).
 
-### LMDB-R-2: cached/auto tiers for R LMDB fact source
-- **Depends on:** LMDB-R-1. Add `cached|auto` + `lmdb_l2_capacity` over
-  `lmdb_arg1_v1` (F# L1/L2 reference). Keep R-1 eager/lazy green.
+### LMDB-R-2A ✅: bounded cached materialisation
+- **Status:** Landed. `lmdb_materialisation(cached)` + `lmdb_l2_capacity(N)`
+  (default 4096, positive int): per-source L1 MRU + bounded L2 true-LRU
+  over `lmdb_arg1_v1_lookup`. Ground hits/misses cache complete buckets
+  (incl. empty); unbound stream-all bypasses the cache. `auto` still
+  rejected (`domain_error`) until LMDB-R-2B.
+
+### LMDB-R-2B: auto materialisation resolution
+- **Depends on:** LMDB-R-2A. Resolve `lmdb_materialisation(auto)` using
+  shared/fleet cost-model conventions (do not invent a new heuristic
+  surface). Keep R-1/R-2A modes green.
 
 ---
 

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -41,7 +41,8 @@ runtime-parser default is native, with the compiled
 
 **Optional LMDB.** Legacy `lmdb(Path)` remains load-everything.
 Versioned `lmdb_arg1_v1(Path)` supports `lmdb_materialisation(lazy)`
-(default) and `eager`; cached/auto remain open (LMDB-R-2).
+(default), `eager`, and `cached` (+ `lmdb_l2_capacity`, default 4096).
+`auto` remains open (LMDB-R-2B).
 
 ## Gaps (relative to Rust / Haskell / F#)
 
@@ -50,14 +51,14 @@ Versioned `lmdb_arg1_v1(Path)` supports `lmdb_materialisation(lazy)`
   forms (`switch_on_constant_a2`, `_a2_fallthrough`, `switch_on_structure_a2`)
   — map to the existing `SwitchOnTerm()` linear no-op (not optimized A2
   dispatch), preserving the full try/retry/trust chain.
-- **LMDB-R-2** cached/auto still open; LMDB-R-0/R-1 landed.
+- **LMDB-R-2B** auto resolution still open; LMDB-R-0/R-1/R-2A landed.
 - **ISO error support** is `tryCatch`-level only, not the three-form
   contract.
 - No dedicated effective-distance cross-target bench row.
 
 ## Path forward
 
-1. LMDB-R-2 cached/auto over `lmdb_arg1_v1`.
+1. LMDB-R-2B auto over `lmdb_arg1_v1`.
 2. ISO three-form adoption if R joins the error-fidelity set.
 3. Effective-distance cross-target matrix row.
 

--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -346,7 +346,11 @@ supported today:
   - `lazy` (default) — ground arg1 exact-key get; unbound stream-all
   - `eager` — stream the v1 DB once at init, `build_fact_indexes`,
     then `fact_table_dispatch` (not legacy `read_facts_lmdb`)
-  - `cached` / `auto` — unsupported in this phase (domain error)
+  - `cached` — per-source L1 MRU + bounded L2 true-LRU over lookup;
+    `lmdb_l2_capacity(N)` (default 4096, positive int) sizes L2 by
+    distinct arg1 keys (empty/missing buckets count). Unbound queries
+    stream-all and bypass the cache.
+  - `auto` — unsupported (domain error; LMDB-R-2B)
   Writer: `lmdb_write_facts_arg1_v1`.
 
 ```prolog

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -1424,18 +1424,31 @@ fact_source_pi_match(Name/Ar, P, Arity) :-
     Name == P, Ar =:= Arity.
 
 %% r_normalize_fact_source_spec(+Spec0, +Options, -Spec)
-%  lmdb_arg1_v1 → lmdb_arg1_v1(Path, Mode); default Mode=lazy.
-%  cached/auto/unknown → domain_error (LMDB-R-2).
-r_normalize_fact_source_spec(lmdb_arg1_v1(Path), Options,
-                             lmdb_arg1_v1(Path, Mode)) :- !,
+%  lmdb_arg1_v1 → lmdb_arg1_v1(Path, Mode) or
+%  lmdb_arg1_v1(Path, cached, Cap). Default Mode=lazy.
+%  auto/unknown → domain_error (LMDB-R-2B).
+r_normalize_fact_source_spec(lmdb_arg1_v1(Path), Options, Spec) :- !,
     option(lmdb_materialisation(Mode0), Options, lazy),
-    r_lmdb_arg1_v1_materialisation(Mode0, Mode).
+    r_lmdb_arg1_v1_materialisation(Mode0, Mode),
+    (   Mode == cached
+    ->  option(lmdb_l2_capacity(Cap0), Options, 4096),
+        r_lmdb_l2_capacity(Cap0, Cap),
+        Spec = lmdb_arg1_v1(Path, cached, Cap)
+    ;   Spec = lmdb_arg1_v1(Path, Mode)
+    ).
 r_normalize_fact_source_spec(Spec, _Options, Spec).
 
 r_lmdb_arg1_v1_materialisation(lazy, lazy) :- !.
 r_lmdb_arg1_v1_materialisation(eager, eager) :- !.
+r_lmdb_arg1_v1_materialisation(cached, cached) :- !.
 r_lmdb_arg1_v1_materialisation(Mode, _) :-
+    % auto and unknowns stay rejected until LMDB-R-2B.
     throw(error(domain_error(lmdb_materialisation_eager_or_lazy, Mode), _)).
+
+r_lmdb_l2_capacity(N, N) :-
+    integer(N), N > 0, !.
+r_lmdb_l2_capacity(N, _) :-
+    throw(error(domain_error(lmdb_l2_capacity_positive_integer, N), _)).
 
 r_lmdb_arg1_v1_arity(Arity) :-
     (   Arity >= 2 -> true
@@ -1444,8 +1457,8 @@ r_lmdb_arg1_v1_arity(Arity) :-
 
 %% emit_external_fact_source(+P, +Arity, +Spec,
 %%                            -DataDecl, -LoweredFunc, -FuncName)
-%  lmdb_arg1_v1(Path, lazy|eager): lazy = on-demand dispatch (default);
-%  eager = stream-once + build_fact_indexes + fact_table_dispatch.
+%  lmdb_arg1_v1(Path, lazy|eager|cached(+Cap)):
+%  lazy = on-demand; eager = stream-once+indexes; cached = L1/L2 LRU.
 emit_external_fact_source(Pred, Arity, lmdb_arg1_v1(Path, lazy),
                           DataDecl, LoweredFunc, FuncName) :- !,
     r_lmdb_arg1_v1_arity(Arity),
@@ -1482,6 +1495,26 @@ emit_external_fact_source(Pred, Arity, lmdb_arg1_v1(Path, eager),
   args <- ~w
   WamRuntime$fact_table_dispatch(program, state, "~w/~w", ~w, ~w, args, state$pc + 1L)
 }', [FuncName, ArgsCollect, Pred, Arity, DataName, IndexesName]).
+emit_external_fact_source(Pred, Arity, lmdb_arg1_v1(Path, cached, Cap),
+                          DataDecl, LoweredFunc, FuncName) :- !,
+    r_lmdb_arg1_v1_arity(Arity),
+    r_pred_name(Pred, RName),
+    format(atom(PathVar), '~w_lmdb_path', [RName]),
+    format(atom(CacheVar), '~w_lmdb_cache', [RName]),
+    format(atom(FuncName), '~w_fact_iter', [RName]),
+    atom_string(Path, PathStr), r_string_literal(PathStr, PathLit),
+    format(string(DataDecl),
+'# External fact source for ~w/~w (lmdb_arg1_v1 cached cap=~w: ~w)
+~w <- ~w
+~w <- WamRuntime$lmdb_arg1_v1_new_cache(~wL)',
+        [Pred, Arity, Cap, PathStr, PathVar, PathLit, CacheVar, Cap]),
+    fact_args_collect(Arity, ArgsCollect),
+    format(string(LoweredFunc),
+'~w <- function(program, state) {
+  args <- ~w
+  WamRuntime$lmdb_arg1_v1_cached_dispatch(program, state, ~w, ~wL, args,
+                                           state$pc + 1L, ~w)
+}', [FuncName, ArgsCollect, PathVar, Arity, CacheVar]).
 emit_external_fact_source(Pred, Arity, Spec,
                           DataDecl, LoweredFunc, FuncName) :-
     r_pred_name(Pred, RName),

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -1443,7 +1443,7 @@ r_lmdb_arg1_v1_materialisation(eager, eager) :- !.
 r_lmdb_arg1_v1_materialisation(cached, cached) :- !.
 r_lmdb_arg1_v1_materialisation(Mode, _) :-
     % auto and unknowns stay rejected until LMDB-R-2B.
-    throw(error(domain_error(lmdb_materialisation_eager_or_lazy, Mode), _)).
+    throw(error(domain_error(lmdb_materialisation, Mode), _)).
 
 r_lmdb_l2_capacity(N, N) :-
     integer(N), N > 0, !.

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3679,8 +3679,7 @@ WamRuntime$lmdb_encode_tagged_field <- function(v, intern_table) {
   else paste0("a:?", v$tag)
 }
 WamRuntime$lmdb_kv_get <- function(path, key) {
-  ad <- getOption("unifyweaver.lmdb_kv_adapter", WamRuntime$lmdb_kv_adapter)
-  if (!is.null(ad)) return(ad$get(path, key))
+  ad <- WamRuntime$lmdb_kv_adapter; if (!is.null(ad)) return(ad$get(path, key))
   pkg <- WamRuntime$lmdb_pick_pkg(); if (is.null(pkg)) return(NULL)
   if (pkg == "thor") {
     env <- tryCatch(thor::mdb_env(path, create = FALSE), error = function(e) NULL)
@@ -3695,8 +3694,7 @@ WamRuntime$lmdb_kv_get <- function(path, key) {
   NULL
 }
 WamRuntime$lmdb_kv_list <- function(path) {
-  ad <- getOption("unifyweaver.lmdb_kv_adapter", WamRuntime$lmdb_kv_adapter)
-  if (!is.null(ad)) return(ad$list(path))
+  ad <- WamRuntime$lmdb_kv_adapter; if (!is.null(ad)) return(ad$list(path))
   pkg <- WamRuntime$lmdb_pick_pkg(); if (is.null(pkg)) return(character(0))
   if (pkg == "thor") {
     env <- tryCatch(thor::mdb_env(path, create = FALSE), error = function(e) NULL)
@@ -3713,8 +3711,7 @@ WamRuntime$lmdb_kv_list <- function(path) {
   character(0)
 }
 WamRuntime$lmdb_kv_put_all <- function(path, pairs) {
-  ad <- getOption("unifyweaver.lmdb_kv_adapter", WamRuntime$lmdb_kv_adapter)
-  if (!is.null(ad)) return(isTRUE(ad$put_all(path, pairs)))
+  ad <- WamRuntime$lmdb_kv_adapter; if (!is.null(ad)) return(isTRUE(ad$put_all(path, pairs)))
   pkg <- WamRuntime$lmdb_pick_pkg(); if (is.null(pkg)) return(FALSE)
   keys <- names(pairs)
   if (pkg == "thor") {

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3679,7 +3679,8 @@ WamRuntime$lmdb_encode_tagged_field <- function(v, intern_table) {
   else paste0("a:?", v$tag)
 }
 WamRuntime$lmdb_kv_get <- function(path, key) {
-  ad <- WamRuntime$lmdb_kv_adapter; if (!is.null(ad)) return(ad$get(path, key))
+  ad <- getOption("unifyweaver.lmdb_kv_adapter", WamRuntime$lmdb_kv_adapter)
+  if (!is.null(ad)) return(ad$get(path, key))
   pkg <- WamRuntime$lmdb_pick_pkg(); if (is.null(pkg)) return(NULL)
   if (pkg == "thor") {
     env <- tryCatch(thor::mdb_env(path, create = FALSE), error = function(e) NULL)
@@ -3694,7 +3695,8 @@ WamRuntime$lmdb_kv_get <- function(path, key) {
   NULL
 }
 WamRuntime$lmdb_kv_list <- function(path) {
-  ad <- WamRuntime$lmdb_kv_adapter; if (!is.null(ad)) return(ad$list(path))
+  ad <- getOption("unifyweaver.lmdb_kv_adapter", WamRuntime$lmdb_kv_adapter)
+  if (!is.null(ad)) return(ad$list(path))
   pkg <- WamRuntime$lmdb_pick_pkg(); if (is.null(pkg)) return(character(0))
   if (pkg == "thor") {
     env <- tryCatch(thor::mdb_env(path, create = FALSE), error = function(e) NULL)
@@ -3711,7 +3713,8 @@ WamRuntime$lmdb_kv_list <- function(path) {
   character(0)
 }
 WamRuntime$lmdb_kv_put_all <- function(path, pairs) {
-  ad <- WamRuntime$lmdb_kv_adapter; if (!is.null(ad)) return(isTRUE(ad$put_all(path, pairs)))
+  ad <- getOption("unifyweaver.lmdb_kv_adapter", WamRuntime$lmdb_kv_adapter)
+  if (!is.null(ad)) return(isTRUE(ad$put_all(path, pairs)))
   pkg <- WamRuntime$lmdb_pick_pkg(); if (is.null(pkg)) return(FALSE)
   keys <- names(pairs)
   if (pkg == "thor") {
@@ -3779,6 +3782,56 @@ WamRuntime$lmdb_write_facts_arg1_v1 <- function(path, facts, intern_table) {
   pairs <- list(); pairs[[WamRuntime$lmdb_schema_key]] <- WamRuntime$lmdb_arg1_v1_id
   for (k in ls(envir = buckets, all.names = TRUE)) pairs[[k]] <- paste(get(k, envir = buckets), collapse = "\n")
   WamRuntime$lmdb_kv_put_all(path, pairs)
+}
+
+# --- lmdb_arg1_v1 cached: per-source L1 MRU + bounded L2 true-LRU ----
+# capacity = max distinct arg1 keys in L2 (empty/missing buckets count).
+# Unbound/stream bypasses the cache (no populate/evict).
+WamRuntime$lmdb_arg1_v1_new_cache <- function(capacity) {
+  e <- new.env(parent = emptyenv())
+  e$capacity <- as.integer(capacity)
+  e$l1_key <- NULL
+  e$l1_val <- NULL
+  e$l2 <- new.env(parent = emptyenv(), hash = TRUE)
+  e$order <- character(0)  # oldest .. newest
+  e
+}
+WamRuntime$lmdb_arg1_v1_cached_lookup <- function(cache, path, key_term, arity, intern_table) {
+  key <- WamRuntime$lmdb_encode_tagged_field(key_term, intern_table)
+  if (!is.null(cache$l1_key) && identical(cache$l1_key, key)) return(cache$l1_val)
+  if (exists(key, envir = cache$l2, inherits = FALSE)) {
+    val <- get(key, envir = cache$l2, inherits = FALSE)
+    cache$order <- c(cache$order[cache$order != key], key)
+    cache$l1_key <- key; cache$l1_val <- val
+    return(val)
+  }
+  tuples <- WamRuntime$lmdb_arg1_v1_lookup(path, key_term, arity, intern_table)
+  if (length(cache$order) >= cache$capacity) {
+    old <- cache$order[[1]]
+    cache$order <- cache$order[-1]
+    if (exists(old, envir = cache$l2, inherits = FALSE))
+      rm(list = old, envir = cache$l2)
+    if (!is.null(cache$l1_key) && identical(cache$l1_key, old)) {
+      cache$l1_key <- NULL; cache$l1_val <- NULL
+    }
+  }
+  assign(key, tuples, envir = cache$l2)
+  cache$order <- c(cache$order, key)
+  cache$l1_key <- key; cache$l1_val <- tuples
+  tuples
+}
+WamRuntime$lmdb_arg1_v1_cached_dispatch <- function(program, state, path, arity, args,
+                                                     resume_pc, cache) {
+  table <- program$intern_table
+  a1 <- WamRuntime$deref(state, args[[1]])
+  ground <- !is.null(a1) && !is.null(a1$tag) && a1$tag %in% c("atom", "int", "float")
+  tuples <- if (ground) {
+    WamRuntime$lmdb_arg1_v1_cached_lookup(cache, path, a1, arity, table)
+  } else {
+    WamRuntime$lmdb_arg1_v1_stream(path, arity, table)
+  }
+  if (!length(tuples)) return(FALSE)
+  WamRuntime$fact_table_iter(program, state, path, tuples, args, 1L, resume_pc)
 }
 
 # Build per-arg hash indexes for a runtime-loaded fact table.

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -4670,7 +4670,7 @@ test(lmdb_r1_materialisation_codegen) :-
                           [lmdb_materialisation(Bad),
                            r_fact_sources([source(bedge/2, lmdb_arg1_v1('/tmp/b.lmdb'))])], Tmp),
                       throw(unexpected_success)),
-                     error(domain_error(lmdb_materialisation_eager_or_lazy, Bad), _), true)),
+                     error(domain_error(lmdb_materialisation, Bad), _), true)),
         write_wam_r_project([user:leg2/2],
             [lmdb_materialisation(eager),
              r_fact_sources([source(leg2/2, lmdb('/tmp/leg2.lmdb'))])], Tmp),
@@ -4762,7 +4762,7 @@ test(lmdb_r2a_cached_codegen) :-
                     [lmdb_materialisation(auto),
                      r_fact_sources([source(autox/2, lmdb_arg1_v1('/tmp/a.lmdb'))])], Tmp),
                throw(unexpected_success)),
-              error(domain_error(lmdb_materialisation_eager_or_lazy, auto), _), true),
+              error(domain_error(lmdb_materialisation, auto), _), true),
         write_wam_r_project([user:legc/2],
             [lmdb_materialisation(cached),
              r_fact_sources([source(legc/2, lmdb('/tmp/legc.lmdb'))])], Tmp),
@@ -4825,18 +4825,19 @@ stopifnot(identical(cache2$order, c("a:bob","a:carol")), !exists("a:alice", envi
 g2 <- nget
 invisible(WamRuntime$lmdb_arg1_v1_cached_lookup(cache2, "mock.lmdb", Atom(WamRuntime$intern(it,"alice")), 2L, it))
 stopifnot(nget>g2, nlist==0L)  # reread after eviction; still no list
-# unbound stream bypasses cache (order/recency unchanged)
-ord0 <- cache2$order; keys0 <- sort(ls(envir=cache2$l2, all.names=TRUE)); l1k0 <- cache2$l1_key
+# generated unbound wrapper streams but leaves its cache/recency unchanged
+ord0 <- cache$order; keys0 <- sort(ls(envir=cache$l2, all.names=TRUE)); l1k0 <- cache$l1_key
 nlist <<- 0L; nget <<- 0L
-all <- WamRuntime$lmdb_arg1_v1_stream("mock.lmdb", 2L, it)
-stopifnot(nlist>=1L, length(all)>=3L)
-stopifnot(identical(cache2$order, ord0), identical(sort(ls(envir=cache2$l2, all.names=TRUE)), keys0),
-          identical(cache2$l1_key, l1k0))
-# generated cached_dispatch ground + CP; arity-3 + escaped
+stu <- WamRuntime$new_state(); stu$regs2[[1]] <- Unbound("U0"); stu$regs2[[2]] <- Unbound("U1")
+stopifnot(isTRUE(pred_chedge_fact_iter(shared_program, stu)), nlist>=1L)
+stopifnot(identical(cache$order, ord0), identical(sort(ls(envir=cache$l2, all.names=TRUE)), keys0),
+          identical(cache$l1_key, l1k0))
+# generated ground wrapper: warm hit has zero I/O and preserves CP behavior
 st <- WamRuntime$new_state(); st$regs2[[1]] <- Atom(WamRuntime$intern(it,"alice"))
-st$regs2[[2]] <- Unbound("V0"); args <- list(st$regs2[[1]], st$regs2[[2]])
-stopifnot(isTRUE(WamRuntime$lmdb_arg1_v1_cached_dispatch(shared_program, st, "mock.lmdb", 2L, args, 0L, cache)),
-          length(st$cps)>=1L)
+st$regs2[[2]] <- Unbound("V0"); nget <<- 0L; nlist <<- 0L
+stopifnot(isTRUE(pred_chedge_fact_iter(shared_program, st)), length(st$cps)>=1L,
+          nget==0L, nlist==0L)
+# arity-3 + escaped
 t3 <- WamRuntime$lmdb_arg1_v1_cached_lookup(cache, "mock.lmdb", Atom(WamRuntime$intern(it,"p")), 3L, it)
 stopifnot(length(t3)==2L, t3[[1]][[3]]$val==3L)
 special <- "tab\tline\npercent%"

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -4665,7 +4665,7 @@ test(lmdb_r1_materialisation_codegen) :-
                    \+ sub_string(C2,_,_,_,'lmdb_arg1_v1_dispatch('),
                    \+ sub_string(C2,_,_,_,'read_facts_lmdb'))),
         delete_directory_and_contents(Tmp),
-        forall(member(Bad, [cached, auto, weird]),
+        forall(member(Bad, [auto, weird]),
                catch((write_wam_r_project([user:bedge/2],
                           [lmdb_materialisation(Bad),
                            r_fact_sources([source(bedge/2, lmdb_arg1_v1('/tmp/b.lmdb'))])], Tmp),
@@ -4720,6 +4720,130 @@ special <- "tab\tline\npercent%"
 stopifnot(WamRuntime$lmdb_write_facts_arg1_v1("mock.lmdb", list(list(Atom(WamRuntime$intern(it,special)), Atom(WamRuntime$intern(it,"value")))), it))
 sr <- WamRuntime$lmdb_arg1_v1_lookup("mock.lmdb", Atom(WamRuntime$intern(it,special)), 2L, it)
 stopifnot(length(sr)==1L, WamRuntime$string_of(it,sr[[1]][[1]]$id)==special); cat("OK\n")
+'), close(S)),
+    process_create(path('Rscript'), [Script], [cwd(RDir), stdout(pipe(O)), stderr(pipe(E)), process(PID)]),
+    read_string(O, _, Out), close(O), read_string(E, _, Err), close(E),
+    process_wait(PID, Status),
+    assertion(Status == exit(0)), assertion(sub_string(Out,_,_,_,"OK")),
+    assertion(\+ sub_string(Err,_,_,_,"Error")),
+    delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
+% LMDB-R-2A: cached materialisation (L1 MRU + bounded L2 LRU).
+% ------------------------------------------------------------------
+test(lmdb_r2a_cached_codegen) :-
+    once((
+        unique_r_tmp_dir('tmp_r_lmdb_r2a_cg', Tmp),
+        write_wam_r_project([user:cedge/2],
+            [lmdb_materialisation(cached),
+             r_fact_sources([source(cedge/2, lmdb_arg1_v1('/tmp/c.lmdb'))])], Tmp),
+        directory_file_path(Tmp, 'R/generated_program.R', P),
+        read_file_to_string(P, C, []),
+        assertion((sub_string(C,_,_,_,'lmdb_arg1_v1_new_cache(4096L)'),
+                   sub_string(C,_,_,_,'lmdb_arg1_v1_cached_dispatch('),
+                   sub_string(C,_,_,_,'lmdb_arg1_v1 cached cap=4096:'),
+                   \+ sub_string(C,_,_,_,'lmdb_arg1_v1_stream('),
+                   \+ sub_string(C,_,_,_,'read_facts_lmdb'))),
+        delete_directory_and_contents(Tmp), make_directory_path(Tmp),
+        write_wam_r_project([user:cedge2/2],
+            [lmdb_materialisation(cached), lmdb_l2_capacity(2),
+             r_fact_sources([source(cedge2/2, lmdb_arg1_v1('/tmp/c2.lmdb'))])], Tmp),
+        directory_file_path(Tmp, 'R/generated_program.R', P2),
+        read_file_to_string(P2, C2, []),
+        assertion(sub_string(C2,_,_,_,'lmdb_arg1_v1_new_cache(2L)')),
+        delete_directory_and_contents(Tmp),
+        forall(member(BadCap, [0, -1, 1.5, foo]),
+               catch((write_wam_r_project([user:badc/2],
+                          [lmdb_materialisation(cached), lmdb_l2_capacity(BadCap),
+                           r_fact_sources([source(badc/2, lmdb_arg1_v1('/tmp/x.lmdb'))])], Tmp),
+                      throw(unexpected_success)),
+                     error(domain_error(lmdb_l2_capacity_positive_integer, BadCap), _), true)),
+        catch((write_wam_r_project([user:autox/2],
+                    [lmdb_materialisation(auto),
+                     r_fact_sources([source(autox/2, lmdb_arg1_v1('/tmp/a.lmdb'))])], Tmp),
+               throw(unexpected_success)),
+              error(domain_error(lmdb_materialisation_eager_or_lazy, auto), _), true),
+        write_wam_r_project([user:legc/2],
+            [lmdb_materialisation(cached),
+             r_fact_sources([source(legc/2, lmdb('/tmp/legc.lmdb'))])], Tmp),
+        directory_file_path(Tmp, 'R/generated_program.R', P3),
+        read_file_to_string(P3, C3, []),
+        assertion((sub_string(C3,_,_,_,'read_facts_lmdb('),
+                   \+ sub_string(C3,_,_,_,'lmdb_arg1_v1_'))),
+        delete_directory_and_contents(Tmp)
+    )).
+
+test(lmdb_r2a_cached_runtime) :-
+    once((rscript_available -> lmdb_r2a_cached_runtime ; true)).
+lmdb_r2a_cached_runtime :-
+    unique_r_tmp_dir('tmp_r_lmdb_r2a_rt', TmpDir),
+    write_wam_r_project([user:chedge/2],
+        [intern_atoms([alice,bob,carol,eve,p,q,r]),
+         lmdb_materialisation(cached), lmdb_l2_capacity(2),
+         r_fact_sources([source(chedge/2, lmdb_arg1_v1('mock.lmdb'))])], TmpDir),
+    directory_file_path(TmpDir, 'R', RDir),
+    directory_file_path(RDir, 'lmdb_r2a_cached.R', Script),
+    setup_call_cleanup(open(Script, write, S), write(S,
+'store <- new.env(parent=emptyenv())
+assign("__uw_schema__",charToRaw("lmdb_arg1_v1"),envir=store)
+assign("a:alice",charToRaw("a:bob\na:eve"),envir=store)
+assign("a:bob",charToRaw("a:carol"),envir=store)
+assign("a:carol",charToRaw("a:eve"),envir=store)
+assign("a:p",charToRaw("a:q\ti:3\na:r\ti:4"),envir=store)
+nget <<- 0L; nlist <<- 0L
+options(unifyweaver.lmdb_kv_adapter=list(
+  get=function(path,key){ nget <<- nget+1L
+    if (exists(key,envir=store,inherits=FALSE)) get(key,envir=store) else NULL },
+  list=function(path){ nlist <<- nlist+1L; ls(envir=store,all.names=TRUE) },
+  put_all=function(path,pairs){ for (k in names(pairs)) assign(k,charToRaw(pairs[[k]]),envir=store); TRUE }))
+source("generated_program.R")
+stopifnot(nget==0L, nlist==0L)  # cached init: no LMDB I/O
+it <- intern_table; cache <- pred_chedge_lmdb_cache
+# positive miss then hit
+nget <<- 0L; nlist <<- 0L
+r1 <- WamRuntime$lmdb_arg1_v1_cached_lookup(cache, "mock.lmdb", Atom(WamRuntime$intern(it,"alice")), 2L, it)
+stopifnot(length(r1)==2L, nget>=1L, nlist==0L)
+g0 <- nget
+r1b <- WamRuntime$lmdb_arg1_v1_cached_lookup(cache, "mock.lmdb", Atom(WamRuntime$intern(it,"alice")), 2L, it)
+stopifnot(length(r1b)==2L, nget==g0, nlist==0L)
+# negative miss then hit
+nget <<- 0L
+mz <- WamRuntime$lmdb_arg1_v1_cached_lookup(cache, "mock.lmdb", Atom(WamRuntime$intern(it,"zzz")), 2L, it)
+stopifnot(length(mz)==0L, nget>=1L, nlist==0L)
+g1 <- nget
+mz2 <- WamRuntime$lmdb_arg1_v1_cached_lookup(cache, "mock.lmdb", Atom(WamRuntime$intern(it,"zzz")), 2L, it)
+stopifnot(length(mz2)==0L, nget==g1, nlist==0L)
+# capacity-2 LRU: fill alice,bob then carol evicts alice; alice rereads
+cache2 <- WamRuntime$lmdb_arg1_v1_new_cache(2L)
+nget <<- 0L
+invisible(WamRuntime$lmdb_arg1_v1_cached_lookup(cache2, "mock.lmdb", Atom(WamRuntime$intern(it,"alice")), 2L, it))
+invisible(WamRuntime$lmdb_arg1_v1_cached_lookup(cache2, "mock.lmdb", Atom(WamRuntime$intern(it,"bob")), 2L, it))
+stopifnot(identical(cache2$order, c("a:alice","a:bob")))
+nget <<- 0L
+invisible(WamRuntime$lmdb_arg1_v1_cached_lookup(cache2, "mock.lmdb", Atom(WamRuntime$intern(it,"carol")), 2L, it))
+stopifnot(identical(cache2$order, c("a:bob","a:carol")), !exists("a:alice", envir=cache2$l2, inherits=FALSE))
+g2 <- nget
+invisible(WamRuntime$lmdb_arg1_v1_cached_lookup(cache2, "mock.lmdb", Atom(WamRuntime$intern(it,"alice")), 2L, it))
+stopifnot(nget>g2, nlist==0L)  # reread after eviction; still no list
+# unbound stream bypasses cache (order/recency unchanged)
+ord0 <- cache2$order; keys0 <- sort(ls(envir=cache2$l2, all.names=TRUE)); l1k0 <- cache2$l1_key
+nlist <<- 0L; nget <<- 0L
+all <- WamRuntime$lmdb_arg1_v1_stream("mock.lmdb", 2L, it)
+stopifnot(nlist>=1L, length(all)>=3L)
+stopifnot(identical(cache2$order, ord0), identical(sort(ls(envir=cache2$l2, all.names=TRUE)), keys0),
+          identical(cache2$l1_key, l1k0))
+# generated cached_dispatch ground + CP; arity-3 + escaped
+st <- WamRuntime$new_state(); st$regs2[[1]] <- Atom(WamRuntime$intern(it,"alice"))
+st$regs2[[2]] <- Unbound("V0"); args <- list(st$regs2[[1]], st$regs2[[2]])
+stopifnot(isTRUE(WamRuntime$lmdb_arg1_v1_cached_dispatch(shared_program, st, "mock.lmdb", 2L, args, 0L, cache)),
+          length(st$cps)>=1L)
+t3 <- WamRuntime$lmdb_arg1_v1_cached_lookup(cache, "mock.lmdb", Atom(WamRuntime$intern(it,"p")), 3L, it)
+stopifnot(length(t3)==2L, t3[[1]][[3]]$val==3L)
+special <- "tab\tline\npercent%"
+stopifnot(WamRuntime$lmdb_write_facts_arg1_v1("mock.lmdb", list(list(Atom(WamRuntime$intern(it,special)), Atom(WamRuntime$intern(it,"value")))), it))
+sr <- WamRuntime$lmdb_arg1_v1_cached_lookup(cache, "mock.lmdb", Atom(WamRuntime$intern(it,special)), 2L, it)
+stopifnot(length(sr)==1L, WamRuntime$string_of(it,sr[[1]][[1]]$id)==special)
+cat("OK\n")
 '), close(S)),
     process_create(path('Rscript'), [Script], [cwd(RDir), stdout(pipe(O)), stderr(pipe(E)), process(PID)]),
     read_string(O, _, Out), close(O), read_string(E, _, Err), close(E),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `lmdb_materialisation(cached)` for `lmdb_arg1_v1(Path)` with a per-source one-entry L1 MRU and bounded L2 true-LRU cache. Lazy remains the default, eager is unchanged, `auto` remains LMDB-R-2B work, and legacy `lmdb(Path)` is unchanged.

## Contract

| Piece | Behavior |
|-------|----------|
| `lmdb_l2_capacity(N)` | positive integer; default **4096**; invalid values fail at code generation |
| L1 | one-entry MRU front |
| L2 | true LRU; capacity counts distinct arg1 keys, including empty/missing buckets |
| Ground | miss uses existing v1 lookup; warm positive/negative hit performs zero LMDB I/O and never lists |
| Unbound | existing stream-all path; bypasses cache without populating or changing recency |

## Implementation

- **Runtime:** compact cache constructor, cached lookup, and cached dispatch in `runtime.R.mustache`; reuses the existing codec, stored adapter seam, lookup, stream, and `fact_table_iter`.
- **Code generation:** normalizes cached mode and capacity, creates one cache per generated source, and emits its cached wrapper.
- No new FactSource abstraction and no copied F#/Haskell cache implementation.

## Review hardening

Review found that the original runtime assertions called `cached_dispatch` or `stream` directly, which did not prove the generated wrapper selected the correct ground/unbound path. Commit `d80dd5f1` now:

- invokes `pred_chedge_fact_iter` for both unbound bypass and warm ground dispatch;
- proves unbound wrapper execution leaves cache keys, L1, and LRU order unchanged;
- proves the generated warm-hit wrapper performs zero gets/lists and preserves choice points;
- uses the fleet-standard `domain_error(lmdb_materialisation, Value)`;
- removes redundant live `getOption` calls, retaining the stored #3904 adapter seam.

## Tests and validation

- `lmdb_r2a_cached_codegen`: cached emission, capacity override/validation, continued auto rejection, and unchanged legacy LMDB.
- `lmdb_r2a_cached_runtime`: actual generated cached program; zero-I/O initialization and warm hits, negative caching, capacity-2 LRU eviction/reread, generated unbound bypass, choice points, arity-3, and escaped payloads.
- Existing R-0/R-1 tests remain in the same focused workflow job.
- GitHub Actions run **#13809**: all 12 jobs green, including focused LMDB regressions and full `r,r_functions` conformance.
- `git diff --check`: clean.

## LOC

| Area | + / − |
|------|-------|
| Production | **+91 / −8** |
| Tests | **+127 / −2** |
| Docs + CI | **+25 / −12** |
| **Total** | **+243 / −22** |

The reusable runtime remains in the existing Mustache template; only small per-source bindings are emitted inline.

## Docs

- Fleet ledger: LMDB-R-2A complete; LMDB-R-2B auto resolution open.
- `WAM_R_STATUS.md` / `WAM_R_TARGET.md`: cached behavior and capacity documented.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
