### PR TITLE
ISO-R-2B: succ/2 three-form parity and R ISO adoption closeout

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -53,10 +53,10 @@ self-contained so a single coding agent can pick it up in isolation.
 | ISO-C | ISO three-form (new) | C | L | — |
 | ISO-GO | ISO three-form (new) | Go | L | — |
 | ISO-SCALA | ISO three-form (new) | Scala | L | — |
-| ISO-R-0 ✅ | shared wiring + `is/2` vertical slice | R | M | done (partial adopter) |
+| ISO-R-0 ✅ | shared wiring + `is/2` vertical slice | R | M | done |
 | ISO-R-1 ✅ | pre-existing catch/throw substrate | R | — | validated (`catch_throw_dyn_aggregator_e2e_rscript`) |
 | ISO-R-2A ✅ | arithmetic comparisons | R | S | done |
-| ISO-R-2B | successor + adoption closeout | R | S | ISO-R-2A |
+| ISO-R-2B ✅ | successor + adoption closeout | R | S | done |
 | ISO-PYTHON | ISO three-form (finish) | Python | S | — |
 | ISO-FSHARP | ISO three-form (finish) | F# | S | — |
 | KERN-FSHARP ✅ | Finish F# native kernel acceleration | F# | L | gate+TC2+TD3+TPD4+TSPD5+WSP3+A* done |
@@ -454,9 +454,9 @@ plumbing there.
   `is_lax/2` (ISO-R-2A later extended comparisons). Runtime helpers live in
   `runtime.R.mustache`
   (`builtin_is_iso` / `builtin_is_lax` + structured error constructors).
-  Existing `catch/3`+`throw/1` substrate is reused by tests but **R remains
-  a partial adopter** until all seven “What Counts As Adoption” items are
-  satisfied (`succ` remains ISO-R-2B).
+  Existing `catch/3`+`throw/1` substrate is reused by tests. ISO-R-2B
+  closed the seven-item adoption unit for the audited surface; remaining
+  concrete builtins without three-form keys match the Python/F# caveat.
 - **Acceptance:** `tests/test_wam_r_iso_unit.pl` + `tests/test_wam_r_iso_smoke.pl`.
 
 ### ISO-R-1 ✅: pre-existing catch/throw substrate
@@ -474,11 +474,19 @@ plumbing there.
 - **Acceptance:** extended `tests/test_wam_r_iso_unit.pl` +
   `tests/test_wam_r_iso_smoke.pl`.
 
