### PR TITLE
ISO-R-2A: arithmetic comparison three-form parity for hybrid WAM R

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -55,7 +55,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | ISO-SCALA | ISO three-form (new) | Scala | L | — |
 | ISO-R-0 ✅ | shared wiring + `is/2` vertical slice | R | M | done (partial adopter) |
 | ISO-R-1 ✅ | pre-existing catch/throw substrate | R | — | validated (`catch_throw_dyn_aggregator_e2e_rscript`) |
-| ISO-R-2A | arithmetic comparisons | R | S | ISO-R-0 | ✅ |
+| ISO-R-2A ✅ | arithmetic comparisons | R | S | done |
 | ISO-R-2B | successor + adoption closeout | R | S | ISO-R-2A |
 | ISO-PYTHON | ISO three-form (finish) | Python | S | — |
 | ISO-FSHARP | ISO three-form (finish) | F# | S | — |
@@ -479,6 +479,7 @@ plumbing there.
   complete adoption checklist in
   `docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`.
   Do **not** claim full R ISO adoption until R-2B lands.
+
 ### ISO-R (ledger parent): New ISO three-form adoption for WAM R target
 - **Lever:** ISO three-form  **Target:** R  **Size:** L  **Depends on:** —
 - **Goal:** Bring the WAM R target from non-adopter to full ISO three-form

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -55,7 +55,7 @@ self-contained so a single coding agent can pick it up in isolation.
 | ISO-SCALA | ISO three-form (new) | Scala | L | — |
 | ISO-R-0 ✅ | shared wiring + `is/2` vertical slice | R | M | done (partial adopter) |
 | ISO-R-1 ✅ | pre-existing catch/throw substrate | R | — | validated (`catch_throw_dyn_aggregator_e2e_rscript`) |
-| ISO-R-2A | arithmetic comparisons | R | S | ISO-R-0 |
+| ISO-R-2A | arithmetic comparisons | R | S | ISO-R-0 | ✅ |
 | ISO-R-2B | successor + adoption closeout | R | S | ISO-R-2A |
 | ISO-PYTHON | ISO three-form (finish) | Python | S | — |
 | ISO-FSHARP | ISO three-form (finish) | F# | S | — |
@@ -450,12 +450,13 @@ plumbing there.
 
 ### ISO-R-0 ✅: shared ISO wiring + `is/2` three-form vertical slice
 - **Status:** Landed. Shared `iso_errors` config/rewrite/audit wired into
-  `wam_r_target.pl`; key table registers **only** `is/2` → `is_iso/2` |
-  `is_lax/2`. Runtime helpers live in `runtime.R.mustache`
+  `wam_r_target.pl`; key table initially registered `is/2` → `is_iso/2` |
+  `is_lax/2` (ISO-R-2A later extended comparisons). Runtime helpers live in
+  `runtime.R.mustache`
   (`builtin_is_iso` / `builtin_is_lax` + structured error constructors).
   Existing `catch/3`+`throw/1` substrate is reused by tests but **R remains
   a partial adopter** until all seven “What Counts As Adoption” items are
-  satisfied (comparisons and succ remain).
+  satisfied (`succ` remains ISO-R-2B).
 - **Acceptance:** `tests/test_wam_r_iso_unit.pl` + `tests/test_wam_r_iso_smoke.pl`.
 
 ### ISO-R-1 ✅: pre-existing catch/throw substrate
@@ -464,15 +465,20 @@ plumbing there.
   unification and rethrow, and is covered by
   `catch_throw_dyn_aggregator_e2e_rscript`. No follow-up implementation card.
 
-### ISO-R-2A: arithmetic comparisons
-- **Depends on:** ISO-R-0. Add the six arithmetic-compare ISO/lax families,
-  reusing the existing evaluator and ISO error constructors.
+### ISO-R-2A ✅: arithmetic comparisons
+- **Status:** Landed. Six families (`</2 >/2 =</2 >=/2 =:=/2 =\=/2`) each
+  expose `_iso`/`_lax` via the shared key table + `r_iso_rewritable_key/1`.
+  Runtime uses one parameterized helper (`builtin_arith_compare_{iso,lax}`)
+  reusing ISO-R-0 `eval_arith_iso` / constructors / `throw_iso_error`.
+  Call/Execute and lowered emission route through the same helpers.
+- **Acceptance:** extended `tests/test_wam_r_iso_unit.pl` +
+  `tests/test_wam_r_iso_smoke.pl`.
 
 ### ISO-R-2B: successor + adoption closeout
 - **Depends on:** ISO-R-2A. Add `succ_iso` / `succ_lax`, then verify the
   complete adoption checklist in
   `docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`.
