### PR TITLE
plawk: add main-input getline forms

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -47,7 +47,7 @@ only (runtime pending) · ❌ missing.
 | `delete arr[k]` | ◐ | `delete arr[$k]` removes the entry keyed by a field (parity with `arr[$k]++`); backward-shift deletion in the runtime (later colliding keys stay reachable), missing key is a no-op. String-literal / var keys are a follow-on |
 | `exit [n]` | ✅ | stops the record loop, runs END, returns N (default 0); `exit` in a rule body, an `if`/`else` branch, or a loop (propagates past the loop) — scalar state at the exit point flows into END |
 | `delete arr[k]` | ❌ | |
-| `getline` | ◐ | **Redirected scalar and record getline landed.** `getline var < "file"` reads into a scalar; `getline < "file"` reads into `$0`, re-splits `$1…$NF` with the active FS (including regex FS), and updates `NF`. Their assignment forms capture the 1/0/-1 status (`status = getline …`), while bare statements discard it; EOF/error preserve the prior target. Handles are keyed by **filename** in the process-wide `@wam_getline_file` registry, so scalar- and record-target sites share one advancing handle. Both canonical conditions work: `while ((getline var < "file") > 0)` and `while ((getline < "file") > 0)`. Redirected record getline does **not** advance NR/FNR. Its v1 runtime sibling forces a physical newline record and preserves RS/RT while reusing the persistent reader; applying RS/RT to this form is a follow-on. Cleanly rejected follow-ons: plain main-input `getline`, bare main-input `getline var`, `cmd | getline`, dynamic filenames, and getline in BEGIN/END. The multi-pass / `over` readers still cover the bulk-scan use |
+| `getline` | ◐ | **Main-input and redirected scalar/record getline landed.** Plain `getline` reads the next record from the primary driver stream into `$0`, re-splits `$1…$NF` with the active FS, updates `NF`, and advances `NR`/`FNR`; `getline var` advances the same stream and counters but preserves `$0`/fields. Both honor the active RS (including regex RS) and RT because they share the driver's reader state. Bare statements, `status = getline` / `status = getline var`, and the canonical `while ((getline …) > 0)` forms return/use 1 on a record, 0 at EOF, or -1 on a read error; EOF/error preserve the target. Redirected `getline var < "file"` and `getline < "file"` use filename-keyed handles; redirected record getline does **not** advance NR/FNR and remains physical-newline-only in v1 while preserving RS/RT. Cleanly rejected follow-ons: `cmd | getline`, dynamic filenames, and getline in BEGIN/END. The multi-pass / `over` readers still cover the bulk-scan use |
 
 ## Functions
 
@@ -193,9 +193,8 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
 7. **`split` / `sub` / `gsub` / `match` / `sprintf`** — the string-builtin
    family; larger, lower priority for the DSL's data-pipeline focus.
 
