### PR TITLE
feat(graph): add exact multi-port exterior Schur reference

### DIFF
--- a/prototypes/mu_cosine/DESIGN_private_boundary_expert.md
+++ b/prototypes/mu_cosine/DESIGN_private_boundary_expert.md
@@ -452,7 +452,9 @@ graph-only primary. Report losses as well as wins.
 ## Staged acceptance
 
 1. **Synthetic identities:** prove exact elimination and sparse-ledger safety on
-   small graphs. This stage cannot authorize private training.
+   small graphs under
+   [`PROTOCOL_synthetic_multiport_schur.md`](PROTOCOL_synthetic_multiport_schur.md).
+   This stage cannot authorize private training.
 2. **Private structural shadow study:** on a freshly authenticated local
    snapshot, measure whether the private interior induces material
    multi-terminal transfer after common-parent retention. No filing labels tune

--- a/prototypes/mu_cosine/PROTOCOL_synthetic_multiport_schur.md
+++ b/prototypes/mu_cosine/PROTOCOL_synthetic_multiport_schur.md
@@ -1,0 +1,202 @@
+# Prospective protocol: synthetic exact multi-port Schur reference
+
+## Status and decision boundary
+
+**PROSPECTIVE, SYNTHETIC ONLY.** Freeze this protocol before evaluating the
+implementation on its required fixtures. It licenses a dense CPU-float64
+correctness reference for exact elimination of a represented graph component.
+It does not license a Pearltrees/private-data load, a sparse approximation, a
+filing experiment, training, deployment, or publication of a private-derived
+operator.
+
+The decision is whether one implementation can:
+
+1. eliminate a grounded multi-port interior without forming an inverse;
+2. reproduce the full system's boundary response;
+3. expose the induced transfer-conductance and residual-shunt ledger; and
+4. fail closed when the result is not a numerically valid grounded
+   resistor-network operator.
+
+Passing every required fixture authorizes the routine as an outcome-blind
+exact reference for a later, separately preregistered approximation study. It
+does not authorize a real private-data run.
+
+## Frozen component snapshot
+
+Each fixture first uses the existing deterministic exterior traversal to
+produce one immutable `ExteriorComponent` snapshot. The snapshot contains:
+
+- one or more canonical retained ports `B` and at least one canonical exterior
+  node `H`;
+- canonical, unique boundary-to-exterior cut edges;
+- canonical, unique undirected edges internal to `H`;
+- canonical edges from `H` to the clamped outside bath;
+- a verified SHA-256 fingerprint over those exact topology fields; and
+- a separate finite nonnegative intrinsic-leakage scalar, sparse node mapping,
+  or `H`-aligned vector.
+
+One positive finite uniform topological conductance `c0` applies to every
+listed graph edge. Per-edge conductances and semantic modulation are deferred.
+The component contains no embeddings, titles, URLs, placements, judge
+outcomes, corpus IDs, private IDs, or machine-local paths. The reducer must use
+the frozen component as its sole topology authority; rereading the source graph
+after discovery is forbidden.
+
+## Frozen exact identities
+
+Assemble the exterior precision `J_HH` from intrinsic leakage, internal-edge
+Laplacian terms, cut-edge diagonal terms, and outside-bath diagonal terms.
+Let `C >= 0` be the port-to-exterior coupling matrix and
+
+\[
+\beta=C\mathbf 1,\qquad D_B=\operatorname{diag}(\beta).
+\]
+
+Solve, without materializing `J_HH^-1`,
+
+\[
+X=J_{HH}^{-1}C^T.
+\]
+
+The exact exterior return and reduced exterior boundary contribution are
+
+\[
+B_H=CX=CJ_{HH}^{-1}C^T,\qquad
+Q_H=D_B-B_H.
+\]
+
+If a caller has an independently assembled public-side boundary precision
+`J_P`, the full reduced precision is `S=J_P+Q_H`. `J_P` is not part of this
+primitive. The direct full-graph parity fixture assembles it independently so
+the test cannot pass merely by repeating the reducer's construction.
+
+For a valid grounded resistor network, recover the joint multi-terminal
+ledger
+
+\[
+\kappa_{ij}=-(Q_H)_{ij}\quad(i\ne j),\qquad
+q=Q_H\mathbf 1,
+\]
+
+and verify
+
+\[
+Q_H=L(\kappa)+\operatorname{diag}(q).
+\]
+
+`kappa` is one joint operator, not independently estimated pairwise
+`1/R_eff` edges. `q` must be retained: interior leakage and represented bath
+shunts cannot generally be expressed using boundary-to-boundary edges alone.
+
+## Numerical contract and fail-closed gates
+
+Use CPU `float64`, the existing dense reference backend, and no jitter,
+pseudoinverse, or explicit inverse. Roundoff-only symmetry cleanup is allowed.
+`B_H` and `Q_H` remain unaltered and fingerprinted. After the material-negative
+gates, the derived public nonnegative bridge, self-return, and residual-shunt
+views may canonicalize a tolerated negative roundoff value to zero; every raw
+value remains recoverable from fingerprinted `B_H` or `Q_H`.
+
+Let
+
+\[
+s_B=\max(1,\max_{ij}|(B_H)_{ij}|,\max_{ij}|(Q_H)_{ij}|,
+           \max_i|\beta_i|),
+\]
+\[
+\tau_{\rm sign}=\max(10^{-12}s_B,64\epsilon_{64}s_B),\qquad
+\tau_{\rm psd}=10^{-10}s_B.
+\]
+
+Every expected-valid fixture must pass all of these gates:
+
+- `J_HH`, `B_H`, and `Q_H` are finite and symmetric within the recorded
+  tolerances;
+- `J_HH` is a Cholesky-factorable SPD M-matrix;
+- the reciprocal condition number of `J_HH` is at least
+  `sqrt(float64_epsilon)` unless the caller supplies a stricter floor;
+- the Cholesky reconstruction uses `rtol=1e-11`, `atol=1e-12`;
+- the relative infinity-norm residual of `J_HH X = C^T` is at most `1e-10`;
+- `B_H` has no entry below `-tau_sign` and no eigenvalue below `-tau_psd`;
+- `Q_H` has no eigenvalue below `-tau_psd`, no positive off-diagonal above
+  `tau_sign`, and no row-sum shunt below `-tau_sign`;
+- reconstruction from `kappa` and `q` agrees with `Q_H` within
+  `rtol=1e-12` and the cut-mass ledger closes within tolerance; and
+- every column of `J_HH^-1 C^T` is nonnegative and its all-one boundary
+  harmonic extension remains in `[0,1]`, each within `1e-10`.
+
+`J_HH` must be SPD. `Q_H` need only be PSD and may be singular when the
+represented exterior has no intrinsic leakage or outside-bath route. The
+routine must not invent a gauge, jitter, or grounding term for that valid
+case.
+
+Values inside the tolerance remain in the recorded operator; they are not a
+license to repair an invalid input. Any failed gate makes that expected-valid
+fixture a failure. Every expected-invalid fixture must be rejected before
+emitting a usable operator.
+
+## Required synthetic fixtures
+
+The frozen additions to the existing bounded-diffusion suite contain:
+
+1. a grounded three-port star with analytic `B_H`, `Q_H`, transfer, self-return,
+   and residual-shunt values, plus a check that `B_H[i,j]` is not generally
+   `1/R_eff(i,j)`;
+2. a four-port branched/cyclic exterior whose `J_P+Q_H` and multi-right-hand-
+   side responses match an independently assembled full-graph Schur solve;
+3. connected parallel multi-port paths whose exact induced transfer exceeds
+   one ordinary branch conductance and is not capped;
+4. an equivalent graph with reversed insertion order and heterogeneous node
+   identifiers, yielding the same canonical component and reduction
+   fingerprints;
+5. a guard that rejects any explicit inverse and verifies immutable outputs
+   plus the recorded numerical diagnostics;
+6. an allowed exterior with an outgoing bath edge, verifying the analytic
+   residual shunt; and
+7. a one-port component plus negative, nonfinite, unknown-node, and
+   insufficient-condition input rejections.
+
+The pre-existing two-port analytic, parallel-path, retained-edge, topology-only,
+and numerical-failure tests remain regression coverage for the delegated
+benchmark path. All fixtures are deterministic synthetic code; no random graph
+generator enters the decision-bearing suite.
+
+## Output and provenance
+
+Each successful result exposes canonical ports and exterior nodes, immutable
+`J_HH`, `C`, harmonic extension, `beta`, `B_H`, and `Q_H`, along with
+`kappa`, self-return, transfer degree, and residual shunt views. It records
+exterior spectral extrema, reciprocal condition and required floor, Cholesky
+reconstruction error, solve residual, maximum-principle violation, minimum
+eigenvalues of `B_H` and `Q_H`, and ledger error.
+
+The reduction SHA-256 binds the verified component fingerprint, canonical node
+tokens, `c0`, leakage vector, required condition floor, and scientific outputs
+using hexadecimal float64 serialization. Equivalent discovery/input order
+must reproduce that fingerprint. Synthetic records may be committed. This
+does not authorize persistence or publication of a real private component or
+operator; those remain private under `DESIGN_private_boundary_expert.md`.
+
+## Acceptance and explicit nonclaims
+
+The reference passes only when every expected-valid fixture passes every gate,
+every expected-invalid case is rejected, the existing delegated two-port
+regressions remain green, and equivalent input order reproduces the scientific
+fingerprints. There is no favorable-subset report or tolerance retuning after
+results.
+
+This protocol deliberately defers:
+
+- sparse support selection, top-`K` truncation, and sparse-DtN optimization;
+- semantic candidate filtering or learned conductance;
+- effective-resistance candidate search beyond analytic fixture diagnostics;
+- private/public loaders and an owner-authorization manifest;
+- harvester authentication repair and any Pearltrees snapshot;
+- real-component structural-shadow or fidelity studies;
+- private-expert representation alignment, training, routing, or evaluation;
+- covariance promotion, filing-performance, CUDA, and scale claims; and
+- differential privacy, release testing, export, or publication.
+
+A later sparse-approximation protocol may consume this exact reference only
+after its support, resource budget, loss, component-level split, stopping
+rule, and untouched evaluation are frozen prospectively.

