### PR TITLE
mu_cosine: plan privacy-aware public STEM harvest gaps

### DIFF
--- a/prototypes/mu_cosine/DESIGN_pearltrees_stem_harvest_plan.md
+++ b/prototypes/mu_cosine/DESIGN_pearltrees_stem_harvest_plan.md
@@ -1,0 +1,282 @@
+# Privacy-aware Pearltrees STEM harvest planning
+
+## Status and scope
+
+This document specifies the first acquisition step after the Pearltrees
+diffusion snapshot work: a deterministic, graph-first plan for filling public
+STEM coverage gaps.  The implementation is
+`prepare_pearltrees_stem_harvest_plan.py`.
+
+The planner is **local-only** and outcome-blind.  It reads existing artifacts
+and writes work orders; it does not call Pearltrees, an embedding model, an LLM,
+or a filing judge.  It does not authorize training, publication, or a HOP
+fidelity rerun.  Those remain downstream of a newly compiled and verified
+snapshot.
+
+## Decision
+
+Harvest outward from an explicit allowlist of core-STEM roots using only the
+containment relations `collection`, `ref`, and `path`.  Stop a branch at the
+first node that lacks a policy-fresh public API response.  Fetching or locally
+revalidating that frontier and recompiling the snapshot is one iteration; the
+planner is then run again from scratch.
+
+This makes the acquisition sequence conservative in two senses:
+
+1. An unknown, masked, malformed, or restricted node is never used as a bridge
+   into its descendants.
+2. A stale work order is never appended to after new visibility evidence
+   arrives.  A new private ancestor can therefore invalidate and scrub the
+   branch before later work is scheduled.
+
+## Inputs
+
+### Verified diffusion snapshot
+
+The authoritative graph and privacy state come from a successfully verified
+`pearltrees-diffusion-snapshot-v1` directory.  An exit-2 snapshot with retained
+unknown visibility is allowed as an acquisition input: those unknown nodes are
+exactly part of the coverage problem.  It is not a training or publication
+asset.
+
+`assembled_dag.tsv` is not authoritative.  It loses relation and visibility
+provenance, mixes historical inputs, and uses `child<TAB>parent` orientation.
+It remains a parity diagnostic only.
+
+### Seed manifest
+
+The human-curated seed file has this exact shape:
+
+```json
+{
+  "exclude_roots": [],
+  "public_cache_not_before": "2026-07-21T00:00:00",
+  "roots": ["pt:123"],
+  "schema": "pearltrees-stem-harvest-seeds-v1",
+  "snapshot_fingerprint": "<64 lowercase hex characters>"
+}
+```
+
+Each root must be retained and explicitly public in that exact snapshot.
+`exclude_roots` are optional topical scope cuts, not privacy overrides.  Their
+containment descendants are omitted even if another path could reach them.
+Changing the snapshot requires an explicit seed-manifest revision.
+`public_cache_not_before` is an offset-free timestamp in the harvester's local
+clock domain.  It is a privacy policy chosen prospectively, before queue counts
+are inspected.  A cached public response older than that cutoff is unresolved;
+it cannot open traversal merely because it was public when first fetched.
+
+Core STEM means roots deliberately chosen for mathematics, physical sciences,
+computer science/AI, engineering, chemistry, biology, and related technical
+disciplines.  Broad environment, development, or political collections are not
+implicitly promoted by title similarity.
+
+### Raw API response cache
+
+Completeness is derived from valid embedded ID claims in `api_responses.db`,
+never filenames or `batch_state.json`.  The exact database SHA-256 must occur in
+the verified snapshot as an `api_sqlite` source; matching an unrelated source
+hash is insufficient.  The SQLite file must be checkpointed (no WAL, SHM, or
+rollback-journal sidecars and no WAL-mode header), pass `quick_check`, and
+remain byte-stable through planning.  The streaming hash has a separate 2-GiB
+ceiling so corpus growth does not inherit the small JSON-artifact limit.
+
+A row counts as fetched-public only when every embedded `info`/`tree` ID claim
+agrees with the cache key, no title or visibility claim is private, at least one
+visibility claim is canonical zero, and `fetched_at` meets the frozen cutoff.
+The snapshot and cache are therefore two views of the same raw evidence rather
+than asynchronously mixed states.
+
+The current stores disagree in coverage, and the per-tree JSON directory also
+contains a batch-array file that the strict snapshot adapter rejects.  V1 uses
+the explicit raw-response SQLite cache.  A later prospective source adapter may
+take the validated union; it must not silently skip incompatible files.
+
+## Privacy states and lanes
+
+The snapshot remains the snapshot-relative visibility authority.  “Public” in
+this plan is not a timeless claim about visibility, licensing, consent, or
+suitability for third-party model training.  Cache inspection decides whether a
+node is a fresh enough acquisition frontier.
+
+- `public`: explicit snapshot-public, not excluded, and backed by a public cache
+  row at or after the prospective cutoff.
+- `private_or_restricted`: snapshot-private/excluded, or a nonzero API
+  visibility.  It is omitted from every work order; only aggregate counts are
+  reported.
+- `stale_public`: snapshot-public with a matching cache row older than the
+  cutoff.  It enters the local revalidation lane and terminates traversal.
+- `unknown` / `missing`: never inferred public.  A first reachable frontier
+  enters the appropriate local lane and terminates traversal.
+- `masked_auth` / malformed / contradictory evidence: consumed conservatively
+  by the upstream snapshot compiler.  Masked or private nodes are excluded and
+  malformed inputs fail snapshot preparation; the planner does not resurrect
+  them as harvest candidates.
+
+The output lanes are deliberately separate:
+
+1. `public_harvest_queue.json` contains only snapshot-public IDs whose exact
+   API response is absent.
+2. `visibility_revalidation_queue.json` is local-private quarantine work for
+   stale-public or missing/unknown frontiers.
+
+No title, URL, account, raw API body, local path, embedding, prompt, or judge
+output appears in these work orders.
+
+## Graph search and priority
+
+For each root independently, breadth-first search follows directed
+parent-to-child containment.  A node is traversable only when both the snapshot
+and the policy-fresh cache resolve it public.  Multi-parent nodes are retained
+as one node; visited sets break cycles without selecting a preferred parent.
+
+Priority is a frozen lexicographic order, not a confidence-weighted score:
+
+1. unresolved seed (`tier 0`);
+2. shared containment frontier touching at least two public in-scope parents or
+   at least two roots (`tier 1`);
+3. other first unresolved containment frontier (`tier 2`).
+
+Within a tier, order by shortest root distance, descending public frontier-link
+count, descending distinct-root count, then numeric tree ID.  Frontier and root
+counts measure structural leverage; they are not probabilities and never modify
+visibility.  The public and revalidation lanes each apply the frozen batch
+limit after sorting and report both emitted and total candidate counts.
+
+Non-containment `alias`, `shortcut`, and `cross_link` evidence is deliberately
+deferred.  It can later suggest where to inspect for bridges, but must not widen
+the first public STEM acquisition frontier.
+
+## Local installation and provenance
+
+The planner writes an exact mode-0700 directory of mode-0600, single-link files
+under an explicit local root, outside every Git worktree.  Installation uses an
+atomic Linux no-replace rename.  The manifest binds:
+
+- snapshot fingerprint;
+- semantic seed/root-set hash;
+- raw API cache hash;
+- prospective cache cutoff, containment relation policy, hop limit, batch
+  limit, frozen policy, and an exact aggregate-count schema;
+- byte count and SHA-256 of every work-order artifact; and
+- a plan fingerprint over the complete frozen core.
+
+The `verify` command requires the snapshot, cache, and seed manifest again.  It
+re-runs the graph search and compares both work-order artifacts byte for
+byte.  Artifact hashes alone provide integrity, not authenticity; they are not
+accepted as a substitute for replay against the bound inputs.
+
+The only console output is aggregate counts and the plan fingerprint.  Errors
+are generic so private titles, IDs, and paths are not copied into logs.
+
+Example:
+
+```bash
+python3 prototypes/mu_cosine/prepare_pearltrees_stem_harvest_plan.py prepare \
+  --snapshot-dir /private/snapshots/attempt-a \
+  --api-cache-db /private/pearltrees/api_responses.db \
+  --seed-manifest /private/config/stem-seeds.json \
+  --local-root /private/harvest-plans \
+  --output-dir /private/harvest-plans/plan-001 \
+  --max-hops 8 \
+  --batch-limit 128 \
+  --local-only
+```
+
+```bash
+python3 prototypes/mu_cosine/prepare_pearltrees_stem_harvest_plan.py verify \
+  --run-dir /private/harvest-plans/plan-001 \
+  --snapshot-dir /private/snapshots/attempt-a \
+  --api-cache-db /private/pearltrees/api_responses.db \
+  --seed-manifest /private/config/stem-seeds.json
+```
+
+## Current harvester execution gate
+
+Inspection of the separate local harvester found a fail-open operational path:
+a masked authentication response can be persisted and marked successful when
+credential refresh is unavailable or fails.  Therefore this PR authorizes work
+order **generation only**.  Neither queue should be executed until the harvester
+is changed to:
+
+- quarantine masked/auth-failure responses rather than recording success;
+- stop the run when reauthentication cannot be established;
+- never mark those IDs processed;
+- use a fresh state file bound to the work-order fingerprint; and
+- recheck the plan fingerprint, cutoff, and current visibility immediately
+  before every network batch (a generated plan otherwise ages); and
+- treat every raw response, log, state file, and cache as local-private.
+
+After each bounded batch: checkpoint the cache, compile raw evidence again, run
+the independent snapshot-consensus step, regenerate the plan, and only then
+resume acquisition.
+
+## Optional public-data model refinement
+
+Phi-family inference is not in the critical path.  A hosted or local model may
+later classify overlap that has been freshly revalidated public to improve STEM
+relevance or train a small local router.  It may not decide privacy, seed
+membership, or whether an unknown node is safe to send externally.  Requests
+must minimize payloads and enforce the chosen provider's zero-data-retention
+route even for public input.  A separate `external_processing_allowed` gate
+must check the source terms and disclosure policy: public visibility alone is
+not consent or authorization for third-party processing.
+
+For a reproducible API experiment:
+
+- discover and freeze the live model plus provider endpoint before labeling;
+- use an explicit model/provider, deterministic parameters, and structured
+  output rather than a random free-model router;
+- disable training/logging and require a zero-data-retention endpoint even
+  though the payload is public;
+- record prompt/version/model/provider hashes and costs locally; and
+- split public nodes into train/calibration holdouts blocked by lineage or
+  parent family before labels arrive; merely node-disjoint rows can still leak
+  closely related graph families.
+
+When API labels are fused with existing mu/judge sources, they are another
+correlated signal and should enter the calibrated joint-posterior and
+margin-gate workflow, not a hand-set weighted blend.  A standalone STEM router
+does not require that exact combiner, but it still requires calibration and a
+lineage-block-disjoint held-out evaluation.  Preserve exact request/response
+provenance locally; deterministic parameters alone do not make a changing
+hosted endpoint reproducible.  Value is established by held-out filing or
+acquisition decisions, not agreement with the same model.
+
+## Future private harvester repository
+
+The browser-automation harvester is already a nested local Git repository.  A
+separate private GitHub repository is reasonable, but repository creation is
+not part of this PR.  Before its first push:
+
+1. confirm the remote repository is private;
+2. start from a fresh/orphan allowlisted history containing only code, public
+   documentation, and synthetic fixtures; copying an allowlist into the current
+   branch does not cleanse reachable old commits;
+3. exclude cookies, API configuration secrets, raw JSON/SQLite, RDFs, logs,
+   state/PID files, work orders, embeddings, models, and generated outputs;
+4. scan the entire history and pending objects for secrets and private data;
+5. rotate any credential that ever entered Git; and
+6. test a clean clone using synthetic data before adding the real local paths.
+
+Private visibility data can support a local personalization overlay, but every
+transitively derived embedding, adapter, checkpoint, prompt cache, and report
+then remains private.  The public corpus and the private overlay are separate
+trust domains, not two splits of one publishable dataset.
+
+## Alternatives rejected for V1
+
+- **Title or embedding similarity as the primary frontier:** risks semantic
+  scope drift and can depend on private text.  Graph containment is the primary
+  geometry; semantic models may later rank only freshly revalidated public ties.
+- **Traverse through unknown nodes:** can expose a private subtree before its
+  ancestor is resolved.
+- **Treat `*private*` as proof of privacy or proof of auth failure:** either
+  inference can be wrong.  The response stays quarantined until authenticated
+  revalidation.
+- **Use legacy assembled DAG or harvester state as truth:** both collapse or mix
+  provenance and have known coverage/ID defects.
+- **One weighted relevance score:** disguises policy choices as statistical
+  confidence.  The explicit tiers make each decision auditable.
+- **Run Phi-3 first:** adds cost, reproducibility, and data-handling questions
+  before the graph and privacy boundary are settled.