-Deferred by design (the DSL's model diverges here): `RS`/multi-char record
-separators, main-input and pipeline `getline` (the `over`/multi-pass readers
-subsume most bulk-scan uses),
+Deferred by design (the DSL's model diverges here): pipeline `cmd | getline`
+(the `over`/multi-pass readers subsume most bulk-scan uses),
 multi-file `FILENAME`/`FNR` (`ARGV[N]`/`ARGC` themselves are landed for rule
 bodies — see the table), C-style `for(;;)` / `do-while` (the `while`
 runtime + for-in cover the loop needs).

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -532,7 +532,8 @@ plawk_program_native_driver_ir(
     plawk_rules_writebin_exprs(Rules, WritebinExprs),
     append(BodyPrintFields, WritebinExprs, PrintExprs0),
     append(PrintExprs0, ScalarExprs, RecordCounterExprs),
-    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
+    plawk_print_record_counter_ir(StatePlan, RecordCounterExprs,
+        RecordLoopPhiIR, RecordCounterIR),
     plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
     plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
     plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
@@ -619,7 +620,8 @@ plawk_program_native_driver_ir(
     plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
     append(PrintFields, BodyPrintFields, PrintExprs),
     append(PrintExprs, ScalarExprs, RecordCounterExprs),
-    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
+    plawk_print_record_counter_ir(ScalarPlan, RecordCounterExprs,
+        RecordLoopPhiIR, RecordCounterIR),
     plawk_state_loop_phi_ir(ScalarPlan, StateLoopPhiIR),
     plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
     plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
@@ -668,7 +670,8 @@ plawk_program_native_driver_ir(
     append(PrintFields, BodyPrintFields, PrintExprs0),
     append(PrintExprs0, WritebinExprs, PrintExprs),
     append(PrintExprs, ScalarExprs, RecordCounterExprs),
-    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
+    plawk_print_record_counter_ir(StatePlan, RecordCounterExprs,
+        RecordLoopPhiIR, RecordCounterIR),
     plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
     plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
     plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
@@ -725,7 +728,8 @@ plawk_program_native_driver_ir(
     append(PrintFields, BodyPrintFields, PrintExprs0),
     append(PrintExprs0, WritebinExprs, PrintExprs),
     append(PrintExprs, ScalarExprs, RecordCounterExprs),
-    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
+    plawk_print_record_counter_ir(StatePlan, RecordCounterExprs,
+        RecordLoopPhiIR, RecordCounterIR),
     plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
     plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
     plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
@@ -818,7 +822,8 @@ plawk_program_native_driver_ir(
     append(PrintFields, BodyPrintFields, PrintExprs0),
     append(PrintExprs0, WritebinExprs, PrintExprs),
     append(PrintExprs, ScalarExprs, RecordCounterExprs),
-    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
+    plawk_print_record_counter_ir(StatePlan, RecordCounterExprs,
+        RecordLoopPhiIR, RecordCounterIR),
     plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
     plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
     plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
@@ -5484,6 +5489,13 @@ plawk_while_cond_operand(special('ARGC'), _Slots, _CondValues, Base, Path, Side,
     !,
     format(atom(Ref), '%~w_cond~w_~w_argc', [Base, Path, Side]),
     format(atom(Line), '  ~w = call i64 @wam_argc()', [Ref]).
+% In a main-input-getline program NR/FNR is an ordinary hidden state slot, so a
+% condition after a successful getline (including a loop back-edge) observes
+% the advanced value rather than the outer record's entry value.
+plawk_while_cond_operand(special('NR'), Slots, CondValues, _Base, _Path, _Side,
+        Ref, []) :-
+    plawk_record_number_value(Slots, CondValues, Ref),
+    !.
 % NR: the current record number. In a rule-body condition it is the loop's
 % %current_nr; in an END condition it is %plawk_nr (the final record count, the
 % same SSA the END expression path reads). No extra line -- both are existing
@@ -6562,11 +6574,21 @@ plawk_slot_llvm_type(scalar_counter(_Name), i64).
 plawk_slot_llvm_type(scalar_double(_Name), double).
 plawk_slot_llvm_type(scalar_string(_Name), i64).
 plawk_slot_llvm_type(scalar_strnum(_Name), i64).
+plawk_slot_llvm_type(scalar_record_number, i64).
 
 plawk_slot_zero_ir(scalar_counter(_Name), '0').
 plawk_slot_zero_ir(scalar_double(_Name), '0.0').
 plawk_slot_zero_ir(scalar_string(_Name), '0').
 plawk_slot_zero_ir(scalar_strnum(_Name), '0').
+plawk_slot_zero_ir(scalar_record_number, '0').
+
+plawk_record_number_slot(Slots, Index) :-
+    nth0(Index, Slots, scalar_record_number),
+    !.
+
+plawk_record_number_value(Slots, Values, Value) :-
+    plawk_record_number_slot(Slots, Index),
+    nth0(Index, Values, Value).
 
 plawk_state_slot_lookup(StatePlan, Name, Index, Slot) :-
     plawk_state_plan_slots(StatePlan, Slots),
@@ -6756,7 +6778,10 @@ plawk_break_predecessor_label(done, RuleIndex, Label) :-
 plawk_final_state_phi_lines([], _HasBreak, _) -->
     [].
 plawk_final_state_phi_lines([Slot | Rest], HasBreak, SlotIndex) -->
-    { format(atom(EofIncoming), '[%slot_~w, %close_stream]', [SlotIndex]),
+    { ( Slot == scalar_record_number
+      -> format(atom(EofIncoming), '[%slot_~w_prev, %close_stream]', [SlotIndex])
+      ;  format(atom(EofIncoming), '[%slot_~w, %close_stream]', [SlotIndex])
+      ),
       ( HasBreak == true
       -> format(atom(BreakIncoming), '[%break_slot_~w, %break_close_stream]', [SlotIndex]),
          Incomings = [EofIncoming, BreakIncoming]
@@ -6789,6 +6814,7 @@ plawk_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
     ( ActionVars \== []
     ; BodyPrintFields \== []
     ; plawk_rules_have_record_getline(Rules)
+    ; plawk_rules_have_main_getline(Rules)
     ),
     findall(Name,
         ( member(Field, PrintFields),
@@ -6797,7 +6823,11 @@ plawk_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
         PrintVars),
     append(ActionVars, PrintVars, Names0),
     sort(Names0, Names),
-    plawk_scalar_typed_slots(Rules, Names, Slots).
+    plawk_scalar_typed_slots(Rules, Names, ScalarSlots),
+    (   plawk_rules_have_main_getline(Rules)
+    ->  append(ScalarSlots, [scalar_record_number], Slots)
+    ;   Slots = ScalarSlots
+    ).
 
 % A bare record-getline has an observable `$0` side effect but no scalar slot.
 % Keep the scalar action-chain driver active even when it is the only action in
@@ -6815,6 +6845,8 @@ plawk_actions_have_record_getline(Actions) :-
 
 plawk_action_has_record_getline(getline_file_record(_File)).
 plawk_action_has_record_getline(getline_file_record_capture(_Status, _File)).
+plawk_action_has_record_getline(getline_main_record).
+plawk_action_has_record_getline(getline_main_record_capture(_Status)).
 plawk_action_has_record_getline(if(_Pattern, ThenActions, ElseActions)) :-
     ( plawk_actions_have_record_getline(ThenActions)
     ; plawk_actions_have_record_getline(ElseActions)
@@ -6825,6 +6857,35 @@ plawk_action_has_record_getline(do_while_loop(Body, _Cond)) :-
     plawk_actions_have_record_getline(Body).
 plawk_action_has_record_getline(foreach_loop(_Layout, Body)) :-
     plawk_actions_have_record_getline(Body).
+
+% Main-input getline advances the same logical NR/FNR counter as the outer
+% record driver. Surface FNR is parsed as NR, so one hidden slot covers both.
+% Keep this detector separate from the record-target detector: `getline var`
+% does not replace $0, but it still advances the shared record number.
+plawk_rules_have_main_getline(Rules) :-
+    member(rule(_Pattern, Actions), Rules),
+    plawk_actions_have_main_getline(Actions),
+    !.
+
+plawk_actions_have_main_getline(Actions) :-
+    member(Action, Actions),
+    plawk_action_has_main_getline(Action),
+    !.
+
+plawk_action_has_main_getline(getline_main_record).
+plawk_action_has_main_getline(getline_main_record_capture(_Status)).
+plawk_action_has_main_getline(getline_main_var(_Var)).
+plawk_action_has_main_getline(getline_main_var_capture(_Status, _Var)).
+plawk_action_has_main_getline(if(_Pattern, ThenActions, ElseActions)) :-
+    ( plawk_actions_have_main_getline(ThenActions)
+    ; plawk_actions_have_main_getline(ElseActions)
+    ).
+plawk_action_has_main_getline(while_loop(_Cond, Body)) :-
+    plawk_actions_have_main_getline(Body).
+plawk_action_has_main_getline(do_while_loop(Body, _Cond)) :-
+    plawk_actions_have_main_getline(Body).
+plawk_action_has_main_getline(foreach_loop(_Layout, Body)) :-
+    plawk_actions_have_main_getline(Body).
 
 %% plawk_scalar_typed_slots(+Rules, +Names, -Slots)
 %
@@ -6990,6 +7051,8 @@ plawk_scalar_strnum_source(set(var(Name), argv_at(N)), Name) :-
     N >= 0.
 plawk_scalar_strnum_source(getline_read(Name, _File), Name).
 plawk_scalar_strnum_source(getline_capture(_Status, Name, _File), Name).
+plawk_scalar_strnum_source(getline_main_var(Name), Name).
+plawk_scalar_strnum_source(getline_main_var_capture(_Status, Name), Name).
 
 % A write is disqualifying unless it is a strnum-preserving source: a field copy
 % (`x = $N`) or a plain var copy (`z = x`, which propagates strnum-ness). Any
@@ -7237,7 +7300,11 @@ plawk_mixed_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
         PrintVars),
     append(ActionVars, PrintVars, Names0),
     sort(Names0, Names),
-    plawk_scalar_typed_slots(Rules, Names, Slots).
+    plawk_scalar_typed_slots(Rules, Names, ScalarSlots),
+    (   plawk_rules_have_main_getline(Rules)
+    ->  append(ScalarSlots, [scalar_record_number], Slots)
+    ;   Slots = ScalarSlots
+    ).
 
 plawk_mixed_assoc_count_plan(Rules, PrintFields, assoc_plan(Tables, [])) :-
     findall(ArrayName,
@@ -7397,6 +7464,12 @@ plawk_mixed_update_action(Action) :-
     plawk_assoc_update_action(Action).
 plawk_mixed_update_action(Action) :-
     plawk_rule_body_print_action(Action).
+% Record-target main getline has no surface scalar update, but it still writes
+% the transient `$0` buffer and advances the hidden NR/FNR slot. The scalar-
+% target forms are admitted by plawk_scalar_action_update/3 above.
+plawk_mixed_update_action(getline_main_record).
+plawk_mixed_update_action(getline_main_record_capture(Status)) :-
+    atom(Status).
 plawk_mixed_update_action(if(_Pattern, ThenActions, ElseActions)) :-
     append(ThenActions, ElseActions, Actions),
     Actions \== [],
@@ -12052,7 +12125,7 @@ plawk_mixed_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], ScalarP
     plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, OutputSeparator, NextPrintIndex).
 plawk_mixed_end_print_lines([special('NR') | Rest], ScalarPlan, AssocPlan, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
-    plawk_end_nr_print_lines(PrintIndex),
+    plawk_end_nr_print_lines(ScalarPlan, PrintIndex),
     { NextPrintIndex is PrintIndex + 1 },
     plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, OutputSeparator, NextPrintIndex).
 plawk_mixed_end_print_lines([special('RT') | Rest], ScalarPlan, AssocPlan, OutputSeparator, PrintIndex) -->
@@ -12210,9 +12283,14 @@ plawk_scalar_loop_phi_lines([], _) -->
 plawk_scalar_loop_phi_lines([Slot | Rest], Index) -->
     { plawk_slot_llvm_type(Slot, Type),
       plawk_slot_zero_ir(Slot, Zero),
-      format(atom(Line),
-          '  %slot_~w = phi ~w [~w, %check_handle_value], [%next_slot_~w, %continue_loop]',
-          [Index, Type, Zero, Index]),
+      ( Slot == scalar_record_number
+      -> format(atom(Line),
+             '  %slot_~w_prev = phi ~w [~w, %check_handle_value], [%next_slot_~w, %continue_loop]',
+             [Index, Type, Zero, Index])
+      ;  format(atom(Line),
+             '  %slot_~w = phi ~w [~w, %check_handle_value], [%next_slot_~w, %continue_loop]',
+             [Index, Type, Zero, Index])
+      ),
       NextIndex is Index + 1
     },
     [Line],
@@ -12274,6 +12352,14 @@ plawk_scalar_rule_body_action(getline_file_record(File)) :-
 plawk_scalar_rule_body_action(getline_file_record_capture(Status, File)) :-
     atom(Status),
     string(File).
+plawk_scalar_rule_body_action(getline_main_record).
+plawk_scalar_rule_body_action(getline_main_record_capture(Status)) :-
+    atom(Status).
+plawk_scalar_rule_body_action(getline_main_var(Var)) :-
+    atom(Var).
+plawk_scalar_rule_body_action(getline_main_var_capture(Status, Var)) :-
+    atom(Status),
+    atom(Var).
 % the store-only half of a rule-level `exit N` (terminal_exit split); it is a
 % plain store with no control, valid anywhere a plain body action is.
 plawk_scalar_rule_body_action(exit_store(_Code)).
@@ -12311,6 +12397,14 @@ plawk_scalar_rule_body_plain_action(getline_file_record(File)) :-
 plawk_scalar_rule_body_plain_action(getline_file_record_capture(Status, File)) :-
     atom(Status),
     string(File).
+plawk_scalar_rule_body_plain_action(getline_main_record).
+plawk_scalar_rule_body_plain_action(getline_main_record_capture(Status)) :-
+    atom(Status).
+plawk_scalar_rule_body_plain_action(getline_main_var(Var)) :-
+    atom(Var).
+plawk_scalar_rule_body_plain_action(getline_main_var_capture(Status, Var)) :-
+    atom(Status),
+    atom(Var).
 % `exit [N]` inside a branch body (`if (c) exit`): the sequence walker lowers it
 % via branch_exit + plawk_branch_to_done_ir (branch to break_close_stream); the
 % store-only marker `exit_store` may appear when a branch ends the rule.
@@ -12950,6 +13044,20 @@ plawk_substitute_operation_reads(Operation, _Slots, _Values, Operation).
 plawk_substitute_scalar_reads(concat(Parts), Slots, Values, concat(SubParts)) :-
     !,
     maplist(plawk_substitute_scalar_read_part(Slots, Values), Parts, SubParts).
+plawk_substitute_scalar_reads(special('NR'), Slots, Values, ssa(Value)) :-
+    plawk_record_number_value(Slots, Values, Value),
+    !.
+plawk_substitute_scalar_reads(sprintf(Format, Args), Slots, Values,
+        sprintf(Format, SubArgs)) :-
+    !,
+    maplist(plawk_substitute_scalar_read_part(Slots, Values), Args, SubArgs).
+plawk_substitute_scalar_reads(ternary(cmp(Left0, Op, Right0), Then0, Else0),
+        Slots, Values, ternary(cmp(Left, Op, Right), Then, Else)) :-
+    !,
+    plawk_substitute_scalar_reads(Left0, Slots, Values, Left),
+    plawk_substitute_scalar_reads(Right0, Slots, Values, Right),
+    plawk_substitute_scalar_reads(Then0, Slots, Values, Then),
+    plawk_substitute_scalar_reads(Else0, Slots, Values, Else).
 plawk_substitute_scalar_read_part(Slots, Values, Part, SubPart) :-
     plawk_substitute_scalar_reads(Part, Slots, Values, SubPart).
 plawk_substitute_scalar_reads(var(Name), Slots, Values, Substituted) :-
@@ -13032,6 +13140,10 @@ plawk_substitute_end_reads(var(Name), StatePlan, Substituted) :-
     -> Substituted = ssa_strnum(Value)   % strnum: text for print, number in arith
     ;  Substituted = ssa(Value)
     ).
+plawk_substitute_end_reads(special('NR'), state_plan(Slots), ssa(Value)) :-
+    plawk_record_number_slot(Slots, Index),
+    !,
+    format(atom(Value), '%final_slot_~w', [Index]).
 plawk_substitute_end_reads(special('NR'), _StatePlan, ssa('%plawk_nr')) :-
     !.
 plawk_substitute_end_reads(Expr0, StatePlan, Expr) :-
@@ -13102,6 +13214,9 @@ plawk_scalar_update_action_name(getline_capture(Status, Var, _File), Name) :-
 % Record-target getline writes only its i64 status slot; `$0` lives in the
 % reserved transient record buffer rather than in the scalar state plan.
 plawk_scalar_update_action_name(getline_file_record_capture(Status, _File), Status).
+plawk_scalar_update_action_name(getline_main_record_capture(Status), Status).
+plawk_scalar_update_action_name(getline_main_var_capture(Status, Var), Name) :-
+    ( Name = Var ; Name = Status ).
 plawk_scalar_update_action_name(dynrec_bind(Vars, _Call, _Types), Name) :-
     plawk_dynrec_binding_names(Vars, Names),
     member(Name, Names).
@@ -13209,6 +13324,11 @@ plawk_scalar_action_update(getline_read(Var, File), Var, set_str(getline(File)))
     string(File).
 plawk_scalar_action_update(getline_capture(_Status, Var, File), Var, set_str(getline(File))) :-
     string(File).
+plawk_scalar_action_update(getline_main_var(Var), Var, set_str(getline_main)) :-
+    atom(Var).
+plawk_scalar_action_update(getline_main_var_capture(_Status, Var), Var,
+        set_str(getline_main)) :-
+    atom(Var).
 % Ternary assignment `x = COND ? A : B`: an i64 value via select (the operation
 % lowers through plawk_scalar_numeric_expr_ir(ternary(...)) -> plawk_i64_expr_ir).
 plawk_scalar_action_update(set(var(Name), ternary(cmp(Left, _Op, Right), Then, Else)),
@@ -13362,6 +13482,113 @@ plawk_getline_record_ir(Prefix, OpIndex, File, StNext, GlobalIR, IR) :-
   ~w = call i64 @wam_getline_file_record(i8* %~w_pathp, i64 ~w)',
         [Base, PathBytes, PathBytes, PathName,
          StNext, Base, PathLen]).
+
+% Main-input getline sites use the driver-owned %handle, hence advance the
+% exact buffered stream the outer record loop is draining. Runtime helpers keep
+% their internal control flow out of the action sequence (whose predecessor
+% labels are tracked by the Prolog lowering). The returned status gates the
+% hidden NR/FNR slot increment.
+plawk_getline_main_record_ir(Prefix, OpIndex, NrInput, StNext, NrNext, IR) :-
+    format(atom(Base), '~w_getline_main_record_~w', [Prefix, OpIndex]),
+    format(atom(StNext), '%~w_status', [Base]),
+    format(atom(NrNext), '%~w_nr', [Base]),
+    format(atom(IR),
+'  ~w = call i64 @wam_getline_main_record(%Value %handle)
+  %~w_got = icmp eq i64 ~w, 1
+  %~w_nr_inc = add i64 ~w, 1
+  ~w = select i1 %~w_got, i64 %~w_nr_inc, i64 ~w',
+        [StNext,
+         Base, StNext,
+         Base, NrInput,
+         NrNext, Base, Base, NrInput]).
+
+plawk_getline_main_var_ir(Prefix, OpIndex, VarInput, NrInput, VarNext, StNext,
+        NrNext, IR) :-
+    format(atom(Base), '~w_getline_main_var_~w', [Prefix, OpIndex]),
+    format(atom(VarNext), '%~w_var', [Base]),
+    format(atom(StNext), '%~w_status', [Base]),
+    format(atom(NrNext), '%~w_nr', [Base]),
+    format(atom(IR),
+'  %~w_lineid = alloca i64
+  store i64 ~w, i64* %~w_lineid
+  ~w = call i64 @wam_getline_main_var(%Value %handle, i64* %~w_lineid)
+  %~w_line = load i64, i64* %~w_lineid
+  %~w_got = icmp eq i64 ~w, 1
+  ~w = select i1 %~w_got, i64 %~w_line, i64 ~w
+  %~w_nr_inc = add i64 ~w, 1
+  ~w = select i1 %~w_got, i64 %~w_nr_inc, i64 ~w',
+        [Base,
+         VarInput, Base,
+         StNext, Base,
+         Base, Base,
+         Base, StNext,
+         VarNext, Base, Base, VarInput,
+         Base, NrInput,
+         NrNext, Base, Base, NrInput]).
+
+% `status = getline`: replace the current record, capture status, and advance
+% NR/FNR only when a record was actually read.
+plawk_scalar_action_sequence_pairs([getline_main_record_capture(Status) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { nth0(StIndex, Slots, StSlot), plawk_slot_name(StSlot, Status),
+      plawk_record_number_slot(Slots, NrIndex),
+      nth0(NrIndex, Values0, NrInput),
+      plawk_getline_main_record_ir(Prefix, OpIndex, NrInput, StNext, NrNext, IR),
+      replace_nth0(StIndex, Values0, StNext, Values1),
+      replace_nth0(NrIndex, Values1, NrNext, Values2),
+      NextOpIndex is OpIndex + 1
+    },
+    [''-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values2, Values, FinalOpIndex, ExitLabel, NextExits).
+% Bare main-input `getline`: same record/counter effects, status discarded.
+plawk_scalar_action_sequence_pairs([getline_main_record | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { plawk_record_number_slot(Slots, NrIndex),
+      nth0(NrIndex, Values0, NrInput),
+      plawk_getline_main_record_ir(Prefix, OpIndex, NrInput, _StNext, NrNext, IR),
+      replace_nth0(NrIndex, Values0, NrNext, Values1),
+      NextOpIndex is OpIndex + 1
+    },
+    [''-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values1, Values, FinalOpIndex, ExitLabel, NextExits).
+
+% `status = getline var`: the persistent line id updates Var on success while
+% $0/NF remain untouched; status and the hidden record number are threaded too.
+plawk_scalar_action_sequence_pairs([getline_main_var_capture(Status, Var) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { nth0(VarIndex, Slots, VarSlot), plawk_slot_name(VarSlot, Var),
+      nth0(VarIndex, Values0, VarInput),
+      nth0(StIndex, Slots, StSlot), plawk_slot_name(StSlot, Status),
+      plawk_record_number_slot(Slots, NrIndex),
+      nth0(NrIndex, Values0, NrInput),
+      plawk_getline_main_var_ir(Prefix, OpIndex, VarInput, NrInput,
+          VarNext, StNext, NrNext, IR),
+      replace_nth0(VarIndex, Values0, VarNext, Values1),
+      replace_nth0(StIndex, Values1, StNext, Values2),
+      replace_nth0(NrIndex, Values2, NrNext, Values3),
+      NextOpIndex is OpIndex + 1
+    },
+    [''-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values3, Values, FinalOpIndex, ExitLabel, NextExits).
+% Bare `getline var`: update Var and NR/FNR, discard status.
+plawk_scalar_action_sequence_pairs([getline_main_var(Var) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { nth0(VarIndex, Slots, VarSlot), plawk_slot_name(VarSlot, Var),
+      nth0(VarIndex, Values0, VarInput),
+      plawk_record_number_slot(Slots, NrIndex),
+      nth0(NrIndex, Values0, NrInput),
+      plawk_getline_main_var_ir(Prefix, OpIndex, VarInput, NrInput,
+          VarNext, _StNext, NrNext, IR),
+      replace_nth0(VarIndex, Values0, VarNext, Values1),
+      replace_nth0(NrIndex, Values1, NrNext, Values2),
+      NextOpIndex is OpIndex + 1
+    },
+    [''-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values2, Values, FinalOpIndex, ExitLabel, NextExits).
 
 % `status = getline < "file"`: update the current record and the status slot.
 plawk_scalar_action_sequence_pairs([getline_file_record_capture(Status, File) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
@@ -13524,8 +13751,9 @@ plawk_scalar_action_sequence_pairs([printf(string(Format), Args) | Rest],
         Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
         OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
     { plawk_rule_body_print_action(printf(string(Format), Args)),
+      maplist(plawk_substitute_print_field(Slots, Values0), Args, SubArgs),
       format(atom(PrintPrefix), '~w_printf_~w', [Prefix, OpIndex]),
-      plawk_prefixed_printf_action_ir(Format, Args, FieldSeparator, PrintPrefix, Pair),
+      plawk_prefixed_printf_action_ir(Format, SubArgs, FieldSeparator, PrintPrefix, Pair),
       NextOpIndex is OpIndex + 1
     },
     [Pair],
@@ -15282,7 +15510,7 @@ plawk_scalar_end_print_lines([var(Name) | Rest], StatePlan, OutputSeparator, Pri
     plawk_scalar_end_print_lines(Rest, StatePlan, OutputSeparator, NextPrintIndex).
 plawk_scalar_end_print_lines([special('NR') | Rest], StatePlan, OutputSeparator, PrintIndex) -->
     plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
-    plawk_end_nr_print_lines(PrintIndex),
+    plawk_end_nr_print_lines(StatePlan, PrintIndex),
     { NextPrintIndex is PrintIndex + 1 },
     plawk_scalar_end_print_lines(Rest, StatePlan, OutputSeparator, NextPrintIndex).
 plawk_scalar_end_print_lines([special('RT') | Rest], StatePlan, OutputSeparator, PrintIndex) -->
@@ -15340,18 +15568,25 @@ plawk_end_field_print_lines(var(Name), StatePlan, PrintIndex) -->
     [FmtPtr, PrintCall].
 plawk_end_field_print_lines(string(Value), _StatePlan, PrintIndex) -->
     plawk_end_string_print_lines(Value, PrintIndex).
-plawk_end_field_print_lines(special('NR'), _StatePlan, PrintIndex) -->
-    plawk_end_nr_print_lines(PrintIndex).
+plawk_end_field_print_lines(special('NR'), StatePlan, PrintIndex) -->
+    plawk_end_nr_print_lines(StatePlan, PrintIndex).
 plawk_end_field_print_lines(special('RT'), _StatePlan, PrintIndex) -->
     plawk_end_rt_print_lines(PrintIndex).
 plawk_end_field_print_lines(Expr, StatePlan, PrintIndex) -->
     { plawk_end_scalar_expr(Expr) },
     plawk_end_expr_print_lines(Expr, StatePlan, PrintIndex).
 
-plawk_end_nr_print_lines(PrintIndex) -->
+plawk_end_nr_value(state_plan(Slots), ValueIR) :-
+    plawk_record_number_slot(Slots, Index),
+    !,
+    format(atom(ValueIR), '%final_slot_~w', [Index]).
+plawk_end_nr_value(_StatePlan, '%plawk_nr').
+
+plawk_end_nr_print_lines(StatePlan, PrintIndex) -->
     { format(atom(FmtVar), 'end_nr_fmt_~w', [PrintIndex]),
       format(atom(PrintVar), 'printed_end_nr_~w', [PrintIndex]),
-      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, '%plawk_nr',
+      plawk_end_nr_value(StatePlan, ValueIR),
+      llvm_emit_printf_i64(plawk_surface_print_i64, FmtVar, PrintVar, ValueIR,
           [FmtPtr, PrintCall])
     },
     [FmtPtr, PrintCall].
@@ -16102,6 +16337,21 @@ plawk_field_cmp_op_code(lt, 2).
 plawk_field_cmp_op_code(le, 3).
 plawk_field_cmp_op_code(gt, 4).
 plawk_field_cmp_op_code(ge, 5).
+
+% Main-input getline needs the record number as ordinary loop-carried state:
+% one outer-loop record and every successful getline both advance it. The
+% hidden slot's loop phi is named *_prev because EOF branches before the
+% current outer record is counted; the lowered record block materializes the
+% current value after a successful driver read.
+plawk_print_record_counter_ir(state_plan(Slots), _Fields, '', RecordCounterIR) :-
+    plawk_record_number_slot(Slots, Index),
+    !,
+    format(atom(RecordCounterIR),
+'  %slot_~w = add i64 %slot_~w_prev, 1
+  %current_nr = add i64 %slot_~w, 0',
+        [Index, Index, Index]).
+plawk_print_record_counter_ir(_StatePlan, Fields, LoopPhiIR, RecordCounterIR) :-
+    plawk_print_record_counter_ir(Fields, LoopPhiIR, RecordCounterIR).
 
 plawk_print_record_counter_ir(Fields, LoopPhiIR, RecordCounterIR) :-
     (   plawk_fields_include_nr(Fields)

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -157,11 +157,9 @@ plawk_action_own_continue(if(_Pattern, Then, Else)) :-
 
 %% plawk_normalise_getline_loops(+Program0, -Program)
 %
-%  Desugar the two supported in-condition forms into the existing while
-%  machinery. `while ((getline var < "file") > 0) BODY` becomes a priming
-%  getline_capture plus a `while (status > 0)` whose body ends in another read.
-%  The record form, `while ((getline < "file") > 0) BODY`, is identical except
-%  that its priming and trailing actions are getline_file_record_capture nodes.
+%  Desugar the supported redirected and main-input getline conditions into the
+%  existing while machinery. Each becomes a priming status-capturing getline
+%  plus a `while (status > 0)` whose body ends in another read of the same form.
 %  `$getline_status` is a reserved i64 slot (users cannot write a `$`-prefixed
 %  name). v1 rewrites rule bodies (and nested if/loop bodies); getline loops in
 %  BEGIN/END/case blocks remain explicit unsupported nodes.
@@ -199,6 +197,24 @@ plawk_norm_getline_actions([getline_loop(Var, File, Body0) | Rest], Out) :-
     !,
     plawk_norm_getline_actions(Body0, Body),
     Read = getline_capture('$getline_status', Var, File),
+    append(Body, [Read], LoopBody),
+    plawk_norm_getline_actions(Rest, Rest1),
+    Out = [ Read,
+            while_loop(cmp(var('$getline_status'), gt, int(0)), LoopBody)
+          | Rest1 ].
+plawk_norm_getline_actions([getline_main_record_loop(Body0) | Rest], Out) :-
+    !,
+    plawk_norm_getline_actions(Body0, Body),
+    Read = getline_main_record_capture('$getline_status'),
+    append(Body, [Read], LoopBody),
+    plawk_norm_getline_actions(Rest, Rest1),
+    Out = [ Read,
+            while_loop(cmp(var('$getline_status'), gt, int(0)), LoopBody)
+          | Rest1 ].
+plawk_norm_getline_actions([getline_main_var_loop(Var, Body0) | Rest], Out) :-
+    !,
+    plawk_norm_getline_actions(Body0, Body),
+    Read = getline_main_var_capture('$getline_status', Var),
     append(Body, [Read], LoopBody),
     plawk_norm_getline_actions(Rest, Rest1),
     Out = [ Read,
@@ -1806,6 +1822,8 @@ plawk_block_action(while_loop(_Cond, _Body)).
 plawk_block_action(do_while_loop(_Body, _Cond)).
 plawk_block_action(getline_loop(_Var, _File, _Body)).
 plawk_block_action(getline_file_record_loop(_File, _Body)).
+plawk_block_action(getline_main_record_loop(_Body)).
+plawk_block_action(getline_main_var_loop(_Var, _Body)).
 plawk_block_action(unsupported_getline(while(_Getline, _Body))).
 
 %% action_sep//0
@@ -1924,10 +1942,9 @@ action(Action) -->
 
 %% getline_action(-Action)//
 %
-%  `getline < "file"` reads a newline-delimited record into `$0`; codegen
-%  refreshes the current transient record so fields and NF re-split under the
-%  active FS. The sibling `getline var < "file"` reads into a scalar. Both use a
-%  filename-keyed shared handle. Unsupported main-input, pipeline, and dynamic
+%  Redirected forms read through a filename-keyed shared handle. Main-input
+%  forms read the next record from the driver's stream: `getline` replaces `$0`
+%  while `getline var` only updates the scalar target. Pipeline and dynamic
 %  filename shapes are retained as unsupported_getline nodes so they fail at
 %  compile time rather than being approximated.
 getline_action(getline_file_record(File)) -->
@@ -1945,8 +1962,20 @@ getline_action(getline_read(Var, File)) -->
     quoted_string(FCodes),
     { string_codes(File, FCodes) },
     !.
+% Try unsupported redirected shapes before the main-input forms: otherwise the
+% latter would accept only the `getline` / `getline var` prefix of a dynamic
+% redirect and the enclosing parse would fail instead of reaching codegen's
+% clean unsupported-feature diagnostic.
 getline_action(unsupported_getline(Reason)) -->
     unsupported_getline_statement(Reason).
+getline_action(getline_main_var(Var)) -->
+    "getline",
+    required_inline_ws,
+    identifier(Var),
+    !.
+getline_action(getline_main_record) -->
+    "getline",
+    identifier_boundary.
 
 % A context grammar used by BEGIN/END rejection. Assignment getline forms are
 % included so `BEGIN { r = getline < "f" }` is rejected at compile time too.
@@ -1969,11 +1998,6 @@ unsupported_getline_statement(file_record_dynamic(File)) -->
     "getline", identifier_boundary, ws,
     "<", ws, getline_dynamic_file_expr(File),
     !.
-unsupported_getline_statement(main_var(Var)) -->
-    "getline", required_ws, identifier(Var),
-    !.
-unsupported_getline_statement(main_record) -->
-    "getline", identifier_boundary.
 
 getline_pipe_command(var(Command)) -->
     identifier(Command).
@@ -2114,9 +2138,27 @@ while_action(getline_loop(Var, File, Body)) -->
     ")", ws,
     body_block(Body),
     { string_codes(File, FCodes) }.
-% Other getline operands in the same while shape are deliberate v1
-% rejections: main-input reads and dynamic filenames must reach codegen as an
-% unsupported node rather than falling out of the parser with exit 2.
+% `while ((getline) > 0) BODY` -- drain the remaining main input into `$0`.
+while_action(getline_main_record_loop(Body)) -->
+    "while", identifier_boundary, ws,
+    "(", ws,
+    "(", ws, "getline", identifier_boundary, ws, ")",
+    ws, ">", ws, "0", ws,
+    ")", ws,
+    body_block(Body),
+    !.
+% `while ((getline var) > 0) BODY` -- drain it into a scalar without changing
+% the surrounding current record.
+while_action(getline_main_var_loop(Var, Body)) -->
+    "while", identifier_boundary, ws,
+    "(", ws,
+    "(", ws, "getline", required_inline_ws, identifier(Var), ws, ")",
+    ws, ">", ws, "0", ws,
+    ")", ws,
+    body_block(Body),
+    !.
+% Other getline operands in the same while shape are deliberate v1 rejections:
+% dynamic filenames must reach codegen rather than falling out of the parser.
 while_action(unsupported_getline(while(Getline, Body))) -->
     "while", identifier_boundary, ws,
     "(", ws,
@@ -2652,6 +2694,22 @@ getline_assignment_action(unsupported_getline(capture(Status, Reason))) -->
     ws, "=", ws,
     unsupported_getline_rhs(Reason).
 
+% Main-input captures are deliberately tried after the unsupported dynamic
+% redirects so `status = getline var < expr` cannot be accepted as a shorter
+% main-input prefix.
+getline_assignment_action(getline_main_var_capture(Status, Var)) -->
+    identifier(Status),
+    ws, "=", ws,
+    "getline",
+    required_inline_ws,
+    identifier(Var),
+    !.
+getline_assignment_action(getline_main_record_capture(Status)) -->
+    identifier(Status),
+    ws, "=", ws,
+    "getline",
+    identifier_boundary.
+
 unsupported_getline_rhs(file_var(Var, File)) -->
     "getline", required_ws, identifier(Var), ws,
     "<", ws, getline_dynamic_file_expr(File),
@@ -2660,11 +2718,6 @@ unsupported_getline_rhs(file_record_dynamic(File)) -->
     "getline", identifier_boundary, ws,
     "<", ws, getline_dynamic_file_expr(File),
     !.
-unsupported_getline_rhs(main_var(Var)) -->
-    "getline", required_ws, identifier(Var),
-    !.
-unsupported_getline_rhs(main_record) -->
-    "getline", identifier_boundary.
 
 % `x = sprintf("fmt", args...)`: format into a string scalar (the printf format
 % engine + string-valued scalars). Tried first -- the `sprintf(` keyword is
@@ -3834,6 +3887,23 @@ required_ws -->
     [Code],
     { code_type(Code, space) },
     ws.
+
+% A getline scalar target must occur in the same statement as the keyword.
+% Unlike required_ws//0 this deliberately stops before newlines and comments,
+% so `getline\nprint $0` is a record getline followed by a print rather than a
+% read into a scalar named `print`.
+required_inline_ws -->
+    [Code],
+    { code_type(Code, space), Code =\= 0'\n, Code =\= 0'\r },
+    inline_ws.
+
+inline_ws -->
+    [Code],
+    { code_type(Code, space), Code =\= 0'\n, Code =\= 0'\r },
+    !,
+    inline_ws.
+inline_ws -->
+    [].
 
 % Whitespace, including newlines and awk-style # comments (a comment
 % runs to end of line; its terminating newline still counts as a

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -8361,6 +8361,112 @@ gl.err:
   ret i64 -1
 }
 
+; awk main-input `getline var`: read from the already-open primary stream.
+; The persistent reader shares the exact handle, buffered position, RS state,
+; regex replay, and RT updates used by the outer record driver. The output slot
+; is written only for a real record, so EOF and read errors preserve the target.
+; Returns the awk 1, 0, or -1 status.
+define i64 @wam_getline_main_var(%Value %handle, i64* %line_id_out) {
+entry:
+  %gmv.line = call %Value @wam_stream_read_line_value(%Value %handle)
+  %gmv.tag = extractvalue %Value %gmv.line, 0
+  %gmv.payload = extractvalue %Value %gmv.line, 1
+  %gmv.is_int = icmp eq i32 %gmv.tag, 1
+  %gmv.negative = icmp slt i64 %gmv.payload, 0
+  %gmv.read_error = and i1 %gmv.is_int, %gmv.negative
+  br i1 %gmv.read_error, label %gmv.error, label %gmv.check_atom
+
+gmv.check_atom:
+  %gmv.is_atom = icmp eq i32 %gmv.tag, 0
+  br i1 %gmv.is_atom, label %gmv.check_eof, label %gmv.error
+
+gmv.check_eof:
+  %gmv.text = call i8* @wam_atom_to_string(i64 %gmv.payload)
+  %gmv.text_null = icmp eq i8* %gmv.text, null
+  br i1 %gmv.text_null, label %gmv.error, label %gmv.compare_eof
+
+gmv.compare_eof:
+  %gmv.eof_text = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof_atom, i32 0, i32 0
+  %gmv.eof_cmp = call i32 @strcmp(i8* %gmv.text, i8* %gmv.eof_text)
+  %gmv.is_eof = icmp eq i32 %gmv.eof_cmp, 0
+  br i1 %gmv.is_eof, label %gmv.eof, label %gmv.success
+
+gmv.success:
+  store i64 %gmv.payload, i64* %line_id_out
+  ret i64 1
+
+gmv.eof:
+  ret i64 0
+
+gmv.error:
+  ret i64 -1
+}
+
+; awk main-input `getline`: read the next primary-stream record into $0.
+; Use the transient reader so a drain loop keeps the main driver constant-space.
+; Snapshot the old record first and restore it on an error; clean EOF does not
+; modify the transient buffer. This shares the outer handle and active RS/RT.
+; Returns the awk 1, 0, or -1 status.
+define i64 @wam_getline_main_record(%Value %handle) {
+entry:
+  %gmr.old_ptr = load i8*, i8** @wam_transient_line_buf
+  %gmr.have_old = icmp ne i8* %gmr.old_ptr, null
+  br i1 %gmr.have_old, label %gmr.snapshot, label %gmr.read_without_snapshot
+
+gmr.snapshot:
+  %gmr.old_len = call i64 @strlen(i8* %gmr.old_ptr)
+  %gmr.snapshot_len = add i64 %gmr.old_len, 1
+  %gmr.snapshot_ptr = call i8* @malloc(i64 %gmr.snapshot_len)
+  %gmr.snapshot_null = icmp eq i8* %gmr.snapshot_ptr, null
+  br i1 %gmr.snapshot_null, label %gmr.error_without_read, label %gmr.save
+
+gmr.save:
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %gmr.snapshot_ptr, i8* %gmr.old_ptr, i64 %gmr.snapshot_len, i1 false)
+  br label %gmr.read
+
+gmr.read_without_snapshot:
+  br label %gmr.read
+
+gmr.read:
+  %gmr.saved_ptr = phi i8* [ %gmr.snapshot_ptr, %gmr.save ], [ null, %gmr.read_without_snapshot ]
+  %gmr.saved_len = phi i64 [ %gmr.old_len, %gmr.save ], [ 0, %gmr.read_without_snapshot ]
+  %gmr.line = call %Value @wam_stream_read_line_transient_value(%Value %handle)
+  %gmr.tag = extractvalue %Value %gmr.line, 0
+  %gmr.payload = extractvalue %Value %gmr.line, 1
+  %gmr.is_int = icmp eq i32 %gmr.tag, 1
+  %gmr.negative = icmp slt i64 %gmr.payload, 0
+  %gmr.read_error = and i1 %gmr.is_int, %gmr.negative
+  br i1 %gmr.read_error, label %gmr.restore_or_error, label %gmr.check_atom
+
+gmr.check_atom:
+  %gmr.is_atom = icmp eq i32 %gmr.tag, 0
+  br i1 %gmr.is_atom, label %gmr.check_record, label %gmr.restore_or_error
+
+gmr.check_record:
+  %gmr.is_record = icmp eq i64 %gmr.payload, 4611686018427387904
+  br i1 %gmr.is_record, label %gmr.success, label %gmr.eof
+
+gmr.success:
+  call void @free(i8* %gmr.saved_ptr)
+  ret i64 1
+
+gmr.eof:
+  call void @free(i8* %gmr.saved_ptr)
+  ret i64 0
+
+gmr.restore_or_error:
+  %gmr.have_snapshot = icmp ne i8* %gmr.saved_ptr, null
+  br i1 %gmr.have_snapshot, label %gmr.restore, label %gmr.error_without_read
+
+gmr.restore:
+  %gmr.restored = call i64 @wam_transient_atom_from_bytes(i8* %gmr.saved_ptr, i64 %gmr.saved_len)
+  call void @free(i8* %gmr.saved_ptr)
+  ret i64 -1
+
+gmr.error_without_read:
+  ret i64 -1
+}
+
 ; awk getline from a literal file into the current record. Reuse the shared
 ; filename registry and persistent reader, but force a physical newline record
 ; for this v1 form and suppress RT changes. On success, copy the persistent

--- a/tests/test_plawk_getline.pl
+++ b/tests/test_plawk_getline.pl
@@ -11,8 +11,8 @@
 % file shares it (as in awk). On EOF the status is 0 and var is unchanged; an
 % open/read error yields -1. The canonical loop is prime-then-re-read:
 %   r = getline v < "f"; while (r > 0) { ...; r = getline v < "f" }
-% (getline inside a while CONDITION is a follow-on; `getline` into $0, plain
-% `getline`, and `cmd | getline` are follow-ons.)
+% The direct while-condition form and the redirected/main-input record forms
+% have their own coverage; `cmd | getline` remains a follow-on.
 
 :- use_module(library(plunit)).
 :- use_module(library(process)).

--- a/tests/test_plawk_getline_main.pl
+++ b/tests/test_plawk_getline_main.pl
@@ -1,0 +1,277 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Main-input getline shares the record driver's stream. Both target forms
+% advance NR/FNR on success; only the record form replaces $0 and therefore
+% changes the lazily projected fields and NF. EOF and read errors preserve the
+% target and return 0/-1 respectively.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../src/unifyweaver/targets/wam_llvm_target',
+              [write_wam_llvm_project/3]).
+
+:- dynamic user:getline_main_runtime_probe/0.
+
+user:getline_main_runtime_probe.
+
+:- begin_tests(plawk_getline_main).
+
+% --- parsing ---------------------------------------------------------------
+
+test(main_record_bare_parses) :-
+    plawk_parse_string("{ getline }\n",
+        program([], [rule(always, [getline_main_record])], [])),
+    !.
+
+test(main_var_bare_parses) :-
+    plawk_parse_string("{ getline line }\n",
+        program([], [rule(always, [getline_main_var(line)])], [])),
+    !.
+
+test(main_record_capture_parses) :-
+    plawk_parse_string("{ status = getline; print status }\n",
+        program([], [rule(always,
+            [getline_main_record_capture(status), print([var(status)])])], [])),
+    !.
+
+test(main_var_capture_parses) :-
+    plawk_parse_string("{ status = getline line; print status, line }\n",
+        program([], [rule(always,
+            [getline_main_var_capture(status, line),
+             print([var(status), var(line)])])], [])),
+    !.
+
+test(main_record_while_normalises) :-
+    plawk_parse_string("{ while ((getline) > 0) print $0 }\n",
+        program(_, [rule(always, Actions)], _)),
+    Actions = [ getline_main_record_capture('$getline_status'),
+                while_loop(cmp(var('$getline_status'), gt, int(0)),
+                    [print([field(0)]),
+                     getline_main_record_capture('$getline_status')]) ],
+    !.
+
+test(main_var_while_normalises) :-
+    plawk_parse_string("{ while ((getline line) > 0) print line }\n",
+        program(_, [rule(always, Actions)], _)),
+    Actions = [ getline_main_var_capture('$getline_status', line),
+                while_loop(cmp(var('$getline_status'), gt, int(0)),
+                    [print([var(line)]),
+                     getline_main_var_capture('$getline_status', line)]) ],
+    !.
+
+% A newline terminates the no-target form rather than being consumed as the
+% whitespace before a variable target.
+test(main_record_newline_boundary) :-
+    plawk_parse_string("{ getline\nprint $0 }\n",
+        program([], [rule(always,
+            [getline_main_record, print([field(0)])])], [])),
+    !.
+
+test(main_record_capture_newline_boundary) :-
+    plawk_parse_string("{ status = getline\nprint status }\n",
+        program([], [rule(always,
+            [getline_main_record_capture(status), print([var(status)])])], [])),
+    !.
+
+% --- runtime ---------------------------------------------------------------
+
+% The first outer record is NR 1. Main getline consumes record 2 and replaces
+% $0; the outer loop then consumes record 3, whose getline sees EOF. This also
+% checks that EOF preserves the record and that END sees all three records.
+test(main_record_updates_fields_counters_and_eof, [condition(clang_available)]) :-
+    mdir(Dir),
+    Src = "BEGIN { FS = \":\"; OFS = \"|\" } { r = getline; print r, NR, FNR, $0, $1, $2, NF } END { print \"end\", NR, FNR }\n",
+    build_run(Dir, 'record_state', Src,
+        "alpha:one\nbeta:two\ngamma:three\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1|2|2|beta:two|beta|two|2\n0|3|3|gamma:three|gamma|three|2\nend|3|3\n"),
+    !.
+
+% Scalar-target getline advances the counters and target, but leaves the outer
+% record and its fields untouched. EOF preserves both the scalar and $0.
+test(main_var_preserves_record_and_eof_target, [condition(clang_available)]) :-
+    mdir(Dir),
+    Src = "BEGIN { FS = \":\"; OFS = \"|\" } { r = getline v; print r, v, NR, FNR, $0, $1, $2, NF } END { print \"end\", NR }\n",
+    build_run(Dir, 'var_state', Src,
+        "outer:one\ninner:two\ntail:three\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1|inner:two|2|2|outer:one|outer|one|2\n0|inner:two|3|3|tail:three|tail|three|2\nend|3\n"),
+    !.
+
+test(main_record_bare_reads, [condition(clang_available)]) :-
+    mdir(Dir),
+    build_run(Dir, 'record_bare',
+        "BEGIN { OFS = \"|\" } { getline; print NR, FNR, $0 }\n",
+        "first\nsecond\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2|2|second\n"),
+    !.
+
+test(main_var_bare_reads, [condition(clang_available)]) :-
+    mdir(Dir),
+    build_run(Dir, 'var_bare',
+        "BEGIN { OFS = \"|\" } { getline v; print NR, FNR, v, $0 }\n",
+        "first\nsecond\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2|2|second|first\n"),
+    !.
+
+% A later guard in the same rule observes the counter and record advanced by
+% getline inside an earlier branch; the hidden NR/FNR value must cross the if
+% join rather than falling back to the outer-loop entry count.
+test(main_record_updates_later_guard, [condition(clang_available)]) :-
+    mdir(Dir),
+    build_run(Dir, 'later_guard',
+        "BEGIN { OFS = \"|\" } { if (NR == 1) getline; if (NR == 2) print NR, FNR, $0 }\n",
+        "first\nsecond\nthird\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2|2|second\n"),
+    !.
+
+test(main_record_while_drains_stream, [condition(clang_available)]) :-
+    mdir(Dir),
+    Src = "BEGIN { OFS = \"|\" } { while ((getline) > 0) print NR, $0; print \"done\", NR, $0 } END { print \"end\", NR }\n",
+    build_run(Dir, 'record_while', Src,
+        "header\nred\ngreen\nblue\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2|red\n3|green\n4|blue\ndone|4|blue\nend|4\n"),
+    !.
+
+test(main_var_while_drains_without_changing_record, [condition(clang_available)]) :-
+    mdir(Dir),
+    Src = "BEGIN { OFS = \"|\" } { while ((getline v) > 0) print NR, v, $0; print \"done\", NR, v, $0 }\n",
+    build_run(Dir, 'var_while', Src,
+        "header\nred\ngreen\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2|red|header\n3|green|header\ndone|3|green|header\n"),
+    !.
+
+% Main getline is sourced through the same persistent reader as the outer
+% driver, so it observes the active regex RS and updates RT to its own match.
+test(main_record_uses_active_regex_rs, [condition(clang_available)]) :-
+    mdir(Dir),
+    Src = "BEGIN { RS = \"[0-9]+\"; OFS = \"|\" } { r = getline; print r, NR, $0, RT } END { print \"end\", NR }\n",
+    build_run(Dir, 'regex_rs', Src,
+        "outer12inner345tail", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1|2|inner|345\n0|3|tail|\nend|3\n"),
+    !.
+
+% A malformed handle exercises the runtime read-error path directly. Both
+% helpers return -1, and the scalar helper leaves its output slot untouched.
+test(main_helpers_return_minus_one_on_read_error, [condition(clang_available)]) :-
+    mdir(Dir),
+    directory_file_path(Dir, 'getline_main_error.ll', LLPath),
+    write_wam_llvm_project(
+        [user:getline_main_runtime_probe/0],
+        [module_name('getline_main_error')], LLPath),
+    read_file_to_string(LLPath, RuntimeIR, []),
+    assertion(once(sub_string(RuntimeIR, _, _, _,
+        '%gmr.line = call %Value @wam_stream_read_line_transient_value'))),
+    setup_call_cleanup(
+        open(LLPath, append, S, [encoding(utf8)]),
+        write(S,
+'\n@.getline_main_keep = private constant [5 x i8] c"keep\\00"
+
+define i32 @main() {
+entry:
+  %slot = alloca i64, align 8
+  store i64 777, i64* %slot
+  %keep_ptr = getelementptr [5 x i8], [5 x i8]* @.getline_main_keep, i64 0, i64 0
+  %seed = call i64 @wam_transient_atom_from_bytes(i8* %keep_ptr, i64 4)
+  %bad0 = insertvalue %Value undef, i32 0, 0
+  %bad = insertvalue %Value %bad0, i64 0, 1
+  %var_status = call i64 @wam_getline_main_var(%Value %bad, i64* %slot)
+  %after = load i64, i64* %slot
+  %var_error = icmp eq i64 %var_status, -1
+  %preserved = icmp eq i64 %after, 777
+  %record_status = call i64 @wam_getline_main_record(%Value %bad)
+  %record_error = icmp eq i64 %record_status, -1
+  %record_ptr = call i8* @wam_atom_to_string(i64 4611686018427387904)
+  %record_cmp = call i32 @strcmp(i8* %record_ptr, i8* %keep_ptr)
+  %record_preserved = icmp eq i32 %record_cmp, 0
+  %both0 = and i1 %var_error, %preserved
+  %both1 = and i1 %both0, %record_error
+  %both = and i1 %both1, %record_preserved
+  %exit = select i1 %both, i32 0, i32 1
+  ret i32 %exit
+}
+'),
+        close(S)),
+    directory_file_path(Dir, 'getline_main_error_bin', Bin),
+    process_create(path(clang), ['-w', LLPath, '-o', Bin, '-lm'],
+        [stdout(null), stderr(std), process(CPid)]),
+    process_wait(CPid, exit(0)),
+    process_create(Bin, [],
+        [stdout(null), stderr(std), process(RPid)]),
+    process_wait(RPid, exit(0)),
+    !.
+
+% --- explicit v1 rejection boundary ---------------------------------------
+
+test(unsupported_getline_shapes_exit_3, [condition(clang_available)]) :-
+    mdir(Dir),
+    Cases = [ pipe-"{ cmd | getline }\n",
+              dynamic_file-"{ getline < filename }\n",
+              dynamic_field-"{ getline < $1 }\n",
+              dynamic_scalar_target-"{ getline v < $1 }\n",
+              begin_record-"BEGIN { getline } { print $0 }\n",
+              begin_var-"BEGIN { getline v } { print $0 }\n",
+              begin_record_capture-"BEGIN { s = getline } { print $0 }\n",
+              begin_var_capture-"BEGIN { s = getline v } { print $0 }\n",
+              end_record-"{ print $0 } END { getline }\n",
+              end_var-"{ print $0 } END { getline v }\n",
+              end_record_capture-"{ print $0 } END { s = getline }\n",
+              end_var_capture-"{ print $0 } END { s = getline v }\n"
+            ],
+    forall(member(Name-Src, Cases),
+        ( build_status(Dir, Name, Src, Status),
+          assertion(Status == exit(3))
+        )),
+    !.
+
+:- end_tests(plawk_getline_main).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+mdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_getline_main', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Src, Bin-Prog) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        format(S, "~s", [Src]), close(S)),
+    atom_concat(Prog0, '_bin', Bin).
+
+build_status(Dir, Name, Src, Status) :-
+    write_prog(Dir, Name, Src, Bin-Prog),
+    process_create(path(swipl),
+        ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, Status).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    write_prog(Dir, Name, Src, Bin-Prog),
+    process_create(path(swipl),
+        ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~s", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).

--- a/tests/test_plawk_getline_record.pl
+++ b/tests/test_plawk_getline_record.pl
@@ -133,17 +133,12 @@ test(record_getline_long_record_prints, [condition(clang_available)]) :-
 
 test(unsupported_getline_shapes_exit_3, [condition(clang_available)]) :-
     rdir(Dir),
-    Cases = [ plain-"{ getline }\n",
-              main_var-"{ getline v }\n",
-              pipe-"{ cmd | getline }\n",
+    Cases = [ pipe-"{ cmd | getline }\n",
               dynamic_file-"{ getline < filename }\n",
               dynamic_field-"{ getline < $1 }\n",
               dynamic_paren-"{ getline < (filename) }\n",
               dynamic_scalar_target-"{ getline v < $1 }\n",
-              capture_main-"{ r = getline }\n",
               capture_dynamic-"{ r = getline < $1 }\n",
-              while_main-"{ while ((getline) > 0) print $0 }\n",
-              while_main_var-"{ while ((getline v) > 0) print $0 }\n",
               while_dynamic-"{ while ((getline < filename) > 0) print $0 }\n",
               begin_ctx-"BEGIN { getline < \"x\" } { print $0 }\n",
               begin_capture-"BEGIN { r = getline < \"x\" } { print $0 }\n",


### PR DESCRIPTION
## Summary

- Add main-input `getline` into `$0` and `getline var` into a scalar.
- Support bare statements, status assignment, and both canonical `while ((getline ...) > 0)` drain idioms.
- Consume the exact stream owned by the outer record driver, so records read by `getline` are not processed again by the surrounding loop.
- Advance `NR` and `FNR` only when a main-input read succeeds.

## Semantics

- `getline` updates `$0`, re-splits fields with the active `FS`, updates `NF`, and advances `NR`/`FNR`.
- `getline var` updates the scalar and advances `NR`/`FNR`, while preserving `$0`, fields, and `NF`.
- Both forms return 1 for a record, 0 at EOF, or -1 on a read error.
- EOF and errors preserve the destination.
- The main-input forms share the driver's active `RS`, `RT`, regex replay, and buffered position.
- The `$0` form uses the transient reader and restores the previous record on failure, retaining the main loop's non-accumulating record storage.

## Implementation

- Extend the parser with distinct record/scalar AST nodes and normalize the two while idioms through the existing loop machinery.
- Lower reads against the driver-owned `%handle`.
- Thread a hidden record-number slot through rule, branch, loop, `next`/`break`, mixed scalar/assoc, and `END` PHIs so post-getline `NR`/`FNR` reads observe the updated count.
- Keep pipelines, dynamic redirections, and getline in `BEGIN`/`END` as clean exit-3 rejections.
- Update the feature audit and remove obsolete unsupported-main-getline expectations.

## Validation

- `tests/test_plawk_getline_main.pl`: 18/18 passed.
- Existing redirected getline suites: 21/21 passed.
- `tests/test_plawk_while.pl`: 15/15 passed.
- `tests/test_plawk_if_bodies.pl`: 13/13 passed.
- Runtime coverage includes field re-splitting, target preservation, 1/0/-1 statuses, outer-loop interaction, later guards, regex `RS`/`RT`, and final `NR`/`FNR`.

## Coordination

This couples to the main record-driver loop and shared `NR`/`FNR` counters; it reuses the transient record buffer + field-recompute path from redirected-record getline (#3912). The driver-loop coupling is the main risk area for review. No known conflict with in-flight work.