--- a/prototypes/mu_cosine/benchmark_bounded_diffusion_fidelity.py
+++ b/prototypes/mu_cosine/benchmark_bounded_diffusion_fidelity.py
@@ -36,6 +36,7 @@ from unifyweaver.graph.bounded_diffusion_fidelity import (  # noqa: E402
     discover_exterior_components,
     ensure_matched_budget,
     evaluate_bounded_domain_fidelity,
+    reduce_exact_exterior_component,
     select_hop_budget_domain,
     select_semantic_resistance_domain,
     select_topology_skeleton_domain,
@@ -143,39 +144,17 @@ def _topology_two_port_schur(
     ledger subtracts both transfer and self-return from the exact Dirichlet
     shunt before checking nonnegative residual ground, M-matrix signs, and SPD;
     it never adds this return on top of the shunt.
-    """
 
-    nodes = component.nodes
-    ports = component.ports
-    node_index = {node: row for row, node in enumerate(nodes)}
-    port_index = {node: row for row, node in enumerate(ports)}
-    precision = np.eye(len(nodes), dtype=float) * intrinsic_leakage
-    coupling = np.zeros((2, len(nodes)), dtype=float)
-    outside_bath_edges = set(component.outside_bath_edges)
-    for node, row in node_index.items():
-        for neighbor in graph[node]:
-            if neighbor in node_index:
-                neighbor_row = node_index[neighbor]
-                if row < neighbor_row:
-                    precision[row, row] += topology_conductance
-                    precision[neighbor_row, neighbor_row] += topology_conductance
-                    precision[row, neighbor_row] -= topology_conductance
-                    precision[neighbor_row, row] -= topology_conductance
-            elif neighbor in port_index:
-                precision[row, row] += topology_conductance
-                coupling[port_index[neighbor], row] += topology_conductance
-            elif (node, neighbor) in outside_bath_edges:
-                precision[row, row] += topology_conductance
-            else:
-                raise ValueError(
-                    "bounded exterior component contains an unknown neighbor"
-                )
-    update = coupling @ np.linalg.solve(precision, coupling.T)
-    if not np.isfinite(update).all() or not np.allclose(update, update.T):
-        raise np.linalg.LinAlgError("two-port topology Schur response is invalid")
-    if np.min(update) < -1e-12:
-        raise np.linalg.LinAlgError("two-port topology Schur response is negative")
-    return update
+    ``graph`` remains in this private helper's signature for benchmark-call
+    compatibility. The reusable reducer deliberately does not read it:
+    ``component`` is the already-fingerprinted authoritative topology snapshot.
+    """
+    del graph
+    return reduce_exact_exterior_component(
+        component,
+        intrinsic_leakage_conductance=intrinsic_leakage,
+        topology_conductance=topology_conductance,
+    ).schur_return
 
 
 def _exact_two_port_exterior_dtn(

--- a/src/unifyweaver/graph/__init__.py
+++ b/src/unifyweaver/graph/__init__.py
@@ -21,12 +21,24 @@ from .local_diffusion import (
     compare_nested_domains,
     select_hop_local_domain,
 )
+from .bounded_diffusion_fidelity import (
+    ExactExteriorSchurReduction,
+    ExteriorComponent,
+    ExteriorComponentDiscovery,
+    ExteriorTraversalLimitError,
+    discover_exterior_components,
+    reduce_exact_exterior_component,
+)
 
 __all__ = [
     "AnchorLeakageCalibrationResult",
     "AnchorScreeningProvenance",
     "LeakageCalibrationMinimalityCertificate",
     "GroundedSemanticDiffusion",
+    "ExactExteriorSchurReduction",
+    "ExteriorComponent",
+    "ExteriorComponentDiscovery",
+    "ExteriorTraversalLimitError",
     "build_grounded_semantic_diffusion",
     "LeakageCalibrationResult",
     "LocalDiffusionDomain",
@@ -37,6 +49,8 @@ __all__ = [
     "calibrate_uniform_leakage",
     "calibrate_uniform_leakage_per_anchor",
     "compare_nested_domains",
+    "discover_exterior_components",
+    "reduce_exact_exterior_component",
     "select_hop_local_domain",
     "combinatorial_laplacian",
     "semantic_conductance_matrix",

--- a/src/unifyweaver/graph/bounded_diffusion_fidelity.py
+++ b/src/unifyweaver/graph/bounded_diffusion_fidelity.py
@@ -30,7 +30,13 @@ from typing import Mapping
 
 import numpy as np
 
-from .leaky_diffusion import _stable_radial_factor
+from .leaky_diffusion import (
+    _DEFAULT_MINIMUM_RECIPROCAL_CONDITION,
+    _positive_unit_interval,
+    _readonly,
+    _stable_radial_factor,
+    _symmetric_part,
+)
 from .local_diffusion import (
     AnchorScreeningProvenance,
     LocalDiffusionDomain,
@@ -55,6 +61,7 @@ __all__ = [
     "BoundedModelSafetyDiagnostics",
     "ExperimentalBoundaryClosure",
     "ExperimentalBoundaryClosureConfig",
+    "ExactExteriorSchurReduction",
     "ExteriorComponent",
     "ExteriorComponentDiscovery",
     "ExteriorTraversalLimitError",
@@ -64,6 +71,7 @@ __all__ = [
     "ensure_matched_budget",
     "evaluate_bounded_domain_fidelity",
     "evaluate_nested_bounded_domain_fidelity",
+    "reduce_exact_exterior_component",
     "select_hop_budget_domain",
     "select_semantic_resistance_domain",
     "select_topology_skeleton_domain",
@@ -232,6 +240,8 @@ class ExteriorComponent:
         for port, omitted in cut_edges:
             if port not in port_set or omitted not in node_set:
                 raise ValueError("component cut edge does not align with its ports")
+        if {port for port, _omitted in cut_edges} != port_set:
+            raise ValueError("every exterior component port needs a cut edge")
         for interior, outside in bath_edges:
             if interior not in node_set or outside in node_set or outside in port_set:
                 raise ValueError("outside bath edge does not leave the component")
@@ -292,6 +302,877 @@ class ExteriorComponent:
             "internal_edge_count": self.internal_edge_count,
             "component_fingerprint": self.component_fingerprint,
         }
+
+
+def _float_hex_vector(value):
+    return [float(item).hex() for item in np.asarray(value, dtype=float)]
+
+
+def _float_hex_matrix(value):
+    return [
+        [float(item).hex() for item in row]
+        for row in np.asarray(value, dtype=float)
+    ]
+
+
+def _exact_reduction_fingerprint_payload(
+    *,
+    component_fingerprint,
+    ports,
+    exterior_nodes,
+    topology_conductance,
+    intrinsic_leakage_conductance,
+    boundary_cut_conductance,
+    exterior_precision,
+    boundary_coupling,
+    harmonic_extension,
+    schur_return,
+    reduced_boundary_precision,
+    minimum_reciprocal_condition,
+):
+    return {
+        "component_fingerprint": str(component_fingerprint),
+        "ports": [_stable_node_token(node) for node in ports],
+        "exterior_nodes": [
+            _stable_node_token(node) for node in exterior_nodes
+        ],
+        "topology_conductance": float(topology_conductance).hex(),
+        "intrinsic_leakage_conductance": _float_hex_vector(
+            intrinsic_leakage_conductance
+        ),
+        "boundary_cut_conductance": _float_hex_vector(
+            boundary_cut_conductance
+        ),
+        "exterior_precision": _float_hex_matrix(exterior_precision),
+        "boundary_coupling": _float_hex_matrix(boundary_coupling),
+        "harmonic_extension": _float_hex_vector(harmonic_extension),
+        "schur_return": _float_hex_matrix(schur_return),
+        "reduced_boundary_precision": _float_hex_matrix(
+            reduced_boundary_precision
+        ),
+        "minimum_reciprocal_condition": float(
+            minimum_reciprocal_condition
+        ).hex(),
+    }
+
+
+def _exterior_leakage_vector(nodes, intrinsic_leakage_conductance):
+    if isinstance(intrinsic_leakage_conductance, Mapping):
+        unknown = set(intrinsic_leakage_conductance).difference(nodes)
+        if unknown:
+            labels = ", ".join(sorted(repr(node) for node in unknown))
+            raise ValueError(
+                "intrinsic leakage mapping contains unknown exterior nodes: "
+                f"{labels}"
+            )
+        values = np.asarray(
+            [
+                intrinsic_leakage_conductance.get(node, 0.0)
+                for node in nodes
+            ],
+            dtype=float,
+        )
+    else:
+        values = np.asarray(intrinsic_leakage_conductance, dtype=float)
+        if values.ndim == 0:
+            values = np.full(len(nodes), float(values), dtype=float)
+    if values.shape != (len(nodes),):
+        raise ValueError(
+            "intrinsic_leakage_conductance must be a scalar, exterior-node "
+            "mapping, or exterior-node-aligned vector"
+        )
+    if not np.isfinite(values).all() or np.any(values < 0.0):
+        raise ValueError(
+            "intrinsic leakage conductance must be finite and nonnegative"
+        )
+    return values
+
+
+@dataclass(frozen=True)
+class ExactExteriorSchurReduction:
+    """Exact grounded multi-port reduction of one frozen exterior component.
+
+    ``schur_return`` is the positive matrix
+    ``C @ exterior_precision^-1 @ C.T``. It is subtracted exactly once from
+    the full-Dirichlet boundary precision. ``reduced_boundary_precision`` is
+    the exterior contribution
+    ``diag(boundary_cut_conductance) - schur_return``;
+    it may be singular when the represented exterior has no route to ground.
+    """
+
+    component_fingerprint: str
+    ports: tuple
+    exterior_nodes: tuple
+    topology_conductance: float
+    intrinsic_leakage_conductance: np.ndarray
+    boundary_cut_conductance: np.ndarray
+    exterior_precision: np.ndarray
+    boundary_coupling: np.ndarray
+    harmonic_extension: np.ndarray
+    schur_return: np.ndarray
+    reduced_boundary_precision: np.ndarray
+    minimum_exterior_precision_eigenvalue: float
+    maximum_exterior_precision_eigenvalue: float
+    reciprocal_condition_number: float
+    minimum_reciprocal_condition: float
+    cholesky_reconstruction_relative_error: float
+    solve_relative_residual: float
+    maximum_principle_violation: float
+    minimum_schur_return_eigenvalue: float
+    minimum_reduced_precision_eigenvalue: float
+    ledger_maximum_absolute_error: float
+    reduction_fingerprint: str
+
+    def __post_init__(self):
+        ports = tuple(self.ports)
+        exterior_nodes = tuple(self.exterior_nodes)
+        component_fingerprint = str(self.component_fingerprint)
+        if len(component_fingerprint) != 64 or any(
+            character not in "0123456789abcdef"
+            for character in component_fingerprint
+        ):
+            raise ValueError(
+                "component_fingerprint must be lowercase SHA-256"
+            )
+        if not ports or not exterior_nodes:
+            raise ValueError("an exact exterior reduction needs ports and nodes")
+        if ports != tuple(sorted(ports, key=_stable_key)):
+            raise ValueError("reduction ports must use canonical stable order")
+        if exterior_nodes != tuple(sorted(exterior_nodes, key=_stable_key)):
+            raise ValueError(
+                "reduction exterior nodes must use canonical stable order"
+            )
+        if len(set(ports)) != len(ports) or len(set(exterior_nodes)) != len(
+            exterior_nodes
+        ):
+            raise ValueError("reduction ports and exterior nodes must be unique")
+        topology = _positive_finite(
+            "topology_conductance", self.topology_conductance
+        )
+        port_count = len(ports)
+        node_count = len(exterior_nodes)
+        arrays = {
+            "intrinsic_leakage_conductance": np.asarray(
+                self.intrinsic_leakage_conductance, dtype=float
+            ),
+            "boundary_cut_conductance": np.asarray(
+                self.boundary_cut_conductance, dtype=float
+            ),
+            "exterior_precision": np.asarray(
+                self.exterior_precision, dtype=float
+            ),
+            "boundary_coupling": np.asarray(
+                self.boundary_coupling, dtype=float
+            ),
+            "harmonic_extension": np.asarray(
+                self.harmonic_extension, dtype=float
+            ),
+            "schur_return": np.asarray(self.schur_return, dtype=float),
+            "reduced_boundary_precision": np.asarray(
+                self.reduced_boundary_precision, dtype=float
+            ),
+        }
+        expected_shapes = {
+            "intrinsic_leakage_conductance": (node_count,),
+            "boundary_cut_conductance": (port_count,),
+            "exterior_precision": (node_count, node_count),
+            "boundary_coupling": (port_count, node_count),
+            "harmonic_extension": (node_count,),
+            "schur_return": (port_count, port_count),
+            "reduced_boundary_precision": (port_count, port_count),
+        }
+        for name, value in arrays.items():
+            if value.shape != expected_shapes[name]:
+                raise ValueError(
+                    f"{name} must have shape {expected_shapes[name]}"
+                )
+            if not np.isfinite(value).all():
+                raise ValueError("exact exterior reduction arrays must be finite")
+        if np.any(arrays["intrinsic_leakage_conductance"] < 0.0):
+            raise ValueError("intrinsic leakage must be nonnegative")
+        if np.any(arrays["boundary_coupling"] < 0.0):
+            raise ValueError("boundary coupling must be nonnegative")
+        expected_beta = np.sum(arrays["boundary_coupling"], axis=1)
+        if not np.allclose(
+            arrays["boundary_cut_conductance"],
+            expected_beta,
+            rtol=1e-12,
+            atol=1e-12,
+        ):
+            raise ValueError(
+                "boundary cut conductance must equal the coupling row sums"
+            )
+        arrays["boundary_cut_conductance"] = expected_beta
+        for name in (
+            "exterior_precision",
+            "schur_return",
+            "reduced_boundary_precision",
+        ):
+            if not np.allclose(
+                arrays[name], arrays[name].T, rtol=0.0, atol=1e-12
+            ):
+                raise ValueError(f"{name} must be symmetric")
+        expected_reduced = np.diag(expected_beta) - arrays["schur_return"]
+        if not np.allclose(
+            arrays["reduced_boundary_precision"],
+            expected_reduced,
+            rtol=1e-12,
+            atol=1e-12,
+        ):
+            raise ValueError(
+                "reduced boundary precision must equal diag(beta) minus "
+                "the Schur return"
+            )
+        precision = arrays["exterior_precision"]
+        coupling = arrays["boundary_coupling"]
+        precision_scale = max(
+            float(np.max(np.abs(precision), initial=0.0)), 1.0
+        )
+        precision_sign_tolerance = max(
+            _M_MATRIX_OFF_DIAGONAL_TOLERANCE * precision_scale,
+            64.0 * np.finfo(float).eps * precision_scale,
+        )
+        precision_off_diagonal = precision - np.diag(np.diag(precision))
+        if (
+            np.max(precision_off_diagonal, initial=0.0)
+            > precision_sign_tolerance
+        ):
+            raise ValueError(
+                "exterior precision violates M-matrix off-diagonal signs"
+            )
+        precision_eigenvalues = np.linalg.eigvalsh(precision)
+        observed_minimum = _positive_finite(
+            "minimum_exterior_precision_eigenvalue",
+            self.minimum_exterior_precision_eigenvalue,
+        )
+        observed_maximum = _positive_finite(
+            "maximum_exterior_precision_eigenvalue",
+            self.maximum_exterior_precision_eigenvalue,
+        )
+        observed_reciprocal = _positive_unit_interval(
+            "reciprocal_condition_number", self.reciprocal_condition_number
+        )
+        required_reciprocal = _positive_unit_interval(
+            "minimum_reciprocal_condition",
+            self.minimum_reciprocal_condition,
+        )
+        expected_minimum = float(precision_eigenvalues[0])
+        expected_maximum = float(precision_eigenvalues[-1])
+        if expected_minimum < 1.0 / np.finfo(float).max:
+            raise ValueError(
+                "exterior precision has an unrepresentable equilibrium scale"
+            )
+        expected_reciprocal = expected_minimum / expected_maximum
+        diagnostics = (
+            (observed_minimum, expected_minimum),
+            (observed_maximum, expected_maximum),
+            (observed_reciprocal, expected_reciprocal),
+        )
+        if any(
+            not math.isclose(left, right, rel_tol=1e-10, abs_tol=0.0)
+            for left, right in diagnostics
+        ):
+            raise ValueError(
+                "exterior precision spectral diagnostics do not match"
+            )
+        if observed_reciprocal < required_reciprocal:
+            raise ValueError(
+                "reciprocal condition violates the recorded contract"
+            )
+        try:
+            lower = np.linalg.cholesky(precision)
+            intermediate = np.linalg.solve(lower, coupling.T)
+            expected_solved = np.linalg.solve(lower.T, intermediate)
+        except np.linalg.LinAlgError as exc:
+            raise ValueError(
+                "exterior precision and coupling fail exact reduction"
+            ) from exc
+        reconstructed = lower @ lower.T
+        reconstruction_relative_error = float(
+            np.linalg.norm(reconstructed - precision, ord="fro")
+            / max(
+                np.linalg.norm(precision, ord="fro"),
+                np.finfo(float).tiny,
+            )
+        )
+        solve_relative_residual = float(
+            np.linalg.norm(
+                precision @ expected_solved - coupling.T, ord=np.inf
+            )
+            / max(
+                np.linalg.norm(coupling.T, ord=np.inf),
+                np.finfo(float).tiny,
+            )
+        )
+        expected_return = _symmetric_part(coupling @ expected_solved)
+        expected_harmonic = expected_solved @ np.ones(port_count)
+        expected_maximum_principle_violation = max(
+            float(np.max(-expected_solved, initial=0.0)),
+            float(np.max(-expected_harmonic, initial=0.0)),
+            float(np.max(expected_harmonic - 1.0, initial=0.0)),
+            0.0,
+        )
+        boundary_scale = max(
+            float(np.max(np.abs(arrays["schur_return"]), initial=0.0)),
+            float(
+                np.max(
+                    np.abs(arrays["reduced_boundary_precision"]),
+                    initial=0.0,
+                )
+            ),
+            float(np.max(expected_beta, initial=0.0)),
+            1.0,
+        )
+        entry_tolerance = max(
+            _M_MATRIX_OFF_DIAGONAL_TOLERANCE * boundary_scale,
+            64.0 * np.finfo(float).eps * boundary_scale,
+        )
+        spectral_tolerance = (
+            _MAXIMUM_PRINCIPLE_RELATIVE_TOLERANCE * boundary_scale
+        )
+        if not np.allclose(
+            arrays["schur_return"],
+            expected_return,
+            rtol=1e-10,
+            atol=entry_tolerance,
+        ):
+            raise ValueError(
+                "Schur return does not match exterior precision and coupling"
+            )
+        if not np.allclose(
+            arrays["harmonic_extension"],
+            expected_harmonic,
+            rtol=1e-10,
+            atol=1e-12,
+        ):
+            raise ValueError(
+                "harmonic extension does not match the exterior solve"
+            )
+        if np.min(arrays["schur_return"]) < -entry_tolerance:
+            raise ValueError("Schur return must be entrywise nonnegative")
+        if (
+            np.min(np.linalg.eigvalsh(arrays["schur_return"]))
+            < -spectral_tolerance
+        ):
+            raise ValueError("Schur return must be positive semidefinite")
+        reduced = arrays["reduced_boundary_precision"]
+        off_diagonal = reduced - np.diag(np.diag(reduced))
+        if np.max(off_diagonal, initial=0.0) > entry_tolerance:
+            raise ValueError(
+                "reduced boundary precision must have nonpositive "
+                "off-diagonal entries"
+            )
+        if np.min(np.linalg.eigvalsh(reduced)) < -spectral_tolerance:
+            raise ValueError(
+                "reduced boundary precision must be positive semidefinite"
+            )
+        residual = reduced @ np.ones(port_count)
+        if np.min(residual, initial=0.0) < -entry_tolerance:
+            raise ValueError(
+                "reduced boundary precision has negative residual grounding"
+            )
+        bridge = np.array(arrays["schur_return"], copy=True)
+        np.fill_diagonal(bridge, 0.0)
+        reconstructed_reduced = (
+            np.diag(np.sum(bridge, axis=1))
+            - bridge
+            + np.diag(residual)
+        )
+        if not np.allclose(
+            reduced,
+            reconstructed_reduced,
+            rtol=1e-12,
+            atol=entry_tolerance,
+        ):
+            raise ValueError(
+                "reduced boundary precision does not reconstruct from its "
+                "transfer and residual-ground ledger"
+            )
+        self_return = np.diag(arrays["schur_return"])
+        transfer = np.sum(arrays["schur_return"], axis=1) - self_return
+        ledger_error = float(
+            np.max(
+                np.abs(expected_beta - self_return - transfer - residual),
+                initial=0.0,
+            )
+        )
+        observed_ledger_error = _finite_nonnegative(
+            "ledger_maximum_absolute_error",
+            self.ledger_maximum_absolute_error,
+        )
+        if not math.isclose(
+            observed_ledger_error,
+            ledger_error,
+            rel_tol=1e-10,
+            abs_tol=1e-15,
+        ):
+            raise ValueError("ledger diagnostic does not match reduction")
+        diagnostic_comparisons = (
+            (
+                "cholesky_reconstruction_relative_error",
+                self.cholesky_reconstruction_relative_error,
+                reconstruction_relative_error,
+                _CHOLESKY_RECONSTRUCTION_RTOL,
+            ),
+            (
+                "solve_relative_residual",
+                self.solve_relative_residual,
+                solve_relative_residual,
+                _SOLVE_RELATIVE_RESIDUAL_TOLERANCE,
+            ),
+            (
+                "maximum_principle_violation",
+                self.maximum_principle_violation,
+                expected_maximum_principle_violation,
+                _MAXIMUM_PRINCIPLE_RELATIVE_TOLERANCE,
+            ),
+        )
+        for name, value, expected, maximum in diagnostic_comparisons:
+            observed = _finite_nonnegative(name, value)
+            if observed > maximum:
+                raise ValueError(f"{name} violates the recorded contract")
+            if not math.isclose(
+                observed, expected, rel_tol=1e-10, abs_tol=1e-15
+            ):
+                raise ValueError(f"{name} does not match the reduction")
+            object.__setattr__(self, name, observed)
+        minimum_return = float(
+            np.min(np.linalg.eigvalsh(arrays["schur_return"]))
+        )
+        minimum_reduced = float(np.min(np.linalg.eigvalsh(reduced)))
+        for name, observed, expected in (
+            (
+                "minimum_schur_return_eigenvalue",
+                float(self.minimum_schur_return_eigenvalue),
+                minimum_return,
+            ),
+            (
+                "minimum_reduced_precision_eigenvalue",
+                float(self.minimum_reduced_precision_eigenvalue),
+                minimum_reduced,
+            ),
+        ):
+            if not math.isfinite(observed) or not math.isclose(
+                observed, expected, rel_tol=1e-10, abs_tol=1e-15
+            ):
+                raise ValueError(f"{name} does not match the reduction")
+        payload = _exact_reduction_fingerprint_payload(
+            component_fingerprint=component_fingerprint,
+            ports=ports,
+            exterior_nodes=exterior_nodes,
+            topology_conductance=topology,
+            intrinsic_leakage_conductance=(
+                arrays["intrinsic_leakage_conductance"]
+            ),
+            boundary_cut_conductance=expected_beta,
+            exterior_precision=precision,
+            boundary_coupling=coupling,
+            harmonic_extension=arrays["harmonic_extension"],
+            schur_return=arrays["schur_return"],
+            reduced_boundary_precision=reduced,
+            minimum_reciprocal_condition=required_reciprocal,
+        )
+        fingerprint = str(self.reduction_fingerprint)
+        if fingerprint != _fingerprint(payload):
+            raise ValueError(
+                "reduction_fingerprint does not match exact reduction"
+            )
+        object.__setattr__(
+            self, "component_fingerprint", component_fingerprint
+        )
+        object.__setattr__(self, "ports", ports)
+        object.__setattr__(self, "exterior_nodes", exterior_nodes)
+        object.__setattr__(self, "topology_conductance", topology)
+        object.__setattr__(
+            self, "minimum_reciprocal_condition", required_reciprocal
+        )
+        object.__setattr__(
+            self, "reciprocal_condition_number", observed_reciprocal
+        )
+        object.__setattr__(
+            self,
+            "minimum_exterior_precision_eigenvalue",
+            observed_minimum,
+        )
+        object.__setattr__(
+            self,
+            "maximum_exterior_precision_eigenvalue",
+            observed_maximum,
+        )
+        object.__setattr__(
+            self, "ledger_maximum_absolute_error", observed_ledger_error
+        )
+        object.__setattr__(self, "reduction_fingerprint", fingerprint)
+        for name, value in arrays.items():
+            object.__setattr__(self, name, _readonly(value))
+
+    @property
+    def bridge_conductance(self):
+        output = np.array(self.schur_return, copy=True)
+        np.fill_diagonal(output, 0.0)
+        return _readonly(np.maximum(output, 0.0))
+
+    @property
+    def self_return_conductance(self):
+        return _readonly(np.maximum(np.diag(self.schur_return), 0.0))
+
+    @property
+    def transfer_degree(self):
+        return _readonly(np.sum(self.bridge_conductance, axis=1))
+
+    @property
+    def residual_ground_conductance(self):
+        residual = self.reduced_boundary_precision @ np.ones(len(self.ports))
+        return _readonly(np.maximum(residual, 0.0))
+
+    @property
+    def pair_conductances(self):
+        return tuple(
+            (
+                self.ports[left],
+                self.ports[right],
+                float(self.schur_return[left, right]),
+            )
+            for left in range(len(self.ports))
+            for right in range(left + 1, len(self.ports))
+            if self.schur_return[left, right] > 0.0
+        )
+
+    @property
+    def self_return_by_port(self):
+        values = self.self_return_conductance
+        return {
+            port: float(values[index])
+            for index, port in enumerate(self.ports)
+        }
+
+    def provenance_dict(self):
+        return {
+            "component_fingerprint": self.component_fingerprint,
+            "reduction_fingerprint": self.reduction_fingerprint,
+            "ports": [_stable_node_token(node) for node in self.ports],
+            "exterior_nodes": [
+                _stable_node_token(node) for node in self.exterior_nodes
+            ],
+            "topology_conductance": self.topology_conductance,
+            "intrinsic_leakage_conductance": (
+                self.intrinsic_leakage_conductance.tolist()
+            ),
+            "boundary_cut_conductance": (
+                self.boundary_cut_conductance.tolist()
+            ),
+            "pair_conductances": [
+                [
+                    _stable_node_token(left),
+                    _stable_node_token(right),
+                    conductance,
+                ]
+                for left, right, conductance in self.pair_conductances
+            ],
+            "self_return_conductance": (
+                self.self_return_conductance.tolist()
+            ),
+            "transfer_degree": self.transfer_degree.tolist(),
+            "residual_ground_conductance": (
+                self.residual_ground_conductance.tolist()
+            ),
+            "minimum_exterior_precision_eigenvalue": (
+                self.minimum_exterior_precision_eigenvalue
+            ),
+            "maximum_exterior_precision_eigenvalue": (
+                self.maximum_exterior_precision_eigenvalue
+            ),
+            "reciprocal_condition_number": (
+                self.reciprocal_condition_number
+            ),
+            "minimum_reciprocal_condition": (
+                self.minimum_reciprocal_condition
+            ),
+            "cholesky_reconstruction_relative_error": (
+                self.cholesky_reconstruction_relative_error
+            ),
+            "solve_relative_residual": self.solve_relative_residual,
+            "maximum_principle_violation": (
+                self.maximum_principle_violation
+            ),
+            "minimum_schur_return_eigenvalue": (
+                self.minimum_schur_return_eigenvalue
+            ),
+            "minimum_reduced_precision_eigenvalue": (
+                self.minimum_reduced_precision_eigenvalue
+            ),
+            "ledger_maximum_absolute_error": (
+                self.ledger_maximum_absolute_error
+            ),
+        }
+
+
+def reduce_exact_exterior_component(
+    component,
+    *,
+    intrinsic_leakage_conductance=0.0,
+    topology_conductance=1.0,
+    minimum_reciprocal_condition=None,
+):
+    """Reduce one complete frozen exterior component without an explicit inverse.
+
+    The component snapshot is the sole topology authority. Outside-bath edges
+    remain clamped to zero, while every listed port is retained jointly. The
+    resulting multi-terminal operator is exact for that frozen Dirichlet
+    exterior and must not be reconstructed from independent pair solves.
+    """
+
+    if not isinstance(component, ExteriorComponent):
+        raise TypeError("component must be an ExteriorComponent")
+    topology = _positive_finite(
+        "topology_conductance", topology_conductance
+    )
+    required_reciprocal = (
+        _DEFAULT_MINIMUM_RECIPROCAL_CONDITION
+        if minimum_reciprocal_condition is None
+        else _positive_unit_interval(
+            "minimum_reciprocal_condition",
+            minimum_reciprocal_condition,
+        )
+    )
+    nodes = component.nodes
+    ports = component.ports
+    node_index = {node: row for row, node in enumerate(nodes)}
+    port_index = {port: row for row, port in enumerate(ports)}
+    leakage = _exterior_leakage_vector(
+        nodes, intrinsic_leakage_conductance
+    )
+    precision = np.diag(leakage)
+    coupling = np.zeros((len(ports), len(nodes)), dtype=float)
+    for left, right in component.internal_edges:
+        left_row = node_index[left]
+        right_row = node_index[right]
+        precision[left_row, left_row] += topology
+        precision[right_row, right_row] += topology
+        precision[left_row, right_row] -= topology
+        precision[right_row, left_row] -= topology
+    for port, exterior in component.cut_edges:
+        port_row = port_index[port]
+        exterior_row = node_index[exterior]
+        precision[exterior_row, exterior_row] += topology
+        coupling[port_row, exterior_row] += topology
+    for exterior, _outside in component.outside_bath_edges:
+        precision[node_index[exterior], node_index[exterior]] += topology
+    raw_precision_scale = float(
+        np.max(np.abs(precision), initial=0.0)
+    )
+    if raw_precision_scale < 1.0 / np.finfo(float).max:
+        raise np.linalg.LinAlgError(
+            "exterior precision has an unrepresentable equilibrium scale"
+        )
+    precision = _symmetric_part(precision)
+    precision_scale = max(
+        float(np.max(np.abs(precision), initial=0.0)), 1.0
+    )
+    precision_sign_tolerance = max(
+        _M_MATRIX_OFF_DIAGONAL_TOLERANCE * precision_scale,
+        64.0 * np.finfo(float).eps * precision_scale,
+    )
+    if np.max(
+        precision - np.diag(np.diag(precision)), initial=0.0
+    ) > precision_sign_tolerance:
+        raise np.linalg.LinAlgError(
+            "exterior precision violates M-matrix off-diagonal signs"
+        )
+    eigenvalues = np.linalg.eigvalsh(precision)
+    minimum = float(eigenvalues[0])
+    maximum = float(eigenvalues[-1])
+    if (
+        not math.isfinite(minimum)
+        or not math.isfinite(maximum)
+        or minimum <= 0.0
+        or maximum <= 0.0
+    ):
+        raise np.linalg.LinAlgError(
+            "exterior precision must be finite and positive definite"
+        )
+    if minimum < 1.0 / np.finfo(float).max:
+        raise np.linalg.LinAlgError(
+            "exterior precision has an unrepresentable equilibrium scale"
+        )
+    reciprocal = minimum / maximum
+    if reciprocal < required_reciprocal:
+        raise np.linalg.LinAlgError(
+            "exterior precision is too ill-conditioned for the requested "
+            "float64 contract: reciprocal condition "
+            f"{reciprocal:.3e} < {required_reciprocal:.3e}"
+        )
+    try:
+        lower = np.linalg.cholesky(precision)
+    except np.linalg.LinAlgError as exc:
+        raise np.linalg.LinAlgError(
+            "exterior precision failed Cholesky factorization"
+        ) from exc
+    reconstructed = lower @ lower.T
+    reconstruction_relative_error = float(
+        np.linalg.norm(reconstructed - precision, ord="fro")
+        / max(
+            np.linalg.norm(precision, ord="fro"),
+            np.finfo(float).tiny,
+        )
+    )
+    if (
+        reconstruction_relative_error > _CHOLESKY_RECONSTRUCTION_RTOL
+        or not np.allclose(
+            reconstructed,
+            precision,
+            rtol=_CHOLESKY_RECONSTRUCTION_RTOL,
+            atol=_CHOLESKY_RECONSTRUCTION_ATOL,
+        )
+    ):
+        raise np.linalg.LinAlgError(
+            "exterior Cholesky factor does not reconstruct precision"
+        )
+    try:
+        intermediate = np.linalg.solve(lower, coupling.T)
+        solved = np.linalg.solve(lower.T, intermediate)
+    except np.linalg.LinAlgError as exc:
+        raise np.linalg.LinAlgError(
+            "exterior multi-right-hand-side solve failed"
+        ) from exc
+    solve_relative_residual = float(
+        np.linalg.norm(precision @ solved - coupling.T, ord=np.inf)
+        / max(
+            np.linalg.norm(coupling.T, ord=np.inf),
+            np.finfo(float).tiny,
+        )
+    )
+    if (
+        not math.isfinite(solve_relative_residual)
+        or solve_relative_residual > _SOLVE_RELATIVE_RESIDUAL_TOLERANCE
+    ):
+        raise np.linalg.LinAlgError(
+            "exterior solve residual violates the float64 contract"
+        )
+    harmonic = solved @ np.ones(len(ports))
+    maximum_principle_violation = max(
+        float(np.max(-solved, initial=0.0)),
+        float(np.max(-harmonic, initial=0.0)),
+        float(np.max(harmonic - 1.0, initial=0.0)),
+        0.0,
+    )
+    if maximum_principle_violation > _MAXIMUM_PRINCIPLE_RELATIVE_TOLERANCE:
+        raise np.linalg.LinAlgError(
+            "exterior harmonic extension violates the maximum principle"
+        )
+    schur_return = _symmetric_part(coupling @ solved)
+    beta = np.sum(coupling, axis=1)
+    scale = max(
+        float(np.max(np.abs(schur_return), initial=0.0)),
+        float(np.max(beta, initial=0.0)),
+        topology,
+        1.0,
+    )
+    tolerance = max(
+        _M_MATRIX_OFF_DIAGONAL_TOLERANCE * scale,
+        64.0 * np.finfo(float).eps * scale,
+    )
+    if np.min(schur_return, initial=0.0) < -tolerance:
+        raise np.linalg.LinAlgError(
+            "exterior Schur return is materially negative"
+        )
+    minimum_return_eigenvalue = float(
+        np.min(np.linalg.eigvalsh(schur_return))
+    )
+    spectral_tolerance = _MAXIMUM_PRINCIPLE_RELATIVE_TOLERANCE * scale
+    if minimum_return_eigenvalue < -spectral_tolerance:
+        raise np.linalg.LinAlgError(
+            "exterior Schur return is not positive semidefinite"
+        )
+    reduced = _symmetric_part(np.diag(beta) - schur_return)
+    off_diagonal = reduced - np.diag(np.diag(reduced))
+    if np.max(off_diagonal, initial=0.0) > tolerance:
+        raise np.linalg.LinAlgError(
+            "reduced boundary precision violates M-matrix signs"
+        )
+    minimum_reduced_eigenvalue = float(
+        np.min(np.linalg.eigvalsh(reduced))
+    )
+    if minimum_reduced_eigenvalue < -spectral_tolerance:
+        raise np.linalg.LinAlgError(
+            "reduced boundary precision is not positive semidefinite"
+        )
+    residual = reduced @ np.ones(len(ports))
+    if np.min(residual, initial=0.0) < -tolerance:
+        raise np.linalg.LinAlgError(
+            "reduced boundary precision has negative residual grounding"
+        )
+    bridge = np.array(schur_return, copy=True)
+    np.fill_diagonal(bridge, 0.0)
+    reconstructed_reduced = (
+        np.diag(np.sum(bridge, axis=1))
+        - bridge
+        + np.diag(residual)
+    )
+    if not np.allclose(
+        reduced,
+        reconstructed_reduced,
+        rtol=1e-12,
+        atol=tolerance,
+    ):
+        raise np.linalg.LinAlgError(
+            "reduced boundary precision does not reconstruct from its "
+            "transfer and residual-ground ledger"
+        )
+    self_return = np.diag(schur_return)
+    transfer = np.sum(schur_return, axis=1) - self_return
+    ledger_error = float(
+        np.max(
+            np.abs(beta - self_return - transfer - residual),
+            initial=0.0,
+        )
+    )
+    if ledger_error > max(tolerance, 1e-12 * scale):
+        raise np.linalg.LinAlgError(
+            "exact exterior reduction does not close its cut-mass ledger"
+        )
+    fingerprint_payload = _exact_reduction_fingerprint_payload(
+        component_fingerprint=component.component_fingerprint,
+        ports=ports,
+        exterior_nodes=nodes,
+        topology_conductance=topology,
+        intrinsic_leakage_conductance=leakage,
+        boundary_cut_conductance=beta,
+        exterior_precision=precision,
+        boundary_coupling=coupling,
+        harmonic_extension=harmonic,
+        schur_return=schur_return,
+        reduced_boundary_precision=reduced,
+        minimum_reciprocal_condition=required_reciprocal,
+    )
+    return ExactExteriorSchurReduction(
+        component_fingerprint=component.component_fingerprint,
+        ports=ports,
+        exterior_nodes=nodes,
+        topology_conductance=topology,
+        intrinsic_leakage_conductance=leakage,
+        boundary_cut_conductance=beta,
+        exterior_precision=precision,
+        boundary_coupling=coupling,
+        harmonic_extension=harmonic,
+        schur_return=schur_return,
+        reduced_boundary_precision=reduced,
+        minimum_exterior_precision_eigenvalue=minimum,
+        maximum_exterior_precision_eigenvalue=maximum,
+        reciprocal_condition_number=reciprocal,
+        minimum_reciprocal_condition=required_reciprocal,
+        cholesky_reconstruction_relative_error=(
+            reconstruction_relative_error
+        ),
+        solve_relative_residual=solve_relative_residual,
+        maximum_principle_violation=maximum_principle_violation,
+        minimum_schur_return_eigenvalue=minimum_return_eigenvalue,
+        minimum_reduced_precision_eigenvalue=(
+            minimum_reduced_eigenvalue
+        ),
+        ledger_maximum_absolute_error=ledger_error,
+        reduction_fingerprint=_fingerprint(fingerprint_payload),
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/test_bounded_diffusion_fidelity.py
+++ b/tests/test_bounded_diffusion_fidelity.py
@@ -21,6 +21,7 @@ from unifyweaver.graph.bounded_diffusion_fidelity import (  # noqa: E402
     _conservative_upper_quantile,
     ExperimentalBoundaryClosure,
     ExperimentalBoundaryClosureConfig,
+    ExactExteriorSchurReduction,
     ExteriorTraversalLimitError,
     ProtectedSetCoverageError,
     build_experimental_boundary_closure,
@@ -28,6 +29,7 @@ from unifyweaver.graph.bounded_diffusion_fidelity import (  # noqa: E402
     ensure_matched_budget,
     evaluate_bounded_domain_fidelity,
     evaluate_nested_bounded_domain_fidelity,
+    reduce_exact_exterior_component,
     select_hop_budget_domain,
     select_semantic_resistance_domain,
     select_topology_skeleton_domain,
@@ -397,6 +399,383 @@ def _schur_precision(full, retained, exterior):
     j_rx = full.precision[np.ix_(retained, exterior)]
     j_xx = full.precision[np.ix_(exterior, exterior)]
     return j_rr - j_rx @ np.linalg.solve(j_xx, j_rx.T)
+
+
+def _exterior_component(graph, ports, *, allowed_exterior_nodes=None):
+    ports = tuple(ports)
+    domain = select_hop_budget_domain(
+        ports, graph, maximum_nodes=len(ports)
+    ).domain
+    discovery = discover_exterior_components(
+        domain,
+        graph,
+        allowed_exterior_nodes=allowed_exterior_nodes,
+    )
+    assert discovery.component_count == 1
+    return discovery.components[0]
+
+
+def test_exact_multiport_schur_matches_grounded_three_port_star_identity():
+    graph = _neighbors((("p", "x"), ("q", "x"), ("r", "x")))
+    component = _exterior_component(graph, ("p", "q", "r"))
+    reduction = reduce_exact_exterior_component(
+        component, intrinsic_leakage_conductance=1.0
+    )
+    expected_return = np.ones((3, 3)) / 4.0
+    expected_reduced = np.eye(3) - expected_return
+
+    assert isinstance(reduction, ExactExteriorSchurReduction)
+    assert np.allclose(
+        reduction.schur_return, expected_return, rtol=1e-10, atol=1e-12
+    )
+    assert np.allclose(
+        reduction.reduced_boundary_precision,
+        expected_reduced,
+        rtol=1e-10,
+        atol=1e-12,
+    )
+    assert np.allclose(
+        reduction.boundary_cut_conductance,
+        np.ones(3),
+        rtol=1e-10,
+        atol=1e-12,
+    )
+    assert np.allclose(
+        reduction.self_return_conductance,
+        np.full(3, 0.25),
+        rtol=1e-10,
+        atol=1e-12,
+    )
+    assert np.allclose(
+        reduction.transfer_degree,
+        np.full(3, 0.5),
+        rtol=1e-10,
+        atol=1e-12,
+    )
+    assert np.allclose(
+        reduction.residual_ground_conductance,
+        np.full(3, 0.25),
+        rtol=1e-10,
+        atol=1e-12,
+    )
+    assert reduction.pair_conductances == (
+        ("p", "q", pytest.approx(0.25)),
+        ("p", "r", pytest.approx(0.25)),
+        ("q", "r", pytest.approx(0.25)),
+    )
+    assert np.allclose(
+        reduction.boundary_cut_conductance,
+        reduction.self_return_conductance
+        + reduction.transfer_degree
+        + reduction.residual_ground_conductance,
+        rtol=1e-10,
+        atol=1e-12,
+    )
+
+    source = np.array([1.0, -1.0, 0.0])
+    effective_resistance = float(
+        source
+        @ np.linalg.solve(reduction.reduced_boundary_precision, source)
+    )
+    assert effective_resistance == pytest.approx(2.0)
+    assert 1.0 / effective_resistance != pytest.approx(
+        reduction.schur_return[0, 1]
+    )
+
+
+def test_exact_multiport_schur_matches_direct_full_graph_elimination():
+    graph = _neighbors(
+        (
+            ("p", "a"),
+            ("q", "a"),
+            ("a", "b"),
+            ("b", "c"),
+            ("c", "a"),
+            ("p", "q"),
+            ("r", "b"),
+            ("s", "c"),
+        )
+    )
+    ports = ("p", "q", "r", "s")
+    exterior = ("a", "b", "c")
+    component = _exterior_component(graph, ports)
+    reduction = reduce_exact_exterior_component(
+        component,
+        intrinsic_leakage_conductance={
+            "a": 0.2,
+            "b": 0.2,
+            "c": 0.2,
+        },
+    )
+    nodes = ports + exterior
+    full = build_grounded_semantic_diffusion(
+        nodes,
+        graph,
+        leakage_conductance={
+            "p": 0.3,
+            "q": 0.3,
+            "r": 0.3,
+            "s": 0.3,
+            "a": 0.2,
+            "b": 0.2,
+            "c": 0.2,
+        },
+    )
+    expected = _schur_precision(
+        full,
+        retained=range(len(ports)),
+        exterior=range(len(ports), len(nodes)),
+    )
+    public_boundary_precision = np.diag(np.full(len(ports), 0.3))
+    public_boundary_precision[0, 0] += 1.0
+    public_boundary_precision[1, 1] += 1.0
+    public_boundary_precision[0, 1] -= 1.0
+    public_boundary_precision[1, 0] -= 1.0
+    observed = (
+        public_boundary_precision + reduction.reduced_boundary_precision
+    )
+    assert np.allclose(observed, expected, rtol=1e-10, atol=1e-12)
+
+    sources = np.array(
+        (
+            (1.0, 0.0, 0.5),
+            (0.0, 1.0, 0.5),
+            (0.5, 0.0, 1.0),
+            (0.0, 0.5, 1.0),
+        )
+    )
+    full_sources = np.zeros((len(nodes), sources.shape[1]))
+    full_sources[: len(ports)] = sources
+    assert np.allclose(
+        np.linalg.solve(observed, sources),
+        full.equilibrium_response(full_sources)[: len(ports)],
+        rtol=1e-10,
+        atol=1e-12,
+    )
+
+
+def test_exact_multiport_schur_does_not_cap_parallel_graph_return():
+    hubs = ("x1", "x2", "x3", "x4")
+    edges = [
+        (port, hub)
+        for port in ("p", "q", "r")
+        for hub in hubs
+    ]
+    edges.extend(zip(hubs, hubs[1:]))
+    graph = _neighbors(edges)
+    component = _exterior_component(graph, ("p", "q", "r"))
+    reduction = reduce_exact_exterior_component(component)
+
+    assert np.allclose(
+        reduction.schur_return,
+        np.full((3, 3), 4.0 / 3.0),
+        rtol=1e-10,
+        atol=1e-12,
+    )
+    assert reduction.schur_return[0, 1] > reduction.topology_conductance
+    assert np.allclose(
+        reduction.residual_ground_conductance,
+        np.zeros(3),
+        rtol=1e-10,
+        atol=1e-12,
+    )
+    assert reduction.minimum_reduced_precision_eigenvalue >= -1e-10
+
+
+def test_exact_multiport_schur_is_invariant_to_input_and_identifier_order():
+    ports = (1, "p", ("r",))
+    edges = (
+        (1, "x"),
+        ("p", "x"),
+        (("r",), "y"),
+        ("x", "y"),
+    )
+    first_graph = _neighbors(edges)
+    second_graph = _neighbors(reversed(edges))
+    first_component = _exterior_component(first_graph, reversed(ports))
+    second_component = _exterior_component(second_graph, ports)
+    first = reduce_exact_exterior_component(
+        first_component,
+        intrinsic_leakage_conductance={"x": 0.1, "y": 0.3},
+    )
+    second = reduce_exact_exterior_component(
+        second_component,
+        intrinsic_leakage_conductance={"y": 0.3, "x": 0.1},
+    )
+
+    assert first.component_fingerprint == second.component_fingerprint
+    assert first.reduction_fingerprint == second.reduction_fingerprint
+    assert first.ports == second.ports
+    assert np.array_equal(first.schur_return, second.schur_return)
+    assert np.array_equal(
+        first.reduced_boundary_precision,
+        second.reduced_boundary_precision,
+    )
+
+
+def test_exact_multiport_schur_avoids_explicit_inverse_and_has_readonly_outputs(
+    monkeypatch,
+):
+    graph = _neighbors((("p", "x"), ("q", "x"), ("r", "x")))
+    component = _exterior_component(graph, ("p", "q", "r"))
+
+    def reject_inverse(*_args, **_kwargs):
+        raise AssertionError("the exact reducer must not form an inverse")
+
+    original_cholesky = np.linalg.cholesky
+    cholesky_calls = []
+
+    def record_cholesky(*args, **kwargs):
+        cholesky_calls.append(1)
+        return original_cholesky(*args, **kwargs)
+
+    monkeypatch.setattr(np.linalg, "inv", reject_inverse)
+    monkeypatch.setattr(np.linalg, "pinv", reject_inverse)
+    monkeypatch.setattr(np.linalg, "cholesky", record_cholesky)
+    reduction = reduce_exact_exterior_component(
+        component, intrinsic_leakage_conductance=0.2
+    )
+
+    assert cholesky_calls
+    assert reduction.schur_return.flags.writeable is False
+    assert reduction.reduced_boundary_precision.flags.writeable is False
+    assert reduction.bridge_conductance.flags.writeable is False
+    assert reduction.solve_relative_residual <= 1e-10
+    assert reduction.cholesky_reconstruction_relative_error <= 1e-11
+    assert reduction.maximum_principle_violation <= 1e-10
+    assert len(reduction.reduction_fingerprint) == 64
+
+
+def test_exact_multiport_schur_accounts_for_outside_bath_grounding():
+    graph = _neighbors(
+        (("p", "x"), ("q", "x"), ("r", "x"), ("x", "z"))
+    )
+    component = _exterior_component(
+        graph,
+        ("p", "q", "r"),
+        allowed_exterior_nodes=("x",),
+    )
+    reduction = reduce_exact_exterior_component(
+        component, intrinsic_leakage_conductance=0.2
+    )
+
+    assert component.outside_bath_edges == (("x", "z"),)
+    assert np.allclose(
+        reduction.schur_return,
+        np.ones((3, 3)) / 4.2,
+        rtol=1e-10,
+        atol=1e-12,
+    )
+    assert np.allclose(
+        reduction.residual_ground_conductance,
+        np.full(3, 1.2 / 4.2),
+        rtol=1e-10,
+        atol=1e-12,
+    )
+
+
+def test_exact_exterior_schur_supports_one_port_and_fails_closed_on_inputs():
+    one_port_graph = _neighbors((("p", "x"),))
+    one_port = reduce_exact_exterior_component(
+        _exterior_component(one_port_graph, ("p",)),
+        intrinsic_leakage_conductance=0.5,
+    )
+    assert one_port.pair_conductances == ()
+    assert one_port.schur_return[0, 0] == pytest.approx(2.0 / 3.0)
+    assert one_port.residual_ground_conductance[0] == pytest.approx(
+        1.0 / 3.0
+    )
+
+    graph = _neighbors((("p", "x"), ("x", "y"), ("y", "q")))
+    component = _exterior_component(graph, ("p", "q"))
+    for bad_topology in (0.0, -1.0, float("nan")):
+        with pytest.raises(ValueError, match="topology_conductance"):
+            reduce_exact_exterior_component(
+                component, topology_conductance=bad_topology
+            )
+    for bad_leakage in (-0.1, float("inf")):
+        with pytest.raises(ValueError, match="leakage"):
+            reduce_exact_exterior_component(
+                component,
+                intrinsic_leakage_conductance=bad_leakage,
+            )
+    with pytest.raises(ValueError, match="unknown exterior"):
+        reduce_exact_exterior_component(
+            component,
+            intrinsic_leakage_conductance={"unknown": 0.2},
+        )
+    with pytest.raises(np.linalg.LinAlgError, match="ill-conditioned"):
+        reduce_exact_exterior_component(
+            component,
+            minimum_reciprocal_condition=0.9,
+        )
+    with pytest.raises(np.linalg.LinAlgError, match="unrepresentable"):
+        reduce_exact_exterior_component(
+            _exterior_component(one_port_graph, ("p",)),
+            topology_conductance=np.nextafter(0.0, 1.0),
+        )
+
+
+def test_exact_multiport_result_rejects_tampered_exposed_state():
+    graph = _neighbors(
+        (
+            ("p", "x"),
+            ("q", "x"),
+            ("x", "y"),
+            ("r", "y"),
+        )
+    )
+    reduction = reduce_exact_exterior_component(
+        _exterior_component(graph, ("p", "q", "r")),
+        intrinsic_leakage_conductance={"x": 0.1, "y": 0.2},
+    )
+
+    with pytest.raises(ValueError, match="harmonic extension"):
+        replace(
+            reduction,
+            harmonic_extension=np.full(
+                len(reduction.exterior_nodes), -100.0
+            ),
+        )
+    with pytest.raises(ValueError, match="Schur return|fingerprint"):
+        replace(
+            reduction,
+            boundary_coupling=np.flip(
+                reduction.boundary_coupling, axis=1
+            ),
+        )
+    canonicalized = replace(
+        reduction,
+        boundary_cut_conductance=(
+            reduction.boundary_cut_conductance + 5e-13
+        ),
+    )
+    assert np.array_equal(
+        canonicalized.boundary_cut_conductance,
+        reduction.boundary_cut_conductance,
+    )
+    assert (
+        canonicalized.reduction_fingerprint
+        == reduction.reduction_fingerprint
+    )
+
+
+def test_exact_multiport_public_residual_shunt_is_roundoff_nonnegative():
+    ports = tuple(f"p{index:03d}" for index in range(64))
+    graph = _neighbors(((port, "x") for port in ports))
+    reduction = reduce_exact_exterior_component(
+        _exterior_component(graph, reversed(ports))
+    )
+
+    assert np.all(reduction.residual_ground_conductance >= 0.0)
+    assert np.allclose(
+        reduction.boundary_cut_conductance,
+        reduction.self_return_conductance
+        + reduction.transfer_degree
+        + reduction.residual_ground_conductance,
+        rtol=1e-10,
+        atol=1e-12,
+    )
 
 
 def _equal_series_closure_fixture():


### PR DESCRIPTION
## Summary

- Freeze a prospective, synthetic-only protocol for exact multi-port exterior Schur reduction.
- Add a reusable dense float64 reducer for fingerprinted exterior components.
- Expose the joint Schur return, reduced boundary precision, transfer/self-return/residual ledger, numerical diagnostics, and deterministic provenance.
- Route the existing two-port benchmark through the reusable reducer.
- Keep private data, Pearltrees snapshots, embeddings, filing labels, sparse fitting, training, and GPU claims out of scope.

## Exact operator

For exterior precision `J_HH` and port coupling `C`, the reducer computes using Cholesky triangular solves:

```text
beta = C 1
B_H  = C J_HH^-1 C^T
Q_H  = diag(beta) - B_H
```

`B_H` is the positive Schur return. `Q_H` is the reduced exterior contribution composed with an independently assembled public-side boundary precision.

The implementation never constructs an inverse or reconstructs a multi-terminal operator from independent pairwise effective resistances.

It verifies:

```text
beta = self_return + transfer_degree + residual_ground
Q_H  = L(transfer) + diag(residual_ground)
```

Raw `B_H` and `Q_H` remain immutable and fingerprinted. Only derived physical-conductance views canonicalize admitted negative roundoff to zero.

## Numerical safeguards

- Uses the fingerprinted exterior component as the sole topology authority.
- Requires finite M-matrix structure, representable scale, sufficient reciprocal condition, and successful Cholesky factorization.
- Checks reconstruction and multi-RHS solve residuals.
- Enforces harmonic-basis nonnegativity and the maximum principle.
- Checks Schur-return nonnegativity/PSD and reduced-precision PSD/M-matrix structure.
- Re-solves and revalidates all exposed result state, preventing copied fingerprints from authenticating altered matrices or diagnostics.
- Fails closed on malformed, nonfinite, negative, ill-conditioned, or subnormal inputs.

## Tests

Coverage includes:

- Analytic three-port star.
- Four-port branched/cyclic full-Schur and multi-RHS parity, including retained boundary topology.
- Parallel paths whose exact transfer exceeds one ordinary branch conductance.
- Canonical ordering and fingerprint invariance.
- Explicit `inv`/`pinv` rejection with confirmed Cholesky use.
- Outside-bath grounding and one-port reduction.
- State-tampering, invalid-input, condition, and subnormal-scale rejection.
- A 64-port roundoff-ledger regression.
- Existing exact two-port closure regressions.

```text
119 passed
```

The synthetic bounded-domain benchmark also completes with experimental exact two-port closure enabled.

## Scope

This PR authorizes only the synthetic exact-reference rung. Sparse approximation and any real private structural-shadow study require separate prospective protocols.