-### ISO-R-2B: successor + adoption closeout
-- **Depends on:** ISO-R-2A. Add `succ_iso` / `succ_lax`, then verify the
-  complete adoption checklist in
-  `docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`.
-  Do **not** claim full R ISO adoption until R-2B lands.
+### ISO-R-2B ✅: successor + adoption closeout
+- **Status:** Landed. `succ/2` → `succ_iso/2` | `succ_lax/2` via shared
+  key table + `r_iso_rewritable_key/1`. Runtime reuses the pre-existing
+  bidirectional bind path as `succ_bind` / `builtin_succ_{iso,lax}`
+  (Execute/Call; no BuiltinCall form from the R compiler). R now meets
+  the seven-item “What Counts As Adoption” unit in
+  `docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` for the audited
+  surface (`catch`/`throw`, constructors, config/rewrite/audit, `is/2`,
+  six compares, `succ/2`). Remaining concrete builtins without three-form
+  keys are the same class of caveat as Python/F# — not claimed as full
+  fleet-wide ISO compatibility for every builtin.
+- **Acceptance:** extended `tests/test_wam_r_iso_unit.pl` +
+  `tests/test_wam_r_iso_smoke.pl`.
 
 ### ISO-R (ledger parent): New ISO three-form adoption for WAM R target
 - **Lever:** ISO three-form  **Target:** R  **Size:** L  **Depends on:** —

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -52,17 +52,19 @@ default 4096), and explicit `auto` (codegen resolves via shared
   forms (`switch_on_constant_a2`, `_a2_fallthrough`, `switch_on_structure_a2`)
   — map to the existing `SwitchOnTerm()` linear no-op (not optimized A2
   dispatch), preserving the full try/retry/trust chain.
-- **ISO error support** is a **partial adopter** after ISO-R-0 + ISO-R-2A:
-  shared config/rewrite/audit, `is/2` three-form, and the six arithmetic
-  comparison families (`<_iso`/`<_lax` … `=\=_iso`/`=\=_lax`). The
-  pre-existing catch/throw substrate is already covered end-to-end;
-  `succ` remains ISO-R-2B. Do not claim complete ISO-R yet.
-- No dedicated effective-distance cross-target bench row.
+- **ISO error support** meets the seven-item adoption unit after ISO-R-0/
+  2A/2B: shared config/rewrite/audit, `is/2`, six arithmetic comparisons,
+  and `succ/2` three-form (`succ_iso`/`succ_lax`), plus pre-existing
+  catch/throw. Same caveat as Python/F#: remaining concrete builtins
+  without three-form keys are out of scope for “complete for every
+  builtin.” Do not describe R as fully ISO-compatible across the entire
+  builtin surface.
 
 ## Path forward
 
-1. ISO-R-2B successor (`succ_iso`/`succ_lax`) + adoption closeout.
-2. Effective-distance cross-target matrix row.
+1. Effective-distance cross-target matrix row.
+2. Optional follow-up: three-form keys for additional audited builtins
+   beyond `is`/compares/`succ` (same class of work as ISO-PYTHON/ISO-FSHARP).
 
 ## Document status
 

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -59,6 +59,7 @@ default 4096), and explicit `auto` (codegen resolves via shared
   without three-form keys are out of scope for “complete for every
   builtin.” Do not describe R as fully ISO-compatible across the entire
   builtin surface.
+- No dedicated effective-distance cross-target bench row.
 
 ## Path forward
 
@@ -68,5 +69,5 @@ default 4096), and explicit `auto` (codegen resolves via shared
 
 ## Document status
 
-Fleet-aligned snapshot updated for CONF-R landing (2026-07-15): opt-in
-harness adapter + measured classic-program readout.
+Fleet-aligned snapshot updated for ISO-R-2B closeout (2026-07-22): audited
+three-form adoption surface plus the remaining effective-distance bench gap.

--- a/docs/WAM_R_TARGET.md
+++ b/docs/WAM_R_TARGET.md
@@ -752,25 +752,33 @@ of the thrown term; `catch/3` unwinds the trail and CP stack to its
 entry snapshot before unifying with the catcher and running the
 recovery. Uncaught throws at the top level become query failure.
 
-### ISO errors (ISO-R-0 + ISO-R-2A partial adoption)
+### ISO errors (ISO-R-0/2A/2B adoption unit)
 
 Shared `iso_errors` config / per-predicate rewrite / `wam_r_iso_audit/3`
 are wired. Project options: `iso_errors(true|false)`,
 `iso_errors(PI, true|false)`, `iso_errors_config(File)`.
 
-Key table: `is/2` → `is_iso/2` | `is_lax/2`, plus the six comparison
-families (`</2 >/2 =</2 >=/2 =:=/2 =\=/2`) → matching `_iso`/`_lax`.
-`succ/2` remains deferred to ISO-R-2B. Explicit `_iso`/`_lax` forms
-survive mode rewrites. Runtime helpers in `runtime.R.mustache`:
-`builtin_is_iso` / `builtin_is_lax`, parameterized
-`builtin_arith_compare_{iso,lax}`, plus structured `error/2` constructors.
-Classify order (ISO arith): unbound → `evaluation_error(zero_divisor)` →
-`type_error(evaluable, Culprit)`. Valid but false comparisons fail
-normally without throwing.
+Key table: `is/2`, the six comparison families, and `succ/2` → matching
+`_iso`/`_lax`. Explicit `_iso`/`_lax` forms survive mode rewrites.
+Runtime helpers in `runtime.R.mustache`: `builtin_is_*`,
+`builtin_arith_compare_*`, `builtin_succ_*` (+ `make_domain_error`),
+and structured `error/2` constructors.
 
-R is still a **partial adopter** until all seven items in
-`docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` §"What Counts As
-Adoption" are satisfied (`succ` + closeout = ISO-R-2B).
+**succ ISO classify order** (Python/F# fleet contract): both unbound →
+`instantiation_error`; bound non-int X → `type_error(integer, X)`; bound
+non-int Y → `type_error(integer, Y)`; X < 0 →
+`type_error(not_less_than_zero, X)`; reverse Y ≤ 0 →
+`domain_error(not_less_than_zero, Y)`; valid inconsistent pairs fail
+normally. Integer overflow follows existing R `IntTerm` arithmetic
+(NA on signed 32-bit wrap) — no target-specific overflow policy.
+
+**Lax float `/`:** host IEEE-754 Inf/NaN via R `/`. ISO arith still
+throws `evaluation_error(zero_divisor)` when a zero divisor is detected.
+
+R satisfies the seven-item adoption checklist in
+`docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` for the audited
+surface. Remaining builtins without three-form keys are the same
+open-ended caveat as Python/F#.
 
 ## Supported WAM instructions
 

--- a/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
+++ b/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
@@ -57,32 +57,32 @@ Survey columns: shipped means code and tests exist in the target today.
 
 | Component | C++ | Elixir | Other WAM targets |
 |---|---|---|---|
-| Prolog config loader (`iso_errors_config/1`, inline overrides) | shipped | shipped | Python and F# plumbing shipped; other targets not adopted |
-| Bare-PI multi-module warning | shipped | shipped | Python and F# plumbing shipped; other targets not adopted |
-| Per-predicate default rewrite | shipped | shipped | Python and F# plumbing shipped; other targets not adopted |
-| Text-path rewrite coverage (`builtin_call`, `put_structure`, `call`, `execute`) | shipped | shipped | target-specific |
-| Audit predicate and report | `wam_cpp_iso_audit/3` | `wam_elixir_iso_audit/3` | `wam_python_iso_audit/3`, `wam_fsharp_iso_audit/3`; others not adopted |
-| `catch/3` + `throw/1` substrate | shipped | shipped | Python and F# shipped; others mostly missing/partial |
-| Error constructors and `throw_iso_error` helper | shipped | shipped | Python and F# shipped; others not adopted |
-| `is_iso/2` / `is_lax/2` | shipped | shipped | Python and F# shipped; others not adopted |
-| ISO/lax arithmetic compares | shipped | shipped | Python and F# shipped; others not adopted |
-| `succ_iso/2` / `succ_lax/2` | shipped | shipped | Python and F# shipped; others not adopted |
-| Lax IEEE-754 float divide behavior | shipped | shipped | Python shipped; F# partial (float div by zero returns nan/inf via CLR; integer div by zero fails silently); others not adopted |
+| Prolog config loader (`iso_errors_config/1`, inline overrides) | shipped | shipped | Python, F#, R shipped; others not adopted |
+| Bare-PI multi-module warning | shipped | shipped | Python, F#, R shipped; others not adopted |
+| Per-predicate default rewrite | shipped | shipped | Python, F#, R shipped; others not adopted |
+| Text-path rewrite coverage (`builtin_call`, `put_structure`, `call`, `execute`) | shipped | shipped | target-specific (R covers all four) |
+| Audit predicate and report | `wam_cpp_iso_audit/3` | `wam_elixir_iso_audit/3` | `wam_python_iso_audit/3`, `wam_fsharp_iso_audit/3`, `wam_r_iso_audit/3`; others not adopted |
+| `catch/3` + `throw/1` substrate | shipped | shipped | Python, F#, R shipped; others mostly missing/partial |
+| Error constructors and `throw_iso_error` helper | shipped | shipped | Python, F#, R shipped; others not adopted |
+| `is_iso/2` / `is_lax/2` | shipped | shipped | Python, F#, R shipped; others not adopted |
+| ISO/lax arithmetic compares | shipped | shipped | Python, F#, R shipped; others not adopted |
+| `succ_iso/2` / `succ_lax/2` | shipped | shipped | Python, F#, R shipped; others not adopted |
+| Lax IEEE-754 float divide behavior | shipped | shipped | Python shipped; R float `/` uses host Inf/NaN; F# partial (float div by zero returns nan/inf via CLR; integer div by zero fails silently); others not adopted |
 
 The C++ and Elixir targets are therefore the current reference consumers. C++
 was the first implementation; Elixir proves the design is not C++-specific.
 Python adopted the catch/throw substrate, ISO error constructors,
 `throw_iso_error`, per-predicate config/rewrite/audit plumbing, arithmetic
 assignment variants, arithmetic comparison variants, and successor variants. F#
-now matches that adoption surface (substrate + config/rewrite/audit +
-`is_iso/2` / `is_lax/2` + six arithmetic-compare ISO/lax variants +
-`succ/2` family). Neither Python nor F# should be described as fully
+and **R** now match that audited adoption surface (substrate + config/rewrite/
+audit + `is_iso`/`is_lax` + six arithmetic-compare ISO/lax variants +
+`succ/2` family). None of Python, F#, or R should be described as fully
 ISO-error compatible until remaining concrete builtins also adopt three-form
-keys. R, Lua, Rust, and the remaining targets are still mostly missing
+keys. Lua, Rust, and the remaining targets are still mostly missing
 ISO three-form adoption. **Haskell** now has a catch/throw + `is_iso`
 substrate and smoke tests (`test_wam_haskell_iso_smoke.pl`, PRs
 #2510/#2526) but is not yet listed as a reference adopter alongside
-C++/Elixir/F#/Python — treat it as partial until the shared status
+C++/Elixir/F#/Python/R — treat it as partial until the shared status
 table is refreshed end-to-end.
 
 ## What Counts As Adoption

--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -853,6 +853,22 @@ emit_line_parts(["execute", "is_iso/2"], I) :- !,
 emit_line_parts(["execute", "is_lax/2"], I) :- !,
     format("~wif (!isTRUE(WamRuntime$builtin_is_lax(program, state))) return(FALSE)~n", [I]),
     format("~wreturn(TRUE)~n", [I]).
+% ISO-R-2B: succ arrives as Call/Execute (not BuiltinCall).
+emit_line_parts(["call", "succ/2"], I) :- !,
+    format("~wif (!isTRUE(WamRuntime$builtin_succ_lax(program, state))) return(FALSE)~n", [I]).
+emit_line_parts(["call", "succ_lax/2"], I) :- !,
+    format("~wif (!isTRUE(WamRuntime$builtin_succ_lax(program, state))) return(FALSE)~n", [I]).
+emit_line_parts(["call", "succ_iso/2"], I) :- !,
+    format("~wif (!isTRUE(WamRuntime$builtin_succ_iso(program, state))) return(FALSE)~n", [I]).
+emit_line_parts(["execute", "succ/2"], I) :- !,
+    format("~wif (!isTRUE(WamRuntime$builtin_succ_lax(program, state))) return(FALSE)~n", [I]),
+    format("~wreturn(TRUE)~n", [I]).
+emit_line_parts(["execute", "succ_lax/2"], I) :- !,
+    format("~wif (!isTRUE(WamRuntime$builtin_succ_lax(program, state))) return(FALSE)~n", [I]),
+    format("~wreturn(TRUE)~n", [I]).
+emit_line_parts(["execute", "succ_iso/2"], I) :- !,
+    format("~wif (!isTRUE(WamRuntime$builtin_succ_iso(program, state))) return(FALSE)~n", [I]),
+    format("~wreturn(TRUE)~n", [I]).
 % ISO-R-2A: arithmetic-compare Call/Execute → shared parameterized helpers.
 emit_line_parts(["call", Key], I) :-
     r_arith_compare_emit(Key, Op, Mode), !,

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -2317,6 +2317,21 @@ iso_errors_audit_classify_line_r([Tok], label) :-
 iso_errors_audit_classify_line_r(["builtin_call", Key0 | _],
                                 builtin_call(Key, 0)) :- !,
     iso_errors_clean_key_token(Key0, Key).
+% succ/2 and other library predicates emit Call/Execute, not BuiltinCall.
+iso_errors_audit_classify_line_r(["execute", Key0 | _],
+                                builtin_call(Key, 0)) :- !,
+    iso_errors_clean_key_token(Key0, Key).
+iso_errors_audit_classify_line_r(["call", Key0 | Rest],
+                                builtin_call(Key, 0)) :- !,
+    (   Rest = [ArityStr | _],
+        \+ sub_string(Key0, _, _, _, "/"),
+        format(string(Key1), "~w/~w", [Key0, ArityStr])
+    ->  Key = Key1
+    ;   iso_errors_clean_key_token(Key0, Key)
+    ).
+iso_errors_audit_classify_line_r(["put_structure", Key0 | _],
+                                builtin_call(Key, 0)) :- !,
+    iso_errors_clean_key_token(Key0, Key).
 iso_errors_audit_classify_line_r(_, other).
 
 wam_r_iso_audit_report([]).

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -2188,8 +2188,8 @@ find_template(RelPath, Template) :-
 % ISO-R-0/R-2A: shared ISO wiring + is/2 + arithmetic comparisons
 % ============================================================================
 % Key-table safety: register a default key only when matching R runtime
-% branches exist.  Catch/throw and is_iso/is_lax ship already; ISO-R-2A
-% adds the six arithmetic-compare families.  succ_* remains ISO-R-2B.
+% branches exist.  Catch/throw, is_*, and compares ship already; ISO-R-2B
+% adds succ_iso / succ_lax.
 
 iso_errors:iso_errors_default_to_iso("is/2", "is_iso/2").
 iso_errors:iso_errors_default_to_lax("is/2", "is_lax/2").
@@ -2200,6 +2200,7 @@ iso_errors:iso_errors_default_to_iso(">=/2", ">=_iso/2").
 iso_errors:iso_errors_default_to_iso("=</2", "=<_iso/2").
 iso_errors:iso_errors_default_to_iso("=:=/2", "=:=_iso/2").
 iso_errors:iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
+iso_errors:iso_errors_default_to_iso("succ/2", "succ_iso/2").
 
 iso_errors:iso_errors_default_to_lax("</2", "<_lax/2").
 iso_errors:iso_errors_default_to_lax(">/2", ">_lax/2").
@@ -2207,6 +2208,7 @@ iso_errors:iso_errors_default_to_lax(">=/2", ">=_lax/2").
 iso_errors:iso_errors_default_to_lax("=</2", "=<_lax/2").
 iso_errors:iso_errors_default_to_lax("=:=/2", "=:=_lax/2").
 iso_errors:iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
+iso_errors:iso_errors_default_to_lax("succ/2", "succ_lax/2").
 
 % Keep the module when present: qualified overrides must not leak to a
 % same-named predicate in another module.
@@ -2247,7 +2249,7 @@ iso_errors_rewrite_line(Mode, Line, OutLine) :-
     ;   OutLine = Line
     ).
 
-%% Keys with matching R runtime branches (ISO-R-0 is/2 + ISO-R-2A compares).
+%% Keys with matching R runtime branches (ISO-R-0/2A/2B).
 r_iso_rewritable_key("is/2").
 r_iso_rewritable_key("</2").
 r_iso_rewritable_key(">/2").
@@ -2255,6 +2257,7 @@ r_iso_rewritable_key(">=/2").
 r_iso_rewritable_key("=</2").
 r_iso_rewritable_key("=:=/2").
 r_iso_rewritable_key("=\\=/2").
+r_iso_rewritable_key("succ/2").
 
 iso_errors_clean_key_token(Token0, Token) :-
     (   string_concat(Token, ",", Token0)

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -1998,6 +1998,11 @@ WamRuntime$make_evaluation_error <- function(table, kind) {
              list(Atom(WamRuntime$intern(table, kind))))
 }
 
+WamRuntime$make_domain_error <- function(table, domain, culprit) {
+  StructTerm(WamRuntime$intern(table, "domain_error"),
+             list(Atom(WamRuntime$intern(table, domain)), culprit))
+}
+
 WamRuntime$throw_iso_error <- function(state, table, err_term) {
   ctx <- Unbound(paste0("V", state$var_counter))
   state$var_counter <- state$var_counter + 1L
@@ -2194,6 +2199,62 @@ WamRuntime$builtin_arith_compare_iso <- function(program, state, op) {
   a <- WamRuntime$eval_arith_iso_value(program, state, a_expr)
   b <- WamRuntime$eval_arith_iso_value(program, state, b_expr)
   isTRUE(WamRuntime$arith_compare_apply(op, a, b))
+}
+
+# ISO-R-2B: successor three-form. Shared bind/unify; lax vs ISO only
+# differ in error reporting. Mirrors Python _execute_succ_{lax,iso}.
+# Integer overflow follows existing R IntTerm arithmetic (NA on wrap).
+WamRuntime$succ_bind <- function(state, x_v, y_v) {
+  if (!is.null(x_v) && !is.null(x_v$tag) && x_v$tag == "int") {
+    if (x_v$val < 0L) return(FALSE)
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 2L),
+                            IntTerm(x_v$val + 1L)))
+  }
+  if (!is.null(y_v) && !is.null(y_v$tag) && y_v$tag == "int") {
+    if (y_v$val <= 0L) return(FALSE)
+    return(WamRuntime$unify(state, WamRuntime$get_reg(state, 1L),
+                            IntTerm(y_v$val - 1L)))
+  }
+  FALSE
+}
+
+WamRuntime$builtin_succ_lax <- function(program, state) {
+  x_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+  y_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 2L))
+  WamRuntime$succ_bind(state, x_v, y_v)
+}
+
+# Classify: both-unbound → non-int X → non-int Y → X<0 type →
+# Y<=0 domain (reverse) → bind. Valid inconsistent pairs fail normally.
+WamRuntime$builtin_succ_iso <- function(program, state) {
+  table <- program$intern_table
+  x_raw <- WamRuntime$get_reg(state, 1L)
+  y_raw <- WamRuntime$get_reg(state, 2L)
+  x_v <- WamRuntime$deref(state, x_raw)
+  y_v <- WamRuntime$deref(state, y_raw)
+  x_unbound <- is.null(x_v) || is.null(x_v$tag) || x_v$tag == "unbound"
+  y_unbound <- is.null(y_v) || is.null(y_v$tag) || y_v$tag == "unbound"
+  if (x_unbound && y_unbound) {
+    WamRuntime$throw_iso_error(state, table,
+      WamRuntime$make_instantiation_error(table))
+  }
+  if (!x_unbound && (is.null(x_v$tag) || x_v$tag != "int")) {
+    WamRuntime$throw_iso_error(state, table,
+      WamRuntime$make_type_error(table, "integer", x_v))
+  }
+  if (!y_unbound && (is.null(y_v$tag) || y_v$tag != "int")) {
+    WamRuntime$throw_iso_error(state, table,
+      WamRuntime$make_type_error(table, "integer", y_v))
+  }
+  if (!x_unbound && x_v$tag == "int" && x_v$val < 0L) {
+    WamRuntime$throw_iso_error(state, table,
+      WamRuntime$make_type_error(table, "not_less_than_zero", x_v))
+  }
+  if (x_unbound && !y_unbound && y_v$tag == "int" && y_v$val <= 0L) {
+    WamRuntime$throw_iso_error(state, table,
+      WamRuntime$make_domain_error(table, "not_less_than_zero", y_v))
+  }
+  WamRuntime$succ_bind(state, x_v, y_v)
 }
 
 # Standard Euclidean GCD; both args coerced to non-negative integers.