-
+  Do **not** claim full R ISO adoption until R-2B lands.
 ### ISO-R (ledger parent): New ISO three-form adoption for WAM R target
 - **Lever:** ISO three-form  **Target:** R  **Size:** L  **Depends on:** —
 - **Goal:** Bring the WAM R target from non-adopter to full ISO three-form

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -57,6 +57,7 @@ default 4096), and explicit `auto` (codegen resolves via shared
   comparison families (`<_iso`/`<_lax` … `=\=_iso`/`=\=_lax`). The
   pre-existing catch/throw substrate is already covered end-to-end;
   `succ` remains ISO-R-2B. Do not claim complete ISO-R yet.
+- No dedicated effective-distance cross-target bench row.
 
 ## Path forward
 

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -52,15 +52,15 @@ default 4096), and explicit `auto` (codegen resolves via shared
   forms (`switch_on_constant_a2`, `_a2_fallthrough`, `switch_on_structure_a2`)
   — map to the existing `SwitchOnTerm()` linear no-op (not optimized A2
   dispatch), preserving the full try/retry/trust chain.
-- **ISO error support** is a **partial adopter** after ISO-R-0: shared
-  config/rewrite/audit + `is/2` → `is_iso`/`is_lax` vertical slice.
-  The pre-existing catch/throw substrate is already covered end-to-end;
-  comparisons/`succ` remain ISO-R-2A/R-2B. Do not claim complete ISO-R yet.
-- No dedicated effective-distance cross-target bench row.
+- **ISO error support** is a **partial adopter** after ISO-R-0 + ISO-R-2A:
+  shared config/rewrite/audit, `is/2` three-form, and the six arithmetic
+  comparison families (`<_iso`/`<_lax` … `=\=_iso`/`=\=_lax`). The
+  pre-existing catch/throw substrate is already covered end-to-end;
+  `succ` remains ISO-R-2B. Do not claim complete ISO-R yet.
 
 ## Path forward
 
-1. ISO-R-2A arithmetic comparisons; ISO-R-2B successor + adoption closeout.
+1. ISO-R-2B successor (`succ_iso`/`succ_lax`) + adoption closeout.
 2. Effective-distance cross-target matrix row.
 
 ## Document status

--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -752,23 +752,25 @@ of the thrown term; `catch/3` unwinds the trail and CP stack to its
 entry snapshot before unifying with the catcher and running the
 recovery. Uncaught throws at the top level become query failure.
 
-### ISO errors (ISO-R-0 partial slice)
+### ISO errors (ISO-R-0 + ISO-R-2A partial adoption)
 
 Shared `iso_errors` config / per-predicate rewrite / `wam_r_iso_audit/3`
 are wired. Project options: `iso_errors(true|false)`,
 `iso_errors(PI, true|false)`, `iso_errors_config(File)`.
 
-Key table (slice only): `is/2` → `is_iso/2` | `is_lax/2`. Comparisons and
-`succ/2` are deferred (ISO-R-2A and ISO-R-2B respectively). Explicit
-`_iso`/`_lax` forms survive mode rewrites. Runtime helpers in
-`runtime.R.mustache`:
-`builtin_is_iso` / `builtin_is_lax` + structured `error/2` constructors.
-Classify order for `is_iso`: unbound → `evaluation_error(zero_divisor)` →
-`type_error(evaluable, Culprit)`.
+Key table: `is/2` → `is_iso/2` | `is_lax/2`, plus the six comparison
+families (`</2 >/2 =</2 >=/2 =:=/2 =\=/2`) → matching `_iso`/`_lax`.
+`succ/2` remains deferred to ISO-R-2B. Explicit `_iso`/`_lax` forms
+survive mode rewrites. Runtime helpers in `runtime.R.mustache`:
+`builtin_is_iso` / `builtin_is_lax`, parameterized
+`builtin_arith_compare_{iso,lax}`, plus structured `error/2` constructors.
+Classify order (ISO arith): unbound → `evaluation_error(zero_divisor)` →
+`type_error(evaluable, Culprit)`. Valid but false comparisons fail
+normally without throwing.
 
 R is still a **partial adopter** until all seven items in
 `docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` §"What Counts As
-Adoption" are satisfied.
+Adoption" are satisfied (`succ` + closeout = ISO-R-2B).
 
 ## Supported WAM instructions
 

--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -853,6 +853,13 @@ emit_line_parts(["execute", "is_iso/2"], I) :- !,
 emit_line_parts(["execute", "is_lax/2"], I) :- !,
     format("~wif (!isTRUE(WamRuntime$builtin_is_lax(program, state))) return(FALSE)~n", [I]),
     format("~wreturn(TRUE)~n", [I]).
+% ISO-R-2A: arithmetic-compare Call/Execute → shared parameterized helpers.
+emit_line_parts(["call", Key], I) :-
+    r_arith_compare_emit(Key, Op, Mode), !,
+    emit_arith_compare_inline(Op, Mode, I, call).
+emit_line_parts(["execute", Key], I) :-
+    r_arith_compare_emit(Key, Op, Mode), !,
+    emit_arith_compare_inline(Op, Mode, I, execute).
 emit_line_parts(["call", PredArity], I) :- !,
     emit_call(PredArity, I).
 emit_line_parts(["call", Pred, ArityStr], I) :- !,
@@ -976,12 +983,50 @@ emit_line_parts(["builtin_call", "is_lax/2", "2"], I) :- !,
 emit_line_parts(["builtin_call", "is_iso/2", "2"], I) :- !,
     format("~wif (!isTRUE(WamRuntime$builtin_is_iso(program, state))) return(FALSE)~n",
            [I]).
+% ISO-R-2A: inline rewritten/default/explicit comparison BuiltinCalls.
+emit_line_parts(["builtin_call", Key, "2"], I) :-
+    r_arith_compare_emit(Key, Op, Mode), !,
+    emit_arith_compare_inline(Op, Mode, I, call).
 
 % --- Default: delegate to step with the same R literal the array uses
 emit_line_parts(Parts, I) :-
     wam_r_target:wam_parts_to_r(Parts, [], Lit),
     format("~wif (!isTRUE(WamRuntime$step(program, state, ~w))) return(FALSE)~n",
            [I, Lit]).
+
+%% r_arith_compare_emit(+Key, -Op, -Mode)
+%  Compact mapping for the six comparison families × three forms.
+%  Mode is iso|lax; Op is the Prolog operator atom used by the R helper.
+r_arith_compare_emit("</2",        "<",    lax).
+r_arith_compare_emit("<_lax/2",    "<",    lax).
+r_arith_compare_emit("<_iso/2",    "<",    iso).
+r_arith_compare_emit(">/2",        ">",    lax).
+r_arith_compare_emit(">_lax/2",    ">",    lax).
+r_arith_compare_emit(">_iso/2",    ">",    iso).
+r_arith_compare_emit(">=/2",       ">=",   lax).
+r_arith_compare_emit(">=_lax/2",   ">=",   lax).
+r_arith_compare_emit(">=_iso/2",   ">=",   iso).
+r_arith_compare_emit("=</2",       "=<",   lax).
+r_arith_compare_emit("=<_lax/2",   "=<",   lax).
+r_arith_compare_emit("=<_iso/2",   "=<",   iso).
+r_arith_compare_emit("=:=/2",      "=:=",  lax).
+r_arith_compare_emit("=:=_lax/2",  "=:=",  lax).
+r_arith_compare_emit("=:=_iso/2",  "=:=",  iso).
+r_arith_compare_emit("=\\=/2",     "=\\=", lax).
+r_arith_compare_emit("=\\=_lax/2", "=\\=", lax).
+r_arith_compare_emit("=\\=_iso/2", "=\\=", iso).
+
+emit_arith_compare_inline(Op, Mode, I, Kind) :-
+    (   Mode == iso
+    ->  Helper = "builtin_arith_compare_iso"
+    ;   Helper = "builtin_arith_compare_lax"
+    ),
+    format("~wif (!isTRUE(WamRuntime$~w(program, state, \"~w\"))) return(FALSE)~n",
+           [I, Helper, Op]),
+    (   Kind == execute
+    ->  format("~wreturn(TRUE)~n", [I])
+    ;   true
+    ).
 
 emit_call(PredArity, I) :-
     format("~w{~n", [I]),

--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -1021,8 +1021,12 @@ emit_arith_compare_inline(Op, Mode, I, Kind) :-
     ->  Helper = "builtin_arith_compare_iso"
     ;   Helper = "builtin_arith_compare_lax"
     ),
+    % R string literals need \\ for each Prolog backslash (e.g. =\=).
+    atom_string(Op, OpStr0),
+    atomic_list_concat(Parts, '\\', OpStr0),
+    atomic_list_concat(Parts, '\\\\', OpStr),
     format("~wif (!isTRUE(WamRuntime$~w(program, state, \"~w\"))) return(FALSE)~n",
-           [I, Helper, Op]),
+           [I, Helper, OpStr]),
     (   Kind == execute
     ->  format("~wreturn(TRUE)~n", [I])
     ;   true

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -2185,15 +2185,28 @@ find_template(RelPath, Template) :-
     read_file_to_string(AbsPath, Template, []).
 
 % ============================================================================
-% ISO-R-0: shared ISO wiring + is/2 three-form vertical slice
+% ISO-R-0/R-2A: shared ISO wiring + is/2 + arithmetic comparisons
 % ============================================================================
-% Key-table safety: register ONLY is/2 until matching R runtime branches
-% exist for comparisons / succ.  Catch/throw already ship in
-% runtime.R.mustache and are reused by the smoke suite, but are not
-% part of this slice's adoption claim.
+% Key-table safety: register a default key only when matching R runtime
+% branches exist.  Catch/throw and is_iso/is_lax ship already; ISO-R-2A
+% adds the six arithmetic-compare families.  succ_* remains ISO-R-2B.
 
 iso_errors:iso_errors_default_to_iso("is/2", "is_iso/2").
 iso_errors:iso_errors_default_to_lax("is/2", "is_lax/2").
+
+iso_errors:iso_errors_default_to_iso("</2", "<_iso/2").
+iso_errors:iso_errors_default_to_iso(">/2", ">_iso/2").
+iso_errors:iso_errors_default_to_iso(">=/2", ">=_iso/2").
+iso_errors:iso_errors_default_to_iso("=</2", "=<_iso/2").
+iso_errors:iso_errors_default_to_iso("=:=/2", "=:=_iso/2").
+iso_errors:iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
+
+iso_errors:iso_errors_default_to_lax("</2", "<_lax/2").
+iso_errors:iso_errors_default_to_lax(">/2", ">_lax/2").
+iso_errors:iso_errors_default_to_lax(">=/2", ">=_lax/2").
+iso_errors:iso_errors_default_to_lax("=</2", "=<_lax/2").
+iso_errors:iso_errors_default_to_lax("=:=/2", "=:=_lax/2").
+iso_errors:iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
 
 % Keep the module when present: qualified overrides must not leak to a
 % same-named predicate in another module.
@@ -2234,8 +2247,14 @@ iso_errors_rewrite_line(Mode, Line, OutLine) :-
     ;   OutLine = Line
     ).
 
