### PR TITLE
plawk: support command pipe getline

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -47,7 +47,7 @@ only (runtime pending) · ❌ missing.
 | `delete arr[k]` | ◐ | `delete arr[$k]` removes the entry keyed by a field (parity with `arr[$k]++`); backward-shift deletion in the runtime (later colliding keys stay reachable), missing key is a no-op. String-literal / var keys are a follow-on |
 | `exit [n]` | ✅ | stops the record loop, runs END, returns N (default 0); `exit` in a rule body, an `if`/`else` branch, or a loop (propagates past the loop) — scalar state at the exit point flows into END |
 | `delete arr[k]` | ❌ | |
-| `getline` | ◐ | **Main-input and redirected scalar/record getline landed.** Plain `getline` reads the next record from the primary driver stream into `$0`, re-splits `$1…$NF` with the active FS, updates `NF`, and advances `NR`/`FNR`; `getline var` advances the same stream and counters but preserves `$0`/fields. Both honor the active RS (including regex RS) and RT because they share the driver's reader state. Bare statements, `status = getline` / `status = getline var`, and the canonical `while ((getline …) > 0)` forms return/use 1 on a record, 0 at EOF, or -1 on a read error; EOF/error preserve the target. Redirected `getline var < "file"` and `getline < "file"` use filename-keyed handles; redirected record getline does **not** advance NR/FNR and remains physical-newline-only in v1 while preserving RS/RT. Cleanly rejected follow-ons: `cmd | getline`, dynamic filenames, and getline in BEGIN/END. The multi-pass / `over` readers still cover the bulk-scan use |
+| `getline` | ◐ | **Main-input, redirected, and command-pipe scalar/record getline landed.** Plain `getline` reads the next record from the primary driver stream into `$0`, re-splits `$1…$NF` with the active FS, updates `NF`, and advances `NR`/`FNR`; `getline var` advances the same stream and counters but preserves `$0`/fields. Both honor the active RS (including regex RS) and RT because they share the driver's reader state. Redirected `getline var < "file"` and `getline < "file"` use filename-keyed handles; redirected record getline does **not** advance NR/FNR and remains physical-newline-only in v1 while preserving RS/RT. Literal-command `"cmd" | getline` and `"cmd" | getline var` use a command-keyed `popen(cmd, "r")` registry shared by both target forms: the record target replaces `$0` and re-splits fields, the scalar target preserves `$0`/fields, and each successful pipe record advances `NR` (therefore also `FNR`, which is intentionally an alias of `NR` in plawk's single-input model). Pipe reads are physical-newline-only and preserve RT in v1; updating RT from the matched pipe separator remains a follow-on. All three families support bare statements, status capture, and canonical while-drain forms, returning 1 on a record, 0 at clean EOF (including a child that merely exits nonzero), or -1 on an actual pipe/open/read/close/allocation failure; EOF/error preserve the target. `cmd | getline` necessarily executes the shell command supplied by the awk program. Cleanly rejected follow-ons: dynamic filenames or commands, and getline in BEGIN/END. The multi-pass / `over` readers still cover the bulk-scan use |
 
 ## Functions
 
@@ -193,8 +193,7 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
 7. **`split` / `sub` / `gsub` / `match` / `sprintf`** — the string-builtin
    family; larger, lower priority for the DSL's data-pipeline focus.
 