@@ -5373,6 +5434,13 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     }
     return(WamRuntime$builtin_arith_compare_lax(program, state, cmp_info$op))
   }
+  # succ/2 family: Execute/Call (compiler does not emit BuiltinCall).
+  if (arity == 2L && (key == "succ/2" || key == "succ_lax/2")) {
+    return(WamRuntime$builtin_succ_lax(program, state))
+  }
+  if (key == "succ_iso/2" && arity == 2L) {
+    return(WamRuntime$builtin_succ_iso(program, state))
+  }
 
   # ----- ^/2 existential scope -----
   # When the WAM compiler emits `Y^Goal` as a Call("^", 2), treat
@@ -5486,23 +5554,6 @@ WamRuntime$call_library <- function(program, state, pred, arity) {
     }
     return(WamRuntime$unify(state, WamRuntime$get_reg(state, 3L),
                             WamRuntime$wam_list_build(keep, table)))
-  }
-
-  # ----- succ/2: successor (bidirectional integer +1) -----
-  if (key == "succ/2") {
-    x_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
-    y_v <- WamRuntime$deref(state, WamRuntime$get_reg(state, 2L))
-    if (!is.null(x_v) && !is.null(x_v$tag) && x_v$tag == "int") {
-      if (x_v$val < 0L) return(FALSE)
-      return(WamRuntime$unify(state, WamRuntime$get_reg(state, 2L),
-                              IntTerm(x_v$val + 1L)))
-    }
-    if (!is.null(y_v) && !is.null(y_v$tag) && y_v$tag == "int") {
-      if (y_v$val <= 0L) return(FALSE)
-      return(WamRuntime$unify(state, WamRuntime$get_reg(state, 1L),
-                              IntTerm(y_v$val - 1L)))
-    }
-    return(FALSE)
   }
 
   # ----- between/3: deterministic mode (test only) -----