-%% Keys with matching R runtime branches (ISO-R-0 slice).
+%% Keys with matching R runtime branches (ISO-R-0 is/2 + ISO-R-2A compares).
 r_iso_rewritable_key("is/2").
+r_iso_rewritable_key("</2").
+r_iso_rewritable_key(">/2").
+r_iso_rewritable_key(">=/2").
+r_iso_rewritable_key("=</2").
+r_iso_rewritable_key("=:=/2").
+r_iso_rewritable_key("=\\=/2").
 
 iso_errors_clean_key_token(Token0, Token) :-
     (   string_concat(Token, ",", Token0)

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -2095,10 +2095,8 @@ WamRuntime$builtin_is_lax <- function(program, state) {
 }
 
 # ISO is/2: structured errors; classify unbound → zero_div → type_error.
-WamRuntime$builtin_is_iso <- function(program, state) {
+WamRuntime$eval_arith_iso <- function(program, state, expr) {
   table <- program$intern_table
-  target <- WamRuntime$get_reg(state, 1L)
-  expr   <- WamRuntime$get_reg(state, 2L)
   if (WamRuntime$iso_term_contains_unbound(state, expr)) {
     WamRuntime$throw_iso_error(state, table,
       WamRuntime$make_instantiation_error(table))
@@ -2113,9 +2111,70 @@ WamRuntime$builtin_is_iso <- function(program, state) {
       WamRuntime$make_type_error(table, "evaluable",
         WamRuntime$iso_arith_culprit(state, expr, table)))
   }
+  n
+}
+
+WamRuntime$builtin_is_iso <- function(program, state) {
+  target <- WamRuntime$get_reg(state, 1L)
+  expr   <- WamRuntime$get_reg(state, 2L)
+  n <- WamRuntime$eval_arith_iso(program, state, expr)
   res <- WamRuntime$arith_to_term(n)
   if (is.null(res)) return(FALSE)
   WamRuntime$unify(state, target, res)
+}
+
+# ISO-R-2A: parameterized arithmetic comparisons (six families × three forms).
+WamRuntime$arith_compare_apply <- function(op, a, b) {
+  switch(op,
+    "<"   = a <  b,
+    ">"   = a >  b,
+    ">="  = a >= b,
+    "=<"  = a <= b,
+    "=:=" = a == b,
+    "=\\=" = a != b,
+    FALSE
+  )
+}
+
+# Map BuiltinCall / Execute keys → list(op, mode) where mode is lax|iso.
+WamRuntime$arith_compare_key_info <- function(pred) {
+  switch(pred,
+    "</2"        = list(op = "<",    mode = "lax"),
+    "<_lax/2"    = list(op = "<",    mode = "lax"),
+    "<_iso/2"    = list(op = "<",    mode = "iso"),
+    ">/2"        = list(op = ">",    mode = "lax"),
+    ">_lax/2"    = list(op = ">",    mode = "lax"),
+    ">_iso/2"    = list(op = ">",    mode = "iso"),
+    ">=/2"       = list(op = ">=",   mode = "lax"),
+    ">=_lax/2"   = list(op = ">=",   mode = "lax"),
+    ">=_iso/2"   = list(op = ">=",   mode = "iso"),
+    "=</2"       = list(op = "=<",   mode = "lax"),
+    "=<_lax/2"   = list(op = "=<",   mode = "lax"),
+    "=<_iso/2"   = list(op = "=<",   mode = "iso"),
+    "=:="/2"     = list(op = "=:=",  mode = "lax"),
+    "=:=_lax/2"  = list(op = "=:=",  mode = "lax"),
+    "=:=_iso/2"  = list(op = "=:=",  mode = "iso"),
+    "=\\=/2"     = list(op = "=\\=", mode = "lax"),
+    "=\\=_lax/2" = list(op = "=\\=", mode = "lax"),
+    "=\\=_iso/2" = list(op = "=\\=", mode = "iso"),
+    NULL
+  )
+}
+
+# Lax/default: silent fail on bad eval (prior R comparison behaviour).
+WamRuntime$builtin_arith_compare_lax <- function(program, state, op) {
+  table <- program$intern_table
+  a <- WamRuntime$eval_arith(state, WamRuntime$get_reg(state, 1L), table)
+  b <- WamRuntime$eval_arith(state, WamRuntime$get_reg(state, 2L), table)
+  if (is.null(a) || is.null(b)) return(FALSE)
+  isTRUE(WamRuntime$arith_compare_apply(op, a, b))
+}
+
+# ISO: per-operand classify (unbound → zero_divisor → non-evaluable), left then right.
+WamRuntime$builtin_arith_compare_iso <- function(program, state, op) {
+  a <- WamRuntime$eval_arith_iso(program, state, WamRuntime$get_reg(state, 1L))
+  b <- WamRuntime$eval_arith_iso(program, state, WamRuntime$get_reg(state, 2L))
+  isTRUE(WamRuntime$arith_compare_apply(op, a, b))
 }
 
 # Standard Euclidean GCD; both args coerced to non-negative integers.
@@ -5027,20 +5086,15 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
   if (pred == "is_iso/2" && arity == 2L) {
     return(WamRuntime$builtin_is_iso(program, state))
   }
-  # Numeric comparison builtins: eval both args, compare.
-  if (arity == 2L && pred %in% c("=:=/2", "=\\=/2", "</2", ">/2", "=</2", ">=/2")) {
-    a <- WamRuntime$eval_arith(state, WamRuntime$get_reg(state, 1L), table)
-    b <- WamRuntime$eval_arith(state, WamRuntime$get_reg(state, 2L), table)
-    if (is.null(a) || is.null(b)) return(FALSE)
-    return(switch(pred,
-      "=:=/2"  = a == b,
-      "=\\=/2" = a != b,
-      "</2"    = a <  b,
-      ">/2"    = a >  b,
-      "=</2"   = a <= b,
-      ">=/2"   = a >= b,
-      FALSE
-    ))
+  # Arithmetic comparisons (ISO-R-2A): default/_lax/_iso share one helper.
+  if (arity == 2L) {
+    cmp_info <- WamRuntime$arith_compare_key_info(pred)
+    if (!is.null(cmp_info)) {
+      if (identical(cmp_info$mode, "iso")) {
+        return(WamRuntime$builtin_arith_compare_iso(program, state, cmp_info$op))
+      }
+      return(WamRuntime$builtin_arith_compare_lax(program, state, cmp_info$op))
+    }
   }
 
   # Type-check builtins: deref A1, classify.
@@ -5285,9 +5339,10 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
   table <- program$intern_table
   key <- if (grepl("/[0-9]+$", pred)) pred else paste0(pred, "/", arity)
 
-  # Explicit is_iso/is_lax arrive as Execute/Call (not builtin_call).
+  # Explicit is_*/compare_* arrive as Execute/Call (not builtin_call).
   # Delegate to call_builtin so evaluation lives in one place.
-  if (key == "is_iso/2" || key == "is_lax/2") {
+  if (key == "is_iso/2" || key == "is_lax/2" ||
+      !is.null(WamRuntime$arith_compare_key_info(key))) {
     return(WamRuntime$call_builtin(program, state, key, arity))
   }
 

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -2151,7 +2151,7 @@ WamRuntime$arith_compare_key_info <- function(pred) {
     "=</2"       = list(op = "=<",   mode = "lax"),
     "=<_lax/2"   = list(op = "=<",   mode = "lax"),
     "=<_iso/2"   = list(op = "=<",   mode = "iso"),
-    "=:="/2"     = list(op = "=:=",  mode = "lax"),
+    "=:=/2"      = list(op = "=:=",  mode = "lax"),
     "=:=_lax/2"  = list(op = "=:=",  mode = "lax"),
     "=:=_iso/2"  = list(op = "=:=",  mode = "iso"),
     "=\\=/2"     = list(op = "=\\=", mode = "lax"),
@@ -5340,10 +5340,19 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
   key <- if (grepl("/[0-9]+$", pred)) pred else paste0(pred, "/", arity)
 
   # Explicit is_*/compare_* arrive as Execute/Call (not builtin_call).
-  # Delegate to call_builtin so evaluation lives in one place.
-  if (key == "is_iso/2" || key == "is_lax/2" ||
-      !is.null(WamRuntime$arith_compare_key_info(key))) {
-    return(WamRuntime$call_builtin(program, state, key, arity))
+  # Invoke helpers directly (avoid call_builtin → call_library recursion).
+  if (key == "is_iso/2" && arity == 2L) {
+    return(WamRuntime$builtin_is_iso(program, state))
+  }
+  if (key == "is_lax/2" && arity == 2L) {
+    return(WamRuntime$builtin_is_lax(program, state))
+  }
+  cmp_info <- WamRuntime$arith_compare_key_info(key)
+  if (!is.null(cmp_info) && arity == 2L) {
+    if (identical(cmp_info$mode, "iso")) {
+      return(WamRuntime$builtin_arith_compare_iso(program, state, cmp_info$op))
+    }
+    return(WamRuntime$builtin_arith_compare_lax(program, state, cmp_info$op))
   }
 
   # ----- ^/2 existential scope -----

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -2095,6 +2095,17 @@ WamRuntime$builtin_is_lax <- function(program, state) {
 }
 
 # ISO is/2: structured errors; classify unbound → zero_div → type_error.
+WamRuntime$eval_arith_iso_value <- function(program, state, expr) {
+  table <- program$intern_table
+  n <- WamRuntime$eval_arith(state, expr, table)
+  if (is.null(n)) {
+    WamRuntime$throw_iso_error(state, table,
+      WamRuntime$make_type_error(table, "evaluable",
+        WamRuntime$iso_arith_culprit(state, expr, table)))
+  }
+  n
+}
+
 WamRuntime$eval_arith_iso <- function(program, state, expr) {
   table <- program$intern_table
   if (WamRuntime$iso_term_contains_unbound(state, expr)) {
@@ -2105,13 +2116,7 @@ WamRuntime$eval_arith_iso <- function(program, state, expr) {
     WamRuntime$throw_iso_error(state, table,
       WamRuntime$make_evaluation_error(table, "zero_divisor"))
   }
-  n <- WamRuntime$eval_arith(state, expr, table)
-  if (is.null(n)) {
-    WamRuntime$throw_iso_error(state, table,
-      WamRuntime$make_type_error(table, "evaluable",
-        WamRuntime$iso_arith_culprit(state, expr, table)))
-  }
-  n
+  WamRuntime$eval_arith_iso_value(program, state, expr)
 }
 
 WamRuntime$builtin_is_iso <- function(program, state) {
@@ -2170,10 +2175,24 @@ WamRuntime$builtin_arith_compare_lax <- function(program, state, op) {
   isTRUE(WamRuntime$arith_compare_apply(op, a, b))
 }
 
-# ISO: per-operand classify (unbound → zero_divisor → non-evaluable), left then right.
+# ISO: scan both operands for the fleet-wide precedence before evaluating
+# either one: unbound → zero_divisor → first non-evaluable operand.
 WamRuntime$builtin_arith_compare_iso <- function(program, state, op) {
-  a <- WamRuntime$eval_arith_iso(program, state, WamRuntime$get_reg(state, 1L))
-  b <- WamRuntime$eval_arith_iso(program, state, WamRuntime$get_reg(state, 2L))
+  table <- program$intern_table
+  a_expr <- WamRuntime$get_reg(state, 1L)
+  b_expr <- WamRuntime$get_reg(state, 2L)
+  if (WamRuntime$iso_term_contains_unbound(state, a_expr) ||
+      WamRuntime$iso_term_contains_unbound(state, b_expr)) {
+    WamRuntime$throw_iso_error(state, table,
+      WamRuntime$make_instantiation_error(table))
+  }
+  if (WamRuntime$iso_term_has_zero_divide_t(state, a_expr, table) ||
+      WamRuntime$iso_term_has_zero_divide_t(state, b_expr, table)) {
+    WamRuntime$throw_iso_error(state, table,
+      WamRuntime$make_evaluation_error(table, "zero_divisor"))
+  }
+  a <- WamRuntime$eval_arith_iso_value(program, state, a_expr)
+  b <- WamRuntime$eval_arith_iso_value(program, state, b_expr)
   isTRUE(WamRuntime$arith_compare_apply(op, a, b))
 }
 

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -546,7 +546,7 @@ test(builtin_call_emitted) :-
         directory_file_path(TmpDir, 'R/generated_program.R', Program),
         read_file_to_string(Program, Code, []),
         assertion(sub_string(Code, _, _, _, 'BuiltinCall("is_lax/2", 2)')),
-        assertion(sub_string(Code, _, _, _, 'BuiltinCall(">/2", 2)')),
+        assertion(sub_string(Code, _, _, _, 'BuiltinCall(">_lax/2", 2)')),
         delete_directory_and_contents(TmpDir)
     )).
 

--- a/tests/test_wam_r_iso_smoke.pl
+++ b/tests/test_wam_r_iso_smoke.pl
@@ -54,12 +54,27 @@ check <- function(name, key) {
 }
 ', []),
     forall(member(Name-Key, Checks),
-           format(S, 'check("~w", "~w")~n', [Name, Key])),
+           (   r_iso_smoke_r_string(Name, NameR),
+               r_iso_smoke_r_string(Key, KeyR),
+               format(S, 'check(~w, ~w)~n', [NameR, KeyR])
+           )),
     write(S,
 'cat(sprintf("RESULT %d/%d\\n", passes, passes + fails))
 quit(status = if (fails == 0L) 0L else 1L)
 '),
     close(S).
+
+%% Escape a Prolog string/atom for an R double-quoted literal.
+r_iso_smoke_r_string(In, Out) :-
+    format(string(S0), '~w', [In]),
+    atom_chars(S0, Cs),
+    maplist(r_iso_smoke_escape_char, Cs, EscParts),
+    atomic_list_concat(EscParts, Esc),
+    format(atom(Out), '"~w"', [Esc]).
+
+r_iso_smoke_escape_char('\\', '\\\\') :- !.
+r_iso_smoke_escape_char('"', '\\"') :- !.
+r_iso_smoke_escape_char(C, C).
 
 unique_tmp(Base, Dir) :-
     get_time(T), format(atom(Dir), '/tmp/~w_~w', [Base, T]),
@@ -241,7 +256,7 @@ main :-
          '>=_iso type'-'r_ge_iso_type/0',
          '=<_iso zdiv'-'r_le_iso_zdiv/0',
          '=:=_iso type'-'r_eq_iso_type/0',
-         '=\\=_iso inst'-'r_ne_iso_inst/0']),
+         'ne_iso inst'-'r_ne_iso_inst/0']),
 
     run_project('cmp lax silent (interpreter)',
         [user:r_lt_lax_bad/0, user:r_eq_lax_bad/0],

--- a/tests/test_wam_r_iso_smoke.pl
+++ b/tests/test_wam_r_iso_smoke.pl
@@ -141,6 +141,11 @@ assert_iso_helpers :-
         catch('<_iso'(1/0, 3), error(evaluation_error(zero_divisor), _), true))),
     assertz((user:r_lt_iso_zdiv_r :-
         catch('<_iso'(3, 1/0), error(evaluation_error(zero_divisor), _), true))),
+    % Fleet-wide precedence scans both operands before evaluation.
+    assertz((user:r_lt_iso_precedence_inst :-
+        catch('<_iso'(foo, _), error(instantiation_error, _), true))),
+    assertz((user:r_lt_iso_precedence_zdiv :-
+        catch('<_iso'(foo, 1/0), error(evaluation_error(zero_divisor), _), true))),
     assertz((user:r_gt_iso_inst :-
         catch('>_iso'(_, 3), error(instantiation_error, _), true))),
     assertz((user:r_ge_iso_type :-
@@ -177,6 +182,7 @@ retract_iso_helpers :-
         r_lt_iso_inst_l/0, r_lt_iso_inst_r/0,
         r_lt_iso_type_l/0, r_lt_iso_type_r/0,
         r_lt_iso_zdiv_l/0, r_lt_iso_zdiv_r/0,
+        r_lt_iso_precedence_inst/0, r_lt_iso_precedence_zdiv/0,
         r_gt_iso_inst/0, r_ge_iso_type/0, r_le_iso_zdiv/0,
         r_eq_iso_type/0, r_ne_iso_inst/0,
         r_lt_lax_bad/0, r_eq_lax_bad/0,
@@ -242,6 +248,7 @@ main :-
         [user:r_lt_iso_inst_l/0, user:r_lt_iso_inst_r/0,
          user:r_lt_iso_type_l/0, user:r_lt_iso_type_r/0,
          user:r_lt_iso_zdiv_l/0, user:r_lt_iso_zdiv_r/0,
+         user:r_lt_iso_precedence_inst/0, user:r_lt_iso_precedence_zdiv/0,
          user:r_gt_iso_inst/0, user:r_ge_iso_type/0,
          user:r_le_iso_zdiv/0, user:r_eq_iso_type/0,
          user:r_ne_iso_inst/0],
@@ -252,6 +259,8 @@ main :-
          '<_iso type R'-'r_lt_iso_type_r/0',
          '<_iso zdiv L'-'r_lt_iso_zdiv_l/0',
          '<_iso zdiv R'-'r_lt_iso_zdiv_r/0',
+         'cmp precedence instantiation'-'r_lt_iso_precedence_inst/0',
+         'cmp precedence zero_divisor'-'r_lt_iso_precedence_zdiv/0',
          '>_iso inst'-'r_gt_iso_inst/0',
          '>=_iso type'-'r_ge_iso_type/0',
          '=<_iso zdiv'-'r_le_iso_zdiv/0',
@@ -285,12 +294,15 @@ main :-
     run_project('cmp functions mode ISO + explicit',
         [user:r_cmp_ok/0, user:r_cmp_false/0,
          user:r_lt_iso_type_l/0, user:r_lt_lax_bad/0,
+         user:r_lt_iso_precedence_inst/0, user:r_lt_iso_precedence_zdiv/0,
          user:r_cmp_plain_zdiv/0],
         [emit_mode(functions), iso_errors(true)],
         ['functions cmp ok'-'r_cmp_ok/0',
          'functions cmp false'-'r_cmp_false/0',
          'functions <_iso type'-'r_lt_iso_type_l/0',
          'functions <_lax silent'-'r_lt_lax_bad/0',
+         'functions precedence instantiation'-'r_lt_iso_precedence_inst/0',
+         'functions precedence zero_divisor'-'r_lt_iso_precedence_zdiv/0',
          'functions default zdiv'-'r_cmp_plain_zdiv/0']),
 
     retract_iso_helpers,

--- a/tests/test_wam_r_iso_smoke.pl
+++ b/tests/test_wam_r_iso_smoke.pl
@@ -1,6 +1,7 @@
 % SPDX-License-Identifier: MIT OR Apache-2.0
 %
-% test_wam_r_iso_smoke.pl - ISO-R-0 generated-R smoke for is/2 three-form.
+% test_wam_r_iso_smoke.pl - ISO-R-0/2A generated-R smoke for is/2 and the
+% six arithmetic-comparison three-form families.
 % Hand-written PASS/FAIL; exit nonzero on failure (F# smoke convention).
 %
 % Usage: swipl -q -f init.pl -s tests/test_wam_r_iso_smoke.pl -g main -t halt
@@ -79,16 +80,21 @@ run_project(Label, Preds, Opts, Checks) :-
         )
     ;   directory_file_path(Tmp, 'R/generated_program.R', Prog),
         read_file_to_string(Prog, Code, []),
-        (   (sub_string(Code,_,_,_,"is_iso/2"); sub_string(Code,_,_,_,"is_lax/2"))
+        (   ( sub_string(Code,_,_,_,"is_iso/2")
+            ; sub_string(Code,_,_,_,"is_lax/2")
+            ; sub_string(Code,_,_,_,"<_iso/2")
+            ; sub_string(Code,_,_,_,"<_lax/2")
+            ; sub_string(Code,_,_,_,">_iso/2")
+            ; sub_string(Code,_,_,_,"=:=_iso/2")
+            )
         ->  pass(Label-codegen-skip-rscript)
-        ;   fail_test(Label, 'missing rewritten is key in codegen')
+        ;   fail_test(Label, 'missing rewritten iso/lax key in codegen')
         )
     ),
     catch(delete_directory_and_contents(Tmp), _, true).
 
-main :-
-    nb_setval(r_iso_smoke_failed, false),
-    % Helpers + scenarios
+assert_iso_helpers :-
+    % is/2 family (ISO-R-0)
     assertz((user:r_ok :- X is 1 + 2, X == 3)),
     assertz((user:r_iso_inst :-
         catch(is_iso(_, _Y), error(instantiation_error, _), true))),
@@ -102,33 +108,94 @@ main :-
     assertz((user:r_plain_bad :- \+ (_ is foo))),
     assertz((user:r_plain_ok_iso :- X is 40 + 2, X == 42)),
 
-    % 1) successful is/2 (ISO default rewrite still succeeds)
+    % Six comparison families: success + false (ISO-R-2A)
+    assertz((user:r_cmp_ok :- 1 < 2, 3 > 2, 2 =< 2, 3 >= 3, 4 =:= 2+2, 1 =\= 2)),
+    assertz((user:r_cmp_false :- \+ (2 < 1), \+ (1 > 2), \+ (3 =< 2),
+                                 \+ (2 >= 3), \+ (1 =:= 2), \+ (2 =\= 2))),
+
+    % ISO errors: unbound / type / zero_divisor on either operand
+    assertz((user:r_lt_iso_inst_l :-
+        catch('<_iso'(_, 3), error(instantiation_error, _), true))),
+    assertz((user:r_lt_iso_inst_r :-
+        catch('<_iso'(3, _), error(instantiation_error, _), true))),
+    assertz((user:r_lt_iso_type_l :-
+        catch('<_iso'(foo, 3), error(type_error(evaluable, _), _), true))),
+    assertz((user:r_lt_iso_type_r :-
+        catch('<_iso'(3, foo), error(type_error(evaluable, _), _), true))),
+    assertz((user:r_lt_iso_zdiv_l :-
+        catch('<_iso'(1/0, 3), error(evaluation_error(zero_divisor), _), true))),
+    assertz((user:r_lt_iso_zdiv_r :-
+        catch('<_iso'(3, 1/0), error(evaluation_error(zero_divisor), _), true))),
+    assertz((user:r_gt_iso_inst :-
+        catch('>_iso'(_, 3), error(instantiation_error, _), true))),
+    assertz((user:r_ge_iso_type :-
+        catch('>=_iso'(foo, 3), error(type_error(evaluable, _), _), true))),
+    assertz((user:r_le_iso_zdiv :-
+        catch('=<_iso'(1/0, 1), error(evaluation_error(zero_divisor), _), true))),
+    assertz((user:r_eq_iso_type :-
+        catch('=:=_iso'(foo, 3), error(type_error(evaluable, _), _), true))),
+    assertz((user:r_ne_iso_inst :-
+        catch('=\\=_iso'(_, 3), error(instantiation_error, _), true))),
+
+    % Lax silent failure for same malformed inputs
+    assertz((user:r_lt_lax_bad :-
+        \+ '<_lax'(_, 3), \+ '<_lax'(foo, 3), \+ '<_lax'(1/0, 3))),
+    assertz((user:r_eq_lax_bad :-
+        \+ '=:=_lax'(foo, 3), \+ '=:=_lax'(_, 1))),
+
+    % Explicit bypass of mode
+    assertz((user:r_cmp_iso_under_lax :-
+        catch('<_iso'(foo, 3), error(type_error(evaluable, _), _), true))),
+    assertz((user:r_cmp_lax_under_iso :- \+ '<_lax'(foo, 3))),
+
+    % Default rewrite paths
+    assertz((user:r_cmp_plain_zdiv :-
+        catch((1/0 < 3), error(evaluation_error(zero_divisor), _), true))),
+    assertz((user:r_cmp_plain_bad :- \+ (foo < 3))),
+    assertz((user:r_cmp_plain_ok :- 1 < 2)).
+
+retract_iso_helpers :-
+    forall(member(P, [
+        r_ok/0, r_iso_inst/0, r_iso_type/0, r_iso_zdiv/0,
+        r_lax_bad/0, r_plain_zdiv/0, r_plain_bad/0, r_plain_ok_iso/0,
+        r_cmp_ok/0, r_cmp_false/0,
+        r_lt_iso_inst_l/0, r_lt_iso_inst_r/0,
+        r_lt_iso_type_l/0, r_lt_iso_type_r/0,
+        r_lt_iso_zdiv_l/0, r_lt_iso_zdiv_r/0,
+        r_gt_iso_inst/0, r_ge_iso_type/0, r_le_iso_zdiv/0,
+        r_eq_iso_type/0, r_ne_iso_inst/0,
+        r_lt_lax_bad/0, r_eq_lax_bad/0,
+        r_cmp_iso_under_lax/0, r_cmp_lax_under_iso/0,
+        r_cmp_plain_zdiv/0, r_cmp_plain_bad/0, r_cmp_plain_ok/0
+    ]), retractall(user:P)).
+
+main :-
+    nb_setval(r_iso_smoke_failed, false),
+    assert_iso_helpers,
+
+    % ----- is/2 (ISO-R-0 regression) -----
     run_project('successful is/2 (iso default, interpreter)',
         [user:r_ok/0],
         [iso_errors(true)],
         ['successful is/2'-'r_ok/0']),
 
-    % 2) ISO-default structured errors via plain is/2 rewrite
     run_project('ISO-default structured errors (interpreter)',
         [user:r_plain_zdiv/0, user:r_plain_ok_iso/0],
         [iso_errors(true)],
         ['ISO-default zero_divisor'-'r_plain_zdiv/0',
          'ISO-default success'-'r_plain_ok_iso/0']),
 
-    % 3) lax-default non-throwing
     run_project('lax-default silent fail (interpreter)',
         [user:r_plain_bad/0],
         [iso_errors(false)],
         ['lax-default silent'-'r_plain_bad/0']),
 
