### PR TITLE
ISO-R-0: shared ISO wiring and is/2 three-form vertical slice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -233,6 +233,11 @@ jobs:
         run: |
           swipl -q -f init.pl -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:switch_on_constant_fallthrough_is_linear_noop,wam_r_generator:switch_on_term_a2_is_switch_on_term_noop,wam_r_generator:switch_on_constant_fallthrough_preserves_backtracking,wam_r_generator:r_a2_switch_hints_are_linear_noop,wam_r_generator:r_a2_fallthrough_preserves_backtracking,wam_r_generator:lmdb_r0_source_dispatch_selection,wam_r_generator:lmdb_arg1_v1_mock_adapter_lookup_and_stream,wam_r_generator:lmdb_arg1_v1_real_binding_e2e_rscript,wam_r_generator:lmdb_r1_materialisation_codegen,wam_r_generator:lmdb_r1_eager_lazy_runtime_parity,wam_r_generator:lmdb_r2a_cached_codegen,wam_r_generator:lmdb_r2a_cached_runtime,wam_r_generator:lmdb_r2b_auto_materialisation_codegen])" -t halt
 
+      - name: Run R ISO-R-0 unit + smoke
+        run: |
+          swipl -q -f init.pl -s tests/test_wam_r_iso_unit.pl -g "run_tests, halt" -t "halt(1)"
+          swipl -q -f init.pl -s tests/test_wam_r_iso_smoke.pl -g main -t halt
+
       - name: Run full R classic conformance
         run: |
           swipl -q -f init.pl -s tests/test_wam_cross_target_conformance.pl -g "run_tests" -t halt

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -53,7 +53,9 @@ self-contained so a single coding agent can pick it up in isolation.
 | ISO-C | ISO three-form (new) | C | L | — |
 | ISO-GO | ISO three-form (new) | Go | L | — |
 | ISO-SCALA | ISO three-form (new) | Scala | L | — |
-| ISO-R | ISO three-form (new) | R | L | — |
+| ISO-R-0 ✅ | shared wiring + `is/2` vertical slice | R | M | done (partial adopter) |
+| ISO-R-1 | catch/throw substrate formalization | R | S | ISO-R-0 |
+| ISO-R-2 | comparisons, succ, remaining adoption | R | M | ISO-R-1 |
 | ISO-PYTHON | ISO three-form (finish) | Python | S | — |
 | ISO-FSHARP | ISO three-form (finish) | F# | S | — |
 | KERN-FSHARP ✅ | Finish F# native kernel acceleration | F# | L | gate+TC2+TD3+TPD4+TSPD5+WSP3+A* done |
@@ -445,19 +447,41 @@ plumbing there.
   6. Config/inline-override plumbing + bare-PI warning.
 - **Acceptance:** `swipl -g run_tests -t halt tests/test_wam_scala_iso_smoke.pl` passes (mirror `tests/test_wam_haskell_iso_smoke.pl`); `tests/test_iso_errors.pl` still green.
 
-### ISO-R: New ISO three-form adoption for WAM R target
+### ISO-R-0 ✅: shared ISO wiring + `is/2` three-form vertical slice
+- **Status:** Landed. Shared `iso_errors` config/rewrite/audit wired into
+  `wam_r_target.pl`; key table registers **only** `is/2` → `is_iso/2` |
+  `is_lax/2`. Runtime helpers live in `runtime.R.mustache`
+  (`builtin_is_iso` / `builtin_is_lax` + structured error constructors).
+  Existing `catch/3`+`throw/1` substrate is reused by tests but **R remains
+  a partial adopter** until all seven “What Counts As Adoption” items are
+  satisfied (comparisons, succ, and the rest of ISO-R-1/R-2).
+- **Acceptance:** `tests/test_wam_r_iso_unit.pl` + `tests/test_wam_r_iso_smoke.pl`.
+
+### ISO-R-1: catch/throw substrate (formalization / remaining gaps)
+- **Depends on:** ISO-R-0. Catch/throw already ship on R `tryCatch`; this
+  card covers any remaining substrate polish called out by the adoption
+  checklist (not claimed complete by ISO-R-0).
+
+### ISO-R-2: comparisons, successor, remaining adoption checklist
+- **Depends on:** ISO-R-1. Six arithmetic-compare families, `succ_iso` /
+  `succ_lax`, and any remaining concrete builtins needed to claim full
+  ISO-R adoption per
+  `docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`.
+
+### ISO-R (ledger parent): New ISO three-form adoption for WAM R target
 - **Lever:** ISO three-form  **Target:** R  **Size:** L  **Depends on:** —
-- **Goal:** Bring the WAM R target from non-adopter (only `tryCatch`/generator `catch/3`) to full ISO three-form adoption mirroring F#/Haskell.
-- **Files to touch:** `src/unifyweaver/targets/wam_r_target.pl`, `src/unifyweaver/targets/wam_r_lowered_emitter.pl`, new `tests/test_wam_r_iso_smoke.pl`
-- **Reference to copy from:** `wam_haskell_target.pl` + `wam_fsharp_target.pl`; `wam_cpp_target.pl` for runtime shapes; spec `docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`. Note: R already keeps a native inline parser hot-path (see spec §"Relationship To Runtime Parser Transpilation") — ISO work is independent of that.
-- **Steps:**
-  1. Import shared `iso_errors` module (6 preds).
-  2. Assert R key tables (`is/2`, 6 compares, `succ/2`).
-  3. Emit R runtime: `catch/3`+`throw/1` on R `tryCatch`/`stop`/`condition` substrate (verify: extend existing `tryCatch` usage at wam_r_target.pl:65), `error(...)` constructors + `throw_iso_error`, `is_iso`/`is_lax`, ISO/lax compares, `succ_iso`/`succ_lax`, lax IEEE-754 divide (R `/` already yields Inf/NaN; add ISO int div-by-zero→`evaluation_error(zero_divisor)`).
-  4. Wire text-path rewrite via `iso_errors_rewrite_text/4`.
-  5. Add `wam_r_iso_audit/3` + report.
-  6. Config/inline-override plumbing + bare-PI warning.
-- **Acceptance:** `swipl -g run_tests -t halt tests/test_wam_r_iso_smoke.pl` passes (mirror `tests/test_wam_haskell_iso_smoke.pl`); `tests/test_iso_errors.pl` still green.
+- **Goal:** Bring the WAM R target from non-adopter to full ISO three-form
+  adoption mirroring F#/Haskell. Split into ISO-R-0/1/2 above; do not claim
+  complete adoption until R-2 lands.
+- **Files to touch:** `src/unifyweaver/targets/wam_r_target.pl`,
+  `src/unifyweaver/targets/wam_r_lowered_emitter.pl`,
+  `templates/targets/r_wam/runtime.R.mustache`,
+  `tests/test_wam_r_iso_unit.pl`, `tests/test_wam_r_iso_smoke.pl`
+- **Reference to copy from:** `wam_haskell_target.pl` + `wam_fsharp_target.pl`;
+  `wam_cpp_target.pl` for runtime shapes; spec
+  `docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`.
+- **Acceptance (full):** all seven adoption items green; smoke + unit +
+  `tests/test_iso_errors.pl`.
 
 ### ISO-PYTHON: Finish Python three-form delta (remaining concrete builtins)
 - **Lever:** ISO three-form  **Target:** Python  **Size:** S  **Depends on:** —

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -54,8 +54,9 @@ self-contained so a single coding agent can pick it up in isolation.
 | ISO-GO | ISO three-form (new) | Go | L | — |
 | ISO-SCALA | ISO three-form (new) | Scala | L | — |
 | ISO-R-0 ✅ | shared wiring + `is/2` vertical slice | R | M | done (partial adopter) |
-| ISO-R-1 | catch/throw substrate formalization | R | S | ISO-R-0 |
-| ISO-R-2 | comparisons, succ, remaining adoption | R | M | ISO-R-1 |
+| ISO-R-1 ✅ | pre-existing catch/throw substrate | R | — | validated (`catch_throw_dyn_aggregator_e2e_rscript`) |
+| ISO-R-2A | arithmetic comparisons | R | S | ISO-R-0 |
+| ISO-R-2B | successor + adoption closeout | R | S | ISO-R-2A |
 | ISO-PYTHON | ISO three-form (finish) | Python | S | — |
 | ISO-FSHARP | ISO three-form (finish) | F# | S | — |
 | KERN-FSHARP ✅ | Finish F# native kernel acceleration | F# | L | gate+TC2+TD3+TPD4+TSPD5+WSP3+A* done |
@@ -454,25 +455,29 @@ plumbing there.
   (`builtin_is_iso` / `builtin_is_lax` + structured error constructors).
   Existing `catch/3`+`throw/1` substrate is reused by tests but **R remains
   a partial adopter** until all seven “What Counts As Adoption” items are
-  satisfied (comparisons, succ, and the rest of ISO-R-1/R-2).
+  satisfied (comparisons and succ remain).
 - **Acceptance:** `tests/test_wam_r_iso_unit.pl` + `tests/test_wam_r_iso_smoke.pl`.
 