--- a/prototypes/mu_cosine/PROTOCOL_bounded_diffusion_fidelity.md
+++ b/prototypes/mu_cosine/PROTOCOL_bounded_diffusion_fidelity.md
@@ -22,6 +22,10 @@ solve may start until the preparer contract in Section 2 is satisfied. The
 same-code fresh-process reproduction and immutable receipt that close this gate
 are specified in
 [`DESIGN_pearltrees_diffusion_consensus.md`](DESIGN_pearltrees_diffusion_consensus.md).
+Public STEM coverage gaps are filled iteratively under the separate local-only
+acquisition contract in
+[`DESIGN_pearltrees_stem_harvest_plan.md`](DESIGN_pearltrees_stem_harvest_plan.md);
+its work orders do not themselves reopen this scientific gate.
 No node IDs, titles, paths, embeddings, or node-level manifests may be published; only
 aggregate summaries and content hashes approved for the local provenance store
 may leave the machine. Results must be labeled relative to this scrubbed

--- a/prototypes/mu_cosine/prepare_pearltrees_stem_harvest_plan.py
+++ b/prototypes/mu_cosine/prepare_pearltrees_stem_harvest_plan.py
@@ -1,0 +1,1190 @@
+#!/usr/bin/env python3
+"""Prepare a deterministic, local-only Pearltrees STEM harvest work order.
+
+The planner consumes a verified diffusion snapshot, an explicit set of public
+STEM roots, and the raw API response cache.  It never calls Pearltrees, an LLM,
+or an embedding model.  Known-public gaps and visibility-revalidation work are
+emitted as separate queues so an authentication failure cannot silently promote
+private or unknown data into the public acquisition lane.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict, deque
+import ctypes
+from datetime import datetime
+import errno
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import sqlite3
+import stat
+import sys
+import tempfile
+
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+import prepare_pearltrees_diffusion_snapshot as diffusion_snapshot  # noqa: E402
+from privacy import is_private_title  # noqa: E402
+
+
+ALGORITHM = "pearltrees-stem-harvest-plan-v1"
+SEED_SCHEMA = "pearltrees-stem-harvest-seeds-v1"
+MANIFEST_SCHEMA = "pearltrees-stem-harvest-plan-manifest-v1"
+QUEUE_SCHEMA = "pearltrees-stem-harvest-queue-v1"
+MARKER_NAME = "LOCAL_ONLY_DO_NOT_PUBLISH"
+MARKER_BYTES = b"LOCAL ONLY - DO NOT PUBLISH PEARLTREES HARVEST WORK ORDERS\n"
+ARTIFACT_NAMES = (
+    "public_harvest_queue.json",
+    "visibility_revalidation_queue.json",
+)
+ALL_FILES = frozenset((*ARTIFACT_NAMES, "manifest.json", MARKER_NAME))
+TRAVERSAL_RELATIONS = frozenset(("collection", "ref", "path"))
+NODE_ID_RE = re.compile(r"pt:([1-9][0-9]*)")
+LOCAL_TIMESTAMP_RE = re.compile(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,6})?"
+)
+MAX_INPUT_BYTES = 64 * 1024 * 1024
+MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+MAX_CACHE_BYTES = 2 * 1024 * 1024 * 1024
+CACHE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
+COUNT_NAMES = frozenset(
+    (
+        "already_fetched_public",
+        "private_or_excluded_seen",
+        "public_candidates_total",
+        "public_queue",
+        "reachable_total",
+        "revalidation_candidates_total",
+        "revalidation_queue",
+        "scope_excluded",
+        "traversable_public",
+    )
+)
+POLICY = {
+    "known_private_nodes_emitted": False,
+    "llm_or_embedding_used": False,
+    "public_queue_requires_explicit_public_snapshot_state": True,
+    "revalidation_queue_is_local_only": True,
+    "unknown_nodes_traversed": False,
+}
+
+
+class HarvestPlanError(ValueError):
+    """Fail-closed input, planning, or installation error."""
+
+
+def _canonical_json(value: object) -> bytes:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError, UnicodeError) as exc:
+        raise HarvestPlanError("value is not canonical JSON") from exc
+    return (encoded + "\n").encode("utf-8")
+
+
+def _duplicate_checked_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise HarvestPlanError("JSON object contains a duplicate key")
+        value[key] = item
+    return value
+
+
+def _reject_nonfinite(_token: str) -> object:
+    raise HarvestPlanError("JSON contains a non-finite number")
+
+
+def _strict_json(data: bytes, label: str) -> object:
+    try:
+        return json.loads(
+            data.decode("utf-8", errors="strict"),
+            object_pairs_hook=_duplicate_checked_object,
+            parse_constant=_reject_nonfinite,
+        )
+    except HarvestPlanError:
+        raise
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise HarvestPlanError(f"{label} is not strict UTF-8 JSON") from exc
+
+
+def _read_bounded(path: Path, label: str, ceiling: int = MAX_INPUT_BYTES) -> bytes:
+    try:
+        record = path.lstat()
+    except OSError as exc:
+        raise HarvestPlanError(f"{label} cannot be inspected") from exc
+    if not stat.S_ISREG(record.st_mode) or path.is_symlink():
+        raise HarvestPlanError(f"{label} must be a non-symlink regular file")
+    if record.st_size > ceiling:
+        raise HarvestPlanError(f"{label} exceeds its read ceiling")
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise HarvestPlanError(f"{label} cannot be read") from exc
+    if len(data) != record.st_size:
+        raise HarvestPlanError(f"{label} changed while being read")
+    return data
+
+
+def _hash_regular_file(path: Path, label: str, ceiling: int) -> str:
+    """Hash a large regular file without retaining a second in-memory copy."""
+
+    try:
+        descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+    except OSError as exc:
+        raise HarvestPlanError(f"{label} cannot be opened") from exc
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_size > ceiling:
+            raise HarvestPlanError(f"{label} is not a bounded regular file")
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > ceiling:
+                raise HarvestPlanError(f"{label} exceeds its read ceiling")
+            digest.update(chunk)
+        after = os.fstat(descriptor)
+    except OSError as exc:
+        raise HarvestPlanError(f"{label} cannot be read") from exc
+    finally:
+        os.close(descriptor)
+    stable_fields = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
+    if total != before.st_size or any(
+        getattr(before, field) != getattr(after, field) for field in stable_fields
+    ):
+        raise HarvestPlanError(f"{label} changed while being read")
+    return digest.hexdigest()
+
+
+def _sqlite_header_uses_wal(path: Path) -> bool:
+    try:
+        descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+        try:
+            header = os.read(descriptor, 20)
+        finally:
+            os.close(descriptor)
+    except OSError as exc:
+        raise HarvestPlanError("API response cache header cannot be read") from exc
+    return (
+        len(header) >= 20
+        and header[:16] == b"SQLite format 3\x00"
+        and (header[18] == 2 or header[19] == 2)
+    )
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _node_id(value: object, label: str = "node ID") -> str:
+    if not isinstance(value, str) or NODE_ID_RE.fullmatch(value) is None:
+        raise HarvestPlanError(f"{label} is not canonical")
+    return value
+
+
+def _node_number(node_id: str) -> str:
+    return NODE_ID_RE.fullmatch(node_id).group(1)  # type: ignore[union-attr]
+
+
+def _node_key(node_id: str) -> int:
+    return int(_node_number(node_id))
+
+
+def _load_jsonl(path: Path, label: str) -> list[dict[str, object]]:
+    data = _read_bounded(path, label)
+    if data and not data.endswith(b"\n"):
+        raise HarvestPlanError(f"{label} is not newline terminated")
+    rows: list[dict[str, object]] = []
+    for line in data.splitlines():
+        value = _strict_json(line, label)
+        if not isinstance(value, dict):
+            raise HarvestPlanError(f"{label} row must be an object")
+        rows.append(value)
+    return rows
+
+
+def _load_seeds(
+    path: Path, expected_snapshot_fingerprint: str
+) -> tuple[list[str], list[str], str, str]:
+    data = _read_bounded(path, "STEM seed manifest", 1_000_000)
+    value = _strict_json(data, "STEM seed manifest")
+    if not isinstance(value, dict) or set(value) != {
+        "exclude_roots",
+        "roots",
+        "schema",
+        "snapshot_fingerprint",
+        "public_cache_not_before",
+    }:
+        raise HarvestPlanError("STEM seed manifest fields mismatch")
+    if (
+        value.get("schema") != SEED_SCHEMA
+        or value.get("snapshot_fingerprint") != expected_snapshot_fingerprint
+        or not isinstance(value.get("roots"), list)
+        or not isinstance(value.get("exclude_roots"), list)
+    ):
+        raise HarvestPlanError("STEM seed manifest schema mismatch")
+    roots = [_node_id(item, "STEM root ID") for item in value["roots"]]
+    exclude_roots = [
+        _node_id(item, "excluded scope root ID") for item in value["exclude_roots"]
+    ]
+    if not roots or len(roots) != len(set(roots)):
+        raise HarvestPlanError("STEM roots must be nonempty and unique")
+    if len(exclude_roots) != len(set(exclude_roots)) or set(roots) & set(exclude_roots):
+        raise HarvestPlanError("scope exclusions must be unique and disjoint from roots")
+    roots = sorted(roots, key=_node_key)
+    exclude_roots = sorted(exclude_roots, key=_node_key)
+    public_cache_not_before = value["public_cache_not_before"]
+    _local_timestamp(public_cache_not_before, "public cache cutoff")
+    semantic_sha = _sha256(
+        _canonical_json(
+            {
+                "exclude_roots": exclude_roots,
+                "roots": roots,
+                "schema": SEED_SCHEMA,
+                "snapshot_fingerprint": expected_snapshot_fingerprint,
+                "public_cache_not_before": public_cache_not_before,
+            }
+        )
+    )
+    return roots, exclude_roots, semantic_sha, public_cache_not_before
+
+
+def _load_snapshot(
+    snapshot_dir: Path,
+) -> tuple[dict[str, dict[str, object]], list[dict[str, object]], str, set[str]]:
+    try:
+        manifest = diffusion_snapshot.verify_snapshot(snapshot_dir)
+    except Exception as exc:
+        raise HarvestPlanError("diffusion snapshot verification failed") from exc
+    fingerprint = manifest.get("snapshot_fingerprint")
+    if not isinstance(fingerprint, str) or re.fullmatch(r"[0-9a-f]{64}", fingerprint) is None:
+        raise HarvestPlanError("diffusion snapshot fingerprint is malformed")
+    nodes_list = _load_jsonl(snapshot_dir / "nodes.jsonl", "snapshot nodes")
+    evidence = _load_jsonl(snapshot_dir / "edge_evidence.jsonl", "snapshot edge evidence")
+    nodes: dict[str, dict[str, object]] = {}
+    for row in nodes_list:
+        node = _node_id(row.get("node_id"))
+        if node in nodes:
+            raise HarvestPlanError("snapshot contains a duplicate node")
+        if row.get("visibility") not in {"public", "private", "unknown"}:
+            raise HarvestPlanError("snapshot node visibility is malformed")
+        if not isinstance(row.get("excluded"), bool):
+            raise HarvestPlanError("snapshot node exclusion is malformed")
+        nodes[node] = row
+    source_records = manifest.get("fingerprint_core", {}).get("source_records")
+    if not isinstance(source_records, list):
+        raise HarvestPlanError("diffusion snapshot source records are malformed")
+    api_sqlite_hashes: set[str] = set()
+    for source in source_records:
+        if (
+            not isinstance(source, dict)
+            or not isinstance(source.get("kind"), str)
+            or not isinstance(source.get("content_records"), list)
+        ):
+            raise HarvestPlanError("diffusion snapshot source records are malformed")
+        for record in source["content_records"]:
+            if (
+                not isinstance(record, dict)
+                or not isinstance(record.get("sha256"), str)
+                or re.fullmatch(r"[0-9a-f]{64}", record["sha256"]) is None
+            ):
+                raise HarvestPlanError("diffusion snapshot source content record is malformed")
+            if source["kind"] == "api_sqlite":
+                api_sqlite_hashes.add(record["sha256"])
+    return nodes, evidence, fingerprint, api_sqlite_hashes
+
+
+def _canonical_cache_id(value: object) -> str:
+    if not isinstance(value, str) or not value.isascii() or not value.isdigit():
+        raise HarvestPlanError("API cache tree ID is not canonical")
+    if value == "0" or (len(value) > 1 and value.startswith("0")):
+        raise HarvestPlanError("API cache tree ID is not canonical")
+    return f"pt:{value}"
+
+
+def _cache_response_status(tree_id: str, raw: object) -> str:
+    if not isinstance(raw, str) or len(raw.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        return "malformed"
+    try:
+        payload = json.loads(
+            raw,
+            object_pairs_hook=_duplicate_checked_object,
+            parse_constant=_reject_nonfinite,
+        )
+    except (HarvestPlanError, json.JSONDecodeError, TypeError, ValueError):
+        return "malformed"
+    if not isinstance(payload, dict):
+        return "malformed"
+    wrappers = [key for key in ("api_response", "response") if key in payload]
+    if len(wrappers) > 1:
+        return "malformed"
+    response = payload[wrappers[0]] if wrappers else payload
+    if not isinstance(response, dict):
+        return "malformed"
+    info = response.get("info", {})
+    tree = response.get("tree", {})
+    if info is None:
+        info = {}
+    if tree is None:
+        tree = {}
+    if not isinstance(info, dict) or not isinstance(tree, dict):
+        return "malformed"
+
+    candidate_ids = [
+        value
+        for value in (
+            info.get("id"),
+            tree.get("id"),
+            payload.get("tree_id"),
+            response.get("treeId"),
+        )
+        if value is not None
+    ]
+    parsed_ids: set[str] = set()
+    for value in candidate_ids:
+        if isinstance(value, bool) or not isinstance(value, (int, str)):
+            return "malformed"
+        try:
+            parsed_ids.add(_canonical_cache_id(str(value)))
+        except HarvestPlanError:
+            return "malformed"
+    if parsed_ids and parsed_ids != {tree_id}:
+        return "malformed"
+
+    public_claim = False
+    private_claim = False
+    masked_claim = False
+    for mapping in (info, tree):
+        title = mapping.get("title")
+        if title is not None and not isinstance(title, str):
+            return "malformed"
+        visibility = mapping.get("visibility")
+        visibility_value: int | None
+        if visibility is None or (isinstance(visibility, str) and not visibility.strip()):
+            visibility_value = None
+        elif isinstance(visibility, bool) or isinstance(visibility, float):
+            return "malformed"
+        else:
+            raw_visibility = str(visibility)
+            if (
+                not raw_visibility.isascii()
+                or not raw_visibility.isdigit()
+                or (len(raw_visibility) > 1 and raw_visibility.startswith("0"))
+            ):
+                return "malformed"
+            visibility_value = int(raw_visibility)
+        normalized_title = (title or "").strip().casefold()
+        exact_mask = visibility_value == 2 and normalized_title in {
+            "*private*",
+            "private",
+        }
+        if visibility_value == 0:
+            public_claim = True
+        if exact_mask:
+            masked_claim = True
+        elif visibility_value not in (None, 0) or is_private_title(title):
+            private_claim = True
+    if private_claim:
+        return "private_or_restricted"
+    if masked_claim:
+        return "masked_auth"
+    return "public" if public_claim else "malformed"
+
+
+def _local_timestamp(value: object, label: str) -> datetime:
+    if not isinstance(value, str) or LOCAL_TIMESTAMP_RE.fullmatch(value) is None:
+        raise HarvestPlanError(f"{label} is not a canonical offset-free ISO timestamp")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise HarvestPlanError(f"{label} is not a valid timestamp") from exc
+    if parsed.tzinfo is not None:
+        raise HarvestPlanError(f"{label} must use the harvester's offset-free clock domain")
+    return parsed
+
+
+def _load_api_cache(
+    path: Path, public_cache_not_before: str
+) -> tuple[dict[str, str], str]:
+    if any(Path(f"{path}{suffix}").exists() for suffix in CACHE_SIDECAR_SUFFIXES):
+        raise HarvestPlanError("API response cache must be checkpointed without sidecars")
+    digest = _hash_regular_file(path, "API response cache", MAX_CACHE_BYTES)
+    if _sqlite_header_uses_wal(path):
+        raise HarvestPlanError("WAL-mode API response caches are not accepted")
+    cutoff = _local_timestamp(public_cache_not_before, "public cache cutoff")
+    uri = f"{path.resolve(strict=True).as_uri()}?mode=ro&immutable=1"
+    try:
+        connection = sqlite3.connect(uri, uri=True)
+        connection.execute("PRAGMA query_only=ON")
+        journal_mode = connection.execute("PRAGMA journal_mode").fetchone()
+        if not journal_mode or str(journal_mode[0]).casefold() == "wal":
+            raise HarvestPlanError("WAL-mode API response caches are not accepted")
+        if connection.execute("PRAGMA quick_check").fetchall() != [("ok",)]:
+            raise HarvestPlanError("API response cache fails SQLite quick_check")
+        columns = {
+            row[1]
+            for row in connection.execute("PRAGMA table_info(api_responses)").fetchall()
+        }
+        if not {"tree_id", "fetched_at", "response_json"}.issubset(columns):
+            raise HarvestPlanError("API response cache schema mismatch")
+        statuses: dict[str, str] = {}
+        for raw_id, fetched_at, response_json in connection.execute(
+            "SELECT tree_id, fetched_at, response_json FROM api_responses ORDER BY tree_id"
+        ):
+            tree_id = _canonical_cache_id(raw_id)
+            if tree_id in statuses:
+                raise HarvestPlanError("API response cache has duplicate tree IDs")
+            status = _cache_response_status(tree_id, response_json)
+            if status == "public":
+                try:
+                    fetched = _local_timestamp(fetched_at, "API cache fetched_at")
+                except HarvestPlanError:
+                    status = "malformed"
+                else:
+                    if fetched < cutoff:
+                        status = "stale_public"
+            statuses[tree_id] = status
+    except HarvestPlanError:
+        raise
+    except sqlite3.Error as exc:
+        raise HarvestPlanError("API response cache cannot be queried") from exc
+    finally:
+        if "connection" in locals():
+            connection.close()
+    if any(Path(f"{path}{suffix}").exists() for suffix in CACHE_SIDECAR_SUFFIXES) or (
+        _hash_regular_file(path, "API response cache", MAX_CACHE_BYTES) != digest
+    ):
+        raise HarvestPlanError("API response cache changed during planning")
+    return statuses, digest
+
+
+def _priority(distance: int, frontier_links: int, root_count: int) -> tuple[int, str]:
+    if distance == 0:
+        return 0, "seed_gap"
+    if frontier_links >= 2 or root_count >= 2:
+        return 1, "shared_containment_frontier"
+    return 2, "direct_containment_frontier"
+
+
+def _queue_row(
+    node_id: str,
+    *,
+    distance: int,
+    frontier_links: int,
+    root_count: int,
+    lane: str,
+    cache_status: str,
+) -> dict[str, object]:
+    tier, reason = _priority(distance, frontier_links, root_count)
+    return {
+        "cache_status": cache_status,
+        "distance_hops": distance,
+        "frontier_links": frontier_links,
+        "priority_tier": tier,
+        "queued_by": ALGORITHM,
+        "reason": f"{lane}_{reason}",
+        "stem_root_count": root_count,
+        "tree_id": _node_number(node_id),
+    }
+
+
+def derive_work_orders(
+    nodes: dict[str, dict[str, object]],
+    evidence: list[dict[str, object]],
+    roots: list[str],
+    exclude_roots: list[str],
+    cache_status: dict[str, str],
+    *,
+    max_hops: int,
+    batch_limit: int,
+) -> tuple[list[dict[str, object]], list[dict[str, object]], dict[str, int]]:
+    """Derive public and revalidation work without statistical weights."""
+
+    if isinstance(max_hops, bool) or not isinstance(max_hops, int) or max_hops < 1:
+        raise HarvestPlanError("max_hops must be a positive integer")
+    if isinstance(batch_limit, bool) or not isinstance(batch_limit, int) or batch_limit < 1:
+        raise HarvestPlanError("batch_limit must be a positive integer")
+    for root in roots:
+        node = nodes.get(root)
+        if node is None or node.get("visibility") != "public" or node.get("excluded") is not False:
+            raise HarvestPlanError("every STEM root must be explicitly public and retained")
+        if cache_status.get(root, "missing") not in {"public", "missing", "stale_public"}:
+            raise HarvestPlanError("a STEM root conflicts with API privacy evidence")
+
+    children: dict[str, set[str]] = defaultdict(set)
+    for row in evidence:
+        if row.get("relation") not in TRAVERSAL_RELATIONS:
+            continue
+        child = _node_id(row.get("child"), "edge child")
+        parent = _node_id(row.get("parent"), "edge parent")
+        if row.get("privacy_endpoint_excluded") is not False:
+            continue
+        if child not in nodes or parent not in nodes:
+            raise HarvestPlanError("edge evidence cites an unknown node")
+        children[parent].add(child)
+
+    scope_excluded: set[str] = set()
+    scope_queue: deque[str] = deque()
+    for root in exclude_roots:
+        if root not in nodes:
+            raise HarvestPlanError("excluded scope root is absent from the snapshot")
+        scope_excluded.add(root)
+        scope_queue.append(root)
+    while scope_queue:
+        parent = scope_queue.popleft()
+        for child in sorted(children.get(parent, ()), key=_node_key):
+            if child not in scope_excluded:
+                scope_excluded.add(child)
+                scope_queue.append(child)
+    if set(roots) & scope_excluded:
+        raise HarvestPlanError("a STEM root lies below an explicit scope exclusion")
+
+    distance_by_node: dict[str, int] = {}
+    roots_by_node: dict[str, set[str]] = defaultdict(set)
+    traversable_public: set[str] = set()
+    for root in roots:
+        queue: deque[tuple[str, int]] = deque([(root, 0)])
+        seen = {root}
+        while queue:
+            node_id, distance = queue.popleft()
+            node = nodes[node_id]
+            if node_id in scope_excluded:
+                continue
+            roots_by_node[node_id].add(root)
+            distance_by_node[node_id] = min(distance_by_node.get(node_id, distance), distance)
+            if (
+                node.get("visibility") != "public"
+                or node.get("excluded") is not False
+                or cache_status.get(node_id, "missing") != "public"
+            ):
+                # This is the first unresolved frontier for this branch.  Do not
+                # traverse through it until a fresh snapshot resolves the node.
+                continue
+            traversable_public.add(node_id)
+            if distance == max_hops:
+                continue
+            for child in sorted(children.get(node_id, ()), key=_node_key):
+                if child in scope_excluded:
+                    continue
+                child_row = nodes[child]
+                candidate_distance = distance + 1
+                roots_by_node[child].add(root)
+                distance_by_node[child] = min(
+                    distance_by_node.get(child, candidate_distance), candidate_distance
+                )
+                if (
+                    child_row.get("visibility") == "public"
+                    and child_row.get("excluded") is False
+                    and cache_status.get(child, "missing") == "public"
+                    and child not in seen
+                ):
+                    seen.add(child)
+                    queue.append((child, candidate_distance))
+
+    frontier_links: dict[str, int] = defaultdict(int)
+    for parent in traversable_public:
+        for child in children.get(parent, ()):
+            if child in distance_by_node:
+                frontier_links[child] += 1
+
+    public_queue: list[dict[str, object]] = []
+    revalidation_queue: list[dict[str, object]] = []
+    counts: defaultdict[str, int] = defaultdict(int, {name: 0 for name in COUNT_NAMES})
+    for node_id in sorted(distance_by_node, key=_node_key):
+        row = nodes[node_id]
+        visibility = row.get("visibility")
+        excluded = row.get("excluded")
+        status = cache_status.get(node_id, "missing")
+        distance = distance_by_node[node_id]
+        links = frontier_links[node_id]
+        root_count = len(roots_by_node[node_id])
+        if excluded is True or visibility == "private":
+            counts["private_or_excluded_seen"] += 1
+            continue
+        if visibility == "public":
+            if status == "public":
+                counts["already_fetched_public"] += 1
+            elif status == "missing":
+                public_queue.append(
+                    _queue_row(
+                        node_id,
+                        distance=distance,
+                        frontier_links=links,
+                        root_count=root_count,
+                        lane="public",
+                        cache_status=status,
+                    )
+                )
+            elif status == "stale_public":
+                revalidation_queue.append(
+                    _queue_row(
+                        node_id,
+                        distance=distance,
+                        frontier_links=links,
+                        root_count=root_count,
+                        lane="public_cache_revalidation",
+                        cache_status=status,
+                    )
+                )
+            else:
+                raise HarvestPlanError("snapshot and API cache privacy states disagree")
+        elif visibility == "unknown":
+            if status == "public":
+                raise HarvestPlanError("snapshot omitted a public API visibility claim")
+            elif status in {"missing", "stale_public"}:
+                revalidation_queue.append(
+                    _queue_row(
+                        node_id,
+                        distance=distance,
+                        frontier_links=links,
+                        root_count=root_count,
+                        lane="unknown_visibility_revalidation",
+                        cache_status=status,
+                    )
+                )
+            else:
+                raise HarvestPlanError("snapshot and API cache privacy states disagree")
+        else:
+            raise HarvestPlanError("reachable node has invalid visibility")
+
+    sort_key = lambda item: (
+        item["priority_tier"],
+        item["distance_hops"],
+        -item["frontier_links"],
+        -item["stem_root_count"],
+        int(item["tree_id"]),
+    )
+    public_queue.sort(key=sort_key)
+    revalidation_queue.sort(key=sort_key)
+    public_total = len(public_queue)
+    revalidation_total = len(revalidation_queue)
+    public_queue = public_queue[:batch_limit]
+    revalidation_queue = revalidation_queue[:batch_limit]
+    public_queue = [dict(row, rank=index) for index, row in enumerate(public_queue, 1)]
+    revalidation_queue = [
+        dict(row, rank=index) for index, row in enumerate(revalidation_queue, 1)
+    ]
+    counts.update(
+        {
+            "public_queue": len(public_queue),
+            "public_candidates_total": public_total,
+            "revalidation_queue": len(revalidation_queue),
+            "revalidation_candidates_total": revalidation_total,
+            "traversable_public": len(traversable_public),
+            "reachable_total": len(distance_by_node),
+            "scope_excluded": len(scope_excluded),
+        }
+    )
+    return public_queue, revalidation_queue, dict(sorted(counts.items()))
+
+
+def _artifact_record(data: bytes) -> dict[str, object]:
+    return {"bytes": len(data), "sha256": _sha256(data)}
+
+
+def _queue_payload(lane: str, rows: list[dict[str, object]]) -> bytes:
+    return _canonical_json(
+        {
+            "count": len(rows),
+            "lane": lane,
+            "maps": rows,
+            "schema": QUEUE_SCHEMA,
+        }
+    )
+
+
+def _path_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_git_worktree_marker(path: Path) -> bool:
+    try:
+        if path.is_file():
+            return path.read_bytes()[:64].lstrip().startswith(b"gitdir:")
+        return path.is_dir() and (path / "HEAD").is_file()
+    except OSError:
+        return True
+
+
+def _safe_output(output_dir: Path, local_root: Path) -> tuple[Path, Path]:
+    output = Path(os.path.abspath(output_dir))
+    root = Path(os.path.abspath(local_root))
+    try:
+        root_mode = root.lstat().st_mode
+        parent_mode = output.parent.lstat().st_mode
+    except OSError as exc:
+        raise HarvestPlanError("local root or output parent is unavailable") from exc
+    if not stat.S_ISDIR(root_mode) or not stat.S_ISDIR(parent_mode):
+        raise HarvestPlanError("local root and output parent must be directories")
+    root = root.resolve(strict=True)
+    parent = output.parent.resolve(strict=True)
+    output = parent / output.name
+    if output.exists() or output.is_symlink():
+        raise HarvestPlanError("output directory already exists")
+    if not _path_within(output, root) or output == root:
+        raise HarvestPlanError("output directory must be below the explicit local root")
+    if _path_within(output, REPO_ROOT.resolve()) or any(
+        _is_git_worktree_marker(ancestor / ".git")
+        for ancestor in (parent, *parent.parents)
+    ):
+        raise HarvestPlanError("local-only output cannot be installed in the Git worktree")
+    return output, parent
+
+
+def _reject_input_output_overlap(output: Path, inputs: list[Path]) -> None:
+    for raw in inputs:
+        try:
+            source = raw.resolve(strict=True)
+        except OSError as exc:
+            raise HarvestPlanError("planner input cannot be resolved") from exc
+        if source == output or _path_within(source, output) or _path_within(output, source):
+            raise HarvestPlanError("planner inputs and output cannot overlap")
+
+
+def _write_private(path: Path, data: bytes) -> None:
+    try:
+        descriptor = os.open(
+            path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+            0o600,
+        )
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+    except OSError as exc:
+        raise HarvestPlanError("local-only artifact could not be written") from exc
+
+
+def _rename_noreplace(source: Path, target: Path) -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    try:
+        renameat2 = libc.renameat2
+    except AttributeError as exc:
+        raise HarvestPlanError("atomic no-replace installation is unavailable") from exc
+    renameat2.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+    renameat2.restype = ctypes.c_int
+    if renameat2(-100, os.fsencode(source), -100, os.fsencode(target), 1) == 0:
+        return
+    number = ctypes.get_errno()
+    if number in {errno.EEXIST, errno.ENOTEMPTY}:
+        raise HarvestPlanError("output appeared during atomic installation")
+    raise HarvestPlanError("atomic no-replace installation failed") from OSError(
+        number, os.strerror(number)
+    )
+
+
+def _validate_queue_rows(rows: object, lane: str) -> list[dict[str, object]]:
+    if not isinstance(rows, list):
+        raise HarvestPlanError("harvest queue maps must be a list")
+    expected_fields = {
+        "cache_status",
+        "distance_hops",
+        "frontier_links",
+        "priority_tier",
+        "queued_by",
+        "rank",
+        "reason",
+        "stem_root_count",
+        "tree_id",
+    }
+    validated: list[dict[str, object]] = []
+    for expected_rank, row in enumerate(rows, 1):
+        if not isinstance(row, dict) or set(row) != expected_fields:
+            raise HarvestPlanError("harvest queue row fields mismatch")
+        for key in ("distance_hops", "frontier_links", "priority_tier", "rank", "stem_root_count"):
+            value = row[key]
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise HarvestPlanError("harvest queue numeric field is malformed")
+        if row["rank"] != expected_rank or row["stem_root_count"] < 1:
+            raise HarvestPlanError("harvest queue rank or root count is malformed")
+        tree_id = _canonical_cache_id(row["tree_id"])
+        tier, suffix = _priority(
+            row["distance_hops"], row["frontier_links"], row["stem_root_count"]
+        )
+        if tier != row["priority_tier"] or row["queued_by"] != ALGORITHM:
+            raise HarvestPlanError("harvest queue priority provenance mismatch")
+        if lane == "known_public":
+            allowed_reasons = {f"public_{suffix}"}
+            allowed_status = {"missing"}
+        else:
+            allowed_reasons = {
+                f"public_cache_revalidation_{suffix}",
+                f"unknown_visibility_revalidation_{suffix}",
+            }
+            allowed_status = {"missing", "stale_public"}
+        if row["reason"] not in allowed_reasons or row["cache_status"] not in allowed_status:
+            raise HarvestPlanError("harvest queue lane semantics mismatch")
+        if _node_number(tree_id) != row["tree_id"]:
+            raise HarvestPlanError("harvest queue tree ID is noncanonical")
+        validated.append(row)
+    sort_key = lambda item: (
+        item["priority_tier"],
+        item["distance_hops"],
+        -item["frontier_links"],
+        -item["stem_root_count"],
+        int(item["tree_id"]),
+    )
+    if validated != sorted(validated, key=sort_key):
+        raise HarvestPlanError("harvest queue order is noncanonical")
+    if len({row["tree_id"] for row in validated}) != len(validated):
+        raise HarvestPlanError("harvest queue contains duplicate tree IDs")
+    return validated
+
+
+def _verify_artifacts(run_dir: Path) -> dict[str, object]:
+    try:
+        directory_record = run_dir.lstat()
+        names = {entry.name for entry in run_dir.iterdir()}
+    except OSError as exc:
+        raise HarvestPlanError("harvest plan cannot be inspected") from exc
+    if not stat.S_ISDIR(directory_record.st_mode) or stat.S_IMODE(directory_record.st_mode) != 0o700:
+        raise HarvestPlanError("harvest plan directory mode must be 0700")
+    if names != ALL_FILES:
+        raise HarvestPlanError("harvest plan file set mismatch")
+    payloads: dict[str, bytes] = {}
+    for name in ALL_FILES:
+        path = run_dir / name
+        record = path.lstat()
+        if (
+            not stat.S_ISREG(record.st_mode)
+            or record.st_nlink != 1
+            or stat.S_IMODE(record.st_mode) != 0o600
+        ):
+            raise HarvestPlanError("harvest plan artifact envelope is invalid")
+        payloads[name] = _read_bounded(path, f"harvest plan {name}")
+    if payloads[MARKER_NAME] != MARKER_BYTES:
+        raise HarvestPlanError("local-only marker mismatch")
+    manifest = _strict_json(payloads["manifest.json"], "harvest plan manifest")
+    if (
+        not isinstance(manifest, dict)
+        or set(manifest)
+        != {"artifacts", "counts", "fingerprint_core", "plan_fingerprint", "policy", "schema"}
+        or manifest.get("schema") != MANIFEST_SCHEMA
+        or _canonical_json(manifest) != payloads["manifest.json"]
+    ):
+        raise HarvestPlanError("harvest plan manifest schema mismatch")
+    records = manifest.get("artifacts")
+    if not isinstance(records, dict) or set(records) != set(ARTIFACT_NAMES):
+        raise HarvestPlanError("harvest plan artifact records mismatch")
+    for name in ARTIFACT_NAMES:
+        if records[name] != _artifact_record(payloads[name]):
+            raise HarvestPlanError("harvest plan artifact hash mismatch")
+    core = manifest.get("fingerprint_core")
+    fingerprint = manifest.get("plan_fingerprint")
+    if isinstance(core, dict):
+        _local_timestamp(core.get("public_cache_not_before"), "public cache cutoff")
+    if (
+        not isinstance(core, dict)
+        or set(core)
+        != {
+            "algorithm",
+            "api_cache_sha256",
+            "artifacts",
+            "batch_limit",
+            "counts",
+            "max_hops",
+            "policy",
+            "public_cache_not_before",
+            "root_set_sha256",
+            "snapshot_fingerprint",
+            "traversal_relations",
+        }
+        or core.get("algorithm") != ALGORITHM
+        or core.get("artifacts") != records
+        or core.get("counts") != manifest.get("counts")
+        or core.get("policy") != manifest.get("policy")
+        or core.get("traversal_relations") != sorted(TRAVERSAL_RELATIONS)
+        or any(
+            not isinstance(core.get(key), str)
+            or re.fullmatch(r"[0-9a-f]{64}", core[key]) is None
+            for key in ("api_cache_sha256", "root_set_sha256", "snapshot_fingerprint")
+        )
+        or any(
+            isinstance(core.get(key), bool)
+            or not isinstance(core.get(key), int)
+            or core[key] < 1
+            for key in ("batch_limit", "max_hops")
+        )
+        or fingerprint != _sha256(_canonical_json(core))
+    ):
+        raise HarvestPlanError("harvest plan fingerprint mismatch")
+    if manifest.get("policy") != POLICY:
+        raise HarvestPlanError("harvest plan policy mismatch")
+    queue_rows: dict[str, list[dict[str, object]]] = {}
+    for name, lane in (
+        ("public_harvest_queue.json", "known_public"),
+        ("visibility_revalidation_queue.json", "local_visibility_revalidation"),
+    ):
+        queue = _strict_json(payloads[name], name)
+        if (
+            not isinstance(queue, dict)
+            or set(queue) != {"count", "lane", "maps", "schema"}
+            or queue.get("schema") != QUEUE_SCHEMA
+            or queue.get("lane") != lane
+            or not isinstance(queue.get("maps"), list)
+            or queue.get("count") != len(queue["maps"])
+            or _canonical_json(queue) != payloads[name]
+        ):
+            raise HarvestPlanError("harvest queue schema mismatch")
+        queue_rows[lane] = _validate_queue_rows(queue["maps"], lane)
+    all_ids = [
+        row["tree_id"]
+        for rows in queue_rows.values()
+        for row in rows
+    ]
+    if len(all_ids) != len(set(all_ids)):
+        raise HarvestPlanError("harvest work lanes overlap")
+    counts = manifest.get("counts")
+    if (
+        not isinstance(counts, dict)
+        or set(counts) != COUNT_NAMES
+        or any(
+            not isinstance(key, str)
+            or isinstance(value, bool)
+            or not isinstance(value, int)
+            or value < 0
+            for key, value in counts.items()
+        )
+    ):
+        raise HarvestPlanError("harvest plan counts are malformed")
+    public = _strict_json(payloads["public_harvest_queue.json"], "public queue")
+    revalidation = _strict_json(
+        payloads["visibility_revalidation_queue.json"], "revalidation queue"
+    )
+    if (
+        counts.get("public_queue") != public["count"]
+        or counts.get("revalidation_queue") != revalidation["count"]
+        or counts.get("public_candidates_total") < public["count"]
+        or counts.get("revalidation_candidates_total") < revalidation["count"]
+    ):
+        raise HarvestPlanError("harvest plan counts disagree with artifacts")
+    return manifest
+
+
+def verify_plan(
+    run_dir: str | os.PathLike[str],
+    snapshot_dir: str | os.PathLike[str],
+    api_cache_db: str | os.PathLike[str],
+    seed_manifest: str | os.PathLike[str],
+) -> dict[str, object]:
+    """Re-derive a plan from its bound inputs and compare exact artifact bytes."""
+
+    run = Path(run_dir)
+    manifest = _verify_artifacts(run)
+    core = manifest["fingerprint_core"]
+    nodes, evidence, snapshot_fingerprint, api_sqlite_hashes = _load_snapshot(
+        Path(snapshot_dir)
+    )
+    roots, exclude_roots, root_set_sha, public_cache_not_before = _load_seeds(
+        Path(seed_manifest), snapshot_fingerprint
+    )
+    cache_status, cache_sha = _load_api_cache(
+        Path(api_cache_db), public_cache_not_before
+    )
+    if cache_sha not in api_sqlite_hashes:
+        raise HarvestPlanError("API cache is not an exact source of the verified snapshot")
+    if (
+        snapshot_fingerprint != core["snapshot_fingerprint"]
+        or root_set_sha != core["root_set_sha256"]
+        or cache_sha != core["api_cache_sha256"]
+        or public_cache_not_before != core["public_cache_not_before"]
+    ):
+        raise HarvestPlanError("harvest plan input binding mismatch")
+    public, revalidation, counts = derive_work_orders(
+        nodes,
+        evidence,
+        roots,
+        exclude_roots,
+        cache_status,
+        max_hops=core["max_hops"],
+        batch_limit=core["batch_limit"],
+    )
+    expected = {
+        "public_harvest_queue.json": _queue_payload("known_public", public),
+        "visibility_revalidation_queue.json": _queue_payload(
+            "local_visibility_revalidation", revalidation
+        ),
+    }
+    for name, data in expected.items():
+        if _read_bounded(run / name, f"harvest plan {name}") != data:
+            raise HarvestPlanError("harvest plan does not reproduce from bound inputs")
+    if manifest["counts"] != counts:
+        raise HarvestPlanError("harvest plan counts do not reproduce from bound inputs")
+    return manifest
+
+
+def prepare_plan(
+    snapshot_dir: str | os.PathLike[str],
+    api_cache_db: str | os.PathLike[str],
+    seed_manifest: str | os.PathLike[str],
+    output_dir: str | os.PathLike[str],
+    local_root: str | os.PathLike[str],
+    *,
+    max_hops: int,
+    batch_limit: int,
+) -> dict[str, object]:
+    output, parent = _safe_output(Path(output_dir), Path(local_root))
+    _reject_input_output_overlap(
+        output, [Path(snapshot_dir), Path(api_cache_db), Path(seed_manifest)]
+    )
+    nodes, evidence, snapshot_fingerprint, api_sqlite_hashes = _load_snapshot(
+        Path(snapshot_dir)
+    )
+    roots, exclude_roots, root_set_sha, public_cache_not_before = _load_seeds(
+        Path(seed_manifest), snapshot_fingerprint
+    )
+    cache_status, cache_sha = _load_api_cache(
+        Path(api_cache_db), public_cache_not_before
+    )
+    if cache_sha not in api_sqlite_hashes:
+        raise HarvestPlanError("API cache is not an exact source of the verified snapshot")
+    public, revalidation, counts = derive_work_orders(
+        nodes,
+        evidence,
+        roots,
+        exclude_roots,
+        cache_status,
+        max_hops=max_hops,
+        batch_limit=batch_limit,
+    )
+    payloads = {
+        "public_harvest_queue.json": _queue_payload("known_public", public),
+        "visibility_revalidation_queue.json": _queue_payload(
+            "local_visibility_revalidation", revalidation
+        ),
+    }
+    artifact_records = {name: _artifact_record(data) for name, data in payloads.items()}
+    core: dict[str, object] = {
+        "algorithm": ALGORITHM,
+        "api_cache_sha256": cache_sha,
+        "artifacts": artifact_records,
+        "batch_limit": batch_limit,
+        "counts": counts,
+        "max_hops": max_hops,
+        "policy": POLICY,
+        "public_cache_not_before": public_cache_not_before,
+        "root_set_sha256": root_set_sha,
+        "snapshot_fingerprint": snapshot_fingerprint,
+        "traversal_relations": sorted(TRAVERSAL_RELATIONS),
+    }
+    manifest: dict[str, object] = {
+        "artifacts": artifact_records,
+        "counts": counts,
+        "fingerprint_core": core,
+        "plan_fingerprint": _sha256(_canonical_json(core)),
+        "policy": POLICY,
+        "schema": MANIFEST_SCHEMA,
+    }
+    temporary = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=parent))
+    os.chmod(temporary, 0o700)
+    try:
+        for name, data in payloads.items():
+            _write_private(temporary / name, data)
+        _write_private(temporary / "manifest.json", _canonical_json(manifest))
+        _write_private(temporary / MARKER_NAME, MARKER_BYTES)
+        descriptor = os.open(temporary, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        _verify_artifacts(temporary)
+        _rename_noreplace(temporary, output)
+        parent_descriptor = os.open(parent, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+        try:
+            os.fsync(parent_descriptor)
+        finally:
+            os.close(parent_descriptor)
+    except Exception:
+        if temporary.exists():
+            shutil.rmtree(temporary)
+        raise
+    return verify_plan(output, snapshot_dir, api_cache_db, seed_manifest)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("--snapshot-dir", required=True)
+    prepare.add_argument("--api-cache-db", required=True)
+    prepare.add_argument("--seed-manifest", required=True)
+    prepare.add_argument("--output-dir", required=True)
+    prepare.add_argument("--local-root", required=True)
+    prepare.add_argument("--local-only", action="store_true", required=True)
+    prepare.add_argument("--max-hops", type=int, default=8)
+    prepare.add_argument("--batch-limit", type=int, default=128)
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--run-dir", required=True)
+    verify.add_argument("--snapshot-dir", required=True)
+    verify.add_argument("--api-cache-db", required=True)
+    verify.add_argument("--seed-manifest", required=True)
+    status = subparsers.add_parser("status")
+    status.add_argument("--run-dir", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        verification = "source_reproduced"
+        if args.command == "prepare":
+            manifest = prepare_plan(
+                args.snapshot_dir,
+                args.api_cache_db,
+                args.seed_manifest,
+                args.output_dir,
+                args.local_root,
+                max_hops=args.max_hops,
+                batch_limit=args.batch_limit,
+            )
+        elif args.command == "verify":
+            manifest = verify_plan(
+                args.run_dir,
+                args.snapshot_dir,
+                args.api_cache_db,
+                args.seed_manifest,
+            )
+        else:
+            manifest = _verify_artifacts(Path(args.run_dir))
+            verification = "structural_integrity_only"
+        print(
+            json.dumps(
+                {
+                    "counts": manifest["counts"],
+                    "plan_fingerprint": manifest["plan_fingerprint"],
+                    "verification": verification,
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except Exception:
+        print(json.dumps({"error": "STEM harvest plan failed closed"}), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/test_prepare_pearltrees_stem_harvest_plan.py
+++ b/prototypes/mu_cosine/test_prepare_pearltrees_stem_harvest_plan.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+"""Contract tests for the privacy-aware STEM harvest planner."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sqlite3
+import stat
+from xml.sax.saxutils import escape
+
+import pytest
+
+import prepare_pearltrees_diffusion_snapshot as snapshot
+import prepare_pearltrees_stem_harvest_plan as planner
+
+
+PHYSICAL_RELATIONS = {
+    "alias": True,
+    "collection": True,
+    "cross_link": False,
+    "path": True,
+    "ref": True,
+    "shortcut": True,
+}
+
+
+def _json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _rdf(
+    nodes: list[tuple[int, str, int | None]], edges: list[tuple[int, int]]
+) -> bytes:
+    by_id = {node_id: (title, visibility) for node_id, title, visibility in nodes}
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" '
+        'xmlns:pt="https://www.pearltrees.com/rdf/0.1/#">',
+    ]
+    for node_id, title, visibility in nodes:
+        lines.extend(
+            [
+                f'  <pt:Tree rdf:about="https://www.pearltrees.com/synthetic/id{node_id}">',
+                f"    <pt:treeId>{node_id}</pt:treeId>",
+                f"    <pt:title>{escape(title)}</pt:title>",
+            ]
+        )
+        if visibility is not None:
+            lines.append(f"    <pt:privacy>{visibility}</pt:privacy>")
+        lines.append("  </pt:Tree>")
+    for child, parent in edges:
+        title, visibility = by_id[child]
+        lines.extend(
+            [
+                "  <pt:RefPearl>",
+                f'    <pt:parentTree rdf:resource="https://www.pearltrees.com/synthetic/id{parent}" />',
+                f'    <pt:seeAlso rdf:resource="https://www.pearltrees.com/synthetic/id{child}" />',
+                f"    <pt:title>{escape(title)}</pt:title>",
+            ]
+        )
+        if visibility is not None:
+            lines.append(f"    <pt:privacy>{visibility}</pt:privacy>")
+        lines.append("  </pt:RefPearl>")
+    lines.append("</rdf:RDF>")
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def _make_snapshot(
+    tmp_path: Path,
+    *,
+    nodes: list[tuple[int, str, int | None]],
+    edges: list[tuple[int, int]],
+    api_cache: Path,
+) -> tuple[Path, dict]:
+    inputs = tmp_path / "snapshot-inputs"
+    local_root = tmp_path / "snapshots"
+    inputs.mkdir()
+    local_root.mkdir()
+    rdf = inputs / "source.rdf"
+    rdf.write_bytes(_rdf(nodes, edges))
+    source_spec = inputs / "sources.json"
+    policy = inputs / "policy.json"
+    _write_json(
+        source_spec,
+        {
+            "schema": "pearltrees-diffusion-source-spec-v1",
+            "snapshot_label": "stem-harvest-test",
+            "sources": [
+                {
+                    "account": "synthetic",
+                    "kind": "rdf",
+                    "path": str(rdf),
+                    "source_id": "synthetic-rdf",
+                },
+                {
+                    "kind": "api_sqlite",
+                    "path": str(api_cache),
+                    "source_id": "synthetic-api-cache",
+                },
+            ],
+        },
+    )
+    _write_json(
+        policy,
+        {
+            "physical_edges": PHYSICAL_RELATIONS,
+            "schema": "pearltrees-diffusion-relation-policy-v1",
+        },
+    )
+    run = local_root / "run"
+    manifest = snapshot.prepare_snapshot(
+        source_spec,
+        policy,
+        run,
+        local_root,
+        minimum_anchors=1,
+        resource_ceiling_bytes=1_000_000,
+    )
+    return run, manifest
+
+
+def _api_tree(tree_id: int, *, visibility: int = 0, title: str = "Public") -> str:
+    return json.dumps(
+        {"tree": {"id": tree_id, "pearls": [], "title": title, "visibility": visibility}},
+        separators=(",", ":"),
+    )
+
+
+def _make_cache(path: Path, rows: list[tuple[int, str]]) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            "CREATE TABLE api_responses (tree_id TEXT PRIMARY KEY, title TEXT, "
+            "fetched_at TEXT, children_count INTEGER, response_json TEXT)"
+        )
+        connection.executemany(
+            "INSERT INTO api_responses VALUES (?,?,?,?,?)",
+            [(str(tree_id), "", "2026-01-01T00:00:00", 0, payload) for tree_id, payload in rows],
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _seed_manifest(
+    path: Path,
+    fingerprint: str,
+    roots: list[int],
+    exclude_roots: list[int] | None = None,
+    *,
+    public_cache_not_before: str = "2026-01-01T00:00:00",
+) -> None:
+    _write_json(
+        path,
+        {
+            "exclude_roots": [f"pt:{value}" for value in (exclude_roots or [])],
+            "public_cache_not_before": public_cache_not_before,
+            "roots": [f"pt:{value}" for value in roots],
+            "schema": planner.SEED_SCHEMA,
+            "snapshot_fingerprint": fingerprint,
+        },
+    )
+
+
+def _basic_case(tmp_path: Path, cache_rows: list[tuple[int, str]] | None = None):
+    cache = tmp_path / "api.db"
+    _make_cache(
+        cache,
+        cache_rows
+        if cache_rows is not None
+        else [(1, _api_tree(1)), (2, _api_tree(2))],
+    )
+    run, manifest = _make_snapshot(
+        tmp_path,
+        nodes=[
+            (1, "STEM root", 0),
+            (2, "Fetched branch", 0),
+            (3, "Public gap", 0),
+            (4, "Unknown frontier", None),
+            (5, "Private branch", 1),
+            (6, "Private descendant", 0),
+            (7, "Behind unresolved", 0),
+        ],
+        edges=[(2, 1), (3, 2), (4, 2), (5, 2), (6, 5), (7, 3)],
+        api_cache=cache,
+    )
+    seeds = tmp_path / "seeds.json"
+    _seed_manifest(seeds, manifest["snapshot_fingerprint"], [1])
+    return run, manifest, cache, seeds
+
+
+def _prepare_basic(tmp_path: Path, cache_rows: list[tuple[int, str]] | None = None):
+    run, manifest, cache, seeds = _basic_case(tmp_path, cache_rows)
+    local = tmp_path / "plans"
+    local.mkdir()
+    output = local / "plan"
+    result = planner.prepare_plan(
+        run,
+        cache,
+        seeds,
+        output,
+        local,
+        max_hops=8,
+        batch_limit=128,
+    )
+    return output, result, manifest
+
+
+def test_separates_public_and_unknown_first_frontiers(tmp_path: Path) -> None:
+    output, manifest, _ = _prepare_basic(tmp_path)
+    public = _json(output / "public_harvest_queue.json")
+    revalidation = _json(output / "visibility_revalidation_queue.json")
+    assert [row["tree_id"] for row in public["maps"]] == ["3"]
+    assert [row["tree_id"] for row in revalidation["maps"]] == ["4"]
+    assert public["maps"][0]["reason"] == "public_direct_containment_frontier"
+    assert revalidation["maps"][0]["cache_status"] == "missing"
+    # Node 7 is behind unresolved node 3; private nodes 5/6 never enter any queue.
+    emitted = {row["tree_id"] for row in public["maps"] + revalidation["maps"]}
+    assert emitted == {"3", "4"}
+    assert manifest["policy"]["unknown_nodes_traversed"] is False
+
+
+def test_next_round_expands_only_after_public_parent_is_fetched(tmp_path: Path) -> None:
+    output, _, _ = _prepare_basic(
+        tmp_path,
+        [(1, _api_tree(1)), (2, _api_tree(2)), (3, _api_tree(3))],
+    )
+    public = _json(output / "public_harvest_queue.json")
+    assert [row["tree_id"] for row in public["maps"]] == ["7"]
+
+
+def test_cache_parser_quarantines_masked_auth_signature() -> None:
+    assert (
+        planner._cache_response_status(
+            "pt:2", _api_tree(2, visibility=2, title="*private*")
+        )
+        == "masked_auth"
+    )
+
+
+def test_cache_parser_private_claim_wins_across_info_and_tree() -> None:
+    payload = json.dumps(
+        {
+            "info": {"id": 2, "title": "Private notes", "visibility": 1},
+            "tree": {"id": 2, "title": "Public", "visibility": 0},
+        },
+        separators=(",", ":"),
+    )
+    assert planner._cache_response_status("pt:2", payload) == "private_or_restricted"
+
+
+def test_cache_parser_rejects_disagreeing_ids() -> None:
+    payload = json.dumps(
+        {
+            "info": {"id": 2, "title": "Public", "visibility": 0},
+            "tree": {"id": 3, "title": "Public", "visibility": 0},
+        },
+        separators=(",", ":"),
+    )
+    assert planner._cache_response_status("pt:2", payload) == "malformed"
+
+
+def test_stale_public_root_stops_traversal_and_enters_revalidation(tmp_path: Path) -> None:
+    run, manifest, cache, seeds = _basic_case(tmp_path)
+    _seed_manifest(
+        seeds,
+        manifest["snapshot_fingerprint"],
+        [1],
+        public_cache_not_before="2026-01-02T00:00:00",
+    )
+    local = tmp_path / "plans"
+    local.mkdir()
+    output = local / "plan"
+    planner.prepare_plan(run, cache, seeds, output, local, max_hops=8, batch_limit=128)
+    assert _json(output / "public_harvest_queue.json")["count"] == 0
+    rows = _json(output / "visibility_revalidation_queue.json")["maps"]
+    assert [(row["tree_id"], row["cache_status"]) for row in rows] == [
+        ("1", "stale_public")
+    ]
+
+
+def test_scope_exclusion_removes_entire_containment_branch(tmp_path: Path) -> None:
+    run, manifest, cache, seeds = _basic_case(tmp_path)
+    _seed_manifest(seeds, manifest["snapshot_fingerprint"], [1], [2])
+    local = tmp_path / "plans"
+    local.mkdir()
+    output = local / "plan"
+    result = planner.prepare_plan(
+        run, cache, seeds, output, local, max_hops=8, batch_limit=128
+    )
+    assert _json(output / "public_harvest_queue.json")["count"] == 0
+    assert _json(output / "visibility_revalidation_queue.json")["count"] == 0
+    # The verified snapshot has already removed privacy-excluded physical edges,
+    # so the explicit topical closure contains only retained branch members.
+    assert result["counts"]["scope_excluded"] == 4
+
+
+def test_shared_frontier_has_lexicographic_bridge_tier(tmp_path: Path) -> None:
+    cache = tmp_path / "api.db"
+    _make_cache(cache, [(value, _api_tree(value)) for value in (1, 2, 10, 11)])
+    run, manifest = _make_snapshot(
+        tmp_path,
+        nodes=[
+            (1, "Root A", 0),
+            (2, "A branch", 0),
+            (10, "Root B", 0),
+            (11, "B branch", 0),
+            (20, "Shared gap", 0),
+        ],
+        edges=[(2, 1), (11, 10), (20, 2), (20, 11)],
+        api_cache=cache,
+    )
+    seeds = tmp_path / "seeds.json"
+    _seed_manifest(seeds, manifest["snapshot_fingerprint"], [10, 1])
+    local = tmp_path / "plans"
+    local.mkdir()
+    output = local / "plan"
+    planner.prepare_plan(run, cache, seeds, output, local, max_hops=8, batch_limit=128)
+    row = _json(output / "public_harvest_queue.json")["maps"][0]
+    assert row["reason"] == "public_shared_containment_frontier"
+    assert row["frontier_links"] == 2
+    assert row["stem_root_count"] == 2
+
+
+def test_batch_limit_preserves_deterministic_rank(tmp_path: Path) -> None:
+    cache = tmp_path / "api.db"
+    _make_cache(cache, [(1, _api_tree(1))])
+    run, manifest = _make_snapshot(
+        tmp_path,
+        nodes=[(1, "Root", 0), (2, "Two", 0), (3, "Three", 0)],
+        edges=[(3, 1), (2, 1)],
+        api_cache=cache,
+    )
+    seeds = tmp_path / "seeds.json"
+    _seed_manifest(seeds, manifest["snapshot_fingerprint"], [1])
+    local = tmp_path / "plans"
+    local.mkdir()
+    output = local / "plan"
+    result = planner.prepare_plan(run, cache, seeds, output, local, max_hops=8, batch_limit=1)
+    assert [row["tree_id"] for row in _json(output / "public_harvest_queue.json")["maps"]] == ["2"]
+    assert result["counts"]["public_candidates_total"] == 2
+    assert result["counts"]["public_queue"] == 1
+
+
+def test_seed_manifest_is_bound_to_exact_snapshot(tmp_path: Path) -> None:
+    run, _, cache, seeds = _basic_case(tmp_path)
+    value = _json(seeds)
+    value["snapshot_fingerprint"] = "0" * 64
+    _write_json(seeds, value)
+    local = tmp_path / "plans"
+    local.mkdir()
+    with pytest.raises(planner.HarvestPlanError, match="schema mismatch"):
+        planner.prepare_plan(
+            run, cache, seeds, local / "plan", local, max_hops=8, batch_limit=128
+        )
+
+
+def test_installed_plan_is_private_and_tamper_fails(tmp_path: Path) -> None:
+    output, manifest, _ = _prepare_basic(tmp_path)
+    assert stat.S_IMODE(output.stat().st_mode) == 0o700
+    assert {stat.S_IMODE(path.stat().st_mode) for path in output.iterdir()} == {0o600}
+    assert planner._verify_artifacts(output)["plan_fingerprint"] == manifest["plan_fingerprint"]
+    queue = output / "public_harvest_queue.json"
+    os.chmod(queue, 0o644)
+    with pytest.raises(planner.HarvestPlanError, match="envelope"):
+        planner._verify_artifacts(output)
+
+
+def test_resealed_cross_lane_semantic_tamper_fails(tmp_path: Path) -> None:
+    output, _, _ = _prepare_basic(tmp_path)
+    queue_path = output / "public_harvest_queue.json"
+    queue = _json(queue_path)
+    queue["maps"][0]["cache_status"] = "masked_auth"
+    queue_bytes = planner._canonical_json(queue)
+    queue_path.write_bytes(queue_bytes)
+    manifest_path = output / "manifest.json"
+    manifest = _json(manifest_path)
+    record = planner._artifact_record(queue_bytes)
+    manifest["artifacts"]["public_harvest_queue.json"] = record
+    manifest["fingerprint_core"]["artifacts"]["public_harvest_queue.json"] = record
+    manifest["plan_fingerprint"] = planner._sha256(
+        planner._canonical_json(manifest["fingerprint_core"])
+    )
+    manifest_path.write_bytes(planner._canonical_json(manifest))
+    with pytest.raises(planner.HarvestPlanError, match="lane semantics"):
+        planner._verify_artifacts(output)
+
+
+@pytest.mark.parametrize("suffix", ["-wal", "-shm", "-journal"])
+def test_cache_sidecar_fails_closed(tmp_path: Path, suffix: str) -> None:
+    run, _, cache, seeds = _basic_case(tmp_path)
+    Path(f"{cache}{suffix}").write_bytes(b"not-a-real-sidecar")
+    local = tmp_path / "plans"
+    local.mkdir()
+    with pytest.raises(planner.HarvestPlanError, match="sidecars"):
+        planner.prepare_plan(
+            run, cache, seeds, local / "plan", local, max_hops=8, batch_limit=128
+        )
+
+
+def test_cache_wal_mode_fails_closed(tmp_path: Path) -> None:
+    cache = tmp_path / "wal.db"
+    _make_cache(cache, [(1, _api_tree(1))])
+    connection = sqlite3.connect(cache)
+    try:
+        assert connection.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+    finally:
+        connection.close()
+    for suffix in ("-wal", "-shm"):
+        sidecar = Path(f"{cache}{suffix}")
+        if sidecar.exists():
+            sidecar.unlink()
+    with pytest.raises(planner.HarvestPlanError, match="WAL-mode"):
+        planner._load_api_cache(cache, "2026-01-01T00:00:00")
+
+
+def test_cache_must_be_exact_api_sqlite_snapshot_source(tmp_path: Path) -> None:
+    run, _, _, seeds = _basic_case(tmp_path)
+    other = tmp_path / "other.db"
+    _make_cache(other, [(1, _api_tree(1)), (2, _api_tree(2)), (3, _api_tree(3))])
+    local = tmp_path / "plans"
+    local.mkdir()
+    with pytest.raises(planner.HarvestPlanError, match="exact source"):
+        planner.prepare_plan(
+            run, other, seeds, local / "plan", local, max_hops=8, batch_limit=128
+        )
+
+
+def test_excluded_ancestor_of_seed_fails_closed(tmp_path: Path) -> None:
+    run, manifest, cache, seeds = _basic_case(tmp_path)
+    _seed_manifest(seeds, manifest["snapshot_fingerprint"], [2], [1])
+    local = tmp_path / "plans"
+    local.mkdir()
+    with pytest.raises(planner.HarvestPlanError, match="below an explicit scope exclusion"):
+        planner.prepare_plan(
+            run, cache, seeds, local / "plan", local, max_hops=8, batch_limit=128
+        )
+
+
+def test_count_schema_is_exact_and_bound_to_fingerprint(tmp_path: Path) -> None:
+    output, _, _ = _prepare_basic(tmp_path)
+    manifest_path = output / "manifest.json"
+    manifest = _json(manifest_path)
+    manifest["counts"]["pt:123"] = 1
+    manifest["fingerprint_core"]["counts"]["pt:123"] = 1
+    manifest["plan_fingerprint"] = planner._sha256(
+        planner._canonical_json(manifest["fingerprint_core"])
+    )
+    manifest_path.write_bytes(planner._canonical_json(manifest))
+    with pytest.raises(planner.HarvestPlanError, match="counts are malformed"):
+        planner._verify_artifacts(output)
+
+
+def test_resealed_manifest_cannot_claim_a_different_cache_cutoff(tmp_path: Path) -> None:
+    run, _, cache, seeds = _basic_case(tmp_path)
+    local = tmp_path / "plans"
+    local.mkdir()
+    bound_output = local / "plan"
+    planner.prepare_plan(
+        run, cache, seeds, bound_output, local, max_hops=8, batch_limit=128
+    )
+    manifest_path = bound_output / "manifest.json"
+    manifest = _json(manifest_path)
+    manifest["fingerprint_core"]["public_cache_not_before"] = "2026-01-02T00:00:00"
+    manifest["plan_fingerprint"] = planner._sha256(
+        planner._canonical_json(manifest["fingerprint_core"])
+    )
+    manifest_path.write_bytes(planner._canonical_json(manifest))
+    assert planner._verify_artifacts(bound_output)["plan_fingerprint"] == manifest[
+        "plan_fingerprint"
+    ]
+    with pytest.raises(planner.HarvestPlanError, match="input binding"):
+        planner.verify_plan(bound_output, run, cache, seeds)
+
+
+def test_output_must_be_below_explicit_local_root(tmp_path: Path) -> None:
+    run, _, cache, seeds = _basic_case(tmp_path)
+    local = tmp_path / "plans"
+    local.mkdir()
+    (tmp_path / "elsewhere").mkdir()
+    with pytest.raises(planner.HarvestPlanError, match="below"):
+        planner.prepare_plan(
+            run,
+            cache,
+            seeds,
+            tmp_path / "elsewhere" / "plan",
+            local,
+            max_hops=8,
+            batch_limit=128,
+        )


### PR DESCRIPTION
## Summary

Add a deterministic, graph-first planner for filling public STEM coverage gaps in the Pearltrees corpus.

The planner consumes:

- a verified Pearltrees diffusion snapshot;
- the exact API SQLite cache used to construct that snapshot; and
- a human-curated manifest of public STEM roots and topical exclusions.

It produces local-only work orders without calling Pearltrees, an LLM, an embedding model, or a filing judge.

## Graph-search policy

- Traverse only directed `collection`, `ref`, and `path` containment edges.
- Start from explicitly public, retained STEM roots.
- Stop each branch at its first unresolved node.
- Never traverse through private, unknown, stale, malformed, or missing evidence.
- Handle multi-parent nodes without selecting an arbitrary preferred parent.
- Break cycles with visited-node memoization.
- Prioritize unresolved seeds, shared containment frontiers, and direct containment frontiers using a frozen lexicographic order rather than a confidence-weighted score.

The planner emits two separate queues:

1. `public_harvest_queue.json` for snapshot-public nodes absent from the API cache.
2. `visibility_revalidation_queue.json` for stale-public or missing/unknown frontiers.

## Privacy and provenance

- Require the API database SHA-256 to appear specifically as an `api_sqlite` source in the verified snapshot.
- Check all `info` and `tree` ID, visibility, and title claims conservatively.
- Exclude masked, private, restricted, and contradictory evidence rather than promoting it into a harvest lane.
- Bind a prospective `public_cache_not_before` cutoff into the seed manifest and plan fingerprint.
- Prevent stale public rows from opening traversal.
- Reject a STEM root contained beneath an explicit topical exclusion.
- Emit no titles, URLs, accounts, paths, raw responses, prompts, embeddings, or node content.
- Freeze the complete aggregate-count schema so accidental ID-bearing fields cannot reach status logs.
- Distinguish structural artifact inspection from full source-reproduced verification.

## SQLite and installation hardening

- Stream the API-cache hash under a separate 2 GiB ceiling instead of retaining the database in memory.
- Reject WAL, shared-memory, and rollback-journal sidecars.
- Reject databases whose SQLite header or reported journal mode indicates WAL.
- Require `quick_check` success and byte stability across planning.
- Install work orders atomically into a mode-0700 local-only directory.
- Write mode-0600, single-link artifacts outside Git worktrees.
- Bind artifacts, counts, policy, cutoff, graph parameters, snapshot, cache, and seed evidence into the plan fingerprint.
- Reproduce work-order bytes exactly during full verification.

## Execution gate

This PR authorizes work-order generation only.

The current browser harvester can persist a masked authentication response and mark it successful when credential refresh fails. Queue execution therefore remains blocked until the harvester:

- quarantines masked or authentication-failure responses;
- fails closed when authenticated access cannot be restored;
- leaves affected IDs unprocessed;
- binds fresh state to the work-order fingerprint; and
- rechecks the plan cutoff, fingerprint, and current visibility before each network batch.

## Optional semantic refinement

The planner is model-agnostic and does not require Phi-family inference.

Graph containment remains the primary acquisition geometry. A small local embedding model may later rank or route only freshly revalidated public candidates. Hosted Phi inference remains an optional public-data labeler or teacher behind a separate external-processing eligibility gate.

Neither embeddings nor hosted labels may determine privacy. When semantic labels are fused with existing μ/judge sources, they should use the calibrated joint-posterior and margin-gate workflow rather than an arbitrary weighted blend. Evaluation should use lineage- or parent-block-disjoint holdouts.

## Scientific scope

These acquisition work orders do not:

- reopen the bounded-diffusion/HOP scientific gate;
- authorize training or publication;
- estimate covariance;
- claim filing improvement; or
- unlock a deployment result.

A newly harvested batch must first be checkpointed, compiled into a fresh verified snapshot, independently reconciled, and replanned.

## Validation

- 71 focused planner and diffusion-snapshot tests pass.
- Python compilation passes.
- `git diff --check` passes.
- Tests cover deterministic