-    % 4) per-predicate override (global ISO, one pred lax)
     run_project('per-predicate override to lax (interpreter)',
         [user:r_plain_bad/0, user:r_plain_zdiv/0],
         [iso_errors(true), iso_errors(r_plain_bad/0, false)],
         ['override lax silent'-'r_plain_bad/0',
          'sibling stays ISO'-'r_plain_zdiv/0']),
 
-    % 5) explicit is_iso bypasses lax mode
     run_project('explicit is_iso under lax mode (interpreter)',
         [user:r_iso_type/0, user:r_iso_inst/0, user:r_iso_zdiv/0],
         [iso_errors(false)],
@@ -136,13 +203,11 @@ main :-
          'explicit is_iso instantiation_error'-'r_iso_inst/0',
          'explicit is_iso zero_divisor'-'r_iso_zdiv/0']),
 
-    % 6) explicit is_lax bypasses ISO mode
     run_project('explicit is_lax under ISO mode (interpreter)',
         [user:r_lax_bad/0],
         [iso_errors(true)],
         ['explicit is_lax silent'-'r_lax_bad/0']),
 
-    % 7) functions/lowered emit mode
     run_project('functions mode ISO-default + explicit',
         [user:r_ok/0, user:r_iso_type/0, user:r_lax_bad/0, user:r_plain_zdiv/0],
         [emit_mode(functions), iso_errors(true)],
@@ -151,8 +216,67 @@ main :-
          'functions explicit is_lax'-'r_lax_bad/0',
          'functions ISO-default zdiv'-'r_plain_zdiv/0']),
 