--- a/tests/test_wam_r_iso_smoke.pl
+++ b/tests/test_wam_r_iso_smoke.pl
@@ -101,6 +101,8 @@ run_project(Label, Preds, Opts, Checks) :-
             ; sub_string(Code,_,_,_,"<_lax/2")
             ; sub_string(Code,_,_,_,">_iso/2")
             ; sub_string(Code,_,_,_,"=:=_iso/2")
+            ; sub_string(Code,_,_,_,"succ_iso")
+            ; sub_string(Code,_,_,_,"succ_lax")
             )
         ->  pass(Label-codegen-skip-rscript)
         ;   fail_test(Label, 'missing rewritten iso/lax key in codegen')
@@ -172,7 +174,36 @@ assert_iso_helpers :-
     assertz((user:r_cmp_plain_zdiv :-
         catch((1/0 < 3), error(evaluation_error(zero_divisor), _), true))),
     assertz((user:r_cmp_plain_bad :- \+ (foo < 3))),
-    assertz((user:r_cmp_plain_ok :- 1 < 2)).
+    assertz((user:r_cmp_plain_ok :- 1 < 2)),
+
+    % succ/2 family (ISO-R-2B)
+    assertz((user:r_succ_fwd :- succ(0, 1), succ(4, 5))),
+    assertz((user:r_succ_back :- succ(X, 5), X =:= 4)),
+    assertz((user:r_succ_pair_ok :- succ(3, 4))),
+    assertz((user:r_succ_pair_bad :- \+ succ(3, 5))),
+    assertz((user:r_succ_lax_bad :-
+        \+ succ_lax(_, _), \+ succ_lax(foo, _), \+ succ_lax(_, foo),
+        \+ succ_lax(-1, _), \+ succ_lax(_, 0), \+ succ_lax(_, -1))),
+    assertz((user:r_succ_iso_inst :-
+        catch(succ_iso(_, _), error(instantiation_error, _), true))),
+    assertz((user:r_succ_iso_type_x :-
+        catch(succ_iso(foo, _), error(type_error(integer, _), _), true))),
+    assertz((user:r_succ_iso_type_y :-
+        catch(succ_iso(_, bar), error(type_error(integer, _), _), true))),
+    assertz((user:r_succ_iso_neg :-
+        catch(succ_iso(-1, _),
+              error(type_error(not_less_than_zero, _), _), true))),
+    assertz((user:r_succ_iso_domain :-
+        catch(succ_iso(_, 0),
+              error(domain_error(not_less_than_zero, _), _), true))),
+    assertz((user:r_succ_iso_mismatch :- \+ succ_iso(3, 5))),
+    assertz((user:r_succ_iso_under_lax :-
+        catch(succ_iso(_, _), error(instantiation_error, _), true))),
+    assertz((user:r_succ_lax_under_iso :- \+ succ_lax(_, _))),
+    assertz((user:r_succ_plain_iso :-
+        catch((succ(_, _)), error(instantiation_error, _), true))),
+    assertz((user:r_succ_plain_lax :- \+ (succ(_, _)))),
+    assertz((user:r_succ_mod_b :- succ(1, 2))).
 
 retract_iso_helpers :-
     forall(member(P, [
@@ -187,7 +218,12 @@ retract_iso_helpers :-
         r_eq_iso_type/0, r_ne_iso_inst/0,
         r_lt_lax_bad/0, r_eq_lax_bad/0,
         r_cmp_iso_under_lax/0, r_cmp_lax_under_iso/0,
-        r_cmp_plain_zdiv/0, r_cmp_plain_bad/0, r_cmp_plain_ok/0
+        r_cmp_plain_zdiv/0, r_cmp_plain_bad/0, r_cmp_plain_ok/0,
+        r_succ_fwd/0, r_succ_back/0, r_succ_pair_ok/0, r_succ_pair_bad/0,
+        r_succ_lax_bad/0, r_succ_iso_inst/0, r_succ_iso_type_x/0,
+        r_succ_iso_type_y/0, r_succ_iso_neg/0, r_succ_iso_domain/0,
+        r_succ_iso_mismatch/0, r_succ_iso_under_lax/0, r_succ_lax_under_iso/0,
+        r_succ_plain_iso/0, r_succ_plain_lax/0, r_succ_mod_b/0
     ]), retractall(user:P)).
 
 main :-