-### ISO-R-1: catch/throw substrate (formalization / remaining gaps)
-- **Depends on:** ISO-R-0. Catch/throw already ship on R `tryCatch`; this
-  card covers any remaining substrate polish called out by the adoption
-  checklist (not claimed complete by ISO-R-0).
+### ISO-R-1 ✅: pre-existing catch/throw substrate
+- **Status:** Already shipped before ISO-R-0. R's `tryCatch` implementation
+  snapshots and unwinds trail/choice-point state, supports catcher
+  unification and rethrow, and is covered by
+  `catch_throw_dyn_aggregator_e2e_rscript`. No follow-up implementation card.
 
-### ISO-R-2: comparisons, successor, remaining adoption checklist
-- **Depends on:** ISO-R-1. Six arithmetic-compare families, `succ_iso` /
-  `succ_lax`, and any remaining concrete builtins needed to claim full
-  ISO-R adoption per
+### ISO-R-2A: arithmetic comparisons
+- **Depends on:** ISO-R-0. Add the six arithmetic-compare ISO/lax families,
+  reusing the existing evaluator and ISO error constructors.
+
+### ISO-R-2B: successor + adoption closeout
+- **Depends on:** ISO-R-2A. Add `succ_iso` / `succ_lax`, then verify the
+  complete adoption checklist in
   `docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`.
 
 ### ISO-R (ledger parent): New ISO three-form adoption for WAM R target
 - **Lever:** ISO three-form  **Target:** R  **Size:** L  **Depends on:** —
 - **Goal:** Bring the WAM R target from non-adopter to full ISO three-form
-  adoption mirroring F#/Haskell. Split into ISO-R-0/1/2 above; do not claim
-  complete adoption until R-2 lands.
+  adoption mirroring F#/Haskell. Split into ISO-R-0/1/2A/2B above; do not
+  claim complete adoption until R-2B lands.
 - **Files to touch:** `src/unifyweaver/targets/wam_r_target.pl`,
   `src/unifyweaver/targets/wam_r_lowered_emitter.pl`,
   `templates/targets/r_wam/runtime.R.mustache`,

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -54,14 +54,13 @@ default 4096), and explicit `auto` (codegen resolves via shared
   dispatch), preserving the full try/retry/trust chain.
 - **ISO error support** is a **partial adopter** after ISO-R-0: shared
   config/rewrite/audit + `is/2` → `is_iso`/`is_lax` vertical slice.
-  Catch/throw substrate exists; comparisons/`succ` and full adoption
-  checklist remain ISO-R-1/R-2. Do not claim complete ISO-R yet.
+  The pre-existing catch/throw substrate is already covered end-to-end;
+  comparisons/`succ` remain ISO-R-2A/R-2B. Do not claim complete ISO-R yet.
 - No dedicated effective-distance cross-target bench row.
 
 ## Path forward
 