-    forall(member(P, [r_ok/0, r_iso_inst/0, r_iso_type/0, r_iso_zdiv/0,
-                      r_lax_bad/0, r_plain_zdiv/0, r_plain_bad/0,
-                      r_plain_ok_iso/0]),
-           retractall(user:P)),
+    % ----- comparisons (ISO-R-2A) -----
+    run_project('cmp success + false (iso default, interpreter)',
+        [user:r_cmp_ok/0, user:r_cmp_false/0],
+        [iso_errors(true)],
+        ['cmp success'-'r_cmp_ok/0',
+         'cmp false'-'r_cmp_false/0']),
+
+    run_project('cmp ISO errors either operand (interpreter)',
+        [user:r_lt_iso_inst_l/0, user:r_lt_iso_inst_r/0,
+         user:r_lt_iso_type_l/0, user:r_lt_iso_type_r/0,
+         user:r_lt_iso_zdiv_l/0, user:r_lt_iso_zdiv_r/0,
+         user:r_gt_iso_inst/0, user:r_ge_iso_type/0,
+         user:r_le_iso_zdiv/0, user:r_eq_iso_type/0,
+         user:r_ne_iso_inst/0],
+        [iso_errors(false)],
+        ['<_iso inst L'-'r_lt_iso_inst_l/0',
+         '<_iso inst R'-'r_lt_iso_inst_r/0',
+         '<_iso type L'-'r_lt_iso_type_l/0',
+         '<_iso type R'-'r_lt_iso_type_r/0',
+         '<_iso zdiv L'-'r_lt_iso_zdiv_l/0',
+         '<_iso zdiv R'-'r_lt_iso_zdiv_r/0',
+         '>_iso inst'-'r_gt_iso_inst/0',
+         '>=_iso type'-'r_ge_iso_type/0',
+         '=<_iso zdiv'-'r_le_iso_zdiv/0',
+         '=:=_iso type'-'r_eq_iso_type/0',
+         '=\\=_iso inst'-'r_ne_iso_inst/0']),
+
+    run_project('cmp lax silent (interpreter)',
+        [user:r_lt_lax_bad/0, user:r_eq_lax_bad/0],
+        [iso_errors(true)],
+        ['<_lax silent'-'r_lt_lax_bad/0',
+         '=:=_lax silent'-'r_eq_lax_bad/0']),
+
+    run_project('cmp explicit iso under lax / lax under iso',
+        [user:r_cmp_iso_under_lax/0, user:r_cmp_lax_under_iso/0],
+        [iso_errors(false)],
+        ['explicit <_iso under lax'-'r_cmp_iso_under_lax/0',
+         'explicit <_lax under iso-mode sibling'-'r_cmp_lax_under_iso/0']),
+
+    run_project('cmp explicit lax under ISO mode',
+        [user:r_cmp_lax_under_iso/0],
+        [iso_errors(true)],
+        ['explicit <_lax under ISO'-'r_cmp_lax_under_iso/0']),
+
+    run_project('cmp default rewrite ISO + lax',
+        [user:r_cmp_plain_ok/0, user:r_cmp_plain_zdiv/0, user:r_cmp_plain_bad/0],
+        [iso_errors(true), iso_errors(r_cmp_plain_bad/0, false)],
+        ['default cmp ok'-'r_cmp_plain_ok/0',
+         'default cmp zdiv ISO'-'r_cmp_plain_zdiv/0',
+         'override cmp silent'-'r_cmp_plain_bad/0']),
+
+    run_project('cmp functions mode ISO + explicit',
+        [user:r_cmp_ok/0, user:r_cmp_false/0,
+         user:r_lt_iso_type_l/0, user:r_lt_lax_bad/0,
+         user:r_cmp_plain_zdiv/0],
+        [emit_mode(functions), iso_errors(true)],
+        ['functions cmp ok'-'r_cmp_ok/0',
+         'functions cmp false'-'r_cmp_false/0',
+         'functions <_iso type'-'r_lt_iso_type_l/0',
+         'functions <_lax silent'-'r_lt_lax_bad/0',
+         'functions default zdiv'-'r_cmp_plain_zdiv/0']),
+
+    retract_iso_helpers,
     (   nb_getval(r_iso_smoke_failed, true) -> halt(1) ; halt(0) ).