@@ -304,6 +340,64 @@ main :-
          'functions precedence instantiation'-'r_lt_iso_precedence_inst/0',
          'functions precedence zero_divisor'-'r_lt_iso_precedence_zdiv/0',
          'functions default zdiv'-'r_cmp_plain_zdiv/0']),
+
+    % ----- succ/2 (ISO-R-2B) -----
+    run_project('succ happy paths (iso default, interpreter)',
+        [user:r_succ_fwd/0, user:r_succ_back/0,
+         user:r_succ_pair_ok/0, user:r_succ_pair_bad/0],
+        [iso_errors(true)],
+        ['succ forward'-'r_succ_fwd/0',
+         'succ reverse'-'r_succ_back/0',
+         'succ pair ok'-'r_succ_pair_ok/0',
+         'succ pair mismatch'-'r_succ_pair_bad/0']),
+
+    run_project('succ ISO errors (interpreter)',
+        [user:r_succ_iso_inst/0, user:r_succ_iso_type_x/0,
+         user:r_succ_iso_type_y/0, user:r_succ_iso_neg/0,
+         user:r_succ_iso_domain/0, user:r_succ_iso_mismatch/0],
+        [iso_errors(false)],
+        ['succ_iso inst'-'r_succ_iso_inst/0',
+         'succ_iso type X'-'r_succ_iso_type_x/0',
+         'succ_iso type Y'-'r_succ_iso_type_y/0',
+         'succ_iso neg'-'r_succ_iso_neg/0',
+         'succ_iso domain'-'r_succ_iso_domain/0',
+         'succ_iso mismatch'-'r_succ_iso_mismatch/0']),
+
+    run_project('succ lax silent + explicit lax under ISO',
+        [user:r_succ_lax_bad/0, user:r_succ_lax_under_iso/0],
+        [iso_errors(true)],
+        ['succ_lax silent'-'r_succ_lax_bad/0',
+         'succ_lax under ISO'-'r_succ_lax_under_iso/0']),
+
+    run_project('succ explicit iso under lax mode',
+        [user:r_succ_iso_under_lax/0, user:r_succ_iso_domain/0],
+        [iso_errors(false)],
+        ['succ_iso under lax'-'r_succ_iso_under_lax/0',
+         'succ_iso domain under lax'-'r_succ_iso_domain/0']),
+
+    run_project('succ default rewrite ISO + lax override',
+        [user:r_succ_plain_iso/0, user:r_succ_plain_lax/0],
+        [iso_errors(true), iso_errors(r_succ_plain_lax/0, false)],
+        ['default succ ISO inst'-'r_succ_plain_iso/0',
+         'override succ lax silent'-'r_succ_plain_lax/0']),
+
+    run_project('succ module-scoped override isolation',
+        [user:r_succ_mod_b/0, user:r_succ_plain_lax/0],
+        [iso_errors(false),
+         iso_errors(mod_a:r_succ_mod_b/0, true)],
+        ['mod_b stays lax success'-'r_succ_mod_b/0',
+         'bare override sibling lax'-'r_succ_plain_lax/0']),
+
+    run_project('succ functions mode ISO + explicit',
+        [user:r_succ_fwd/0, user:r_succ_back/0,
+         user:r_succ_iso_domain/0, user:r_succ_lax_bad/0,
+         user:r_succ_plain_iso/0],
+        [emit_mode(functions), iso_errors(true)],
+        ['functions succ forward'-'r_succ_fwd/0',
+         'functions succ reverse'-'r_succ_back/0',
+         'functions succ_iso domain'-'r_succ_iso_domain/0',
+         'functions succ_lax silent'-'r_succ_lax_bad/0',
+         'functions default succ ISO'-'r_succ_plain_iso/0']),
 
     retract_iso_helpers,
     (   nb_getval(r_iso_smoke_failed, true) -> halt(1) ; halt(0) ).

