### PR TITLE
LMDB-R-2B: shared auto materialisation resolution for versioned arg1 source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run R focused regressions (switch-index + LMDB)
         run: |
-          swipl -q -f init.pl -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:switch_on_constant_fallthrough_is_linear_noop,wam_r_generator:switch_on_term_a2_is_switch_on_term_noop,wam_r_generator:switch_on_constant_fallthrough_preserves_backtracking,wam_r_generator:r_a2_switch_hints_are_linear_noop,wam_r_generator:r_a2_fallthrough_preserves_backtracking,wam_r_generator:lmdb_r0_source_dispatch_selection,wam_r_generator:lmdb_arg1_v1_mock_adapter_lookup_and_stream,wam_r_generator:lmdb_arg1_v1_real_binding_e2e_rscript,wam_r_generator:lmdb_r1_materialisation_codegen,wam_r_generator:lmdb_r1_eager_lazy_runtime_parity,wam_r_generator:lmdb_r2a_cached_codegen,wam_r_generator:lmdb_r2a_cached_runtime])" -t halt
+          swipl -q -f init.pl -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:switch_on_constant_fallthrough_is_linear_noop,wam_r_generator:switch_on_term_a2_is_switch_on_term_noop,wam_r_generator:switch_on_constant_fallthrough_preserves_backtracking,wam_r_generator:r_a2_switch_hints_are_linear_noop,wam_r_generator:r_a2_fallthrough_preserves_backtracking,wam_r_generator:lmdb_r0_source_dispatch_selection,wam_r_generator:lmdb_arg1_v1_mock_adapter_lookup_and_stream,wam_r_generator:lmdb_arg1_v1_real_binding_e2e_rscript,wam_r_generator:lmdb_r1_materialisation_codegen,wam_r_generator:lmdb_r1_eager_lazy_runtime_parity,wam_r_generator:lmdb_r2a_cached_codegen,wam_r_generator:lmdb_r2a_cached_runtime,wam_r_generator:lmdb_r2b_auto_materialisation_codegen])" -t halt
 
       - name: Run full R classic conformance
         run: |

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -49,7 +49,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | LMDB-R-0 ✅ | LMDB lookup source (prereq) | R | M | done (`lmdb_arg1_v1`) |
 | LMDB-R-1 ✅ | eager/lazy materialisation | R | S | done (`lmdb_materialisation`) |
 | LMDB-R-2A ✅ | bounded cached materialisation | R | S | done (`cached` + L2) |
-| LMDB-R-2B | auto materialisation resolution | R | S | LMDB-R-2A |
+| LMDB-R-2B ✅ | auto materialisation resolution | R | S | done (shared `resolve_auto_lmdb_materialisation/2`) |
 | ISO-C | ISO three-form (new) | C | L | — |
 | ISO-GO | ISO three-form (new) | Go | L | — |
 | ISO-SCALA | ISO three-form (new) | Scala | L | — |
@@ -365,13 +365,15 @@ path, not the reverse index.
 - **Status:** Landed. `lmdb_materialisation(cached)` + `lmdb_l2_capacity(N)`
   (default 4096, positive int): per-source L1 MRU + bounded L2 true-LRU
   over `lmdb_arg1_v1_lookup`. Ground hits/misses cache complete buckets
-  (incl. empty); unbound stream-all bypasses the cache. `auto` still
-  rejected (`domain_error`) until LMDB-R-2B.
+  (incl. empty); unbound stream-all bypasses the cache.
 
