### PR TITLE
docs(pearltrees): harvester onboarding pointer + orientation skill

### DIFF
--- a/docs/pearltrees_harvester_onboarding.md
+++ b/docs/pearltrees_harvester_onboarding.md
@@ -1,0 +1,36 @@
+# Pearltrees data — the truncation gap and where recovery lives
+
+A short pointer. The **full harvester onboarding lives in the harvester repo**, not here.
+
+## The RDF export is capped
+
+Pearltrees RDF exports **silently truncate at ~24 MB / exactly 5004 `<pt:Tree>` elements** — a
+server-side cap. The XML still closes cleanly, so there is no parse error and nothing looks wrong.
+This made the API-only harvest look ~93% incomplete and multi-parent filing folders look like
+20/880 — both artifacts of the truncation. Background write-up: `docs/pearltrees_data_completion.md`.
+
+## Recovering the missing data
+
+Where recovery tooling *may* be available (present only when the private harvester checkout exists;
+paths relative to this repo root):
+
+- **`.local/tools/browser-automation/`** — the private harvester repo (`s243a/pt-harvester`,
+  nested under the gitignored `.local/`). Its onboarding doc,
+  **`.local/tools/browser-automation/docs/ONBOARDING.md`**, is the full pipeline map:
+  the credentialed API backfill (re-fetch the trees the export dropped), the data layout, and the
+  contentType legend. Start there for anything harvest-related.
+- **`scripts/build_pearltrees_dag.py`** (this repo) — the *assemble* step: unions the RDF exports +
+  API trees + `api_tree_paths` into `assembled_dag.tsv` + `assembled_titles.tsv`, and emits the
+  backfill queue. Its docstring explains the data flow. Read-only on inputs.
+
+On a clone without `.local/`, the harvester and harvested data are absent; the assemble/consume code
+in this repo (`scripts/`, `prototypes/mu_cosine/`) is present but has nothing to read.
+
+## Interpreting harvested data (this repo)
+
+- `prototypes/mu_cosine/SKILL_understand_pearltrees.md` — turn harvested trees into typed membership
+  relations (the contentType typing + principal-parent / nested-set ordering).
+- Consumers: `prototypes/mu_cosine/{sample_product_kalman_pearltrees_campaign,run_pearltrees_fusion,eval_pearltrees_filing,filing_ranker}.py`.
+
+The current recovered state is **partial** (396/880 multi-parent folders) pending a chunked
+re-export + API backfill.

--- a/skills/SKILL_INDEX.md
+++ b/skills/SKILL_INDEX.md
@@ -11,6 +11,12 @@ Available skills for AI agents. Load skills as needed based on user request.
 | **Cross-Links** | `skill_mindmap_cross_links.md` | Add links between mindmaps |
 | **Folder Suggestion** | `skill_folder_suggestion.md` | Find best folder for mindmap |
 
+## Pearltrees / Harvester
+
+| Skill | File | Use When |
+|-------|------|----------|
+| **Harvester Orientation** | `skill_pearltrees_harvester.md` | Onboard to Pearltrees; find where harvested data / code lives; the RDF-truncation gap; (re)harvest |
+
 ## Bookmark Tools
 
 | Skill | File | Use When |
@@ -47,6 +53,10 @@ Available skills for AI agents. Load skills as needed based on user request.
 | "where should this go" | `skill_folder_suggestion.md` |
 | "file bookmark" | `skill_bookmark_filing.md` |
 | "save bookmark" | `skill_bookmark_filing.md` |
+| "where is the pearltrees data" | `skill_pearltrees_harvester.md` |
+| "onboard pearltrees" / "harvester" | `skill_pearltrees_harvester.md` |
+| "rebuild the dag" / "assembled_dag" | `skill_pearltrees_harvester.md` |
+| "reharvest pearltrees" | `skill_pearltrees_harvester.md` |
 
 ## Documentation References
 