-1. ISO-R-1 catch/throw substrate polish; ISO-R-2 comparisons + succ +
-   remaining adoption checklist.
+1. ISO-R-2A arithmetic comparisons; ISO-R-2B successor + adoption closeout.
 2. Effective-distance cross-target matrix row.
 
 ## Document status

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -52,13 +52,16 @@ default 4096), and explicit `auto` (codegen resolves via shared
   forms (`switch_on_constant_a2`, `_a2_fallthrough`, `switch_on_structure_a2`)
   — map to the existing `SwitchOnTerm()` linear no-op (not optimized A2
   dispatch), preserving the full try/retry/trust chain.
-- **ISO error support** is `tryCatch`-level only, not the three-form
-  contract.
+- **ISO error support** is a **partial adopter** after ISO-R-0: shared
+  config/rewrite/audit + `is/2` → `is_iso`/`is_lax` vertical slice.
+  Catch/throw substrate exists; comparisons/`succ` and full adoption
+  checklist remain ISO-R-1/R-2. Do not claim complete ISO-R yet.
 - No dedicated effective-distance cross-target bench row.
 
 ## Path forward
 
-1. ISO three-form adoption if R joins the error-fidelity set.
+1. ISO-R-1 catch/throw substrate polish; ISO-R-2 comparisons + succ +
+   remaining adoption checklist.
 2. Effective-distance cross-target matrix row.
 
 ## Document status

--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -759,8 +759,9 @@ are wired. Project options: `iso_errors(true|false)`,
 `iso_errors(PI, true|false)`, `iso_errors_config(File)`.
 
 Key table (slice only): `is/2` → `is_iso/2` | `is_lax/2`. Comparisons and
-`succ/2` are deferred (ISO-R-2). Explicit `_iso`/`_lax` forms survive mode
-rewrites. Runtime helpers in `runtime.R.mustache`:
+`succ/2` are deferred (ISO-R-2A and ISO-R-2B respectively). Explicit
+`_iso`/`_lax` forms survive mode rewrites. Runtime helpers in
+`runtime.R.mustache`:
 `builtin_is_iso` / `builtin_is_lax` + structured `error/2` constructors.
 Classify order for `is_iso`: unbound → `evaluation_error(zero_divisor)` →
 `type_error(evaluable, Culprit)`.

--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -552,31 +552,27 @@ shorthand (input / output / any), the same convention
 [`design/WAM_R_MODE_ANALYSIS_PLAN.md`](design/WAM_R_MODE_ANALYSIS_PLAN.md)
 for the phase roadmap and measured impact.
 
-### `is/2` specialisation (phase 3)
+### `is/2` specialisation (phase 3 + ISO-R-0)
 
-Two complementary specialisations targeting the `is/2` arithmetic
-builtin (dominant cost on arith-heavy recursive predicates):
+ISO-R-0 rewrites default `is/2` to `is_lax/2` (or `is_iso/2` under
+`iso_errors(true)`). Evaluation lives in shared runtime helpers
+`WamRuntime$builtin_is_lax` / `builtin_is_iso` (also used by the
+interpreter path).
 
-**Runtime fast-path** (in `WamRuntime$call_builtin`'s is/2 branch).
-When the expression is a 2-arg arithmetic struct (`+`, `-`, `*`,
-`//`, `mod`) with both operands derefing to ints, bypasses the
-recursive `eval_arith` walk + `arith_to_term` dispatch and
-fast-binds when the target is unbound. Falls through to the
-original slow path for floats, nested expressions, unbound vars in
-the RHS, etc. Always active, no codegen flag needed.
+**Runtime.** `builtin_is_lax` keeps the prior fail-on-bad-eval behaviour
+and the binary-int fast path (`+ - * // mod`). `builtin_is_iso`
+classifies unbound → zero_divisor → non-evaluable and throws structured
+`error/2`.
 
-**Lowered-emitter inline.** For `builtin_call is/2 2` lines in a
-lowered function body, the emitter emits inline R that bypasses
-`WamRuntime$step` → `WamRuntime$call_builtin` (saving 2 function
-calls + 2 switch lookups per is/2 hit). Always fires when the
-lowered emitter handles the clause; the runtime fast-path then
-applies inside the inline body.
+**Lowered-emitter inline.** For `builtin_call is/2|is_lax/2|is_iso/2 2`
+(and Execute forms of the explicit keys), the emitter calls the matching
+helper instead of `WamRuntime$step(... BuiltinCall(...))`.
 
 Note: phase 4 broadens lowered emission from the older
 `multi_clause_1` shape to `multi_clause_n`: when every clause is in
 the lowered emitter's supported instruction subset, each clause is
-emitted inline. That means lowered-emitter inline `is/2` now applies
-to clause 2+ as well as deterministic predicates and first clauses.
+emitted inline. That means the inlined `is_*` helper path applies to
+clause 2+ as well as deterministic predicates and first clauses.
 
 ## Supported features
 
@@ -755,6 +751,23 @@ raises a `prolog_throw` condition carrying a `copy_term`'d snapshot
 of the thrown term; `catch/3` unwinds the trail and CP stack to its
 entry snapshot before unifying with the catcher and running the
 recovery. Uncaught throws at the top level become query failure.
+
+### ISO errors (ISO-R-0 partial slice)
+
+Shared `iso_errors` config / per-predicate rewrite / `wam_r_iso_audit/3`
+are wired. Project options: `iso_errors(true|false)`,
+`iso_errors(PI, true|false)`, `iso_errors_config(File)`.
+
+Key table (slice only): `is/2` → `is_iso/2` | `is_lax/2`. Comparisons and
+`succ/2` are deferred (ISO-R-2). Explicit `_iso`/`_lax` forms survive mode
+rewrites. Runtime helpers in `runtime.R.mustache`:
+`builtin_is_iso` / `builtin_is_lax` + structured `error/2` constructors.
+Classify order for `is_iso`: unbound → `evaluation_error(zero_divisor)` →
+`type_error(evaluable, Culprit)`.
+
+R is still a **partial adopter** until all seven items in
+`docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` §"What Counts As
+Adoption" are satisfied.
 
 ## Supported WAM instructions
 
@@ -935,7 +948,7 @@ Coverage map (e2e tests, by feature group):
 | `mode_analysis_phase1_comments` | Mode-analysis visibility: `mode_comments(on)` option prepends `# Mode analysis:` block to each lowered function with per-clause head-binding states; covers `+`, `-`, `?`, undeclared mode shapes |
 | `mode_analysis_phase2_get_constant_inlined` | Mode-analysis phase 2: structural assertion that `get_constant` head match is emitted as inline `WamRuntime$deref + identical()` when the target A-register's declared mode is `+`; falls back to `WamRuntime$step` when no mode declaration or `mode_specialise(off)` |
 | `mode_analysis_phase2_get_constant_e2e_rscript` | Mode-analysis phase 2: e2e correctness -- a predicate with `:- mode(p(+))` and three clauses compiles + runs via Rscript, queries return correct true/false matching across the multi-clause backtracking path |
-| `mode_analysis_phase3_is_inlined` | Mode-analysis phase 3: structural assertion that `builtin_call is/2 2` is emitted as inline `WamRuntime$eval_arith + bind/unify` in the lowered function (instead of `WamRuntime$step(... BuiltinCall("is/2", 2))`) |
+| `mode_analysis_phase3_is_inlined` | Mode-analysis phase 3: structural assertion that rewritten `is_lax/2` is emitted as `WamRuntime$builtin_is_lax(...)` in the lowered function (instead of `WamRuntime$step(... BuiltinCall(...))`) |
 | `mode_analysis_phase3_is_e2e_rscript` | Mode-analysis phase 3: e2e correctness -- a predicate using `is/2` with simple binary int op (runtime fast-path), nested arith (slow path), and negative-result arith compiles + runs via Rscript with correct values |
 | `mode_analysis_phase4_multiclause_n_e2e_rscript` | Mode-analysis phase 4: all-supported-clause `multi_clause_n` lowering, including direct R-wrapper execution of clause 2's inline `is/2` path |
 | `mode_analysis_get_value_inlined` | Mode-analysis follow-up: structural assertion that repeated bound head variables compile `get_value` to an inline atomic identity fast path with safe fallback |

--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -842,6 +842,17 @@ emit_line_parts(["proceed"], I) :- !,
     format("~wreturn(TRUE)~n", [I]).
 emit_line_parts(["fail"], I) :- !,
     format("~wreturn(FALSE)~n", [I]).
+% Explicit is_iso/is_lax arrive as Call/Execute; route to shared helpers.
+emit_line_parts(["call", "is_iso/2"], I) :- !,
+    format("~wif (!isTRUE(WamRuntime$builtin_is_iso(program, state))) return(FALSE)~n", [I]).
+emit_line_parts(["call", "is_lax/2"], I) :- !,
+    format("~wif (!isTRUE(WamRuntime$builtin_is_lax(program, state))) return(FALSE)~n", [I]).
+emit_line_parts(["execute", "is_iso/2"], I) :- !,
+    format("~wif (!isTRUE(WamRuntime$builtin_is_iso(program, state))) return(FALSE)~n", [I]),
+    format("~wreturn(TRUE)~n", [I]).
+emit_line_parts(["execute", "is_lax/2"], I) :- !,
+    format("~wif (!isTRUE(WamRuntime$builtin_is_lax(program, state))) return(FALSE)~n", [I]),
+    format("~wreturn(TRUE)~n", [I]).
 emit_line_parts(["call", PredArity], I) :- !,
     emit_call(PredArity, I).
 emit_line_parts(["call", Pred, ArityStr], I) :- !,
@@ -953,21 +964,18 @@ emit_line_parts(["get_value", XStr, AiStr], I) :-
 % function-call + switch-dispatch hop. The inline path is semantically
 % identical to the slow path; it just avoids two function calls and
 % two switch lookups per call. Used heavily on arith-heavy workloads
-% where is/2 is the dominant builtin.
+% where is/2 is the dominant builtin. is_lax/2 shares the lax helper;
+% is_iso/2 routes through the shared ISO helper (no duplicated classify).
 
 emit_line_parts(["builtin_call", "is/2", "2"], I) :- !,
-    format("~w{~n", [I]),
-    format("~w  is_target_ <- WamRuntime$get_reg(state, 1L)~n", [I]),
-    format("~w  is_expr_   <- WamRuntime$get_reg(state, 2L)~n", [I]),
-    format("~w  is_n_      <- WamRuntime$eval_arith(state, is_expr_, intern_table)~n", [I]),
-    format("~w  if (is.null(is_n_)) return(FALSE)~n", [I]),
-    format("~w  is_res_    <- WamRuntime$arith_to_term(is_n_)~n", [I]),
-    format("~w  if (is.null(is_res_)) return(FALSE)~n", [I]),
-    format("~w  is_target_d_ <- WamRuntime$deref(state, is_target_)~n", [I]),
-    format("~w  if (!is.null(is_target_d_) && !is.null(is_target_d_$tag) && is_target_d_$tag == \"unbound\") {~n", [I]),
-    format("~w    WamRuntime$bind(state, is_target_d_$name, is_res_)~n", [I]),
-    format("~w  } else if (!isTRUE(WamRuntime$unify(state, is_target_, is_res_))) return(FALSE)~n", [I]),
-    format("~w}~n", [I]).
+    format("~wif (!isTRUE(WamRuntime$builtin_is_lax(program, state))) return(FALSE)~n",
+           [I]).
+emit_line_parts(["builtin_call", "is_lax/2", "2"], I) :- !,
+    format("~wif (!isTRUE(WamRuntime$builtin_is_lax(program, state))) return(FALSE)~n",
+           [I]).
+emit_line_parts(["builtin_call", "is_iso/2", "2"], I) :- !,
+    format("~wif (!isTRUE(WamRuntime$builtin_is_iso(program, state))) return(FALSE)~n",
+           [I]).
 
 % --- Default: delegate to step with the same R literal the array uses
 emit_line_parts(Parts, I) :-

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -48,7 +48,14 @@
     reg_to_int/2,                    % +RegName, -Index
     constant_to_r_term/2,            % +ConstStr, -RTermLiteral
     intern_r_atom/2,                 % +AtomStr, -Id
-    wam_r_resolve_emit_mode/2        % +Options, -Mode
+    wam_r_resolve_emit_mode/2,       % +Options, -Mode
+    % --- ISO-R-0: shared wiring + is/2 vertical slice -----
+    iso_errors_resolve_options/2,
+    iso_errors_load_config/2,
+    iso_errors_mode_for/3,
+    iso_errors_rewrite_text/4,
+    wam_r_iso_audit/3,
+    wam_r_iso_audit_report/1
 ]).
 
 :- use_module(library(lists)).
@@ -58,7 +65,11 @@
     compile_predicate_to_wam_text/3,
     compile_predicate_to_wam_items/3
 ]).
-:- use_module('../targets/wam_text_parser', [wam_classify_constant_token/2]).
+:- use_module('../targets/wam_text_parser', [
+    wam_classify_constant_token/2,
+    wam_tokenize_line/2,
+    wam_recognise_instruction/2
+]).
 :- use_module(wam_ir_mode, [wam_ir_mode/4]).
 :- use_module('../core/template_system', [render_template/3]).
 % Lowered emitter: real Phase-2 implementation lives there. We keep the
@@ -75,6 +86,16 @@
               wam_target_runtime_parser/3]).
 :- use_module('../core/cost_model',
              [resolve_auto_lmdb_materialisation/2]).
+:- use_module('../core/iso_errors',
+             [ iso_errors_resolve_options/2,
+               iso_errors_load_config/2,
+               iso_errors_mode_for/3,
+               iso_errors_warn_multi_module/2,
+               iso_errors_rewrite/4,
+               iso_errors_rewrite_item/3,
+               iso_errors_audit_normalise_pi/2,
+               iso_errors_audit_walk/5
+             ]).
 
 % ============================================================================
 % EMIT MODE
@@ -942,7 +963,12 @@ compile_predicates_for_project(Predicates, Options,
                                       CompilePredicates),
     wam_r_resolve_emit_mode(Options, EmitMode),
     wam_r_emit_ir_mode(Options, EmitMode, IrMode),