-### LMDB-R-2B: auto materialisation resolution
-- **Depends on:** LMDB-R-2A. Resolve `lmdb_materialisation(auto)` using
-  shared/fleet cost-model conventions (do not invent a new heuristic
-  surface). Keep R-1/R-2A modes green.
+### LMDB-R-2B ✅: auto materialisation resolution
+- **Status:** Landed. Explicit `lmdb_materialisation(auto)` resolves at
+  codegen via shared `resolve_auto_lmdb_materialisation/2` into the
+  existing eager/lazy/cached emitters. **Absent option stays lazy** —
+  the shared resolver is not consulted (its no-metadata default is
+  eager). Unknown modes retain `domain_error(lmdb_materialisation, Value)`.
+  LMDB-R sequence (R-0 → R-1 → R-2A → R-2B) complete.
 
 ---
 

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -41,8 +41,9 @@ runtime-parser default is native, with the compiled
 
 **Optional LMDB.** Legacy `lmdb(Path)` remains load-everything.
 Versioned `lmdb_arg1_v1(Path)` supports `lmdb_materialisation(lazy)`
-(default), `eager`, and `cached` (+ `lmdb_l2_capacity`, default 4096).
-`auto` remains open (LMDB-R-2B).
+(default when omitted), `eager`, `cached` (+ `lmdb_l2_capacity`,
+default 4096), and explicit `auto` (codegen resolves via shared
+`resolve_auto_lmdb_materialisation/2`). LMDB-R-0/R-1/R-2A/R-2B complete.
 
 ## Gaps (relative to Rust / Haskell / F#)
 
@@ -51,16 +52,14 @@ Versioned `lmdb_arg1_v1(Path)` supports `lmdb_materialisation(lazy)`
   forms (`switch_on_constant_a2`, `_a2_fallthrough`, `switch_on_structure_a2`)
   — map to the existing `SwitchOnTerm()` linear no-op (not optimized A2
   dispatch), preserving the full try/retry/trust chain.
-- **LMDB-R-2B** auto resolution still open; LMDB-R-0/R-1/R-2A landed.
 - **ISO error support** is `tryCatch`-level only, not the three-form
   contract.
 - No dedicated effective-distance cross-target bench row.
 
 ## Path forward
 
-1. LMDB-R-2B auto over `lmdb_arg1_v1`.
-2. ISO three-form adoption if R joins the error-fidelity set.
-3. Effective-distance cross-target matrix row.
+1. ISO three-form adoption if R joins the error-fidelity set.
+2. Effective-distance cross-target matrix row.
 
 ## Document status
 

--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -343,14 +343,17 @@ supported today:
   (arity ≥ 2). Schema key `__uw_schema__=lmdb_arg1_v1`; values are
   NL-buckets of TAB-tagged args 2..N (atom payloads URL-percent-encoded).
   Materialisation via project option `lmdb_materialisation(Mode)`:
-  - `lazy` (default) — ground arg1 exact-key get; unbound stream-all
+  - omit / `lazy` — ground arg1 exact-key get; unbound stream-all
+    (absent option stays lazy; shared resolver is not consulted)
   - `eager` — stream the v1 DB once at init, `build_fact_indexes`,
     then `fact_table_dispatch` (not legacy `read_facts_lmdb`)
   - `cached` — per-source L1 MRU + bounded L2 true-LRU over lookup;
     `lmdb_l2_capacity(N)` (default 4096, positive int) sizes L2 by
     distinct arg1 keys (empty/missing buckets count). Unbound queries
     stream-all and bypass the cache.