--- a/tests/test_wam_r_iso_unit.pl
+++ b/tests/test_wam_r_iso_unit.pl
@@ -1,8 +1,8 @@
 % SPDX-License-Identifier: MIT OR Apache-2.0
 %
-% test_wam_r_iso_unit.pl - Prolog-only unit tests for R WAM ISO-R-0
-% (shared config/rewrite/audit + is/2 key table). End-to-end generated-R
-% behaviour is covered by tests/test_wam_r_iso_smoke.pl.
+% test_wam_r_iso_unit.pl - Prolog-only unit tests for R WAM ISO-R-0/2A
+% (shared config/rewrite/audit + is/2 + six arithmetic-compare families).
+% End-to-end generated-R behaviour is covered by tests/test_wam_r_iso_smoke.pl.
 
 :- encoding(utf8).
 :- use_module(library(plunit)).
@@ -117,6 +117,50 @@ test(iso_errors_text_rewrite_per_pred_override) :-
     iso_errors_rewrite_text(Config, other/0, Wam2, OutWam2),
     assertion(sub_string(OutWam2, _, _, _, "builtin_call is_iso/2 2")).
 
+test(iso_errors_text_rewrite_comparison_iso) :-
+    Wam0 = 'cmp/0:\n  builtin_call </2 2\n  builtin_call >/2 2\n  builtin_call >=/2 2\n  builtin_call =</2 2\n  builtin_call =:=/2 2\n  builtin_call =\\=/2 2',
+    iso_errors_rewrite_text(iso_config(true, []), cmp/0, Wam0, IsoWam),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call <_iso/2 2")),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call >_iso/2 2")),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call >=_iso/2 2")),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call =<_iso/2 2")),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call =:=_iso/2 2")),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call =\\=_iso/2 2")).
+
+test(iso_errors_text_rewrite_comparison_lax) :-
+    Wam0 = 'cmp/0:\n  builtin_call </2 2\n  builtin_call >/2 2\n  builtin_call =:=/2 2',
+    iso_errors_rewrite_text(iso_config(false, []), cmp/0, Wam0, LaxWam),
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call <_lax/2 2")),
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call >_lax/2 2")),
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call =:=_lax/2 2")).
+
+test(iso_errors_text_rewrite_comparison_shapes) :-
+    Wam0 = 'cmp/0:\n  put_structure </2, A1\n  call </2 2\n  execute </2\n  proceed',
+    iso_errors_rewrite_text(iso_config(true, []), cmp/0, Wam0, IsoWam),
+    assertion(sub_string(IsoWam, _, _, _, "put_structure <_iso/2")),
+    assertion(sub_string(IsoWam, _, _, _, "call <_iso/2")),
+    assertion(sub_string(IsoWam, _, _, _, "execute <_iso/2")),
+    iso_errors_rewrite_text(iso_config(false, []), cmp/0, Wam0, LaxWam),
+    assertion(sub_string(LaxWam, _, _, _, "put_structure <_lax/2")),
+    assertion(sub_string(LaxWam, _, _, _, "call <_lax/2")),
+    assertion(sub_string(LaxWam, _, _, _, "execute <_lax/2")).
+
+test(iso_errors_text_rewrite_comparison_explicit_survives) :-
+    Wam0 = 'cmp/0:\n  builtin_call <_iso/2 2\n  builtin_call >_lax/2 2\n  proceed',
+    iso_errors_rewrite_text(iso_config(true, []), cmp/0, Wam0, IsoWam),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call <_iso/2 2")),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call >_lax/2 2")),
+    iso_errors_rewrite_text(iso_config(false, []), cmp/0, Wam0, LaxWam),
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call <_iso/2 2")),
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call >_lax/2 2")).
+
+test(iso_errors_text_rewrite_succ_not_yet) :-
+    % ISO-R-2B owns succ_*; R must not rewrite succ/2 yet.
+    Wam0 = 'succ_demo/0:\n  builtin_call succ/2 2',
+    iso_errors_rewrite_text(iso_config(true, []), succ_demo/0, Wam0, IsoWam),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call succ/2 2")),
+    \+ sub_string(IsoWam, _, _, _, "succ_iso").
+
 test(iso_errors_audit_structure) :-
     setup_call_cleanup(
         assertz((user:r_iso_audit_pred :- X is 1 + 2, X = 3)),
@@ -131,6 +175,21 @@ test(iso_errors_audit_structure) :-
             ))
         ),
         retractall(user:r_iso_audit_pred)).