-    compile_all_predicates(CompilePredicates, Options, EmitMode, IrMode, 1,
+    % ISO-R-0: resolve once per project; warn on bare-PI multi-module
+    % overrides. Rewrite is applied per predicate before array/lowered.
+    iso_errors_resolve_options(Options, IsoConfig),
+    iso_errors_warn_multi_module(IsoConfig, CompilePredicates),
+    compile_all_predicates(CompilePredicates, Options, EmitMode, IrMode,
+                           IsoConfig, 1,
                            [], [], [], [], [], [], [],
                            AllInstrs, TopLevelLabelEntries,
                            AllLabelEntries, Wrappers, LoweredEntries,
@@ -970,11 +996,11 @@ same_predicate_indicator(P0, P1) :-
 predicate_indicator_key(_:Pred/Arity, Pred/Arity) :- !.
 predicate_indicator_key(Pred/Arity, Pred/Arity).
 
-compile_all_predicates([], _, _, _, _, Instrs, TopLabels, AllLabels, Wrappers,
+compile_all_predicates([], _, _, _, _, _, Instrs, TopLabels, AllLabels, Wrappers,
                        Lowered, FactComments, Dispatch,
                        Instrs, TopLabels, AllLabels, Wrappers,
                        Lowered, FactComments, Dispatch).
-compile_all_predicates([Pred|Rest], Options, EmitMode, IrMode, BasePC,
+compile_all_predicates([Pred|Rest], Options, EmitMode, IrMode, IsoConfig, BasePC,
                        InstrAcc, TopLabelAcc, AllLabelAcc, WrapperAcc, LoweredAcc,
                        FactCommentAcc, LoweredDispAcc,
                        AllInstrs, TopLevelLabelEntries,
@@ -1015,8 +1041,12 @@ compile_all_predicates([Pred|Rest], Options, EmitMode, IrMode, BasePC,
         % to P/Arity defaults compile_predicate_to_wam's module to
         % `user`, which silently produces "no clauses" for predicates
         % defined in any other module.
-        compile_predicate_to_wam_text(Pred, [], WamCode),
-        compile_r_predicate_array_wam(Pred, IrMode, WamCode, WamForArray),
+        compile_predicate_to_wam_text(Pred, [], WamCode0),
+        % ISO rewrite before array vs lowered choice (ISO-R-0).
+        iso_errors_pi_for_rewrite(Pred, RewritePI),
+        iso_errors_rewrite_text(IsoConfig, RewritePI, WamCode0, WamCode),
+        compile_r_predicate_array_wam(Pred, IrMode, IsoConfig, RewritePI,
+                                      WamCode, WamForArray),
         WamCodeForLower = WamCode,
         atom_string(WamCode, WamStr),
         split_string(WamStr, "\n", "", WamLines),
@@ -1097,7 +1127,7 @@ compile_all_predicates([Pred|Rest], Options, EmitMode, IrMode, BasePC,
         NewLoweredDispAcc = LoweredDispAcc,
         emit_r_wrapper(P, Arity, BasePC, WrapperCode)
     ),
-    compile_all_predicates(Rest, Options, EmitMode, IrMode, NewPC,
+    compile_all_predicates(Rest, Options, EmitMode, IrMode, IsoConfig, NewPC,
                            NewInstrs, NewTopLabels, NewAllLabels,
                            [WrapperCode|WrapperAcc], NewLoweredAcc,
                            NewFactCommentAcc,
@@ -1106,9 +1136,24 @@ compile_all_predicates([Pred|Rest], Options, EmitMode, IrMode, BasePC,
                            AllLabelEntries, AllWrappers, AllLowered,
                            AllFactComments, AllLoweredDispatch).
 
-compile_r_predicate_array_wam(_Pred, wam_text, WamCode, WamCode).
-compile_r_predicate_array_wam(Pred, wam_items_bridge, _WamCode, Items) :-
-    compile_predicate_to_wam_items(Pred, [], Items).
+compile_r_predicate_array_wam(_Pred, wam_text, _IsoConfig, _RewritePI,
+                              WamCode, WamCode).
+compile_r_predicate_array_wam(Pred, wam_items_bridge, IsoConfig, RewritePI,
+                              _WamCode, Items) :-
+    compile_predicate_to_wam_items(Pred, [], Items0),
+    iso_errors_rewrite(IsoConfig, RewritePI, Items0, Items1),
+    % Drop rewrites to keys R has not implemented yet (cross-target
+    % multifile pollution from F#/Haskell/Python compare/succ tables).
+    maplist(r_iso_filter_item_rewrite, Items0, Items1, Items).
+
+r_iso_filter_item_rewrite(Item0, Item1, Item) :-
+    (   Item0 == Item1
+    ->  Item = Item1
+    ;   arg(1, Item0, OldKey),
+        r_iso_rewritable_key(OldKey)
+    ->  Item = Item1
+    ;   Item = Item0
+    ).
 
 %% emit_lowered_dispatch_entry(+Pred, +Arity, +FuncName, -Entry)
 %  Generates an `assign("Pred/Arity", FuncName, envir = ...)` line
@@ -2138,3 +2183,125 @@ find_template(RelPath, Template) :-
     ;   AbsPath = RelPath
     ),
     read_file_to_string(AbsPath, Template, []).
+
+% ============================================================================
+% ISO-R-0: shared ISO wiring + is/2 three-form vertical slice
+% ============================================================================
+% Key-table safety: register ONLY is/2 until matching R runtime branches
+% exist for comparisons / succ.  Catch/throw already ship in
+% runtime.R.mustache and are reused by the smoke suite, but are not
+% part of this slice's adoption claim.
+
+iso_errors:iso_errors_default_to_iso("is/2", "is_iso/2").
+iso_errors:iso_errors_default_to_lax("is/2", "is_lax/2").
+
+iso_errors_pi_for_rewrite(_M:Pred/Arity, Pred/Arity) :- !.
+iso_errors_pi_for_rewrite(Pred/Arity, Pred/Arity) :- !.
+iso_errors_pi_for_rewrite(PI, PI).
+
+%% iso_errors_rewrite_text(+Config, +PI, +WamText, -RewrittenText)
+%  Per-target adapter: tokenize → recognise → shared rewrite_item → splice.
+%  Covers builtin_call / put_structure / call / execute via the shared
+%  item rewriter.  Not exported by core/iso_errors.pl.
+iso_errors_rewrite_text(Config, PI, WamText, RewrittenText) :-
+    iso_errors_mode_for(Config, PI, Mode),
+    (   Mode == false,
+        \+ iso_errors_has_lax_entries
+    ->  RewrittenText = WamText
+    ;   atom_string(WamText, S),
+        split_string(S, "\n", "", Lines),
+        maplist(iso_errors_rewrite_line(Mode), Lines, RewrittenLines),
+        atomic_list_concat(RewrittenLines, '\n', RewrittenText)
+    ).
+
+iso_errors_has_lax_entries :- iso_errors:iso_errors_default_to_lax(_, _), !.
+
+iso_errors_rewrite_line(Mode, Line, OutLine) :-
+    (   wam_tokenize_line(Line, Tokens),
+        wam_recognise_instruction(Tokens, Item0),
+        iso_errors_rewrite_item(Mode, Item0, Item1),
+        Item0 \== Item1,
+        arg(1, Item0, OldKey),
+        % ISO-R-0: only keep rewrites for keys this target implements.
+        % Other loaded targets' multifile tables must not route R codegen
+        % to missing >_lax / succ_iso arms.
+        r_iso_rewritable_key(OldKey),
+        arg(1, Item1, NewKey),
+        iso_errors_splice_line(Line, OldKey, NewKey, OutLine)
+    ->  true
+    ;   OutLine = Line
+    ).
+
+%% Keys with matching R runtime branches (ISO-R-0 slice).
+r_iso_rewritable_key("is/2").
+
+iso_errors_clean_key_token(Token0, Token) :-
+    (   string_concat(Token, ",", Token0)
+    ->  true
+    ;   Token = Token0
+    ).
+
+iso_errors_splice_line(Line, Key, NewKey, OutLine) :-
+    sub_string(Line, Before, KLen, _After, Key),
+    string_length(Key, KLen),
+    sub_string(Line, 0, Before, _, Pre),
+    PostStart is Before + KLen,
+    sub_string(Line, PostStart, _, 0, Post),
+    string_concat(Pre, NewKey, T1),
+    string_concat(T1, Post, OutLine), !.
+
+%% wam_r_iso_audit(+Predicates, +Options, -Audit)
+wam_r_iso_audit(Predicates, Options, Audit) :-
+    iso_errors_resolve_options(Options, Config),
+    findall(audit(PI, Mode, Sites), (
+        member(P, Predicates),
+        iso_errors_audit_normalise_pi(P, PI),
+        iso_errors_mode_for(Config, PI, Mode),
+        iso_errors_audit_predicate_r(PI, Mode, Sites)
+    ), Audit).
+
+iso_errors_audit_predicate_r(PI, Mode, Sites) :-
+    (   catch(
+            ( iso_errors_audit_wam_for_pi_r(PI, WamText),
+              iso_errors_audit_parse_lines_r(WamText, Items)
+            ),
+            _, fail)
+    ->  iso_errors_audit_walk(Items, 0, Mode, [], SitesRev),
+        reverse(SitesRev, Sites)
+    ;   Sites = []
+    ).
+
+iso_errors_audit_wam_for_pi_r(Module:Pred/Arity, WamText) :- !,
+    compile_predicate_to_wam_text(Module:Pred/Arity, [], WamText).
+iso_errors_audit_wam_for_pi_r(Pred/Arity, WamText) :-
+    compile_predicate_to_wam_text(Pred/Arity, [], WamText).
+
+iso_errors_audit_parse_lines_r(WamText, Items) :-
+    atom_string(WamText, S),
+    split_string(S, "\n", "", Lines),
+    maplist(iso_errors_audit_parse_one_r, Lines, MaybeItems),
+    exclude(==(skip), MaybeItems, Items).
+
+iso_errors_audit_parse_one_r(Line, Item) :-
+    split_string(Line, " \t", " \t", Parts0),
+    exclude(==(""), Parts0, Parts),
+    iso_errors_audit_classify_line_r(Parts, Item).
+
+iso_errors_audit_classify_line_r([], skip).
+iso_errors_audit_classify_line_r([Tok], label) :-
+    string_concat(_, ":", Tok), !.
+iso_errors_audit_classify_line_r(["builtin_call", Key0 | _],
+                                builtin_call(Key, 0)) :- !,
+    iso_errors_clean_key_token(Key0, Key).
+iso_errors_audit_classify_line_r(_, other).
+
+wam_r_iso_audit_report([]).
+wam_r_iso_audit_report([audit(PI, Mode, Sites)|Rest]) :-
+    format('~w [~w]~n', [PI, Mode]),
+    (   Sites == []
+    ->  format('  (no builtin_call sites)~n', [])
+    ;   forall(member(site(PC, Orig, Res, Src, Flip), Sites),
+               format('  pc=~w  ~w -> ~w  (~w)  flip-changes=~w~n',
+                      [PC, Orig, Res, Src, Flip]))
+    ),
+    wam_r_iso_audit_report(Rest).

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -2195,7 +2195,9 @@ find_template(RelPath, Template) :-
 iso_errors:iso_errors_default_to_iso("is/2", "is_iso/2").
 iso_errors:iso_errors_default_to_lax("is/2", "is_lax/2").
 
-iso_errors_pi_for_rewrite(_M:Pred/Arity, Pred/Arity) :- !.
+% Keep the module when present: qualified overrides must not leak to a
+% same-named predicate in another module.
+iso_errors_pi_for_rewrite(M:Pred/Arity, M:Pred/Arity) :- !.
 iso_errors_pi_for_rewrite(Pred/Arity, Pred/Arity) :- !.
 iso_errors_pi_for_rewrite(PI, PI).
 

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -1978,6 +1978,146 @@ WamRuntime$eval_arith <- function(state, term, table) {
   NULL
 }
 
+# ----------------------------------------------------------
+# ISO-R-0: structured error helpers + is_iso / is_lax
+# ----------------------------------------------------------
+# Shared by interpreter BuiltinCall and Execute/Call library fallback.
+# Classify order for is_iso: unbound → zero_divisor → non-evaluable.
+
+WamRuntime$make_instantiation_error <- function(table) {
+  Atom(WamRuntime$intern(table, "instantiation_error"))
+}
+
+WamRuntime$make_type_error <- function(table, expected, culprit) {
+  StructTerm(WamRuntime$intern(table, "type_error"),
+             list(Atom(WamRuntime$intern(table, expected)), culprit))
+}
+
+WamRuntime$make_evaluation_error <- function(table, kind) {
+  StructTerm(WamRuntime$intern(table, "evaluation_error"),
+             list(Atom(WamRuntime$intern(table, kind))))
+}
+
+WamRuntime$throw_iso_error <- function(state, table, err_term) {
+  ctx <- Unbound(paste0("V", state$var_counter))
+  state$var_counter <- state$var_counter + 1L
+  wrapped <- StructTerm(WamRuntime$intern(table, "error"), list(err_term, ctx))
+  cond <- structure(
+    list(message = "prolog_throw", error_term = wrapped),
+    class = c("prolog_throw", "condition")
+  )
+  stop(cond)
+}
+
+WamRuntime$iso_term_contains_unbound <- function(state, term) {
+  v <- WamRuntime$deref(state, term)
+  if (is.null(v) || is.null(v$tag)) return(FALSE)
+  if (v$tag == "unbound") return(TRUE)
+  if (v$tag == "struct") {
+    for (a in v$args) {
+      if (WamRuntime$iso_term_contains_unbound(state, a)) return(TRUE)
+    }
+  }
+  FALSE
+}
+
+WamRuntime$iso_term_has_zero_divide_t <- function(state, term, table) {
+  v <- WamRuntime$deref(state, term)
+  if (is.null(v) || is.null(v$tag) || v$tag != "struct") return(FALSE)
+  op <- WamRuntime$string_of(table, v$fid)
+  if (op %in% c("/", "//", "mod", "rem") && length(v$args) == 2L) {
+    rhs <- WamRuntime$deref(state, v$args[[2]])
+    if (!is.null(rhs) && !is.null(rhs$tag)) {
+      if (rhs$tag == "int" && rhs$val == 0L) return(TRUE)
+      if (rhs$tag == "float" && rhs$val == 0) return(TRUE)
+    }
+  }
+  for (a in v$args) {
+    if (WamRuntime$iso_term_has_zero_divide_t(state, a, table)) return(TRUE)
+  }
+  FALSE
+}
+
+WamRuntime$iso_arith_culprit <- function(state, term, table) {
+  v <- WamRuntime$deref(state, term)
+  if (!is.null(v) && !is.null(v$tag) && v$tag == "atom") {
+    return(StructTerm(WamRuntime$intern(table, "/"),
+                      list(v, IntTerm(0L))))
+  }
+  if (!is.null(v) && !is.null(v$tag) && v$tag == "struct") {
+    name <- WamRuntime$string_of(table, v$fid)
+    return(StructTerm(WamRuntime$intern(table, "/"),
+                      list(Atom(WamRuntime$intern(table, name)),
+                           IntTerm(as.integer(length(v$args))))))
+  }
+  StructTerm(WamRuntime$intern(table, "/"),
+             list(Atom(WamRuntime$intern(table, "unknown")), IntTerm(0L)))
+}
+
+# Lax is/2 body (also powers is_lax/2). Fail silently on bad eval.
+WamRuntime$builtin_is_lax <- function(program, state) {
+  table <- program$intern_table
+  target <- WamRuntime$get_reg(state, 1L)
+  expr   <- WamRuntime$get_reg(state, 2L)
+  expr_d <- WamRuntime$deref(state, expr)
+  if (!is.null(expr_d) && is.list(expr_d) && !is.null(expr_d$tag) &&
+      expr_d$tag == "struct" && length(expr_d$args) == 2L) {
+    a_d <- WamRuntime$deref(state, expr_d$args[[1L]])
+    b_d <- WamRuntime$deref(state, expr_d$args[[2L]])
+    if (!is.null(a_d) && !is.null(b_d) &&
+        !is.null(a_d$tag) && !is.null(b_d$tag) &&
+        a_d$tag == "int" && b_d$tag == "int") {
+      op <- WamRuntime$string_of(table, expr_d$fid)
+      fast_val <- switch(op,
+        "+"   = a_d$val + b_d$val,
+        "-"   = a_d$val - b_d$val,
+        "*"   = a_d$val * b_d$val,
+        "//"  = a_d$val %/% b_d$val,
+        "mod" = a_d$val %% b_d$val,
+        NULL)
+      if (!is.null(fast_val)) {
+        res <- IntTerm(as.integer(fast_val))
+        target_d <- WamRuntime$deref(state, target)
+        if (!is.null(target_d) && !is.null(target_d$tag) &&
+            target_d$tag == "unbound") {
+          WamRuntime$bind(state, target_d$name, res)
+          return(TRUE)
+        }
+        return(WamRuntime$unify(state, target, res))
+      }
+    }
+  }
+  n <- WamRuntime$eval_arith(state, expr, table)
+  if (is.null(n)) return(FALSE)
+  res <- WamRuntime$arith_to_term(n)
+  if (is.null(res)) return(FALSE)
+  WamRuntime$unify(state, target, res)
+}
+
+# ISO is/2: structured errors; classify unbound → zero_div → type_error.
+WamRuntime$builtin_is_iso <- function(program, state) {
+  table <- program$intern_table
+  target <- WamRuntime$get_reg(state, 1L)
+  expr   <- WamRuntime$get_reg(state, 2L)
+  if (WamRuntime$iso_term_contains_unbound(state, expr)) {
+    WamRuntime$throw_iso_error(state, table,
+      WamRuntime$make_instantiation_error(table))
+  }
+  if (WamRuntime$iso_term_has_zero_divide_t(state, expr, table)) {
+    WamRuntime$throw_iso_error(state, table,
+      WamRuntime$make_evaluation_error(table, "zero_divisor"))
+  }
+  n <- WamRuntime$eval_arith(state, expr, table)
+  if (is.null(n)) {
+    WamRuntime$throw_iso_error(state, table,
+      WamRuntime$make_type_error(table, "evaluable",
+        WamRuntime$iso_arith_culprit(state, expr, table)))
+  }
+  res <- WamRuntime$arith_to_term(n)
+  if (is.null(res)) return(FALSE)
+  WamRuntime$unify(state, target, res)
+}
+
 # Standard Euclidean GCD; both args coerced to non-negative integers.
 wam_gcd <- function(a, b) {
   a <- abs(as.integer(a)); b <- abs(as.integer(b))
@@ -4879,51 +5019,13 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
     return(!isTRUE(ok))
   }
 
-  # is/2: eval A2, unify with A1.
-  #
-  # Fast path: when the expression is a 2-arg arithmetic struct whose
-  # both args deref to ints, and the operator is one of the common
-  # integer ops, do the arith inline and skip the eval_arith recursion
-  # (which would otherwise call itself 2-3 times for this single op)
-  # and the arith_to_term dispatch. Additionally, when the target derefs
-  # to unbound, fast-bind (skipping unify). Falls through to the slow
-  # path for anything else.
-  if (pred == "is/2" && arity == 2L) {
-    target <- WamRuntime$get_reg(state, 1L)
-    expr   <- WamRuntime$get_reg(state, 2L)
-    expr_d <- WamRuntime$deref(state, expr)
-    if (!is.null(expr_d) && is.list(expr_d) && !is.null(expr_d$tag) &&
-        expr_d$tag == "struct" && length(expr_d$args) == 2L) {
-      a_d <- WamRuntime$deref(state, expr_d$args[[1L]])
-      b_d <- WamRuntime$deref(state, expr_d$args[[2L]])
-      if (!is.null(a_d) && !is.null(b_d) &&
-          !is.null(a_d$tag) && !is.null(b_d$tag) &&
-          a_d$tag == "int" && b_d$tag == "int") {
-        op <- WamRuntime$string_of(table, expr_d$fid)
-        fast_val <- switch(op,
-          "+"   = a_d$val + b_d$val,
-          "-"   = a_d$val - b_d$val,
-          "*"   = a_d$val * b_d$val,
-          "//"  = a_d$val %/% b_d$val,
-          "mod" = a_d$val %% b_d$val,
-          NULL)
-        if (!is.null(fast_val)) {
-          res <- IntTerm(as.integer(fast_val))
-          target_d <- WamRuntime$deref(state, target)
-          if (!is.null(target_d) && !is.null(target_d$tag) &&
-              target_d$tag == "unbound") {
-            WamRuntime$bind(state, target_d$name, res)
-            return(TRUE)
-          }
-          return(WamRuntime$unify(state, target, res))
-        }
-      }
-    }
-    n <- WamRuntime$eval_arith(state, expr, table)
-    if (is.null(n)) return(FALSE)
-    res <- WamRuntime$arith_to_term(n)
-    if (is.null(res)) return(FALSE)
-    return(WamRuntime$unify(state, target, res))
+  # is/2 and is_lax/2 share the lax body. is_iso/2 throws structured
+  # ISO errors (unbound → zero_divisor → non-evaluable).
+  if (arity == 2L && (pred == "is/2" || pred == "is_lax/2")) {
+    return(WamRuntime$builtin_is_lax(program, state))
+  }
+  if (pred == "is_iso/2" && arity == 2L) {
+    return(WamRuntime$builtin_is_iso(program, state))
   }
   # Numeric comparison builtins: eval both args, compare.
   if (arity == 2L && pred %in% c("=:=/2", "=\\=/2", "</2", ">/2", "=</2", ">=/2")) {
@@ -5182,6 +5284,12 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
 WamRuntime$call_library <- function(program, state, pred, arity) {
   table <- program$intern_table
   key <- if (grepl("/[0-9]+$", pred)) pred else paste0(pred, "/", arity)
+
+  # Explicit is_iso/is_lax arrive as Execute/Call (not builtin_call).
+  # Delegate to call_builtin so evaluation lives in one place.
+  if (key == "is_iso/2" || key == "is_lax/2") {
+    return(WamRuntime$call_builtin(program, state, key, arity))
+  }
 
   # ----- ^/2 existential scope -----
   # When the WAM compiler emits `Y^Goal` as a Call("^", 2), treat

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -545,7 +545,7 @@ test(builtin_call_emitted) :-
             TmpDir),
         directory_file_path(TmpDir, 'R/generated_program.R', Program),
         read_file_to_string(Program, Code, []),
-        assertion(sub_string(Code, _, _, _, 'BuiltinCall("is/2", 2)')),
+        assertion(sub_string(Code, _, _, _, 'BuiltinCall("is_lax/2", 2)')),
         assertion(sub_string(Code, _, _, _, 'BuiltinCall(">/2", 2)')),
         delete_directory_and_contents(TmpDir)
     )).
@@ -1000,23 +1000,19 @@ e2e_mode_phase2_get_constant :-
 % Mode-analysis phase 3: is/2 specialisations.
 %
 % Two combined changes:
-%   (a) Runtime fast-path: the is/2 handler in call_builtin recognises
-%       simple binary int-only expressions and bypasses eval_arith's
-%       recursion + arith_to_term dispatch, plus fast-binds the target
-%       when it derefs to unbound.
-%   (b) Lowered-emitter inline: the lowered emitter emits is/2 directly,
-%       skipping the WamRuntime$step -> WamRuntime$call_builtin
-%       function-call + switch hop.
+%   (a) Runtime fast-path: builtin_is_lax (shared with is_lax/2 after
+%       ISO-R-0 rewrite) recognises simple binary int-only expressions.
+%   (b) Lowered-emitter inline: emits WamRuntime$builtin_is_lax(...)
+%       directly, skipping step → call_builtin dispatch.
 %
-% Two structural assertions on the codegen (for (b)), plus an e2e
-% Rscript correctness check covering simple + nested + non-int cases
-% (validates both (a) and (b) together).
+% ISO-R-0 always rewrites default is/2 → is_lax/2 (lax default), so the
+% structural assertion looks for the shared lax helper call.
 % ------------------------------------------------------------------
 test(mode_analysis_phase3_is_inlined) :-
     once((
         retractall(user:p3_compute(_, _)),
         % Single-clause arith predicate; lowered emitter will emit the
-        % is/2 inline form for this clause body.
+        % shared is_lax helper for this clause body.
         assertz((user:p3_compute(N, R) :- R is N * 2 + 1)),
         unique_r_tmp_dir('tmp_r_phase3_is_inlined', TmpDir),
         write_wam_r_project(
@@ -1025,14 +1021,12 @@ test(mode_analysis_phase3_is_inlined) :-
             TmpDir),
         directory_file_path(TmpDir, 'R/generated_program.R', Program),
         read_file_to_string(Program, Code, []),
-        % Inline is/2 form present.
         assertion(sub_string(Code, _, _, _,
-            'is_target_ <- WamRuntime$get_reg(state, 1L)')),
-        assertion(sub_string(Code, _, _, _,
-            'is_n_      <- WamRuntime$eval_arith(state, is_expr_,')),
-        % AND the step-delegating form for builtin_call is/2 is absent.
+            'WamRuntime$builtin_is_lax(program, state)')),
         assertion(\+ sub_string(Code, _, _, _,
             'WamRuntime$step(program, state, BuiltinCall("is/2"')),
+        assertion(\+ sub_string(Code, _, _, _,
+            'WamRuntime$step(program, state, BuiltinCall("is_lax/2"')),
         delete_directory_and_contents(TmpDir)
     )).
 

--- a/tests/test_wam_r_iso_smoke.pl
+++ b/tests/test_wam_r_iso_smoke.pl
@@ -1,0 +1,158 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_wam_r_iso_smoke.pl - ISO-R-0 generated-R smoke for is/2 three-form.
+% Hand-written PASS/FAIL; exit nonzero on failure (F# smoke convention).
+%
+% Usage: swipl -q -f init.pl -s tests/test_wam_r_iso_smoke.pl -g main -t halt
+
+:- encoding(utf8).
+:- use_module('../src/unifyweaver/targets/wam_r_target',
+              [write_wam_r_project/3]).
+:- use_module(library(filesex), [delete_directory_and_contents/1,
+                                  make_directory_path/1,
+                                  directory_file_path/3]).
+:- use_module(library(process)).
+
+pass(Name) :- format('[PASS] ~w~n', [Name]).
+fail_test(Name, Reason) :-
+    format('[FAIL] ~w: ~w~n', [Name, Reason]),
+    nb_setval(r_iso_smoke_failed, true).
+
+rscript_available :-
+    catch(
+        ( process_create(path('Rscript'), ['--version'],
+                         [stdout(null), stderr(null), process(PID)]),
+          process_wait(PID, exit(0))
+        ), _, fail).
+
+run_rscript(Drive, Dir, ExitCode, OutText) :-
+    setup_call_cleanup(
+        process_create(path('Rscript'), [Drive],
+                       [cwd(Dir), stdout(pipe(Out)), stderr(pipe(Err)),
+                        process(PID)]),
+        ( read_string(Out, _, OutStr),
+          read_string(Err, _, ErrStr),
+          process_wait(PID, exit(ExitCode)),
+          string_concat(OutStr, ErrStr, OutText)
+        ),
+        ( catch(close(Out), _, true), catch(close(Err), _, true) )).
+
+write_driver(Path, Checks) :-
+    open(Path, write, S),
+    format(S,
+'source("R/wam_runtime.R")
+source("R/generated_program.R")
+passes <- 0L; fails <- 0L
+check <- function(name, key) {
+  start_pc <- shared_labels[[key]]
+  ok <- tryCatch(
+    !is.null(start_pc) && isTRUE(WamRuntime$run_predicate(shared_program, start_pc, list())),
+    error = function(e) { message(conditionMessage(e)); FALSE })
+  if (isTRUE(ok)) { passes <<- passes + 1L; cat(sprintf("[PASS] %s\\n", name)) }
+  else { fails <<- fails + 1L; cat(sprintf("[FAIL] %s\\n", name)) }
+}
+', []),
+    forall(member(Name-Key, Checks),
+           format(S, 'check("~w", "~w")~n', [Name, Key])),
+    write(S,
+'cat(sprintf("RESULT %d/%d\\n", passes, passes + fails))
+quit(status = if (fails == 0L) 0L else 1L)
+'),
+    close(S).
+
+unique_tmp(Base, Dir) :-
+    get_time(T), format(atom(Dir), '/tmp/~w_~w', [Base, T]),
+    catch(delete_directory_and_contents(Dir), _, true),
+    make_directory_path(Dir).
+
+run_project(Label, Preds, Opts, Checks) :-
+    format('--- ~w ---~n', [Label]),
+    unique_tmp('uw_r_iso_smoke', Tmp),
+    write_wam_r_project(Preds, Opts, Tmp),
+    directory_file_path(Tmp, 'drive.R', Drive),
+    write_driver(Drive, Checks),
+    (   rscript_available
+    ->  run_rscript(Drive, Tmp, Exit, Out),
+        write(Out),
+        (   Exit == 0 -> pass(Label)
+        ;   fail_test(Label, ['Rscript exit=', Exit])
+        )
+    ;   directory_file_path(Tmp, 'R/generated_program.R', Prog),
+        read_file_to_string(Prog, Code, []),
+        (   (sub_string(Code,_,_,_,"is_iso/2"); sub_string(Code,_,_,_,"is_lax/2"))
+        ->  pass(Label-codegen-skip-rscript)
+        ;   fail_test(Label, 'missing rewritten is key in codegen')
+        )
+    ),
+    catch(delete_directory_and_contents(Tmp), _, true).
+
+main :-
+    nb_setval(r_iso_smoke_failed, false),
+    % Helpers + scenarios
+    assertz((user:r_ok :- X is 1 + 2, X == 3)),
+    assertz((user:r_iso_inst :-
+        catch(is_iso(_, _Y), error(instantiation_error, _), true))),
+    assertz((user:r_iso_type :-
+        catch(is_iso(_, foo), error(type_error(evaluable, _), _), true))),
+    assertz((user:r_iso_zdiv :-
+        catch(is_iso(_, 1 / 0), error(evaluation_error(zero_divisor), _), true))),
+    assertz((user:r_lax_bad :- \+ is_lax(_, foo))),
+    assertz((user:r_plain_zdiv :-
+        catch((_X is 1 / 0), error(evaluation_error(zero_divisor), _), true))),
+    assertz((user:r_plain_bad :- \+ (_ is foo))),
+    assertz((user:r_plain_ok_iso :- X is 40 + 2, X == 42)),
+
+    % 1) successful is/2 (ISO default rewrite still succeeds)
+    run_project('successful is/2 (iso default, interpreter)',
+        [user:r_ok/0],
+        [iso_errors(true)],
+        ['successful is/2'-'r_ok/0']),
+
+    % 2) ISO-default structured errors via plain is/2 rewrite
+    run_project('ISO-default structured errors (interpreter)',
+        [user:r_plain_zdiv/0, user:r_plain_ok_iso/0],
+        [iso_errors(true)],
+        ['ISO-default zero_divisor'-'r_plain_zdiv/0',
+         'ISO-default success'-'r_plain_ok_iso/0']),
+
+    % 3) lax-default non-throwing
+    run_project('lax-default silent fail (interpreter)',
+        [user:r_plain_bad/0],
+        [iso_errors(false)],
+        ['lax-default silent'-'r_plain_bad/0']),
+
+    % 4) per-predicate override (global ISO, one pred lax)
+    run_project('per-predicate override to lax (interpreter)',
+        [user:r_plain_bad/0, user:r_plain_zdiv/0],
+        [iso_errors(true), iso_errors(r_plain_bad/0, false)],
+        ['override lax silent'-'r_plain_bad/0',
+         'sibling stays ISO'-'r_plain_zdiv/0']),
+
+    % 5) explicit is_iso bypasses lax mode
+    run_project('explicit is_iso under lax mode (interpreter)',
+        [user:r_iso_type/0, user:r_iso_inst/0, user:r_iso_zdiv/0],
+        [iso_errors(false)],
+        ['explicit is_iso type_error'-'r_iso_type/0',
+         'explicit is_iso instantiation_error'-'r_iso_inst/0',
+         'explicit is_iso zero_divisor'-'r_iso_zdiv/0']),
+
+    % 6) explicit is_lax bypasses ISO mode
+    run_project('explicit is_lax under ISO mode (interpreter)',
+        [user:r_lax_bad/0],
+        [iso_errors(true)],
+        ['explicit is_lax silent'-'r_lax_bad/0']),
+
+    % 7) functions/lowered emit mode
+    run_project('functions mode ISO-default + explicit',
+        [user:r_ok/0, user:r_iso_type/0, user:r_lax_bad/0, user:r_plain_zdiv/0],
+        [emit_mode(functions), iso_errors(true)],
+        ['functions successful is'-'r_ok/0',
+         'functions explicit is_iso'-'r_iso_type/0',
+         'functions explicit is_lax'-'r_lax_bad/0',
+         'functions ISO-default zdiv'-'r_plain_zdiv/0']),
+
+    forall(member(P, [r_ok/0, r_iso_inst/0, r_iso_type/0, r_iso_zdiv/0,
+                      r_lax_bad/0, r_plain_zdiv/0, r_plain_bad/0,
+                      r_plain_ok_iso/0]),
+           retractall(user:P)),
+    (   nb_getval(r_iso_smoke_failed, true) -> halt(1) ; halt(0) ).

--- a/tests/test_wam_r_iso_unit.pl
+++ b/tests/test_wam_r_iso_unit.pl
@@ -1,0 +1,156 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_wam_r_iso_unit.pl - Prolog-only unit tests for R WAM ISO-R-0
+% (shared config/rewrite/audit + is/2 key table). End-to-end generated-R
+% behaviour is covered by tests/test_wam_r_iso_smoke.pl.
+
+:- encoding(utf8).
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [delete_directory_and_contents/1]).
+:- use_module('../src/unifyweaver/targets/wam_r_target').
+
+:- begin_tests(wam_r_iso_errors_config).
+
+iso_errors_temp_config_file(Path, Lines) :-
+    tmp_file('tmp_wam_r_iso_cfg', Path),
+    setup_call_cleanup(
+        open(Path, write, Out),
+        forall(member(L, Lines), format(Out, '~w~n', [L])),
+        close(Out)).
+
+test(iso_errors_config_loader_basic) :-
+    iso_errors_temp_config_file(Path, [
+        'iso_errors_default(true).',
+        'iso_errors_override(legacy_lookup/3, false).',
+        'iso_errors_override(experimental:my_pred/2, true).',
+        'ignored_fact(ok).'
+    ]),
+    setup_call_cleanup(
+        true,
+        (   iso_errors_load_config(Path, Config),
+            assertion(Config == iso_config(true,
+                [legacy_lookup/3-false,
+                 (experimental:my_pred/2)-true])),
+            iso_errors_mode_for(Config, user:legacy_lookup/3, M1),
+            assertion(M1 == false),
+            iso_errors_mode_for(Config, user:never_listed/2, M2),
+            assertion(M2 == true),
+            iso_errors_mode_for(Config, experimental:my_pred/2, M3),
+            assertion(M3 == true)
+        ),
+        delete_file(Path)).
+
+test(iso_errors_inline_wins_over_file) :-
+    iso_errors_temp_config_file(Path, [
+        'iso_errors_default(false).',
+        'iso_errors_override(legacy_lookup/3, false).'
+    ]),
+    setup_call_cleanup(
+        true,
+        (   iso_errors_resolve_options(
+                [iso_errors_config(Path),
+                 iso_errors(true),
+                 iso_errors(legacy_lookup/3, true)],
+                Config),
+            iso_errors_mode_for(Config, user:legacy_lookup/3, M1),
+            assertion(M1 == true),
+            iso_errors_mode_for(Config, user:never_listed/2, M2),
+            assertion(M2 == true)
+        ),
+        delete_file(Path)).
+
+test(iso_errors_module_scoped_and_bare_pi) :-
+    Config = iso_config(false, [
+        (mod_a:arith/1)-true,
+        bare_arith/1-true
+    ]),
+    iso_errors_mode_for(Config, mod_a:arith/1, M1),
+    assertion(M1 == true),
+    iso_errors_mode_for(Config, mod_b:arith/1, M2),
+    assertion(M2 == false),
+    iso_errors_mode_for(Config, user:bare_arith/1, M3),
+    assertion(M3 == true).
+
+test(iso_errors_text_rewrite_builtin_call_is_to_iso) :-
+    Wam0 = 'demo/0:\n  put_variable 4, 1\n  put_integer 1, 2\n  builtin_call is/2 2\n  proceed',
+    iso_errors_rewrite_text(iso_config(true, []), demo/0, Wam0, IsoWam),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call is_iso/2 2")),
+    \+ sub_string(IsoWam, _, _, _, "builtin_call is/2 2").
+
+test(iso_errors_text_rewrite_builtin_call_is_to_lax) :-
+    Wam0 = 'demo/0:\n  builtin_call is/2 2\n  proceed',
+    iso_errors_rewrite_text(iso_config(false, []), demo/0, Wam0, LaxWam),
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call is_lax/2 2")),
+    \+ sub_string(LaxWam, _, _, _, "builtin_call is/2 2").
+
+test(iso_errors_text_rewrite_put_structure_call_execute) :-
+    Wam0 = 'demo/0:\n  put_structure is/2, A1\n  call is/2 2\n  execute is/2\n  proceed',
+    iso_errors_rewrite_text(iso_config(true, []), demo/0, Wam0, IsoWam),
+    assertion(sub_string(IsoWam, _, _, _, "put_structure is_iso/2")),
+    assertion(sub_string(IsoWam, _, _, _, "call is_iso/2")),
+    assertion(sub_string(IsoWam, _, _, _, "execute is_iso/2")),
+    iso_errors_rewrite_text(iso_config(false, []), demo/0, Wam0, LaxWam),
+    assertion(sub_string(LaxWam, _, _, _, "put_structure is_lax/2")),
+    assertion(sub_string(LaxWam, _, _, _, "call is_lax/2")),
+    assertion(sub_string(LaxWam, _, _, _, "execute is_lax/2")).
+
+test(iso_errors_text_rewrite_explicit_iso_survives) :-
+    Wam0 = 'demo/0:\n  builtin_call is_iso/2 2\n  proceed',
+    iso_errors_rewrite_text(iso_config(true, []), demo/0, Wam0, IsoWam),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call is_iso/2 2")),
+    iso_errors_rewrite_text(iso_config(false, []), demo/0, Wam0, LaxWam),
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call is_iso/2 2")).
+
+test(iso_errors_text_rewrite_explicit_lax_survives) :-
+    Wam0 = 'demo/0:\n  builtin_call is_lax/2 2\n  proceed',
+    iso_errors_rewrite_text(iso_config(true, []), demo/0, Wam0, IsoWam),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call is_lax/2 2")),
+    iso_errors_rewrite_text(iso_config(false, []), demo/0, Wam0, LaxWam),
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call is_lax/2 2")).
+
+test(iso_errors_text_rewrite_per_pred_override) :-
+    Config = iso_config(true, [demo/0-false]),
+    Wam0 = 'demo/0:\n  builtin_call is/2 2\n  proceed',
+    iso_errors_rewrite_text(Config, demo/0, Wam0, OutWam),
+    assertion(sub_string(OutWam, _, _, _, "builtin_call is_lax/2 2")),
+    Wam2 = 'other/0:\n  builtin_call is/2 2\n  proceed',
+    iso_errors_rewrite_text(Config, other/0, Wam2, OutWam2),
+    assertion(sub_string(OutWam2, _, _, _, "builtin_call is_iso/2 2")).
+
+test(iso_errors_audit_structure) :-
+    setup_call_cleanup(
+        assertz((user:r_iso_audit_pred :- X is 1 + 2, X = 3)),
+        (   wam_r_iso_audit(
+                [user:r_iso_audit_pred/0],
+                [iso_errors(r_iso_audit_pred/0, true)],
+                Audit),
+            assertion((
+                Audit = [audit(user:r_iso_audit_pred/0, true, Sites)],
+                Sites \= [],
+                memberchk(site(_, "is/2", "is_iso/2", default, true), Sites)
+            ))
+        ),
+        retractall(user:r_iso_audit_pred)).
+
+test(iso_errors_project_generation_selects_concrete_key) :-
+    once((
+        TmpDir = '/tmp/uw_r_iso_rewrite_unit',
+        catch(delete_directory_and_contents(TmpDir), _, true),
+        setup_call_cleanup(
+            assertz((user:r_iso_rewrite_demo :- X is 1 + 2, X == 3)),
+            (   write_wam_r_project(
+                    [user:r_iso_rewrite_demo/0],
+                    [iso_errors(true)],
+                    TmpDir),
+                string_concat(TmpDir, '/R/generated_program.R', ProgPath),
+                read_file_to_string(ProgPath, Code, []),
+                assertion(sub_string(Code, _, _, _, "is_iso/2")),
+                assertion(\+ sub_string(Code, _, _, _, 'BuiltinCall("is/2"'))
+            ),
+            (   retractall(user:r_iso_rewrite_demo),
+                catch(delete_directory_and_contents(TmpDir), _, true)
+            )
+        )
+    )).
+
+:- end_tests(wam_r_iso_errors_config).

--- a/tests/test_wam_r_iso_unit.pl
+++ b/tests/test_wam_r_iso_unit.pl
@@ -153,4 +153,26 @@ test(iso_errors_project_generation_selects_concrete_key) :-
         )
     )).
 