-  - `auto` — unsupported (domain error; LMDB-R-2B)
+  - `auto` — resolved at codegen via shared
+    `resolve_auto_lmdb_materialisation/2` into eager/lazy/cached
+    (no runtime auto conditional)
   Writer: `lmdb_write_facts_arg1_v1`.
 
 ```prolog

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -73,6 +73,8 @@
 :- use_module(wam_runtime_parser_capability,
              [parser_dependent_body_goal/2,
               wam_target_runtime_parser/3]).
+:- use_module('../core/cost_model',
+             [resolve_auto_lmdb_materialisation/2]).
 
 % ============================================================================
 % EMIT MODE
@@ -1424,12 +1426,15 @@ fact_source_pi_match(Name/Ar, P, Arity) :-
     Name == P, Ar =:= Arity.
 
 %% r_normalize_fact_source_spec(+Spec0, +Options, -Spec)
-%  lmdb_arg1_v1 → lmdb_arg1_v1(Path, Mode) or
-%  lmdb_arg1_v1(Path, cached, Cap). Default Mode=lazy.
-%  auto/unknown → domain_error (LMDB-R-2B).
+%  lmdb_arg1_v1 → concrete Mode via existing R-1/R-2A emitters.
+%  Absent lmdb_materialisation → lazy (R default; do NOT call the
+%  shared resolver, whose no-metadata default is eager).
+%  Explicit auto/lazy/eager/cached → resolve_auto_lmdb_materialisation/2.
 r_normalize_fact_source_spec(lmdb_arg1_v1(Path), Options, Spec) :- !,
-    option(lmdb_materialisation(Mode0), Options, lazy),
-    r_lmdb_arg1_v1_materialisation(Mode0, Mode),
+    (   option(lmdb_materialisation(_), Options)
+    ->  resolve_auto_lmdb_materialisation(Options, Mode)
+    ;   Mode = lazy
+    ),
     (   Mode == cached
     ->  option(lmdb_l2_capacity(Cap0), Options, 4096),
         r_lmdb_l2_capacity(Cap0, Cap),
@@ -1437,13 +1442,6 @@ r_normalize_fact_source_spec(lmdb_arg1_v1(Path), Options, Spec) :- !,
     ;   Spec = lmdb_arg1_v1(Path, Mode)
     ).
 r_normalize_fact_source_spec(Spec, _Options, Spec).
-
-r_lmdb_arg1_v1_materialisation(lazy, lazy) :- !.
-r_lmdb_arg1_v1_materialisation(eager, eager) :- !.
-r_lmdb_arg1_v1_materialisation(cached, cached) :- !.
-r_lmdb_arg1_v1_materialisation(Mode, _) :-
-    % auto and unknowns stay rejected until LMDB-R-2B.
-    throw(error(domain_error(lmdb_materialisation, Mode), _)).
 
 r_lmdb_l2_capacity(N, N) :-
     integer(N), N > 0, !.

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -4665,12 +4665,11 @@ test(lmdb_r1_materialisation_codegen) :-
                    \+ sub_string(C2,_,_,_,'lmdb_arg1_v1_dispatch('),
                    \+ sub_string(C2,_,_,_,'read_facts_lmdb'))),
         delete_directory_and_contents(Tmp),
-        forall(member(Bad, [auto, weird]),
-               catch((write_wam_r_project([user:bedge/2],
-                          [lmdb_materialisation(Bad),
-                           r_fact_sources([source(bedge/2, lmdb_arg1_v1('/tmp/b.lmdb'))])], Tmp),
-                      throw(unexpected_success)),
-                     error(domain_error(lmdb_materialisation, Bad), _), true)),
+        catch((write_wam_r_project([user:bedge/2],
+                    [lmdb_materialisation(weird),
+                     r_fact_sources([source(bedge/2, lmdb_arg1_v1('/tmp/b.lmdb'))])], Tmp),
+               throw(unexpected_success)),
+              error(domain_error(lmdb_materialisation, weird), _), true),
         write_wam_r_project([user:leg2/2],
             [lmdb_materialisation(eager),
              r_fact_sources([source(leg2/2, lmdb('/tmp/leg2.lmdb'))])], Tmp),
@@ -4758,11 +4757,6 @@ test(lmdb_r2a_cached_codegen) :-
                            r_fact_sources([source(badc/2, lmdb_arg1_v1('/tmp/x.lmdb'))])], Tmp),
                       throw(unexpected_success)),
                      error(domain_error(lmdb_l2_capacity_positive_integer, BadCap), _), true)),
-        catch((write_wam_r_project([user:autox/2],
-                    [lmdb_materialisation(auto),
-                     r_fact_sources([source(autox/2, lmdb_arg1_v1('/tmp/a.lmdb'))])], Tmp),
-               throw(unexpected_success)),
-              error(domain_error(lmdb_materialisation, auto), _), true),
         write_wam_r_project([user:legc/2],
             [lmdb_materialisation(cached),
              r_fact_sources([source(legc/2, lmdb('/tmp/legc.lmdb'))])], Tmp),
@@ -4852,6 +4846,87 @@ cat("OK\n")
     assertion(Status == exit(0)), assertion(sub_string(Out,_,_,_,"OK")),
     assertion(\+ sub_string(Err,_,_,_,"Error")),
     delete_directory_and_contents(TmpDir).
+
+% ------------------------------------------------------------------
+% LMDB-R-2B: shared auto materialisation resolution (codegen-time).
+% ------------------------------------------------------------------
+%% lmdb_r_mode_markers(+Mode, +Code) — concrete path only, no auto runtime.
+lmdb_r_mode_markers(lazy, C) :-
+    assertion((sub_string(C,_,_,_,'lmdb_arg1_v1_dispatch('),
+               sub_string(C,_,_,_,'lmdb_arg1_v1 lazy:'),
+               \+ sub_string(C,_,_,_,'lmdb_arg1_v1_stream('),
+               \+ sub_string(C,_,_,_,'lmdb_arg1_v1_cached_dispatch('))).
+lmdb_r_mode_markers(eager, C) :-
+    assertion((sub_string(C,_,_,_,'lmdb_arg1_v1_stream('),
+               sub_string(C,_,_,_,'build_fact_indexes('),
+               sub_string(C,_,_,_,'lmdb_arg1_v1 eager:'),
+               \+ sub_string(C,_,_,_,'lmdb_arg1_v1_dispatch('),
+               \+ sub_string(C,_,_,_,'lmdb_arg1_v1_cached_dispatch('))).
+lmdb_r_mode_markers(cached, C) :-
+    assertion((sub_string(C,_,_,_,'lmdb_arg1_v1_cached_dispatch('),
+               sub_string(C,_,_,_,'lmdb_arg1_v1_new_cache('),
+               \+ sub_string(C,_,_,_,'lmdb_arg1_v1_dispatch('),
+               \+ sub_string(C,_,_,_,'lmdb_arg1_v1_stream('))).
+
+lmdb_r_gen_mode(Tmp, ExtraOpts, Mode) :-
+    append([r_fact_sources([source(aedge/2, lmdb_arg1_v1('/tmp/a.lmdb'))])],
+           ExtraOpts, Opts),
+    write_wam_r_project([user:aedge/2], Opts, Tmp),
+    directory_file_path(Tmp, 'R/generated_program.R', P),
+    read_file_to_string(P, C, []),
+    lmdb_r_mode_markers(Mode, C),
+    assertion(\+ sub_string(C,_,_,_,'resolve_auto_lmdb')),
+    delete_directory_and_contents(Tmp), make_directory_path(Tmp).
+
+test(lmdb_r2b_auto_materialisation_codegen) :-
+    once((
+        unique_r_tmp_dir('tmp_r_lmdb_r2b', Tmp),
+        % 1) absent option → lazy (must not invoke shared no-metadata eager)
+        lmdb_r_gen_mode(Tmp, [], lazy),
+        % 2) explicit modes pass through
+        forall(member(M, [lazy, eager, cached]),
+               lmdb_r_gen_mode(Tmp, [lmdb_materialisation(M)], M)),
+        % 3) auto → eager at 1k
+        lmdb_r_gen_mode(Tmp, [lmdb_materialisation(auto), fact_count(1000)], eager),
+        % 4) auto → cached (default + explicit capacity)
+        lmdb_r_gen_mode(Tmp, [lmdb_materialisation(auto), fact_count(297000)], cached),
+        write_wam_r_project([user:aedge/2],
+            [lmdb_materialisation(auto), fact_count(297000), lmdb_l2_capacity(7),
+             r_fact_sources([source(aedge/2, lmdb_arg1_v1('/tmp/a.lmdb'))])], Tmp),
+        directory_file_path(Tmp, 'R/generated_program.R', PCap),
+        read_file_to_string(PCap, CCap, []),
+        assertion(sub_string(CCap,_,_,_,'lmdb_arg1_v1_new_cache(7L)')),
+        lmdb_r_mode_markers(cached, CCap),
+        delete_directory_and_contents(Tmp), make_directory_path(Tmp),
+        % 5) large + segregated → lazy
+        lmdb_r_gen_mode(Tmp,
+            [lmdb_materialisation(auto), fact_count(9930000),
+             workload_segregated(true)], lazy),
+        % 6) budget-overflow branches
+        lmdb_r_gen_mode(Tmp,
+            [lmdb_materialisation(auto), fact_count(2000), memory_budget(1000)],
+            cached),
+        lmdb_r_gen_mode(Tmp,
+            [lmdb_materialisation(auto), fact_count(2000), memory_budget(1000),
+             workload_segregated(true)], lazy),
+        % 7) explicit auto, no metadata → shared resolver (eager)
+        lmdb_r_gen_mode(Tmp, [lmdb_materialisation(auto)], eager),
+        % 8) unknown mode → generic domain_error
+        catch((write_wam_r_project([user:aedge/2],
+                    [lmdb_materialisation(bogus),
+                     r_fact_sources([source(aedge/2, lmdb_arg1_v1('/tmp/a.lmdb'))])], Tmp),
+               throw(unexpected_success)),
+              error(domain_error(lmdb_materialisation, bogus), _), true),
+        % 9) legacy lmdb(Path) unchanged under auto metadata
+        write_wam_r_project([user:legb/2],
+            [lmdb_materialisation(auto), fact_count(297000),
+             r_fact_sources([source(legb/2, lmdb('/tmp/legb.lmdb'))])], Tmp),
+        directory_file_path(Tmp, 'R/generated_program.R', PLeg),
+        read_file_to_string(PLeg, CLeg, []),
+        assertion((sub_string(CLeg,_,_,_,'read_facts_lmdb('),
+                   \+ sub_string(CLeg,_,_,_,'lmdb_arg1_v1_'))),
+        delete_directory_and_contents(Tmp)
+    )).
 
 % ------------------------------------------------------------------
 % End-to-end: cut barrier truncates state$cps back to the depth at the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Explicit `lmdb_materialisation(auto)` for `lmdb_arg1_v1(Path)` resolves at codegen time via shared `resolve_auto_lmdb_materialisation/2`. Concrete eager/lazy/cached modes continue through the existing R-1/R-2A emission paths.

**Compatibility:** when `lmdb_materialisation(...)` is absent, R stays **lazy**. The shared resolver is invoked only for an explicit option (its no-metadata default is eager).

## Behavior

| Input | Result |
|-------|--------|
| No option | lazy |
| Explicit lazy/eager/cached | unchanged |
| `auto` + `fact_count(1000)` | eager |
| `auto` + `fact_count(297000)` | cached (default or explicit `lmdb_l2_capacity`) |
| large + `workload_segregated(true)` | lazy |
| budget overflow, non-segregated | cached |
| budget overflow, segregated | lazy |
| `auto`, no metadata | shared resolver (eager) |
| unknown mode | `domain_error(lmdb_materialisation, Value)` |
| legacy `lmdb(Path)` | unaffected |

## Changes / LOC

| Area | Diff |
|------|------|
| Production (`wam_r_target.pl`) | +10 / −12 (net −2) |
| Tests | +86 / −11 |
| Docs | +20 / −16 |
| CI | +1 / −1 |

No R runtime or Mustache changes. No R-specific heuristic copy.

## Validation

Local:
- Focused R LMDB + switch-index regressions (incl. R-2B) — pass
- `CONFORMANCE_TARGETS=r,r_functions` classic conformance — pass
- Shared cost-model suite (`tests/core/test_cost_model.pl`, 56) — pass
- `git diff --check` — clean

Hosted workflow (`UnifyWeaver Tests`):
- Main `test` job — pass
- WAM R Conformance (interpreter + functions) — pass
- Conformance smokes + C# query smoke — pass

LMDB-R-0 → R-1 → R-2A → R-2B sequence marked complete in status docs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