--- a/tests/test_wam_r_iso_smoke.pl
+++ b/tests/test_wam_r_iso_smoke.pl
@@ -190,6 +190,11 @@ assert_iso_helpers :-
         catch(succ_iso(foo, _), error(type_error(integer, _), _), true))),
     assertz((user:r_succ_iso_type_y :-
         catch(succ_iso(_, bar), error(type_error(integer, _), _), true))),
+    % Classification precedence: X type before Y type; Y type before X range.
+    assertz((user:r_succ_iso_precedence_x :-
+        catch(succ_iso(foo, bar), error(type_error(integer, foo), _), true))),
+    assertz((user:r_succ_iso_precedence_y :-
+        catch(succ_iso(-1, bar), error(type_error(integer, bar), _), true))),
     assertz((user:r_succ_iso_neg :-
         catch(succ_iso(-1, _),
               error(type_error(not_less_than_zero, _), _), true))),
@@ -221,7 +226,8 @@ retract_iso_helpers :-
         r_cmp_plain_zdiv/0, r_cmp_plain_bad/0, r_cmp_plain_ok/0,
         r_succ_fwd/0, r_succ_back/0, r_succ_pair_ok/0, r_succ_pair_bad/0,
         r_succ_lax_bad/0, r_succ_iso_inst/0, r_succ_iso_type_x/0,