+test(iso_errors_project_generation_preserves_module_scope) :-
+    once((
+        TmpDir = '/tmp/uw_r_iso_module_scope_unit',
+        catch(delete_directory_and_contents(TmpDir), _, true),
+        setup_call_cleanup(
+            assertz((mod_b:r_iso_scope_demo :- X is 1 + 2, X == 3)),
+            (   write_wam_r_project(
+                    [mod_b:r_iso_scope_demo/0],
+                    [iso_errors(false),
+                     iso_errors(mod_a:r_iso_scope_demo/0, true)],
+                    TmpDir),
+                string_concat(TmpDir, '/R/generated_program.R', ProgPath),
+                read_file_to_string(ProgPath, Code, []),
+                assertion(sub_string(Code, _, _, _, "is_lax/2")),
+                assertion(\+ sub_string(Code, _, _, _, 'BuiltinCall("is_iso/2"'))
+            ),
+            (   retractall(mod_b:r_iso_scope_demo),
+                catch(delete_directory_and_contents(TmpDir), _, true)
+            )
+        )
+    )).
+
 :- end_tests(wam_r_iso_errors_config).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

ISO-R-0 vertical slice: shared `iso_errors` wiring plus `is/2` → `is_iso/2` | `is_lax/2`.

R remains a **partial adopter** — this does not claim complete ISO-R. Catch/throw already existed and are reused by tests; comparisons/`succ` stay for ISO-R-1/R-2.