--- a/skills/skill_pearltrees_harvester.md
+++ b/skills/skill_pearltrees_harvester.md
@@ -1,0 +1,37 @@
+# Skill: Pearltrees Harvester Orientation
+
+Where the Pearltrees harvest/assemble/consume pieces live and which resource to use. The **full
+harvester detail lives in the harvester repo** (`.local/tools/browser-automation/docs/ONBOARDING.md`);
+this skill routes to it and to the UnifyWeaver-side pieces.
+
+> This is an on-demand reference skill (load when the task calls for it), not an auto-run tool.
+
+## Which resource for which task
+
+| Task | Resource |
+|---|---|
+| Full harvester pipeline / (re)harvest | `.local/tools/browser-automation/docs/ONBOARDING.md` (PRIVATE, needs `.local`) |
+| The truncation gap + recovery pointer | `docs/pearltrees_harvester_onboarding.md` |
+| Interpret harvested data → typed relations | `prototypes/mu_cosine/SKILL_understand_pearltrees.md` + `parse_pearltrees.py` |
+| Rebuild the DAG from all sources (assemble) | `scripts/build_pearltrees_dag.py` (its docstring) |
+| Why the data looks incomplete | `docs/pearltrees_data_completion.md` |
+| File a bookmark into the hierarchy | `skills/skill_bookmark_filing.md` |
+
+## Where the data is (gitignored, under `.local/`)
+
+- `.local/data/api_tree_paths_v8.jsonl` — canonical materialized paths (`path_ids` = root→node).
+- `.local/data/pearltrees_api/trees/` — per-tree JSONs; pearls with `contentType==1` are the filed
+  bookmarks (the filing ground truth for `eval_pearltrees_filing.py`).
+- `.local/data/pearltrees_api/assembled_dag.tsv` (`parent<TAB>child`) + `assembled_titles.tsv` (`id<TAB>title`).
+- `.local/data/pearltrees_api/pearltrees_api.db` (SQLite `trees`,`pearls`), `api_responses.db` (raw cache).
+
+## Two non-obvious facts
+
+1. **The RDF export truncates at ~24 MB / exactly 5004 trees** (silent server cap; XML still closes
+   cleanly). The assembled DAG (union of RDF + API + path files) is the recovered view, and is still
+   a *partial* recovery (396/880 multi-parent folders) pending a chunked re-export + API backfill.
+   Never treat the API-only or RDF-only counts as ground truth.
+2. **The harvester is private.** `.local/tools/browser-automation/` is its own git repo (remote
+   `s243a/pt-harvester`), using session cookies, nested under the gitignored `.local/` so it never
+   enters UnifyWeaver commits. On a clone without `.local`, harvesting and harvested data are absent.
+   Never commit cookies, logs, or `.local/` contents to a public repo.


### PR DESCRIPTION
 ## What

  The UnifyWeaver-side half of the Pearltrees onboarding (the harvester repo has its own
  `docs/ONBOARDING.md` with the full detail; that PR is already merged there).

  - **`docs/pearltrees_harvester_onboarding.md`** — a short pointer: the RDF export cap
    (~24 MB / exactly 5004 trees, silent truncation) and where recovery lives — the private harvester
    repo at `.local/tools/browser-automation/` (its `docs/ONBOARDING.md` is the full pipeline map) and
    the assemble step `scripts/build_pearltrees_dag.py`.
  - **`skills/skill_pearltrees_harvester.md`** — an on-demand orientation skill routing to the
    harvester ONBOARDING and the UnifyWeaver-side pieces (interpret / assemble / consume), registered
    in `skills/SKILL_INDEX.md`.

  ## Why

  The two existing Pearltrees skills cover *tasks* (`SKILL_understand_pearltrees.md` = interpret; the
  harvester repo = fetch). This adds the *orientation* layer — where everything lives and how the
  pieces fit — so a new agent can get onboarded.

  ## Placement / safety

  The skill goes in `skills/`, the repo's **on-demand** skill location (loaded deliberately via the
  index/router, never auto-scanned). The one path that *is* auto-loaded, `.claude/skills/`, is
  gitignored, so a committed skill can never land in an auto-run position — discoverability without the
  attack surface.

  ## Scope

  Docs-only, off latest `main`. Every full-path reference verified to resolve. Nothing sensitive is
  committed; harvested data, cookies, and logs stay gitignored under `.local/`.