-        r_succ_iso_type_y/0, r_succ_iso_neg/0, r_succ_iso_domain/0,
+        r_succ_iso_type_y/0, r_succ_iso_precedence_x/0,
+        r_succ_iso_precedence_y/0, r_succ_iso_neg/0, r_succ_iso_domain/0,
         r_succ_iso_mismatch/0, r_succ_iso_under_lax/0, r_succ_lax_under_iso/0,
         r_succ_plain_iso/0, r_succ_plain_lax/0, r_succ_mod_b/0
     ]), retractall(user:P)).
@@ -353,12 +359,15 @@ main :-
 
     run_project('succ ISO errors (interpreter)',
         [user:r_succ_iso_inst/0, user:r_succ_iso_type_x/0,
-         user:r_succ_iso_type_y/0, user:r_succ_iso_neg/0,
+         user:r_succ_iso_type_y/0, user:r_succ_iso_precedence_x/0,
+         user:r_succ_iso_precedence_y/0, user:r_succ_iso_neg/0,
          user:r_succ_iso_domain/0, user:r_succ_iso_mismatch/0],
         [iso_errors(false)],
         ['succ_iso inst'-'r_succ_iso_inst/0',
          'succ_iso type X'-'r_succ_iso_type_x/0',
          'succ_iso type Y'-'r_succ_iso_type_y/0',
+         'succ_iso precedence X type'-'r_succ_iso_precedence_x/0',
+         'succ_iso precedence Y type'-'r_succ_iso_precedence_y/0',
          'succ_iso neg'-'r_succ_iso_neg/0',
          'succ_iso domain'-'r_succ_iso_domain/0',
          'succ_iso mismatch'-'r_succ_iso_mismatch/0']),
@@ -390,12 +399,15 @@ main :-
 
     run_project('succ functions mode ISO + explicit',
         [user:r_succ_fwd/0, user:r_succ_back/0,
-         user:r_succ_iso_domain/0, user:r_succ_lax_bad/0,
+         user:r_succ_iso_domain/0, user:r_succ_iso_precedence_x/0,
+         user:r_succ_iso_precedence_y/0, user:r_succ_lax_bad/0,
          user:r_succ_plain_iso/0],
         [emit_mode(functions), iso_errors(true)],
         ['functions succ forward'-'r_succ_fwd/0',
          'functions succ reverse'-'r_succ_back/0',
          'functions succ_iso domain'-'r_succ_iso_domain/0',
+         'functions succ_iso precedence X'-'r_succ_iso_precedence_x/0',
+         'functions succ_iso precedence Y'-'r_succ_iso_precedence_y/0',
          'functions succ_lax silent'-'r_succ_lax_bad/0',
          'functions default succ ISO'-'r_succ_plain_iso/0']),
 

--- a/tests/test_wam_r_iso_unit.pl
+++ b/tests/test_wam_r_iso_unit.pl
@@ -154,12 +154,62 @@ test(iso_errors_text_rewrite_comparison_explicit_survives) :-
     assertion(sub_string(LaxWam, _, _, _, "builtin_call <_iso/2 2")),
     assertion(sub_string(LaxWam, _, _, _, "builtin_call >_lax/2 2")).
 
-test(iso_errors_text_rewrite_succ_not_yet) :-
-    % ISO-R-2B owns succ_*; R must not rewrite succ/2 yet.
-    Wam0 = 'succ_demo/0:\n  builtin_call succ/2 2',
+test(iso_errors_text_rewrite_succ_iso) :-
+    Wam0 = 'succ_demo/0:\n  execute succ/2\n  call succ/2 2\n  proceed',
     iso_errors_rewrite_text(iso_config(true, []), succ_demo/0, Wam0, IsoWam),