## Behavior

| Case | Result |
|------|--------|
| `iso_errors(true)` default `is/2` | rewritten to `is_iso/2` |
| `iso_errors(false)` / absent default | rewritten to `is_lax/2` (same fail-on-bad-eval as prior `is/2`) |
| `is_iso` unbound / `1/0` / atom | structured `instantiation_error` / `evaluation_error(zero_divisor)` / `type_error(evaluable,_)` |
| `is_lax` bad expr | silent fail |
| Explicit `_iso`/`_lax` | survive mode rewrite |
| Legacy compare/`succ` keys | **not** registered; rewrite filtered to `is/2` only (avoids multifile pollution from F#/Haskell tables) |

## LOC

| Area | Diff |
|------|------|
| Production (`wam_r_target.pl` + lowered + runtime.mustache) | +352 / −69 (net +283) |
| Tests (new unit+smoke + generator updates) | +325 / −17 |
| Docs | +78 / −38 |
| CI | +5 / −0 |

Production exceeds the ~180 soft budget mainly because:
1. relocating the existing `is/2` body into shared `builtin_is_lax` (not new heuristic);
2. the required structured-error helper set + `is_iso` classify path;
3. the per-target `rewrite_text` adapter + audit (not exported by core).

## Validation

Local:
- `tests/test_wam_r_iso_unit.pl` — pass
- `tests/test_wam_r_iso_smoke.pl` — pass
- focused R regressions (switch-index + LMDB + is/2) — pass
- `CONFORMANCE_TARGETS=r,r_functions` — pass
- `tests/test_iso_errors.pl` — pass
- `git diff --check` — clean

Hosted workflow (`UnifyWeaver Tests`):
- Main `test` — pass
- WAM R Conformance (interpreter + functions) — pass
- Conformance smokes + C# query smoke — pass

## Out of scope (ISO-R-1+)

Comparisons, `succ_*`, claiming full adoption checklist.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