+
+test(iso_errors_audit_comparison) :-
+    setup_call_cleanup(
+        assertz((user:r_iso_audit_cmp :- 1 < 2, 3 > 2)),
+        (   wam_r_iso_audit(
+                [user:r_iso_audit_cmp/0],
+                [iso_errors(true)],
+                Audit),
+            assertion((
+                Audit = [audit(user:r_iso_audit_cmp/0, true, Sites)],
+                memberchk(site(_, "</2", "<_iso/2", default, true), Sites),
+                memberchk(site(_, ">/2", ">_iso/2", default, true), Sites)
+            ))
+        ),
+        retractall(user:r_iso_audit_cmp)).
 
 test(iso_errors_project_generation_selects_concrete_key) :-
     once((
@@ -148,6 +207,28 @@ test(iso_errors_project_generation_selects_concrete_key) :-
                 assertion(\+ sub_string(Code, _, _, _, 'BuiltinCall("is/2"'))
             ),
             (   retractall(user:r_iso_rewrite_demo),
+                catch(delete_directory_and_contents(TmpDir), _, true)
+            )
+        )
+    )).
+
+test(iso_errors_project_generation_comparison_keys) :-
+    once((
+        TmpDir = '/tmp/uw_r_iso_cmp_rewrite_unit',
+        catch(delete_directory_and_contents(TmpDir), _, true),
+        setup_call_cleanup(
+            assertz((user:r_iso_cmp_rewrite :- 1 < 2, 4 =:= 2 + 2)),
+            (   write_wam_r_project(
+                    [user:r_iso_cmp_rewrite/0],
+                    [iso_errors(true)],
+                    TmpDir),
+                string_concat(TmpDir, '/R/generated_program.R', ProgPath),
+                read_file_to_string(ProgPath, Code, []),
+                assertion(sub_string(Code, _, _, _, "<_iso/2")),
+                assertion(sub_string(Code, _, _, _, "=:=_iso/2")),
+                assertion(\+ sub_string(Code, _, _, _, 'BuiltinCall("</2"'))
+            ),
+            (   retractall(user:r_iso_cmp_rewrite),
                 catch(delete_directory_and_contents(TmpDir), _, true)
             )
         )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **ISO-R-2A**: six arithmetic-comparison families with `_iso`/`_lax` three-form parity for hybrid WAM R, reusing the ISO-R-0 substrate. R remains a **partial** ISO adopter (`succ` = ISO-R-2B).

## Verified pre-existing (not reimplemented)

- `catch/3` + `throw/1` snapshot/unwind, catcher unification, rethrow, top-level handling
- ISO-R-0: `is_iso/2`, `is_lax/2`, error constructors, config/rewrite/audit, module-scoped overrides (`#3925`)
- Default R comparisons already existed and silently fail on bad eval (preserved as the lax path)

## Contract

| Mode | Behavior |
|------|----------|
| Lax / default (rewritten) | Successful compares work; malformed/unbound/zero-div fail silently |
| ISO | unbound → `instantiation_error`; zero divisor → `evaluation_error(zero_divisor)`; else → `type_error(evaluable, Culprit)`; valid-but-false fails without throw |
| Explicit `_iso` / `_lax` | Survive mode changes; module-qualified overrides preserved |

Families: `</2`, `>/2`, `=</2`, `>=/2`, `=:=/2`, `=\=/2` → matching `_iso`/`_lax`.

## Runtime paths

- Shared `iso_errors` key tables + `r_iso_rewritable_key/1` (registers compares only after runtime exists; `succ_*` still excluded)
- Parameterized `builtin_arith_compare_{iso,lax}` + `arith_compare_key_info` / `r_arith_compare_emit` mappings
- Reuses the ISO-R-0 evaluator, unbound/zero-div/culprit helpers, constructors, and `throw_iso_error`; comparison ISO mode scans both operands before evaluation to preserve fleet-wide error precedence
- `call_builtin` + `call_library` (Call/Execute) + lowered emitter Call/Execute/`builtin_call` all route to the same helpers
- Backslash-safe emission for `=\=` Op strings in lowered R

## LOC breakdown (vs `main`)

| Area | + | − | net |
|------|--:|--:|----:|
| Production (`wam_r_target.pl`, `wam_r_lowered_emitter.pl`, `runtime.R.mustache`) | 184 | 33 | **151** |
| Tests | 254 | 22 | 232 |
| Docs | 31 | 21 | 10 |
| **Total** | 469 | 76 | 393 |

Production exceeds the ~120 aim because the review fix added an explicit two-operand precedence scan and factored the post-classification evaluator; the rest remains compact mapping/wiring with no duplicated per-op runtime branches.

## Review correction

Review found that ISO comparison evaluation classified the left operand completely before inspecting the right. The reference fleet contract scans both operands first, so a right-side unbound or zero-divisor must outrank a left-side type error. Commit `c45f92f` fixes that ordering and adds interpreter + functions regressions. It also repairs the malformed ISO-R-2A ledger row and restores an unrelated R status bullet dropped by the original docs edit.

## Tests run (local)

| Suite | Result |
|-------|--------|
| `tests/test_wam_r_iso_unit.pl` | pass (19) |
| `tests/test_wam_r_iso_smoke.pl` | pass (interpreter + functions) |
| `tests/test_iso_errors.pl` | pass |
| Focused R generator (`builtin_call_emitted`, arith/`is` e2e) | pass |
| `CONFORMANCE_TARGETS=r,r_functions` | pass |
| `git diff --check` | clean |

## Hosted CI

Updated review head: **R ISO unit/smoke and WAM R Conformance (interpreter + functions) are green**. Remaining fleet jobs are still running.

## Status docs

- ISO-R-2A marked complete; ISO-R-2B (`succ`) and full R ISO adoption remain pending

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