-Deferred by design (the DSL's model diverges here): pipeline `cmd | getline`
-(the `over`/multi-pass readers subsume most bulk-scan uses),
-multi-file `FILENAME`/`FNR` (`ARGV[N]`/`ARGC` themselves are landed for rule
+Deferred by design (the DSL's model diverges here): multi-file `FILENAME`/`FNR`
+(`ARGV[N]`/`ARGC` themselves are landed for rule
 bodies — see the table), C-style `for(;;)` / `do-while` (the `while`
 runtime + for-in cover the loop needs).

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -6883,7 +6883,9 @@ plawk_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
     append(ActionVars, PrintVars, Names0),
     sort(Names0, Names),
     plawk_scalar_typed_slots(Rules, Names, ScalarSlots),
-    (   plawk_rules_have_main_getline(Rules)
+    (   ( plawk_rules_have_main_getline(Rules)
+        ; plawk_rules_have_pipe_getline(Rules)
+        )
     ->  append(ScalarSlots, [scalar_record_number], Slots)
     ;   Slots = ScalarSlots
     ).
@@ -6906,6 +6908,8 @@ plawk_action_has_record_getline(getline_file_record(_File)).
 plawk_action_has_record_getline(getline_file_record_capture(_Status, _File)).
 plawk_action_has_record_getline(getline_main_record).
 plawk_action_has_record_getline(getline_main_record_capture(_Status)).
+plawk_action_has_record_getline(getline_pipe_record(_Command)).
+plawk_action_has_record_getline(getline_pipe_record_capture(_Status, _Command)).
 plawk_action_has_record_getline(if(_Pattern, ThenActions, ElseActions)) :-
     ( plawk_actions_have_record_getline(ThenActions)
     ; plawk_actions_have_record_getline(ElseActions)
@@ -6945,6 +6949,35 @@ plawk_action_has_main_getline(do_while_loop(Body, _Cond)) :-
     plawk_actions_have_main_getline(Body).
 plawk_action_has_main_getline(foreach_loop(_Layout, Body)) :-
     plawk_actions_have_main_getline(Body).
+
+% Pipe getline reads do not consume the driver-owned stream, but POSIX awk
+% still advances NR on every successful command-output record. Keep their
+% detector separate from main-input getline so the source-stream distinction
+% remains explicit while both opt into the same hidden record-number slot.
+plawk_rules_have_pipe_getline(Rules) :-
+    member(rule(_Pattern, Actions), Rules),
+    plawk_actions_have_pipe_getline(Actions),
+    !.
+
+plawk_actions_have_pipe_getline(Actions) :-
+    member(Action, Actions),
+    plawk_action_has_pipe_getline(Action),
+    !.
+
+plawk_action_has_pipe_getline(getline_pipe_record(_Command)).
+plawk_action_has_pipe_getline(getline_pipe_record_capture(_Status, _Command)).
+plawk_action_has_pipe_getline(getline_pipe_read(_Var, _Command)).
+plawk_action_has_pipe_getline(getline_pipe_capture(_Status, _Var, _Command)).
+plawk_action_has_pipe_getline(if(_Pattern, ThenActions, ElseActions)) :-
+    ( plawk_actions_have_pipe_getline(ThenActions)
+    ; plawk_actions_have_pipe_getline(ElseActions)
+    ).
+plawk_action_has_pipe_getline(while_loop(_Cond, Body)) :-
+    plawk_actions_have_pipe_getline(Body).
+plawk_action_has_pipe_getline(do_while_loop(Body, _Cond)) :-
+    plawk_actions_have_pipe_getline(Body).
+plawk_action_has_pipe_getline(foreach_loop(_Layout, Body)) :-
+    plawk_actions_have_pipe_getline(Body).
 
 %% plawk_scalar_typed_slots(+Rules, +Names, -Slots)
 %
@@ -7099,8 +7132,8 @@ plawk_scalar_strnum_field_source(set(var(Name), int(field(FieldIndex))), Name) :
 
 % A strnum source: any assignment whose value is an external string of unknown
 % numericness -- a field copy, a command-line argument (`x = ARGV[N]`), or a
-% getline read (`getline var < "file"` / `status = getline var < "file"`). These
-% are POSIX strnums: their runtime content decides numeric vs lexical comparison.
+% getline read (`getline var < "file"`, main-input, or command-output). These are
+% POSIX strnums: their runtime content decides numeric vs lexical comparison.
 % All store an interned atom id into the slot (via set_str for argv/getline, via
 % the field-intern for a field), so they share the scalar_strnum representation.
 plawk_scalar_strnum_source(Action, Name) :-
@@ -7112,6 +7145,8 @@ plawk_scalar_strnum_source(getline_read(Name, _File), Name).
 plawk_scalar_strnum_source(getline_capture(_Status, Name, _File), Name).
 plawk_scalar_strnum_source(getline_main_var(Name), Name).
 plawk_scalar_strnum_source(getline_main_var_capture(_Status, Name), Name).
+plawk_scalar_strnum_source(getline_pipe_read(Name, _Command), Name).
+plawk_scalar_strnum_source(getline_pipe_capture(_Status, Name, _Command), Name).
 
 % A write is disqualifying unless it is a strnum-preserving source: a field copy
 % (`x = $N`) or a plain var copy (`z = x`, which propagates strnum-ness). Any
@@ -7360,7 +7395,9 @@ plawk_mixed_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
     append(ActionVars, PrintVars, Names0),
     sort(Names0, Names),
     plawk_scalar_typed_slots(Rules, Names, ScalarSlots),
-    (   plawk_rules_have_main_getline(Rules)
+    (   ( plawk_rules_have_main_getline(Rules)
+        ; plawk_rules_have_pipe_getline(Rules)
+        )
     ->  append(ScalarSlots, [scalar_record_number], Slots)
     ;   Slots = ScalarSlots
     ).
@@ -7529,6 +7566,11 @@ plawk_mixed_update_action(Action) :-
 plawk_mixed_update_action(getline_main_record).
 plawk_mixed_update_action(getline_main_record_capture(Status)) :-
     atom(Status).
+plawk_mixed_update_action(getline_pipe_record(Command)) :-
+    string(Command).
+plawk_mixed_update_action(getline_pipe_record_capture(Status, Command)) :-
+    atom(Status),
+    string(Command).
 plawk_mixed_update_action(if(_Pattern, ThenActions, ElseActions)) :-
     append(ThenActions, ElseActions, Actions),
     Actions \== [],
@@ -12419,6 +12461,18 @@ plawk_scalar_rule_body_action(getline_main_var(Var)) :-
 plawk_scalar_rule_body_action(getline_main_var_capture(Status, Var)) :-
     atom(Status),
     atom(Var).
+plawk_scalar_rule_body_action(getline_pipe_record(Command)) :-
+    string(Command).
+plawk_scalar_rule_body_action(getline_pipe_record_capture(Status, Command)) :-
+    atom(Status),
+    string(Command).
+plawk_scalar_rule_body_action(getline_pipe_read(Var, Command)) :-
+    atom(Var),
+    string(Command).
+plawk_scalar_rule_body_action(getline_pipe_capture(Status, Var, Command)) :-
+    atom(Status),
+    atom(Var),
+    string(Command).
 % the store-only half of a rule-level `exit N` (terminal_exit split); it is a
 % plain store with no control, valid anywhere a plain body action is.
 plawk_scalar_rule_body_action(exit_store(_Code)).
@@ -12464,6 +12518,18 @@ plawk_scalar_rule_body_plain_action(getline_main_var(Var)) :-
 plawk_scalar_rule_body_plain_action(getline_main_var_capture(Status, Var)) :-
     atom(Status),
     atom(Var).
+plawk_scalar_rule_body_plain_action(getline_pipe_record(Command)) :-
+    string(Command).
+plawk_scalar_rule_body_plain_action(getline_pipe_record_capture(Status, Command)) :-
+    atom(Status),
+    string(Command).
+plawk_scalar_rule_body_plain_action(getline_pipe_read(Var, Command)) :-
+    atom(Var),
+    string(Command).
+plawk_scalar_rule_body_plain_action(getline_pipe_capture(Status, Var, Command)) :-
+    atom(Status),
+    atom(Var),
+    string(Command).
 % `exit [N]` inside a branch body (`if (c) exit`): the sequence walker lowers it
 % via branch_exit + plawk_branch_to_done_ir (branch to break_close_stream); the
 % store-only marker `exit_store` may appear when a branch ends the rule.
@@ -13276,6 +13342,9 @@ plawk_scalar_update_action_name(getline_file_record_capture(Status, _File), Stat
 plawk_scalar_update_action_name(getline_main_record_capture(Status), Status).
 plawk_scalar_update_action_name(getline_main_var_capture(Status, Var), Name) :-
     ( Name = Var ; Name = Status ).
+plawk_scalar_update_action_name(getline_pipe_record_capture(Status, _Command), Status).
+plawk_scalar_update_action_name(getline_pipe_capture(Status, Var, _Command), Name) :-
+    ( Name = Var ; Name = Status ).
 plawk_scalar_update_action_name(dynrec_bind(Vars, _Call, _Types), Name) :-
     plawk_dynrec_binding_names(Vars, Names),
     member(Name, Names).
@@ -13388,6 +13457,17 @@ plawk_scalar_action_update(getline_main_var(Var), Var, set_str(getline_main)) :-
 plawk_scalar_action_update(getline_main_var_capture(_Status, Var), Var,
         set_str(getline_main)) :-
     atom(Var).
+% Command-output getline is a strnum-producing scalar source, just like file
+% and main-input getline. The dedicated sequence clauses perform the runtime
+% call; this declaration supplies slot planning and surface validation.
+plawk_scalar_action_update(getline_pipe_read(Var, Command), Var,
+        set_str(getline_pipe(Command))) :-
+    atom(Var),
+    string(Command).
+plawk_scalar_action_update(getline_pipe_capture(_Status, Var, Command), Var,
+        set_str(getline_pipe(Command))) :-
+    atom(Var),
+    string(Command).
 % Ternary assignment `x = COND ? A : B`: an i64 value via select (the operation
 % lowers through plawk_scalar_numeric_expr_ir(ternary(...)) -> plawk_i64_expr_ir).
 plawk_scalar_action_update(set(var(Name), ternary(cmp(Left, _Op, Right), Then, Else)),
@@ -13542,6 +13622,62 @@ plawk_getline_record_ir(Prefix, OpIndex, File, StNext, GlobalIR, IR) :-
         [Base, PathBytes, PathBytes, PathName,
          StNext, Base, PathLen]).
 
+% Command-output getline mirrors redirected-file getline, but keys a popen
+% registry by the literal command string and advances the shared logical
+% NR/FNR slot on success. The record-target runtime helper replaces the
+% reserved transient `$0` buffer only for status 1; the scalar-target helper
+% writes an interned line id through its out pointer. Both therefore preserve
+% their destination on EOF/error.
+plawk_getline_pipe_record_ir(Prefix, OpIndex, Command, NrInput, StNext,
+        NrNext, GlobalIR, IR) :-
+    format(atom(Base), '~w_getline_pipe_record_~w', [Prefix, OpIndex]),
+    format(atom(CommandName), '~w_command', [Base]),
+    llvm_emit_c_string_global(CommandName, Command, GlobalIR, CommandLen,
+        CommandBytes),
+    format(atom(StNext), '%~w_status', [Base]),
+    format(atom(NrNext), '%~w_nr', [Base]),
+    format(atom(IR),
+'  %~w_commandp = getelementptr [~w x i8], [~w x i8]* @.~w, i64 0, i64 0
+  ~w = call i64 @wam_getline_pipe_record(i8* %~w_commandp, i64 ~w)
+  %~w_got = icmp eq i64 ~w, 1
+  %~w_nr_inc = add i64 ~w, 1
+  ~w = select i1 %~w_got, i64 %~w_nr_inc, i64 ~w',
+        [Base, CommandBytes, CommandBytes, CommandName,
+         StNext, Base, CommandLen,
+         Base, StNext,
+         Base, NrInput,
+         NrNext, Base, Base, NrInput]).
+
+plawk_getline_pipe_ir(Prefix, OpIndex, Command, VarInput, NrInput, VarNext,
+        StNext, NrNext, GlobalIR, IR) :-
+    format(atom(Base), '~w_getline_pipe_~w', [Prefix, OpIndex]),
+    format(atom(CommandName), '~w_command', [Base]),
+    llvm_emit_c_string_global(CommandName, Command, CommandGlobalIR, CommandLen,
+        CommandBytes),
+    format(atom(LineIdName), '~w_lineid_slot', [Base]),
+    format(atom(LineIdGlobalIR), '@~w = private global i64 0', [LineIdName]),
+    atomic_list_concat([CommandGlobalIR, LineIdGlobalIR], '\n', GlobalIR),
+    format(atom(VarNext), '%~w_var', [Base]),
+    format(atom(StNext), '%~w_status', [Base]),
+    format(atom(NrNext), '%~w_nr', [Base]),
+    format(atom(IR),
+'  %~w_commandp = getelementptr [~w x i8], [~w x i8]* @.~w, i64 0, i64 0
+  store i64 ~w, i64* @~w
+  ~w = call i64 @wam_getline_pipe(i8* %~w_commandp, i64 ~w, i64* @~w)
+  %~w_line = load i64, i64* @~w
+  %~w_got = icmp eq i64 ~w, 1
+  ~w = select i1 %~w_got, i64 %~w_line, i64 ~w
+  %~w_nr_inc = add i64 ~w, 1
+  ~w = select i1 %~w_got, i64 %~w_nr_inc, i64 ~w',
+        [Base, CommandBytes, CommandBytes, CommandName,
+         VarInput, LineIdName,
+         StNext, Base, CommandLen, LineIdName,
+         Base, LineIdName,
+         Base, StNext,
+         VarNext, Base, Base, VarInput,
+         Base, NrInput,
+         NrNext, Base, Base, NrInput]).
+
 % Main-input getline sites use the driver-owned %handle, hence advance the
 % exact buffered stream the outer record loop is draining. Runtime helpers keep
 % their internal control flow out of the action sequence (whose predecessor
@@ -13584,6 +13720,78 @@ plawk_getline_main_var_ir(Prefix, OpIndex, VarInput, NrInput, VarNext, StNext,
          VarNext, Base, Base, VarInput,
          Base, NrInput,
          NrNext, Base, Base, NrInput]).
+
+% `status = "cmd" | getline`: replace `$0`, capture status, and advance the
+% hidden logical NR/FNR slot only after a successful command-output read.
+plawk_scalar_action_sequence_pairs([getline_pipe_record_capture(Status, Command) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { string(Command),
+      nth0(StIndex, Slots, StSlot), plawk_slot_name(StSlot, Status),
+      plawk_record_number_slot(Slots, NrIndex),
+      nth0(NrIndex, Values0, NrInput),
+      plawk_getline_pipe_record_ir(Prefix, OpIndex, Command, NrInput, StNext,
+          NrNext, GlobalIR, IR),
+      replace_nth0(StIndex, Values0, StNext, Values1),
+      replace_nth0(NrIndex, Values1, NrNext, Values2),
+      NextOpIndex is OpIndex + 1
+    },
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values2, Values, FinalOpIndex, ExitLabel, NextExits).
+% Bare record-target pipe getline has the same `$0` and counter effects while
+% discarding the status value.
+plawk_scalar_action_sequence_pairs([getline_pipe_record(Command) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { string(Command),
+      plawk_record_number_slot(Slots, NrIndex),
+      nth0(NrIndex, Values0, NrInput),
+      plawk_getline_pipe_record_ir(Prefix, OpIndex, Command, NrInput, _StNext,
+          NrNext, GlobalIR, IR),
+      replace_nth0(NrIndex, Values0, NrNext, Values1),
+      NextOpIndex is OpIndex + 1
+    },
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values1, Values, FinalOpIndex, ExitLabel, NextExits).
+
+% `status = "cmd" | getline var`: update Var only on success, capture status,
+% and advance NR/FNR without changing `$0` or NF.
+plawk_scalar_action_sequence_pairs([getline_pipe_capture(Status, Var, Command) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { string(Command),
+      nth0(VarIndex, Slots, VarSlot), plawk_slot_name(VarSlot, Var),
+      nth0(VarIndex, Values0, VarInput),
+      nth0(StIndex, Slots, StSlot), plawk_slot_name(StSlot, Status),
+      plawk_record_number_slot(Slots, NrIndex),
+      nth0(NrIndex, Values0, NrInput),
+      plawk_getline_pipe_ir(Prefix, OpIndex, Command, VarInput, NrInput,
+          VarNext, StNext, NrNext, GlobalIR, IR),
+      replace_nth0(VarIndex, Values0, VarNext, Values1),
+      replace_nth0(StIndex, Values1, StNext, Values2),
+      replace_nth0(NrIndex, Values2, NrNext, Values3),
+      NextOpIndex is OpIndex + 1
+    },
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values3, Values, FinalOpIndex, ExitLabel, NextExits).
+% Bare scalar-target pipe getline discards status while preserving the same
+% success-gated Var and record-number updates.
+plawk_scalar_action_sequence_pairs([getline_pipe_read(Var, Command) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
+    { string(Command),
+      nth0(VarIndex, Slots, VarSlot), plawk_slot_name(VarSlot, Var),
+      nth0(VarIndex, Values0, VarInput),
+      plawk_record_number_slot(Slots, NrIndex),
+      nth0(NrIndex, Values0, NrInput),
+      plawk_getline_pipe_ir(Prefix, OpIndex, Command, VarInput, NrInput,
+          VarNext, _StNext, NrNext, GlobalIR, IR),
+      replace_nth0(VarIndex, Values0, VarNext, Values1),
+      replace_nth0(NrIndex, Values1, NrNext, Values2),
+      NextOpIndex is OpIndex + 1
+    },
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        NextOpIndex, Values2, Values, FinalOpIndex, ExitLabel, NextExits).
 
 % `status = getline`: replace the current record, capture status, and advance
 % NR/FNR only when a record was actually read.
@@ -16502,9 +16710,9 @@ plawk_field_cmp_op_code(le, 3).
 plawk_field_cmp_op_code(gt, 4).
 plawk_field_cmp_op_code(ge, 5).
 
-% Main-input getline needs the record number as ordinary loop-carried state:
-% one outer-loop record and every successful getline both advance it. The
-% hidden slot's loop phi is named *_prev because EOF branches before the
+% Main-input and pipe getline need the record number as ordinary loop-carried
+% state: one outer-loop record and every successful getline both advance it.
+% The hidden slot's loop phi is named *_prev because EOF branches before the
 % current outer record is counted; the lowered record block materializes the
 % current value after a successful driver read.
 plawk_print_record_counter_ir(state_plan(Slots), _Fields, '', RecordCounterIR) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -157,9 +157,10 @@ plawk_action_own_continue(if(_Pattern, Then, Else)) :-
 
 %% plawk_normalise_getline_loops(+Program0, -Program)
 %
-%  Desugar the supported redirected and main-input getline conditions into the
-%  existing while machinery. Each becomes a priming status-capturing getline
-%  plus a `while (status > 0)` whose body ends in another read of the same form.
+%  Desugar the supported redirected, main-input, and command-pipe getline
+%  conditions into the existing while machinery. Each becomes a priming
+%  status-capturing getline plus a `while (status > 0)` whose body ends in
+%  another read of the same form.
 %  `$getline_status` is a reserved i64 slot (users cannot write a `$`-prefixed
 %  name). v1 rewrites rule bodies (and nested if/loop bodies); getline loops in
 %  BEGIN/END/case blocks remain explicit unsupported nodes.
@@ -215,6 +216,24 @@ plawk_norm_getline_actions([getline_main_var_loop(Var, Body0) | Rest], Out) :-
     !,
     plawk_norm_getline_actions(Body0, Body),
     Read = getline_main_var_capture('$getline_status', Var),
+    append(Body, [Read], LoopBody),
+    plawk_norm_getline_actions(Rest, Rest1),
+    Out = [ Read,
+            while_loop(cmp(var('$getline_status'), gt, int(0)), LoopBody)
+          | Rest1 ].
+plawk_norm_getline_actions([getline_pipe_record_loop(Command, Body0) | Rest], Out) :-
+    !,
+    plawk_norm_getline_actions(Body0, Body),
+    Read = getline_pipe_record_capture('$getline_status', Command),
+    append(Body, [Read], LoopBody),
+    plawk_norm_getline_actions(Rest, Rest1),
+    Out = [ Read,
+            while_loop(cmp(var('$getline_status'), gt, int(0)), LoopBody)
+          | Rest1 ].
+plawk_norm_getline_actions([getline_pipe_loop(Var, Command, Body0) | Rest], Out) :-
+    !,
+    plawk_norm_getline_actions(Body0, Body),
+    Read = getline_pipe_capture('$getline_status', Var, Command),
     append(Body, [Read], LoopBody),
     plawk_norm_getline_actions(Rest, Rest1),
     Out = [ Read,
@@ -1452,14 +1471,16 @@ begin_actions_rest([Action | Actions]) -->
 begin_actions_rest([]) -->
     [].
 
-begin_action(Action) -->
-    begin_assignment(Action),
-    !.
 % getline is deliberately not executable in BEGIN in this phase. Preserve the
 % surface as an explicit node so codegen reports a compile error (exit 3)
-% instead of a parse error or an ignored BEGIN action.
+% instead of a parse error or an ignored BEGIN action. Try this before an
+% ordinary BEGIN assignment: `FS = "cmd" | getline` otherwise commits to the
+% valid `FS = "cmd"` prefix and leaves the pipe behind.
 begin_action(unsupported_getline(begin(Action))) -->
     getline_context_action(Action),
+    !.
+begin_action(Action) -->
+    begin_assignment(Action),
     !.
 begin_action(Action) -->
     print_action(Action),
@@ -1824,6 +1845,8 @@ plawk_block_action(getline_loop(_Var, _File, _Body)).
 plawk_block_action(getline_file_record_loop(_File, _Body)).
 plawk_block_action(getline_main_record_loop(_Body)).
 plawk_block_action(getline_main_var_loop(_Var, _Body)).
+plawk_block_action(getline_pipe_record_loop(_Command, _Body)).
+plawk_block_action(getline_pipe_loop(_Var, _Command, _Body)).
 plawk_block_action(unsupported_getline(while(_Getline, _Body))).
 
 %% action_sep//0
@@ -1944,9 +1967,26 @@ action(Action) -->
 %
 %  Redirected forms read through a filename-keyed shared handle. Main-input
 %  forms read the next record from the driver's stream: `getline` replaces `$0`
-%  while `getline var` only updates the scalar target. Pipeline and dynamic
-%  filename shapes are retained as unsupported_getline nodes so they fail at
-%  compile time rather than being approximated.
+%  while `getline var` only updates the scalar target. A string-literal command
+%  may precede `| getline`; dynamic command and filename shapes are retained as
+%  unsupported_getline nodes so they fail at compile time rather than being
+%  approximated. The scalar-target pipe clause precedes its record sibling so
+%  the latter cannot accept only the `... | getline` prefix.
+getline_action(getline_pipe_read(Var, Command)) -->
+    quoted_string(CCodes),
+    ws, "|", ws,
+    "getline",
+    required_inline_ws,
+    identifier(Var),
+    { string_codes(Command, CCodes) },
+    !.
+getline_action(getline_pipe_record(Command)) -->
+    quoted_string(CCodes),
+    ws, "|", ws,
+    "getline",
+    identifier_boundary,
+    { string_codes(Command, CCodes) },
+    !.
 getline_action(getline_file_record(File)) -->
     "getline",
     identifier_boundary,
@@ -1985,9 +2025,14 @@ getline_context_action(Action) -->
     getline_assignment_action(Action).
 
 % Unsupported statement forms. Longest shapes come first so the trailing
-% tokens cannot be left for the enclosing action grammar.
+% tokens cannot be left for the enclosing action grammar. A pipe target is
+% consumed before the record form for the same prefix reason as above.
+unsupported_getline_statement(pipe_var(Command, Var)) -->
+    getline_dynamic_pipe_expr(Command), ws,
+    "|", ws, "getline", required_inline_ws, identifier(Var),
+    !.
 unsupported_getline_statement(pipe(Command)) -->
-    getline_pipe_command(Command), ws,
+    getline_dynamic_pipe_expr(Command), ws,
     "|", ws, "getline", identifier_boundary,
     !.
 unsupported_getline_statement(file_var(Var, File)) -->
@@ -1999,11 +2044,16 @@ unsupported_getline_statement(file_record_dynamic(File)) -->
     "<", ws, getline_dynamic_file_expr(File),
     !.
 
-getline_pipe_command(var(Command)) -->
-    identifier(Command).
-getline_pipe_command(string(Command)) -->
-    quoted_string(Codes),
-    { string_codes(Command, Codes) }.
+% Consume a non-literal command expression solely for an explicit v1
+% rejection. Parentheses need a dedicated shape for the same reason as a
+% dynamic redirected filename. Literal strings are handled by the supported
+% clauses above and deliberately excluded here.
+getline_dynamic_pipe_expr(paren(Expr)) -->
+    "(", ws, scalar_value_expr(Expr), ws, ")",
+    !.
+getline_dynamic_pipe_expr(Expr) -->
+    scalar_value_expr(Expr),
+    { Expr \= string(_) }.
 
 % Consume a non-string-literal filename expression solely so v1 can reject it
 % as an explicit unsupported node (build exit 3). Parenthesised scalar values
@@ -2115,6 +2165,30 @@ delete_action(delete_assoc(var(Name), KeyExpr)) -->
 % the general action block, and the codegen (bin/plawk) rejects it with a clean
 % not-yet diagnostic until the loop runtime lands. The condition is a scalar
 % comparison for now; a general boolean condition is a follow-on.
+% `while (("cmd" | getline var) > 0) BODY` -- drain a literal command's
+% stdout into a scalar. Keep this before the record form so the target cannot
+% be left behind as trailing input.
+while_action(getline_pipe_loop(Var, Command, Body)) -->
+    "while", identifier_boundary, ws,
+    "(", ws,
+    "(", ws, quoted_string(CCodes), ws,
+    "|", ws, "getline", required_inline_ws, identifier(Var), ws, ")",
+    ws, ">", ws, "0", ws,
+    ")", ws,
+    body_block(Body),
+    { string_codes(Command, CCodes) },
+    !.
+% `while (("cmd" | getline) > 0) BODY` -- drain it into `$0`.
+while_action(getline_pipe_record_loop(Command, Body)) -->
+    "while", identifier_boundary, ws,
+    "(", ws,
+    "(", ws, quoted_string(CCodes), ws,
+    "|", ws, "getline", identifier_boundary, ws, ")",
+    ws, ">", ws, "0", ws,
+    ")", ws,
+    body_block(Body),
+    { string_codes(Command, CCodes) },
+    !.
 % `while ((getline < "file") > 0) BODY` -- read successive newline-delimited
 % file records into `$0`. It normalises to a priming record read plus the same
 % status-slot while machinery used by scalar-target getline.
@@ -2667,6 +2741,28 @@ assignment_action(set(var(Name), Value)) -->
     ws,
     scalar_value_expr(Value).
 
+% Pipe captures use a literal command and mirror the two statement targets.
+% The scalar-target form is tried first because it extends the record prefix.
+getline_assignment_action(getline_pipe_capture(Status, Var, Command)) -->
+    identifier(Status),
+    ws, "=", ws,
+    quoted_string(CCodes),
+    ws, "|", ws,
+    "getline",
+    required_inline_ws,
+    identifier(Var),
+    { string_codes(Command, CCodes) },
+    !.
+getline_assignment_action(getline_pipe_record_capture(Status, Command)) -->
+    identifier(Status),
+    ws, "=", ws,
+    quoted_string(CCodes),
+    ws, "|", ws,
+    "getline",
+    identifier_boundary,
+    { string_codes(Command, CCodes) },
+    !.
+
 % `status = getline < "file"`: update `$0` and capture 1/0/-1 in status.
 getline_assignment_action(getline_file_record_capture(Status, File)) -->
     identifier(Status),
@@ -2717,6 +2813,14 @@ unsupported_getline_rhs(file_var(Var, File)) -->
 unsupported_getline_rhs(file_record_dynamic(File)) -->
     "getline", identifier_boundary, ws,
     "<", ws, getline_dynamic_file_expr(File),
+    !.
+unsupported_getline_rhs(pipe_var(Command, Var)) -->
+    getline_dynamic_pipe_expr(Command), ws,
+    "|", ws, "getline", required_inline_ws, identifier(Var),
+    !.
+unsupported_getline_rhs(pipe(Command)) -->
+    getline_dynamic_pipe_expr(Command), ws,
+    "|", ws, "getline", identifier_boundary,
     !.
 
 % `x = sprintf("fmt", args...)`: format into a string scalar (the printf format

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1624,6 +1624,8 @@ declare i8* @strerror(i32)
 declare i32 @getrusage(i32, i8*)
 declare i8* @popen(i8*, i8*)
 declare i32 @pclose(i8*)
+declare i32 @fgetc(i8*)
+declare i32 @ferror(i8*)
 declare i64 @fread(i8*, i64, i64, i8*)
 declare i64 @fwrite(i8*, i64, i64, i8*)
 declare i32 @memcmp(i8*, i8*, i64)
@@ -8513,6 +8515,239 @@ gr.copy_error:
 
 gr.return_status:
   ret i64 %gr.status
+}
+
+; awk pipe getline: run a command through the host shell and read its stdout
+; one physical newline record at a time. Commands share a process-wide
+; registry keyed by command text, so repeated calls continue the same pipe.
+; A terminal state is retained after pclose so EOF and errors never respawn
+; the command. Capacity is 64 distinct commands.
+;
+; The output slot is written only after a complete record is available.
+; Returns 1 for a record, 0 for clean EOF, and -1 for popen, read, allocation,
+; or pclose errors. The command exit status does not turn pipe EOF into an
+; error. A final partial record is returned before a rare pclose error is
+; reported on the following call.
+@wam_getline_pipe_reg_ids = internal global [64 x i64] zeroinitializer
+@wam_getline_pipe_reg_fp = internal global [64 x i8*] zeroinitializer
+@wam_getline_pipe_reg_state = internal global [64 x i8] zeroinitializer
+@wam_getline_pipe_reg_n = internal global i64 0
+
+define i64 @wam_getline_pipe(i8* %cmdptr, i64 %cmdlen, i64* %line_id_out) {
+entry:
+  %gp.cid = call i64 @wam_intern_atom(i8* %cmdptr, i64 %cmdlen)
+  %gp.n = load i64, i64* @wam_getline_pipe_reg_n
+  br label %gp.scan
+
+gp.scan:
+  %gp.i = phi i64 [ 0, %entry ], [ %gp.i1, %gp.scan_next ]
+  %gp.scan_done = icmp sge i64 %gp.i, %gp.n
+  br i1 %gp.scan_done, label %gp.open, label %gp.scan_body
+
+gp.scan_body:
+  %gp.idp = getelementptr [64 x i64], [64 x i64]* @wam_getline_pipe_reg_ids, i64 0, i64 %gp.i
+  %gp.id = load i64, i64* %gp.idp
+  %gp.hit = icmp eq i64 %gp.id, %gp.cid
+  br i1 %gp.hit, label %gp.found, label %gp.scan_next
+
+gp.scan_next:
+  %gp.i1 = add i64 %gp.i, 1
+  br label %gp.scan
+
+gp.found:
+  %gp.found_statep = getelementptr [64 x i8], [64 x i8]* @wam_getline_pipe_reg_state, i64 0, i64 %gp.i
+  %gp.found_state = load i8, i8* %gp.found_statep
+  switch i8 %gp.found_state, label %gp.err [
+    i8 1, label %gp.found_open
+    i8 2, label %gp.eof
+    i8 3, label %gp.err
+  ]
+
+gp.found_open:
+  %gp.found_fpp = getelementptr [64 x i8*], [64 x i8*]* @wam_getline_pipe_reg_fp, i64 0, i64 %gp.i
+  %gp.found_fp = load i8*, i8** %gp.found_fpp
+  %gp.found_fp_null = icmp eq i8* %gp.found_fp, null
+  br i1 %gp.found_fp_null, label %gp.err, label %gp.ready
+
+gp.open:
+  %gp.full = icmp sge i64 %gp.n, 64
+  br i1 %gp.full, label %gp.err, label %gp.open_command
+
+gp.open_command:
+  %gp.command = call i8* @wam_atom_to_string(i64 %gp.cid)
+  %gp.command_null = icmp eq i8* %gp.command, null
+  br i1 %gp.command_null, label %gp.err, label %gp.do_popen
+
+gp.do_popen:
+  %gp.mode = alloca [2 x i8], align 1
+  %gp.mode_ptr = getelementptr [2 x i8], [2 x i8]* %gp.mode, i64 0, i64 0
+  store i8 114, i8* %gp.mode_ptr
+  %gp.mode_end = getelementptr i8, i8* %gp.mode_ptr, i64 1
+  store i8 0, i8* %gp.mode_end
+  %gp.opened_fp = call i8* @popen(i8* %gp.command, i8* %gp.mode_ptr)
+  %gp.open_failed = icmp eq i8* %gp.opened_fp, null
+  br i1 %gp.open_failed, label %gp.err, label %gp.store
+
+gp.store:
+  %gp.store_idp = getelementptr [64 x i64], [64 x i64]* @wam_getline_pipe_reg_ids, i64 0, i64 %gp.n
+  store i64 %gp.cid, i64* %gp.store_idp
+  %gp.store_fpp = getelementptr [64 x i8*], [64 x i8*]* @wam_getline_pipe_reg_fp, i64 0, i64 %gp.n
+  store i8* %gp.opened_fp, i8** %gp.store_fpp
+  %gp.store_statep = getelementptr [64 x i8], [64 x i8]* @wam_getline_pipe_reg_state, i64 0, i64 %gp.n
+  store i8 1, i8* %gp.store_statep
+  %gp.n1 = add i64 %gp.n, 1
+  store i64 %gp.n1, i64* @wam_getline_pipe_reg_n
+  br label %gp.ready
+
+gp.ready:
+  %gp.fp = phi i8* [ %gp.found_fp, %gp.found_open ], [ %gp.opened_fp, %gp.store ]
+  %gp.fpp = phi i8** [ %gp.found_fpp, %gp.found_open ], [ %gp.store_fpp, %gp.store ]
+  %gp.statep = phi i8* [ %gp.found_statep, %gp.found_open ], [ %gp.store_statep, %gp.store ]
+  %gp.buf0 = call i8* @malloc(i64 256)
+  %gp.buf0_null = icmp eq i8* %gp.buf0, null
+  br i1 %gp.buf0_null, label %gp.alloc_error, label %gp.read
+
+gp.read:
+  %gp.buf = phi i8* [ %gp.buf0, %gp.ready ], [ %gp.append_buf, %gp.append ]
+  %gp.len = phi i64 [ 0, %gp.ready ], [ %gp.len1, %gp.append ]
+  %gp.cap = phi i64 [ 256, %gp.ready ], [ %gp.append_cap, %gp.append ]
+  %gp.ch = call i32 @fgetc(i8* %gp.fp)
+  %gp.at_end = icmp eq i32 %gp.ch, -1
+  br i1 %gp.at_end, label %gp.read_end, label %gp.check_newline
+
+gp.check_newline:
+  %gp.is_newline = icmp eq i32 %gp.ch, 10
+  br i1 %gp.is_newline, label %gp.finish_open, label %gp.ensure
+
+gp.ensure:
+  %gp.full_buf = icmp uge i64 %gp.len, %gp.cap
+  br i1 %gp.full_buf, label %gp.grow, label %gp.append
+
+gp.grow:
+  %gp.new_cap = mul i64 %gp.cap, 2
+  %gp.grown = call i8* @realloc(i8* %gp.buf, i64 %gp.new_cap)
+  %gp.grow_failed = icmp eq i8* %gp.grown, null
+  br i1 %gp.grow_failed, label %gp.realloc_error, label %gp.append
+
+gp.append:
+  %gp.append_buf = phi i8* [ %gp.buf, %gp.ensure ], [ %gp.grown, %gp.grow ]
+  %gp.append_cap = phi i64 [ %gp.cap, %gp.ensure ], [ %gp.new_cap, %gp.grow ]
+  %gp.dst = getelementptr i8, i8* %gp.append_buf, i64 %gp.len
+  %gp.byte = trunc i32 %gp.ch to i8
+  store i8 %gp.byte, i8* %gp.dst
+  %gp.len1 = add i64 %gp.len, 1
+  br label %gp.read
+
+gp.finish_open:
+  %gp.open_has_chars = icmp ugt i64 %gp.len, 0
+  br i1 %gp.open_has_chars, label %gp.open_check_cr, label %gp.open_intern_empty
+
+gp.open_check_cr:
+  %gp.open_last_idx = sub i64 %gp.len, 1
+  %gp.open_last_ptr = getelementptr i8, i8* %gp.buf, i64 %gp.open_last_idx
+  %gp.open_last = load i8, i8* %gp.open_last_ptr
+  %gp.open_last_is_cr = icmp eq i8 %gp.open_last, 13
+  %gp.open_trimmed_len = select i1 %gp.open_last_is_cr, i64 %gp.open_last_idx, i64 %gp.len
+  br label %gp.open_intern
+
+gp.open_intern_empty:
+  br label %gp.open_intern
+
+gp.open_intern:
+  %gp.open_final_len = phi i64 [ %gp.open_trimmed_len, %gp.open_check_cr ], [ 0, %gp.open_intern_empty ]
+  %gp.line_id = call i64 @wam_intern_atom(i8* %gp.buf, i64 %gp.open_final_len)
+  call void @free(i8* %gp.buf)
+  store i64 %gp.line_id, i64* %line_id_out
+  ret i64 1
+
+gp.read_end:
+  %gp.read_error = call i32 @ferror(i8* %gp.fp)
+  %gp.read_failed = icmp ne i32 %gp.read_error, 0
+  br i1 %gp.read_failed, label %gp.io_error, label %gp.close_at_eof
+
+gp.close_at_eof:
+  %gp.close_status = call i32 @pclose(i8* %gp.fp)
+  store i8* null, i8** %gp.fpp
+  %gp.close_ok = icmp ne i32 %gp.close_status, -1
+  %gp.terminal_state = select i1 %gp.close_ok, i8 2, i8 3
+  store i8 %gp.terminal_state, i8* %gp.statep
+  %gp.have_partial = icmp ugt i64 %gp.len, 0
+  br i1 %gp.have_partial, label %gp.finish_partial, label %gp.finish_empty
+
+gp.finish_partial:
+  %gp.partial_last_idx = sub i64 %gp.len, 1
+  %gp.partial_last_ptr = getelementptr i8, i8* %gp.buf, i64 %gp.partial_last_idx
+  %gp.partial_last = load i8, i8* %gp.partial_last_ptr
+  %gp.partial_last_is_cr = icmp eq i8 %gp.partial_last, 13
+  %gp.partial_len = select i1 %gp.partial_last_is_cr, i64 %gp.partial_last_idx, i64 %gp.len
+  %gp.partial_id = call i64 @wam_intern_atom(i8* %gp.buf, i64 %gp.partial_len)
+  call void @free(i8* %gp.buf)
+  store i64 %gp.partial_id, i64* %line_id_out
+  ret i64 1
+
+gp.finish_empty:
+  call void @free(i8* %gp.buf)
+  %gp.empty_status = select i1 %gp.close_ok, i64 0, i64 -1
+  ret i64 %gp.empty_status
+
+gp.alloc_error:
+  %gp.alloc_close = call i32 @pclose(i8* %gp.fp)
+  store i8* null, i8** %gp.fpp
+  store i8 3, i8* %gp.statep
+  ret i64 -1
+
+gp.realloc_error:
+  %gp.realloc_close = call i32 @pclose(i8* %gp.fp)
+  store i8* null, i8** %gp.fpp
+  store i8 3, i8* %gp.statep
+  call void @free(i8* %gp.buf)
+  ret i64 -1
+
+gp.io_error:
+  %gp.io_close = call i32 @pclose(i8* %gp.fp)
+  store i8* null, i8** %gp.fpp
+  store i8 3, i8* %gp.statep
+  call void @free(i8* %gp.buf)
+  ret i64 -1
+
+gp.eof:
+  ret i64 0
+
+gp.err:
+  ret i64 -1
+}
+
+; Pipe getline into the current record. The scalar helper owns command state
+; and produces a persistent atom. On success copy it into the reserved
+; transient record buffer so existing field and NF projections see the new
+; record immediately. EOF and errors do not touch the transient destination.
+define i64 @wam_getline_pipe_record(i8* %cmdptr, i64 %cmdlen) {
+entry:
+  %gpr.line_id_slot = alloca i64, align 8
+  %gpr.status = call i64 @wam_getline_pipe(i8* %cmdptr, i64 %cmdlen, i64* %gpr.line_id_slot)
+  %gpr.got = icmp eq i64 %gpr.status, 1
+  br i1 %gpr.got, label %gpr.copy, label %gpr.return_status
+
+gpr.copy:
+  %gpr.line_id = load i64, i64* %gpr.line_id_slot
+  %gpr.line_ptr = call i8* @wam_atom_to_string(i64 %gpr.line_id)
+  %gpr.line_null = icmp eq i8* %gpr.line_ptr, null
+  br i1 %gpr.line_null, label %gpr.copy_error, label %gpr.copy_bytes
+
+gpr.copy_bytes:
+  %gpr.line_len = call i64 @strlen(i8* %gpr.line_ptr)
+  %gpr.transient_id = call i64 @wam_transient_atom_from_bytes(i8* %gpr.line_ptr, i64 %gpr.line_len)
+  %gpr.copy_failed = icmp slt i64 %gpr.transient_id, 0
+  br i1 %gpr.copy_failed, label %gpr.copy_error, label %gpr.success
+
+gpr.success:
+  ret i64 1
+
+gpr.copy_error:
+  ret i64 -1
+
+gpr.return_status:
+  ret i64 %gpr.status
 }
 
 ; awk ENVIRON["NAME"]: look up an environment variable by its NUL-terminated

--- a/tests/test_plawk_getline_pipe.pl
+++ b/tests/test_plawk_getline_pipe.pl
@@ -1,0 +1,292 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% Command-pipe getline runs a literal shell command once and advances through
+% its stdout through a command-keyed registry. Both target forms advance the
+% logical NR counter on success (and therefore FNR, which is an NR alias in
+% plawk); only the record form replaces $0 and its lazily projected fields.
+% Physical newlines delimit records in v1. EOF/error preserve the destination.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- begin_tests(plawk_getline_pipe).
+
+% --- parsing ---------------------------------------------------------------
+
+test(pipe_record_bare_parses) :-
+    plawk_parse_string("{ \"echo a:b\" | getline }\n",
+        program([], [rule(always,
+            [getline_pipe_record("echo a:b")])], [])),
+    !.
+
+test(pipe_var_bare_parses) :-
+    plawk_parse_string("{ \"echo value\" | getline line }\n",
+        program([], [rule(always,
+            [getline_pipe_read(line, "echo value")])], [])),
+    !.
+
+test(pipe_record_capture_parses) :-
+    plawk_parse_string("{ status = \"echo value\" | getline; print status }\n",
+        program([], [rule(always,
+            [getline_pipe_record_capture(status, "echo value"),
+             print([var(status)])])], [])),
+    !.
+
+test(pipe_var_capture_parses) :-
+    plawk_parse_string(
+        "{ status = \"echo value\" | getline line; print status, line }\n",
+        program([], [rule(always,
+            [getline_pipe_capture(status, line, "echo value"),
+             print([var(status), var(line)])])], [])),
+    !.
+
+test(pipe_record_while_normalises) :-
+    plawk_parse_string(
+        "{ while ((\"seq 3\" | getline) > 0) print $0 }\n",
+        program(_, [rule(always, Actions)], _)),
+    Actions = [ getline_pipe_record_capture('$getline_status', "seq 3"),
+                while_loop(cmp(var('$getline_status'), gt, int(0)),
+                    [print([field(0)]),
+                     getline_pipe_record_capture('$getline_status',
+                         "seq 3")]) ],
+    !.
+
+test(pipe_var_while_normalises) :-
+    plawk_parse_string(
+        "{ while ((\"seq 3\" | getline line) > 0) print line }\n",
+        program(_, [rule(always, Actions)], _)),
+    Actions = [ getline_pipe_capture('$getline_status', line, "seq 3"),
+                while_loop(cmp(var('$getline_status'), gt, int(0)),
+                    [print([var(line)]),
+                     getline_pipe_capture('$getline_status', line,
+                         "seq 3")]) ],
+    !.
+
+% A scalar pipe read appears inside the normalized loop body. Its scratch output
+% must have stable storage rather than an alloca executed once per record; the
+% latter exhausts the stack on a long drain.
+test(pipe_var_while_uses_constant_stack_ir) :-
+    Src = "{ while ((\"seq 3\" | getline line) > 0) print line }\n",
+    plawk_parse_string(Src, Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _,
+        '_lineid_slot = private global i64 0'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '_lineid = alloca i64')),
+    !.
+
+% --- runtime ---------------------------------------------------------------
+
+% The record form re-splits with the active regex FS and advances the shared
+% NR/FNR value. This is a bare statement, so its status is intentionally unused.
+test(pipe_record_bare_resplits_and_advances_nr,
+        [condition(clang_available)]) :-
+    pdir(Dir),
+    Src = "BEGIN { FS = \"[,:]+\"; OFS = \"|\" } { \"echo left::right,tail\" | getline; print NR, FNR, $0, $1, $2, $3, NF }\n",
+    build_run(Dir, 'record_bare', Src, "trigger\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2|2|left::right,tail|left|right|tail|3\n"),
+    !.
+
+% Scalar-target pipe getline advances NR/FNR but preserves the current record,
+% its fields, and NF.
+test(pipe_var_bare_preserves_record, [condition(clang_available)]) :-
+    pdir(Dir),
+    Src = "BEGIN { FS = \":\"; OFS = \"|\" } { \"echo inner:two\" | getline v; print NR, FNR, v, $0, $1, $2, NF }\n",
+    build_run(Dir, 'var_bare', Src, "outer:one\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2|2|inner:two|outer:one|outer|one|2\n"),
+    !.
+
+% The command is opened once. The second read observes clean EOF, returns 0,
+% does not increment NR, and leaves the successful pipe record in $0.
+test(pipe_record_status_eof_preserves_record,
+        [condition(clang_available)]) :-
+    pdir(Dir),
+    Src = "BEGIN { FS = \":\"; OFS = \"|\" } { r = \"echo one:two\" | getline; print r, NR, $0, $1, $2, NF; r = \"echo one:two\" | getline; print r, NR, $0, $1, $2, NF }\n",
+    build_run(Dir, 'record_eof', Src, "outer:main\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1|2|one:two|one|two|2\n0|2|one:two|one|two|2\n"),
+    !.
+
+test(pipe_var_status_eof_preserves_target,
+        [condition(clang_available)]) :-
+    pdir(Dir),
+    Src = "BEGIN { OFS = \"|\" } { v = \"keep\"; r = \"echo fresh\" | getline v; print r, v, NR, $0; r = \"echo fresh\" | getline v; print r, v, NR, $0 }\n",
+    build_run(Dir, 'var_eof', Src, "outer\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1|fresh|2|outer\n0|fresh|2|outer\n"),
+    !.
+
+test(pipe_record_while_drains, [condition(clang_available)]) :-
+    pdir(Dir),
+    Src = "BEGIN { OFS = \"|\" } { while ((\"seq 3\" | getline) > 0) print NR, FNR, $0, NF; print \"done\", NR, $0 } END { print \"end\", NR, FNR }\n",
+    build_run(Dir, 'record_while', Src, "header\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2|2|1|1\n3|3|2|1\n4|4|3|1\ndone|4|3\nend|4|4\n"),
+    !.
+
+test(pipe_var_while_drains_without_changing_record,
+        [condition(clang_available)]) :-
+    pdir(Dir),
+    Src = "BEGIN { FS = \":\"; OFS = \"|\" } { while ((\"seq 3\" | getline v) > 0) print NR, FNR, v, $0, $1, $2, NF; print \"done\", NR, v, $0 }\n",
+    build_run(Dir, 'var_while', Src, "outer:row\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "2|2|1|outer:row|outer|row|2\n3|3|2|outer:row|outer|row|2\n4|4|3|outer:row|outer|row|2\ndone|4|3|outer:row\n"),
+    !.
+
+% Record and scalar forms share one registry entry for identical command text.
+% The assoc update/END lookup also forces the mixed driver, whose hidden NR
+% slot must carry both successful reads through to the print and END report.
+test(pipe_forms_share_command_registry, [condition(clang_available)]) :-
+    pdir(Dir),
+    Src = "BEGIN { OFS = \"|\" } { seen[$1]++; a = \"seq 2\" | getline v; b = \"seq 2\" | getline; print a, v, b, $0, NR, FNR } END { print seen[\"outer\"], NR }\n",
+    build_run(Dir, 'shared_registry', Src, "outer\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1|1|1|2|3|3\n1|3\n"),
+    !.
+
+% The pipe reader grows its line buffer and the record target refreshes direct
+% $0 consumers after the transient buffer moves.
+test(pipe_record_long_line, [condition(clang_available)]) :-
+    pdir(Dir),
+    Src = "{ \"printf %05000d 0; echo\" | getline; print $0 }\n",
+    build_run(Dir, 'long_record', Src, "trigger\n", Out, St),
+    assertion(St == 0),
+    length(ZeroCodes, 5000),
+    maplist(=(0'0), ZeroCodes),
+    string_codes(Zeros, ZeroCodes),
+    string_concat(Zeros, "\n", Expected),
+    assertion(Out == Expected),
+    !.
+
+% Pipe getline is physical-newline-only in v1. It does not consume the active
+% regex RS or replace the RT captured by the main-input reader.
+test(pipe_record_ignores_rs_and_preserves_rt,
+        [condition(clang_available)]) :-
+    pdir(Dir),
+    Src = "BEGIN { RS = \"[0-9]+\"; OFS = \"|\" } { r = \"echo left45right\" | getline; print r, NR, $0, RT }\n",
+    build_run(Dir, 'rs_rt', Src, "trigger123", Out, St),
+    assertion(St == 0),
+    assertion(Out == "1|2|left45right|123\n"),
+    !.
+
+% Once popen succeeds, a child that exits nonzero without output is still a
+% clean pipe EOF, as in gawk. The child status is not a getline read error.
+test(pipe_record_nonzero_command_is_eof,
+        [condition(clang_available)]) :-
+    pdir(Dir),
+    Src = "BEGIN { FS = \":\"; OFS = \"|\" } { r = \"false\" | getline; print r, NR, FNR, $0, $1, $2, NF }\n",
+    build_run(Dir, 'record_error', Src, "outer:main\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0|1|1|outer:main|outer|main|2\n"),
+    !.
+
+test(pipe_var_nonzero_command_is_eof,
+        [condition(clang_available)]) :-
+    pdir(Dir),
+    Src = "BEGIN { OFS = \"|\" } { v = \"keep\"; r = \"false\" | getline v; print r, v, NR, FNR, $0 }\n",
+    build_run(Dir, 'var_error', Src, "outer\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "0|keep|1|1|outer\n"),
+    !.
+
+% Hold fds 3..8 open, then limit the executed binary to fds 0..9. The dynamic
+% loader can reuse fd 9, but popen cannot create its two-fd pipe. This
+% deterministically exercises a real spawn/open failure: both forms return -1
+% and preserve their destinations and NR/FNR.
+test(pipe_spawn_error_returns_minus_one_and_preserves_targets,
+        [condition(clang_available)]) :-
+    pdir(Dir),
+    Src = "BEGIN { FS = \":\"; OFS = \"|\" } { v = \"keep\"; a = \"echo record\" | getline; b = \"echo scalar\" | getline v; print a, b, v, NR, FNR, $0, $1, $2, NF }\n",
+    build_run_low_nofile(Dir, 'spawn_error', Src, "outer:main\n", Out, St),
+    assertion(St == 0),
+    assertion(Out == "-1|-1|keep|1|1|outer:main|outer|main|2\n"),
+    !.
+
+% --- explicit v1 rejection boundary ---------------------------------------
+
+test(unsupported_pipe_getline_shapes_exit_3,
+        [condition(clang_available)]) :-
+    pdir(Dir),
+    Cases = [ dynamic_record-"{ cmd = \"echo x\"; cmd | getline }\n",
+              dynamic_var-"{ cmd = \"echo x\"; cmd | getline v }\n",
+              dynamic_field-"{ $1 | getline }\n",
+              dynamic_paren-"{ (cmd) | getline }\n",
+              capture_dynamic-"{ s = cmd | getline }\n",
+              while_dynamic-"{ while ((cmd | getline) > 0) print $0 }\n",
+              begin_record-"BEGIN { \"echo x\" | getline } { print $0 }\n",
+              begin_var-"BEGIN { \"echo x\" | getline v } { print $0 }\n",
+              begin_capture-"BEGIN { s = \"echo x\" | getline } { print $0 }\n",
+              end_record-"{ print $0 } END { \"echo x\" | getline }\n",
+              end_var-"{ print $0 } END { \"echo x\" | getline v }\n",
+              end_capture-"{ print $0 } END { s = \"echo x\" | getline }\n"
+            ],
+    forall(member(Name-Src, Cases),
+        ( build_status(Dir, Name, Src, Status),
+          assertion(Status == exit(3))
+        )),
+    !.
+
+:- end_tests(plawk_getline_pipe).
+
+% --- helpers ---------------------------------------------------------------
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+pdir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_getline_pipe', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+write_prog(Dir, Name, Src, Bin-Prog) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        format(S, "~s", [Src]), close(S)),
+    atom_concat(Prog0, '_bin', Bin).
+
+build_status(Dir, Name, Src, Status) :-
+    write_prog(Dir, Name, Src, Bin-Prog),
+    process_create(path(swipl),
+        ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(Pid)]),
+    process_wait(Pid, Status).
+
+build_run(Dir, Name, Src, Input, Out, RunStatus) :-
+    write_prog(Dir, Name, Src, Bin-Prog),
+    process_create(path(swipl),
+        ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    process_create(Bin, [],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~s", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).
+
+build_run_low_nofile(Dir, Name, Src, Input, Out, RunStatus) :-
+    write_prog(Dir, Name, Src, Bin-Prog),
+    process_create(path(swipl),
+        ['examples/plawk/bin/plawk', build, Prog, '-o', Bin],
+        [stdout(null), stderr(null), process(BPid)]),
+    process_wait(BPid, exit(0)),
+    RunCommand =
+        'exec 3</dev/null 4</dev/null 5</dev/null 6</dev/null 7</dev/null 8</dev/null; ulimit -n 10; exec "$1"',
+    process_create(path(sh),
+        ['-c', RunCommand, sh, Bin],
+        [stdin(pipe(In)), stdout(pipe(RS)), stderr(std), process(RPid)]),
+    format(In, "~s", [Input]),
+    close(In),
+    read_string(RS, _, Out),
+    close(RS),
+    process_wait(RPid, exit(RunStatus)).


### PR DESCRIPTION
## Summary

- parse and lower literal-command `"cmd" | getline` and `"cmd" | getline var`
- support bare statements, status capture, and canonical while-drain forms
- add a command-keyed `popen(cmd, "r")` registry shared by record and scalar targets
- update `$0`/fields/NF only for the record target and update scalar variables only for the scalar target
- advance the hidden NR slot on successful pipe records; FNR follows because it is an NR alias in plawk
- keep dynamic commands and pipe getline in BEGIN/END as explicit exit-3 rejections
- document the landed surface and the physical-newline/RT follow-on

## Semantics

Pipe reads return 1 for a record, 0 for clean EOF, and -1 for actual pipe/open/read/close/allocation failures. EOF and errors preserve the destination and do not advance NR.

A child that starts successfully and exits nonzero without output is clean EOF, matching POSIX/gawk behavior. The focused tests separately force a real `popen` failure to exercise the -1 path deterministically.

The registry retains open and terminal state per literal command, closes with `pclose` when EOF is observed, and does not respawn a drained command. Pipe records are physical-newline-delimited in v1 and leave RT unchanged.

Scalar while-drains use stable per-site output storage. This avoids loop-local scratch allocation and was validated with a 1,000,000-record drain.

## Validation

- `tests/test_plawk_getline_pipe.pl`: 20/20 passed
- `tests/test_plawk_getline.pl`: 10/10 passed
- `tests/test_plawk_getline_record.pl`: 11/11 passed
- `tests/test_plawk_getline_main.pl`: 18/18 passed
- 1,000,000-record scalar while-drain: exit 0 with correct count and NR
- generated LLVM compile/link/execute probes
- `git diff --check`
- independent implementation review completed with no remaining findings

## Coordination

Adds a popen-based command registry alongside the filename registry; reuses the transient-buffer/field-recompute path from #3912 and the hidden NR-slot threading from #3917. `popen` executes a shell command—this is inherent to awk's `cmd | getline` and is driven by the user's program. No known conflict with in-flight work.