-    assertion(sub_string(IsoWam, _, _, _, "builtin_call succ/2 2")),
-    \+ sub_string(IsoWam, _, _, _, "succ_iso").
+    assertion(sub_string(IsoWam, _, _, _, "execute succ_iso/2")),
+    assertion(sub_string(IsoWam, _, _, _, "call succ_iso/2")),
+    \+ sub_string(IsoWam, _, _, _, "execute succ/2\n").
+
+test(iso_errors_text_rewrite_succ_lax) :-
+    Wam0 = 'succ_demo/0:\n  execute succ/2\n  proceed',
+    iso_errors_rewrite_text(iso_config(false, []), succ_demo/0, Wam0, LaxWam),
+    assertion(sub_string(LaxWam, _, _, _, "execute succ_lax/2")),
+    \+ sub_string(LaxWam, _, _, _, "execute succ/2\n").
+
+test(iso_errors_text_rewrite_succ_explicit_survives) :-
+    Wam0 = 'succ_demo/0:\n  execute succ_iso/2\n  execute succ_lax/2\n  proceed',
+    iso_errors_rewrite_text(iso_config(true, []), succ_demo/0, Wam0, IsoWam),
+    assertion(sub_string(IsoWam, _, _, _, "execute succ_iso/2")),
+    assertion(sub_string(IsoWam, _, _, _, "execute succ_lax/2")),
+    iso_errors_rewrite_text(iso_config(false, []), succ_demo/0, Wam0, LaxWam),
+    assertion(sub_string(LaxWam, _, _, _, "execute succ_iso/2")),
+    assertion(sub_string(LaxWam, _, _, _, "execute succ_lax/2")).
+
+test(iso_errors_audit_succ) :-
+    setup_call_cleanup(
+        assertz((user:r_iso_audit_succ :- succ(1, 2))),
+        (   wam_r_iso_audit(
+                [user:r_iso_audit_succ/0],
+                [iso_errors(true)],
+                Audit),
+            assertion((
+                Audit = [audit(user:r_iso_audit_succ/0, true, Sites)],
+                memberchk(site(_, "succ/2", "succ_iso/2", default, true), Sites)
+            ))
+        ),
+        retractall(user:r_iso_audit_succ)).
+
+test(iso_errors_project_generation_succ_keys) :-
+    once((
+        TmpDir = '/tmp/uw_r_iso_succ_rewrite_unit',
+        catch(delete_directory_and_contents(TmpDir), _, true),
+        setup_call_cleanup(
+            assertz((user:r_iso_succ_rewrite :- succ(3, 4))),
+            (   write_wam_r_project(
+                    [user:r_iso_succ_rewrite/0],
+                    [iso_errors(true)],
+                    TmpDir),
+                string_concat(TmpDir, '/R/generated_program.R', ProgPath),
+                read_file_to_string(ProgPath, Code, []),
+                assertion(sub_string(Code, _, _, _, "succ_iso")),
+                assertion(\+ sub_string(Code, _, _, _, 'Execute("succ", 2)'))
+            ),
+            (   retractall(user:r_iso_succ_rewrite),
+                catch(delete_directory_and_contents(TmpDir), _, true)
+            )
+        )
+    )).
 
 test(iso_errors_audit_structure) :-
     setup_call_cleanup(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **ISO-R-2B**: `succ/2` → `succ_iso/2` | `succ_lax/2`, plus an evidence-based closeout of R’s seven-item ISO adoption unit for the audited surface.

## Verified pre-existing (not reimplemented)

- Bidirectional `succ/2` already lived in `call_library` (forward N≥0 → N+1; reverse S>0 → S−1; silent fail otherwise)
- Generator e2e already covers `succ` both directions (`higherorder_listutil_e2e_rscript` / `hl_succ_*`)
- ISO-R-0/2A: catch/throw, constructors, config/rewrite/audit, `is/2`, six compares, module-scoped overrides, comparison error precedence

## Contract (Python/F# fleet; reverse-mode domain)

| Mode | Behavior |
|------|----------|
| Lax/default | Same as prior R `succ/2` (silent fail on both-unbound, non-int, N<0, S≤0) |
| ISO | both unbound → `instantiation_error`; non-int X → `type_error(integer,X)`; non-int Y → `type_error(integer,Y)`; X<0 → `type_error(not_less_than_zero,X)`; reverse Y≤0 → `domain_error(not_less_than_zero,Y)`; inconsistent bound pairs fail normally |
| Explicit `_iso`/`_lax` | Survive mode changes |

Integer overflow: existing R `IntTerm` / signed 32-bit wrap → NA; no new target-specific policy.

## Runtime paths

- Compiler emits **Execute/Call** for `succ` (not `BuiltinCall`) — verified on generated WAM
- `succ_bind` + `builtin_succ_{lax,iso}`; `make_domain_error` added
- `call_library` routes `succ/2`, `succ_lax/2`, `succ_iso/2`
- Lowered Call/Execute inlines the same helpers
- Key tables + `r_iso_rewritable_key("succ/2")` registered only after runtime paths exist
- Audit classifier extended to Call/Execute/`put_structure` so `wam_r_iso_audit/3` sees succ sites

## Adoption checklist evidence

1. catch/throw — pre-existing + e2e  
2. error constructors — + `domain_error`  
3. shared config/overrides — ISO-R-0  
4. per-predicate rewrite — succ registered  
5. explicit `_iso`/`_lax` survive — unit+smoke  
6. ISO throw / lax fail / override bypass — smoke  
7. `wam_r_iso_audit/3` — unit covers succ Execute sites  

**Caveat (same class as Python/F#):** remaining concrete builtins beyond `is`/compares/`succ` lack three-form keys — not claimed as “fully compatible for every builtin.” Lax float `/` uses host IEEE-754 Inf/NaN; ISO still throws `zero_divisor`.

## LOC (vs main)

| Area | + | − | net |
|------|--:|--:|----:|
| Production | 105 | 20 | **85** (under ~90 aim) |
| Tests | 163 | 7 | **156** (includes exact mixed-error precedence coverage) |
| Docs | 68 | 49 | **19** |

## Review follow-up

Review found no runtime correctness defect. Commit `909d9cd` adds exact mixed-condition checks proving that X type errors precede Y type errors and Y type errors precede X range errors. It also restores the unrelated effective-distance benchmark gap in `WAM_R_STATUS.md` and refreshes that document’s status date.

## Tests (local)

| Suite | Result |
|-------|--------|
| `tests/test_wam_r_iso_unit.pl` | pass (23) |
| `tests/test_wam_r_iso_smoke.pl` | pass (is + cmp + succ, interpreter + functions) |
| `tests/test_iso_errors.pl` | pass |
| `wam_r_generator:higherorder_listutil_e2e_rscript` (succ regressions) | pass |
| `CONFORMANCE_TARGETS=r,r_functions` | pass |
| `git diff --check` | clean |

## Hosted CI

Original head: **SUCCESS**. Updated review head `909d9cd`: **WAM R Conformance (interpreter + functions) SUCCESS**. The unrelated main test and C# query jobs are still running.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9748a055-a632-4d75-9b1b-6d3cd9dbf421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

