### PR TITLE
mu_cosine: hybrid-candidate null, wiki-density gradient, gap targets + filing assistant v1

### DIFF
--- a/prototypes/mu_cosine/REPORT_hybrid_candidates.md
+++ b/prototypes/mu_cosine/REPORT_hybrid_candidates.md
@@ -1,0 +1,156 @@
+# Hybrid candidate generation: μ-certainty precondition test + the recall-ceiling control
+
+**Verdict up front: two honest nulls that redirect the program.** (1) The precondition for
+certainty-weighted μ ranking — μ must beat e5 at least in densely-trained regions — **fails in every
+stratum**, including the densest (h1, sib) and independent of training mass. (2) The
+candidate-recall "ceiling" (0.680 @ K=50) is **not a candidate-generation problem**: it is pure
+truncation of e5's own list (e5@100 = 0.801), and at any matched pool size pure e5 dominates every
+μ- or graph-augmented pool. Certainty-weighted hybrid generation is dead on this evidence; the
+lever is K (plus ranking precision within a longer list), not a second source.
+
+Harness: `hybrid_candidates.py` (measurement only; no fitted combiner). Query sampling, catalog,
+folds-free descriptive design mirror `filing_ranker.py` (seed 7, 1200 queries, manifest sha
+`fcf5e1d6…`, 335-folder catalog); the harness reproduces the standing e5@50 = 0.680 exactly.
+μ = `model_pt_filing_lin.pt` (the deployed single-path LINEAGE fine-tune), scored as
+μ_LINEAGE(judge=graph) over the full catalog via `eval_pearltrees_filing.score_cond`. Graph source
+= candidates by d_sym(anchor→f) on the record-majority principal-parent graph (anchor = bookmark's
+e5-nearest graph folder, outcome-blind). Region bins via `fit_bias_states.pair_distance_features`
++ `soft_bin_weights` (hard argmax, τ=0.25). Training mass = campaign TRAIN-side rows (node-disjoint
+seed-0 split — the fine-tune's own) touching the true folder's title ±1 DAG hop.
+
+## A. Budget-matched recall@50 (candidate generation)
+
+| pool (budget 50 unless noted) | recall | vs e5@50 |
+|---|---|---|
+| e5@50 (baseline) | 0.680 | — |
+| e5@40 + graph@10 | 0.681 | +7 rescued, −6 displaced |
+| e5@40 + mu@10 | 0.682 | +31 rescued, −29 displaced |
+| e5@40 + mu@5 + graph@5 | 0.677 | +20 rescued, −23 displaced |
+
+Matched-budget nulls: every fill source displaces about as many e5 hits as it rescues.
+
+**Pool-size control (the decisive table)** — same #candidates per row:
+
+| pool | recall |
+|---|---|
+| e5@60 | 0.709 |
+| e5@75 | **0.745** |
+| e5@100 | **0.801** |
+| e5@150 | 0.870 |
+| e5@50 ∪ mu@50 (pool 100) | 0.745 |
+| e5@75 ∪ mu@25 (pool 100) | 0.773 |
+
+e5@50∪mu@50 (0.745) merely matches e5@75 and loses to e5@100 by −0.056. The 78 μ-"rescued"
+queries' true folders sit at e5 rank median 122 (IQR 84–171) — μ surfaces folders e5 itself
+reaches by K≈150, just later in its own ordering. **There is no complementary μ coverage beyond
+list extension.** The unmatched upper bounds (e5@50∪graph = 0.686; e5@50∪mu@50 = 0.745) are
+pool-size artifacts, reported only to close the loop.
+
+## B. The certainty precondition (DESCRIPTIVE; stratification uses the true folder)
+
+Per-stratum MRR over the identical full catalog, e5-cos vs μ_LINEAGE:
+
+| region bin (anchor→true) | n | MRR_e5 | MRR_μ | med rank e5 | med rank μ | μ wins |
+|---|---|---|---|---|---|---|
+| h1 | 23 | 0.667 | 0.389 | 1 | 6 | 0.17 |
+| h2 | 4 | 0.084 | 0.092 | 12 | 76 | 0.25 |
+| sib | 122 | **0.912** | 0.309 | 1 | 8 | 0.02 |
+| cous | 4 | 0.507 | 0.084 | 25 | 22 | 0.50 |
+| rand | 154 | 0.227 | 0.080 | 15 | 84 | 0.25 |
+| missing | 893 | 0.211 | 0.085 | 20 | 85 | 0.25 |
+
+| train mass of true folder | n | MRR_e5 | MRR_μ |
+|---|---|---|---|
+| zero | 449 | 0.291 | 0.118 |
+| ≤ median | 397 | 0.299 | 0.102 |
+| > median | 354 | 0.291 | 0.118 |
+
+| true folder in μ's train split? | n | MRR_e5 | MRR_μ |
+|---|---|---|---|
+| train-node | 362 | 0.281 | **0.092** |
+| held-node | 838 | 0.299 | 0.122 |
+
+Three findings, each fatal to certainty-weighted μ ranking:
+
+1. **μ loses everywhere**, including exactly where it should be strongest: h1 (direct
+   principal-parent, the LINEAGE training relation itself) 0.389 vs 0.667, and sib 0.309 vs 0.912.
+2. **Training density does not modulate μ quality**: MRR_μ is flat (0.118 / 0.102 / 0.118) across
+   zero/low/high training mass. The epistemic-certainty weight `w_μ(region)` would multiply a
+   signal that is uniformly inferior — there is no region where the gate would open.
+3. **No train-side advantage** (train-node 0.092 vs held-node 0.122 — if anything reversed), so
+   the failure is not a generalization gap; the head's catalog-wide ordering is simply weak,
+   consistent with the standing "μ heads ≤0.11 as rankers" result.
+
+## Program consequences
+
+- **Retire** the certainty-weighted hybrid-generator idea (this was the cheap test that killed it
+  before build-out — the precondition was checked first, as intended).
+- **Recall lever = K.** Raising K 50→100 buys +0.121 recall for free; the binding problem moves to
+  ranking precision within the longer list and the escalation/routing policy
+  (`filing_ranker.py`'s margin gate), not to candidate sourcing.
+- The failure mass lives in the `missing` stratum (893/1200 queries: anchor and true folder share
+  no graph relation within the horizon; e5 MRR 0.211 there vs 0.912 for sib). That stratum is
+  partly an artifact of the **partial DAG recovery** (396/880 multi-parent folders; RDF
+  truncation) — completing the harvest may convert `missing` rows into graph-covered rows, which
+  is where graph features actually work. Data completion, not modeling, is the path into that mass.
+- Where the anchor IS graph-related to the true folder (sib/h1), e5 already solves filing
+  (MRR 0.9 / 0.67) — consistent with the blend's null: there was little headroom to begin with.
+
+## B′. Corrected density axis: wiki-semantic proximity (owner's objection, upheld in part)
+
+The owner's objection to B's density axis was correct: μ's semantic competence comes from the
+Wikipedia-trained base (`model_prod_namecond_full.pt`, enwiki/simplewiki pairs; the Pearltrees
+fine-tune is a thin 800-step corpus onboarding over 799 rows), so "training near the region" must
+be measured as SEMANTIC proximity to the full wiki training cloud, not Pearltrees graph-touch.
+Redone with density = mean top-5 e5 cosine to the 8,964 campaign training titles
+(`~/mu_data/campaign_100k_e5.pt`), terciles:
+
+| bookmark wiki-density | n | MRR_e5 | MRR_μ | med rank μ | μ/e5 ratio | μ wins |
+|---|---|---|---|---|---|---|
+| near | 400 | 0.355 | 0.175 | 30 | 0.49 | 0.22 |
+| mid | 400 | 0.238 | 0.090 | 90 | 0.38 | 0.24 |
+| far | 400 | 0.287 | 0.074 | 100 | 0.26 | 0.21 |
+| both near (bm ∧ folder) | 187 | 0.411 | 0.219 | — | 0.53 | 0.22 |
+
+(True-folder density shows the same direction, weaker: MRR_μ 0.131 near → 0.089 far.)
+
+Two-sided finding:
+- **The generalization hypothesis is CONFIRMED directionally**: μ's MRR more than doubles far→near
+  and its relative gap to e5 halves (ratio 0.26 → 0.53). Cross-corpus semantic transfer from the
+  wiki training is real and measurable; B's "density doesn't modulate μ" was an artifact of the
+  Pearltrees-only row count. Certainty-∝-training-proximity is the right model for μ.
+- **The ranking precondition still fails**: e5 rises on the same axis and μ never crosses — best
+  stratum 0.219 vs 0.411, μ wins 22%. A wiki-density certainty gate would be correctly ordered
+  but never opens (μ ≥ e5 nowhere).
+
+Consequence: to make μ cross anywhere, the lever is TRAINING-CLOUD COVERAGE, not weighting —
+i.e. gap-directed data (the tail-augmentation result: Haiku tail-augmentation helped at ~30%
+tail-weight; and the #3936 privacy-aware public STEM gap-harvest plan, for which the far stratum
+here is the empirical target list).
+
+## B″. The gap-target list (emit_gap_targets.py)
+
+`emit_gap_targets.py` materializes §B′ into the #3936 work order: all 1,515 harness titles
+(1,192 bookmarks + 323 folders) ranked by ascending wiki-density, with each row's 3 nearest
+training-cloud titles → `~/mu_data/gap_targets.tsv` (PRIVATE — personal titles; the harvest
+itself targets public sources near these regions). Two findings from the list:
+
+- **The gap mass is NOT STEM.** The farthest rows are news/politics/current-events commentary
+  (whistleblower, election, healthcare-policy headlines). A gap harvest scoped to STEM would miss
+  the actual gap — the target branches are politics/journalism/current-events categories.
+- **The training cloud contains admin junk.** Nearest-cloud neighbors include Wikipedia
+  maintenance categories (`Monthly_clean-up_category…`, `AOC_profile_template_missing_ID…`) —
+  the campaign predates the enwiki correct-ingest rule (content subtree excludes ~14% admin
+  cats), so some training mass is spent on categories with no semantic content, and the density
+  measure is slightly polluted by them. A cloud rebuild on the correct-ingest subtree is the
+  clean upgrade. (Minor: harvested bookmark titles carry unescaped HTML entities, e.g. `&#39;`.)
+
+## Caveats
+
+Single seed (sampling seed 7, deterministic scores — no fit, so fold variance does not apply);
+stratification is outcome-aware (diagnostic only); μ tested is the single-path LINEAGE fine-tune
+under judge=graph conditioning — other heads/judges were already ≤0.11 as rankers in
+REPORT_pearltrees_candidate_lineage.md and were not retested here. B′ density uses the campaign
+training titles as the cloud (the base model also saw earlier graded data not counted here);
+underscored enwiki titles vs natural-text Pearltrees titles shift e5 cosines slightly but
+identically across strata.

--- a/prototypes/mu_cosine/emit_gap_targets.py
+++ b/prototypes/mu_cosine/emit_gap_targets.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Emit the wiki-training-cloud GAP-TARGET list for the STEM gap harvest (#3936).
+
+REPORT_hybrid_candidates.md §B′: μ's competence tracks e5 proximity to the wiki training cloud
+(MRR_μ 0.074 far-tercile → 0.175 near → 0.219 both-near), so the demonstrated lever for making μ
+competitive anywhere is training-cloud COVERAGE. This script turns that finding into a work order:
+the bookmarks and folders sitting FAR from the 8,964 campaign training titles, ranked farthest
+first — the empirical target list for gap-directed harvesting/augmentation.
+
+Per row: kind (bookmark|folder), title, wiki_density (mean top-5 e5 cosine to the training cloud),
+and the 3 nearest training titles (to show what the cloud's closest coverage currently is).
+
+PRIVACY: bookmark/folder titles come from a personal Pearltrees account. Output goes to the
+durable PRIVATE data home (~/mu_data), never into the repo. The harvest itself targets PUBLIC
+STEM sources near these regions (#3936's privacy-aware framing) — this list only says WHERE the
+gaps are, in the model's own input space.
+
+  python3 emit_gap_targets.py                       # writes ~/mu_data/gap_targets.tsv
+  python3 emit_gap_targets.py --deciles 3           # keep the bottom-3 density deciles only
+"""
+import argparse
+import os
+import random
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from filing_ranker import load_graph_universe
+from mu_attention import build_e5_tables
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default=os.path.expanduser("~/mu_data/gap_targets.tsv"))
+    ap.add_argument("--cloud", default=os.path.expanduser("~/mu_data/campaign_100k_e5.pt"))
+    ap.add_argument("--e5-cache", default="/tmp/mu_data/pt_ranker_e5.pt")
+    ap.add_argument("--max-queries", type=int, default=1200)
+    ap.add_argument("--seed", type=int, default=7, help="query sampling (= the harness manifest)")
+    ap.add_argument("--deciles", type=int, default=10,
+                    help="keep the bottom-N density deciles (10 = everything, farthest first)")
+    ap.add_argument("--topn", type=int, default=3, help="nearest cloud titles shown per row")
+    a = ap.parse_args(argv)
+
+    import torch
+    universe, titles, neighbors, parents_dir, queries, cand, cut_ext = load_graph_universe(2)
+    queries = sorted(queries)
+    if len(queries) > a.max_queries:
+        queries = random.Random(a.seed).sample(queries, a.max_queries)
+    f_titles = sorted({cand[f] for f in cand})
+    q_titles = sorted({q for q, _ in queries})
+    ext = sorted({x for xs in cut_ext.values() for x in xs})
+    names = sorted(set(q_titles) | set(f_titles) | {titles[n] for n in universe}
+                   | {titles[x] for x in ext})
+    _, ptbl, idx = build_e5_tables(names, cache_path=a.e5_cache, batch_size=128)
+    P = ptbl.numpy()
+
+    z = torch.load(a.cloud, map_location="cpu", weights_only=False)
+    W = z["passage"].numpy()
+    Wn = W / np.linalg.norm(W, axis=1, keepdims=True)
+    cloud_names = z["names"]
+
+    rows = []
+    for kind, tl in (("bookmark", q_titles), ("folder", f_titles)):
+        X = np.stack([P[idx[t]] for t in tl])
+        X = X / np.linalg.norm(X, axis=1, keepdims=True)
+        S = X @ Wn.T
+        top = np.argsort(-S, axis=1)[:, :max(5, a.topn)]
+        dens = np.sort(S, axis=1)[:, -5:].mean(axis=1)
+        for i, t in enumerate(tl):
+            near = "; ".join(cloud_names[j] for j in top[i, :a.topn])
+            rows.append((kind, t, float(dens[i]), near))
+
+    dens_all = np.array([r[2] for r in rows])
+    cut = np.quantile(dens_all, a.deciles / 10.0)
+    keep = sorted((r for r in rows if r[2] <= cut), key=lambda r: r[2])
+    os.makedirs(os.path.dirname(a.out), exist_ok=True)
+    with open(a.out, "w", encoding="utf-8") as f:
+        f.write("# gap targets (farthest from the wiki training cloud first) — PRIVATE, do not "
+                "commit\n# kind\ttitle\twiki_density\tnearest_cloud_titles\n")
+        for kind, t, d, near in keep:
+            f.write(f"{kind}\t{t}\t{d:.4f}\t{near}\n")
+    print(f"cloud: {len(cloud_names)} training titles; scored {len(rows)} targets "
+          f"({len(q_titles)} bookmarks + {len(f_titles)} folders)")
+    print(f"kept bottom {a.deciles} decile(s): {len(keep)} rows -> {a.out}")
+    b = [r for r in keep if r[0] == "bookmark"]
+    fo = [r for r in keep if r[0] == "folder"]
+    print(f"  bookmarks {len(b)} (density {b[0][2]:.3f}–{b[-1][2]:.3f})" if b else "  bookmarks 0")
+    print(f"  folders   {len(fo)} (density {fo[0][2]:.3f}–{fo[-1][2]:.3f})" if fo else "  folders 0")
+    print("\nfarthest 10 (the sharpest gaps):")
+    for kind, t, d, near in keep[:10]:
+        print(f"  {d:.3f} {kind:8s} {t[:48]:48s} | near: {near[:60]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/filing_assistant.py
+++ b/prototypes/mu_cosine/filing_assistant.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Filing assistant v1: e5 ranking @ K=100 + margin routing — the honest, deployable loop.
+
+Grounding (REPORT_hybrid_candidates.md): the recall@50 = 0.680 "ceiling" was pure K-truncation
+(e5@100 = 0.801, e5@150 = 0.870); at matched pool size pure e5 beats every μ/graph-augmented pool;
+and no μ head beats e5 in any stratum. So the deployable v1 is the champion ranker used honestly:
+e5-cos over the folder catalog, a longer candidate list (K=100), and margin-gated escalation —
+confident placements auto-suggested, low-margin ones routed to review (a human or judge).
+
+  eval mode     python3 filing_assistant.py eval [--top-k 100] [--min-bm 3]
+      Honest numbers on the standing harness population (seed 7, ≤1200 queries, ≥3-bookmark
+      catalog — identical manifest to filing_ranker.py): MRR / recall@1 / @5 with misses (true
+      folder outside top-K) scored rank ∞, for K ∈ {50, K}, plus the margin-routing table
+      (fraction routed vs kept recall@1). Title-equivalence grading throughout.
+
+  suggest mode  python3 filing_assistant.py suggest "Some new bookmark title" [--top-n 5]
+      Rank folders for new bookmark title(s) (repeatable arg, or --from-file, one per line).
+      Catalog = folders with ≥ --min-bm recorded bookmarks (default 1: every folder actually in
+      use as a filing destination). Duplicate titles are merged (all tree ids shown). Each
+      suggestion prints e5 cosine; the query prints its top-2 margin and a routing verdict at
+      --margin (default 0.05 — see the eval routing table for the measured kept-R@1 tradeoff).
+
+No μ, no blend, no diffusion — those are nulls as rankers on this task (REPORTs); revisit only if
+a future head beats e5 somewhere (gap-directed training is the demonstrated path — §B′/B″).
+"""
+import argparse
+import hashlib
+import os
+import random
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from eval_filing import load_filing, metrics
+from mu_attention import E5_MODEL, build_e5_tables
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+TREES = os.path.join(ROOT, "..", "..", ".local", "data", "pearltrees_api", "trees")
+
+
+def catalog_tables(min_bm, cache_tag):
+    """Folder catalog + unit e5 passage vectors (cached per catalog)."""
+    queries, cand = load_filing(TREES, min_bm)
+    f_ids = sorted(cand)
+    f_titles = [cand[fid] for fid in f_ids]
+    names = sorted(set(f_titles))
+    cache = f"/tmp/mu_data/filing_assistant_e5_{cache_tag}.pt"
+    _, ptbl, idx = build_e5_tables(names, cache_path=cache, batch_size=128)
+    P = ptbl.numpy()
+    cand_vec = np.stack([P[idx[t]] for t in f_titles])
+    return queries, f_ids, f_titles, cand_vec
+
+
+def encode_queries(titles):
+    from sentence_transformers import SentenceTransformer
+    model = SentenceTransformer(E5_MODEL)
+    q = model.encode(["query: " + t.replace("_", " ") for t in titles], batch_size=64,
+                     convert_to_numpy=True, normalize_embeddings=True, show_progress_bar=False)
+    return q
+
+
+def ranks_np(cos, truepos):
+    """1-based rank of the best acceptable folder (title-equivalence; ties broken pessimistically
+    against later columns, matching eval_pearltrees_filing.ranks_from)."""
+    out = []
+    for r in range(cos.shape[0]):
+        best = None
+        for tp in truepos[r]:
+            rank = 1 + int(((cos[r] > cos[r][tp]) |
+                            ((cos[r] == cos[r][tp]) & (np.arange(cos.shape[1]) < tp))).sum())
+            best = rank if best is None else min(best, rank)
+        out.append(best)
+    return np.array(out)
+
+
+def run_eval(a):
+    queries, f_ids, f_titles, cand_vec = catalog_tables(a.min_bm, f"eval{a.min_bm}")
+    by_title = {}
+    for j, t in enumerate(f_titles):
+        by_title.setdefault(t, []).append(j)
+    queries = sorted(queries)
+    if len(queries) > a.max_queries:
+        queries = random.Random(a.seed).sample(queries, a.max_queries)
+    q_titles = [q for q, _ in queries]
+    cand_by_id = dict(zip(f_ids, f_titles))
+    truepos = [sorted(by_title[cand_by_id[fid]]) for _, fid in queries]
+    qman = hashlib.sha256("\n".join(f"{q}\t{fid}" for q, fid in queries).encode()).hexdigest()
+    print(f"eval: {len(queries)} queries (manifest sha {qman[:16]}) over "
+          f"{len(f_ids)} folders (min_bm={a.min_bm})")
+
+    qv = encode_queries(q_titles)
+    cos = qv @ cand_vec.T
+    ranks = ranks_np(cos, truepos)
+
+    for K in sorted({50, a.top_k}):
+        rk = np.where(ranks <= K, ranks, 10**6)
+        m = metrics(list(rk))
+        print(f"  e5 @ K={K:<4d} recall@K {np.mean(ranks <= K):.3f}  "
+              f"MRR {m['MRR']:.3f}  R@1 {m['recall@1']:.3f}  R@5 {m['recall@5']:.3f}")
+
+    # margin routing on the K=top_k list (miss = rank ∞ stays a miss when kept)
+    srt = np.sort(cos, axis=1)
+    margin = srt[:, -1] - srt[:, -2]
+    rk = np.where(ranks <= a.top_k, ranks, 10**6)
+    print(f"\n  margin routing (top1−top2 e5 cosine; K={a.top_k}):")
+    print(f"  {'t':>7s} {'routed':>7s} {'kept_n':>7s} {'kept R@1':>9s} {'kept R@5':>9s}")
+    for t in (0.0, 0.005, 0.01, 0.02, 0.03, 0.05, 0.08, 0.12):
+        kept = margin >= t
+        if kept.sum() == 0:
+            continue
+        print(f"  {t:7.3f} {1 - kept.mean():7.2f} {int(kept.sum()):7d} "
+              f"{np.mean(rk[kept] <= 1):9.3f} {np.mean(rk[kept] <= 5):9.3f}")
+    print("\n  DESCRIPTIVE thresholds (post-hoc grid, no bootstrap) — pick t for the "
+          "auto-file/review tradeoff you want; suggest mode defaults to t=0.05.")
+
+
+def run_suggest(a):
+    titles = list(a.title or [])
+    if a.from_file:
+        titles += [ln.strip() for ln in open(a.from_file, encoding="utf-8") if ln.strip()]
+    if not titles:
+        print("no titles given — pass positional titles or --from-file", file=sys.stderr)
+        sys.exit(2)
+    _, f_ids, f_titles, cand_vec = catalog_tables(a.min_bm, f"sugg{a.min_bm}")
+    # catalog hygiene (suggest only — eval keeps the standing manifest): drop degenerate titles
+    # with no letters/digits ("?", "-", …) — e5 places them near everything (observed: a "?"
+    # folder ranked #1 for every query)
+    keep = [j for j, t in enumerate(f_titles) if any(c.isalnum() for c in t)]
+    dropped = len(f_titles) - len(keep)
+    if dropped:
+        print(f"(catalog hygiene: dropped {dropped} degenerate folder title(s))")
+    f_ids = [f_ids[j] for j in keep]
+    cand_vec = cand_vec[keep]
+    f_titles = [f_titles[j] for j in keep]
+    by_title = {}
+    for j, t in enumerate(f_titles):
+        by_title.setdefault(t, []).append(f_ids[j])
+    uniq_titles = sorted(by_title)
+    tvec = {}
+    for j, t in enumerate(f_titles):
+        tvec.setdefault(t, cand_vec[j])
+    U = np.stack([tvec[t] for t in uniq_titles])
+
+    qv = encode_queries(titles)
+    cos = qv @ U.T
+    for i, bt in enumerate(titles):
+        order = np.argsort(-cos[i])
+        margin = float(cos[i][order[0]] - cos[i][order[1]]) if len(order) > 1 else float("inf")
+        verdict = "AUTO-FILE candidate" if margin >= a.margin else "ROUTE TO REVIEW (low margin)"
+        print(f"\n» {bt}")
+        print(f"  margin {margin:.3f} → {verdict} (t={a.margin})")
+        for r, j in enumerate(order[:a.top_n], 1):
+            t = uniq_titles[j]
+            ids = ",".join(str(x) for x in by_title[t][:4])
+            print(f"  {r}. {cos[i][j]:.3f}  {t}   [tree {ids}]")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = ap.add_subparsers(dest="mode", required=True)
+    ev = sub.add_parser("eval", help="honest metrics on the standing harness population")
+    ev.add_argument("--top-k", type=int, default=100)
+    ev.add_argument("--min-bm", type=int, default=3, help="catalog floor (3 = standing harness)")
+    ev.add_argument("--max-queries", type=int, default=1200)
+    ev.add_argument("--seed", type=int, default=7)
+    sg = sub.add_parser("suggest", help="file new bookmark title(s)")
+    sg.add_argument("title", nargs="*", help="bookmark title(s) to file")
+    sg.add_argument("--from-file", help="file with one bookmark title per line")
+    sg.add_argument("--top-n", type=int, default=5)
+    sg.add_argument("--min-bm", type=int, default=1, help="catalog floor (1 = all in-use folders)")
+    sg.add_argument("--margin", type=float, default=0.05, help="auto-file vs review threshold")
+    a = ap.parse_args(argv)
+    (run_eval if a.mode == "eval" else run_suggest)(a)
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/hybrid_candidates.py
+++ b/prototypes/mu_cosine/hybrid_candidates.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Hybrid candidate-generation harness: can μ / graph sources lift the e5 recall@50 ceiling?
+
+MEASUREMENT ONLY — no fitted combiner, no deployment claim. Two questions, in order:
+
+  A (recall ceiling)  candidate-recall@50 = 0.680 caps every ranker (filing_ranker.py). Do μ- or
+     graph-sourced candidates ADD true folders the e5 top-50 misses, at a MATCHED budget of 50?
+     Sources: e5 top-K (baseline) | μ_LINEAGE top-K (trained filing head) | graph lineage
+     neighborhood of the bookmark's anchor. Unions are budget-matched (e5 top-(50−m) + m fill
+     slots from the source, deduped) so recall gains are never an artifact of a bigger pool.
+     Unmatched full unions are reported separately as upper bounds.
+
+  B (precondition, per the project owner): for μ to deserve ranking weight anywhere, μ must beat
+     e5's distance at least in regions with dense nearby training. Stratify queries by
+     (i) the graph region bin of (anchor → true folder) — hop h1..h5 / sib / cous / rand /
+         missing, via fit_bias_states.pair_distance_features + soft_bin_weights (hard argmax);
+     (ii) the TRUE folder's training mass — # of campaign TRAIN-side rows (node-disjoint seed-0
+          split, the fine-tune's own split) touching the folder title or a 1-hop DAG neighbor.
+     Report per-stratum MRR/median-rank of e5 vs μ over the FULL folder catalog (identical pools).
+     The campaign sampled hop bins ~uniformly (~50 rows each), so BIN-level density is flat by
+     design — the node-level training mass is the honest "closely trained neighbours" axis.
+
+  Stratification uses the true folder (outcome-AWARE) — legitimate for a descriptive diagnostic,
+  never for feature construction. All candidate sources are outcome-blind. Ranks are graded by
+  title-equivalence (eval_pearltrees_filing.ranks_from). Query sampling matches filing_ranker.py
+  (seed 7, ≤1200) so recall@50 is comparable with the standing 0.680.
+
+  python3 hybrid_candidates.py                 # one torch job (μ scoring; cached after first run)
+  python3 hybrid_candidates.py --skip-mu       # torch-free: graph source + e5 baseline only
+"""
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from eval_pearltrees_filing import campaign_train_nodes, ranks_from
+from filing_ranker import load_graph_universe
+from fit_bias_states import BINS, pair_distance_features, soft_bin_weights
+from mu_attention import build_e5_tables
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+
+
+def file_sha(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()[:16]
+
+
+def d_sym_to_candidates(parents_dir, anchor, f_node_ids, hmax=6, cap=13):
+    """d_sym(anchor, f) for every candidate folder id, np.inf when no common ancestor."""
+    from sample_channel_campaign import ancestors
+
+    anc_a = ancestors(parents_dir, anchor, hmax)
+    anc_a[anchor] = 0
+    out = np.full(len(f_node_ids), np.inf)
+    for j, f in enumerate(f_node_ids):
+        anc_f = ancestors(parents_dir, f, hmax)
+        anc_f[f] = 0
+        common = set(anc_a) & set(anc_f)
+        if common:
+            out[j] = min(min(anc_a[c] + anc_f[c] for c in common), cap)
+    return out
+
+
+def budget_union(e5_order, fill_orders, K, m_fill):
+    """e5 top-(K − Σm) plus, per source, its top-m unseen candidates; any slots a sparse source
+    can't fill are backfilled from e5's continuation (budget always exactly K)."""
+    base = K - sum(m_fill.values())
+    sel = list(e5_order[:base])
+    have = set(sel)
+    for name, order in fill_orders.items():
+        m = m_fill[name]
+        for c in order:
+            if m == 0:
+                break
+            if c not in have:
+                sel.append(c)
+                have.add(c)
+                m -= 1
+    for c in e5_order[base:]:
+        if len(sel) >= K:
+            break
+        if c not in have:
+            sel.append(c)
+            have.add(c)
+    return sel
+
+
+def recall_of(sel_lists, truepos):
+    hits = [any(c in set(tp) for c in sel) for sel, tp in zip(sel_lists, truepos)]
+    return float(np.mean(hits)), np.array(hits)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--top-k", type=int, default=50)
+    ap.add_argument("--max-queries", type=int, default=1200)
+    ap.add_argument("--seed", type=int, default=7, help="query-sampling seed (= filing_ranker)")
+    ap.add_argument("--hops", type=int, default=2)
+    ap.add_argument("--ckpt", default=os.path.join(ROOT, "model_pt_filing_lin.pt"),
+                    help="trained μ checkpoint (LINEAGE head; the Pearltrees single-path decision)")
+    ap.add_argument("--judge", default="graph", help="judge conditioning for the LINEAGE head")
+    ap.add_argument("--skip-mu", action="store_true", help="torch-free: skip the μ source")
+    ap.add_argument("--mu-cache", default="/tmp/mu_data/hybrid_cand_mu.npz")
+    ap.add_argument("--e5-cache", default="/tmp/mu_data/pt_ranker_e5.pt")
+    ap.add_argument("--fill", type=int, default=10, help="budget slots granted to each fill source")
+    a = ap.parse_args(argv)
+
+    universe, titles, neighbors, parents_dir, queries, cand, cut_ext = load_graph_universe(a.hops)
+
+    import random
+    queries = sorted(queries)
+    if len(queries) > a.max_queries:
+        queries = random.Random(a.seed).sample(queries, a.max_queries)
+    f_ids = sorted(cand)
+    f_titles = [cand[fid] for fid in f_ids]
+    by_title = {}
+    for j, t in enumerate(f_titles):
+        by_title.setdefault(t, []).append(j)
+    q_titles = [q for q, _ in queries]
+    truepos = [sorted(by_title[cand[fid]]) for _, fid in queries]
+    qman = hashlib.sha256("\n".join(f"{q}\t{fid}" for q, fid in queries).encode()).hexdigest()
+    B, K = len(queries), a.top_k
+    print(f"queries: {B} (manifest sha {qman[:16]}); catalog: {len(f_ids)} folders; budget K={K}")
+
+    # e5 tables — names constructed exactly as filing_ranker.py so its cache is reusable
+    ext_nodes = sorted({x for xs in cut_ext.values() for x in xs})
+    names = sorted(set(q_titles) | set(f_titles) | {titles[n] for n in universe}
+                   | {titles[x] for x in ext_nodes})
+    qtbl, ptbl, idx = build_e5_tables(names, cache_path=a.e5_cache, batch_size=128)
+    Q, P = qtbl.numpy(), ptbl.numpy()
+    uni_vec = np.stack([P[idx[titles[n]]] for n in universe])
+    cand_vec = np.stack([P[idx[t]] for t in f_titles])
+    qv = np.stack([Q[idx[t]] for t in q_titles])
+    cos_cand = qv @ cand_vec.T                                   # [B, n_cand]
+    cos_uni = qv @ uni_vec.T
+    anchors = [universe[int(i)] for i in np.argmax(cos_uni, axis=1)]   # outcome-blind anchors
+    e5_orders = np.argsort(-cos_cand, axis=1)
+
+    # ---- μ_LINEAGE scores over the full catalog (one torch job; cached) ----
+    M_mu = None
+    if not a.skip_mu:
+        mu_key = hashlib.sha256(json.dumps(
+            [qman, len(f_ids), file_sha(a.ckpt), a.judge, "LINEAGE"]).encode()).hexdigest()[:16]
+        if os.path.exists(a.mu_cache) and str(np.load(a.mu_cache)["key"]) == mu_key:
+            M_mu = np.load(a.mu_cache)["M"]
+            print(f"μ scores loaded from cache ({a.mu_cache})")
+        else:
+            import torch
+
+            from eval_pearltrees_filing import score_cond
+            from fine_tune_pearltrees_filing import load_with_lineage_ops
+            from mu_attention import Tokenizer
+            torch.set_num_threads(4)
+            torch.manual_seed(0)
+            mdl, _ = load_with_lineage_ops(a.ckpt, dev="cpu")
+            mdl.eval()
+            tok = Tokenizer(qtbl, ptbl, idx, {}, {})
+            print(f"scoring μ_LINEAGE({os.path.basename(a.ckpt)}, judge={a.judge}) "
+                  f"for {B}×{len(f_ids)} pairs …")
+            M_mu = np.array(score_cond(mdl, tok, q_titles, f_titles, "LINEAGE", a.judge))
+            os.makedirs(os.path.dirname(a.mu_cache), exist_ok=True)
+            np.savez_compressed(a.mu_cache, M=M_mu, key=mu_key)
+            print(f"μ scores cached -> {a.mu_cache}")
+        mu_orders = np.argsort(-M_mu, axis=1)
+
+    # ---- graph source: candidates by d_sym to the anchor (outcome-blind), e5 tie-break ----
+    print("graph source: d_sym(anchor → candidate) …")
+    fid_strs = [str(f) for f in f_ids]
+    dsym_cache = {}
+    graph_orders = np.zeros((B, len(f_ids)), dtype=int)
+    graph_dsym = np.zeros((B, len(f_ids)))
+    for b in range(B):
+        anc = anchors[b]
+        if anc not in dsym_cache:
+            dsym_cache[anc] = d_sym_to_candidates(parents_dir, anc, fid_strs)
+        d = dsym_cache[anc]
+        graph_dsym[b] = d
+        graph_orders[b] = np.lexsort((-cos_cand[b], d))          # near first, e5 breaks ties
+        if (b + 1) % 300 == 0:
+            print(f"  {b + 1}/{B}")
+
+    # ================= A: budget-matched recall =================
+    print("\n=== A. candidate-recall@%d (budget-matched; baseline must reproduce 0.680) ===" % K)
+    r_e5, hit_e5 = recall_of([e5_orders[b][:K] for b in range(B)], truepos)
+    print(f"  e5@{K}                          : {r_e5:.3f}")
+    rows = []
+    variants = {}
+    graph_fill = [[c for c in graph_orders[b] if np.isfinite(graph_dsym[b][c])] for b in range(B)]
+    variants[f"e5@{K - a.fill} + graph@{a.fill}"] = [
+        budget_union(e5_orders[b], {"g": graph_fill[b]}, K, {"g": a.fill}) for b in range(B)]
+    if M_mu is not None:
+        variants[f"e5@{K - a.fill} + mu@{a.fill}"] = [
+            budget_union(e5_orders[b], {"m": mu_orders[b]}, K, {"m": a.fill}) for b in range(B)]
+        variants[f"e5@{K - a.fill} + mu@{a.fill // 2} + graph@{a.fill - a.fill // 2}"] = [
+            budget_union(e5_orders[b],
+                         {"m": mu_orders[b], "g": graph_fill[b]}, K,
+                         {"m": a.fill // 2, "g": a.fill - a.fill // 2}) for b in range(B)]
+    for name, sels in variants.items():
+        r, hit = recall_of(sels, truepos)
+        rescues = int((hit & ~hit_e5).sum())
+        lost = int((hit_e5 & ~hit).sum())
+        rows.append((name, r, rescues, lost))
+        print(f"  {name:32s}: {r:.3f}  (+{rescues} rescued, −{lost} displaced vs e5@{K})")
+    # unmatched upper bounds — pool-size artifacts allowed, labeled as such
+    ub = [list(e5_orders[b][:K]) + [c for c in graph_fill[b]] for b in range(B)]
+    r_ubg, _ = recall_of(ub, truepos)
+    print(f"  UPPER BOUND e5@{K} ∪ graph(all finite d_sym): {r_ubg:.3f}  (unmatched pool)")
+    if M_mu is not None:
+        ub2 = [list(e5_orders[b][:K]) + list(mu_orders[b][:K]) for b in range(B)]
+        r_ubm, _ = recall_of(ub2, truepos)
+        print(f"  UPPER BOUND e5@{K} ∪ mu@{K}              : {r_ubm:.3f}  (unmatched pool)")
+
+    # ================= B: per-region μ vs e5 precondition =================
+    print("\n=== B. precondition (DESCRIPTIVE): does μ beat e5 where training is dense? ===")
+    train_nodes = campaign_train_nodes(0)
+    # node-level training mass: campaign TRAIN rows touching the folder title or a 1-hop neighbor
+    from node_disjoint_eval import node_disjoint_pair_split
+    from run_pearltrees_fusion import load_pearltrees_campaign
+    ds = load_pearltrees_campaign(require_55=False)
+    strata = [("principal" if t.startswith("principal") else t) for t in ds["tags"]]
+    split = node_disjoint_pair_split(ds["pairs"], 0, strata=strata)
+    train_rows = [ds["pairs"][i] for i in split.train]
+    touch = Counter()
+    for x, y in train_rows:
+        touch[x] += 1
+        touch[y] += 1
+    id_by_title = defaultdict(list)
+    for n in universe:
+        id_by_title[titles[n]].append(n)
+
+    def train_mass(fid):
+        t = cand[fid]
+        mass = touch.get(t, 0)
+        for n in id_by_title.get(t, []):
+            for nb in neighbors.get(n, []):
+                mass += touch.get(titles[nb], 0)
+        return mass
+
+    # region bin of (anchor → true folder), via the bias-state binning (hard argmax)
+    pairs_at = [(anchors[b], str(queries[b][1])) for b in range(B)]
+    feats = pair_distance_features(parents_dir, pairs_at)
+    Wb = soft_bin_weights(feats, tau=0.25)
+    bin_of = [BINS[int(i)] for i in np.argmax(Wb, axis=1)]
+
+    strat_defs = {"region bin (anchor→true)": bin_of}
+    mass_all = np.array([train_mass(queries[b][1]) for b in range(B)])
+    qm = np.quantile(mass_all[mass_all > 0], [0.5]) if (mass_all > 0).any() else [1]
+    mass_bin = ["zero" if m == 0 else ("low" if m <= qm[0] else "high") for m in mass_all]
+    strat_defs["train mass of true folder (0 / ≤med / >med)"] = mass_bin
+    held_bin = ["train-node" if cand[queries[b][1]] in train_nodes else "held-node"
+                for b in range(B)]
+    strat_defs["true folder in μ's train split?"] = held_bin
+
+    if M_mu is None:
+        print("  (μ skipped — rerun without --skip-mu for the comparison)")
+    else:
+        import torch
+        ranks_e5 = ranks_from(torch.tensor(cos_cand), truepos)
+        ranks_mu = ranks_from(torch.tensor(M_mu), truepos)
+        re5, rmu = np.array(ranks_e5, float), np.array(ranks_mu, float)
+        for title_, lab in strat_defs.items():
+            print(f"  -- by {title_} --")
+            print(f"  {'stratum':12s} {'n':>5s} {'MRR_e5':>8s} {'MRR_mu':>8s} "
+                  f"{'med_e5':>7s} {'med_mu':>7s} {'mu wins':>8s}")
+            order = [b_ for b_ in BINS] + ["zero", "low", "high", "train-node", "held-node"]
+            seen_s = sorted(set(lab), key=lambda s: order.index(s) if s in order else 99)
+            for s in seen_s:
+                m = np.array([x == s for x in lab])
+                if m.sum() == 0:
+                    continue
+                wins = float(np.mean(rmu[m] < re5[m]))
+                print(f"  {s:12s} {int(m.sum()):5d} {np.mean(1 / re5[m]):8.3f} "
+                      f"{np.mean(1 / rmu[m]):8.3f} {np.median(re5[m]):7.0f} "
+                      f"{np.median(rmu[m]):7.0f} {wins:8.2f}")
+        print("\n  Read: μ earns ranking weight only in strata where MRR_mu ≥ MRR_e5 (esp. "
+              "high-mass / train-node rows). All DESCRIPTIVE — stratification uses the true "
+              "folder; no combiner is fit here.")
+
+    print("\nDone. (Phase A budget-matched numbers are the ceiling result; Phase B is the "
+          "μ-certainty precondition.)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Two commits closing the certainty-weighted-hybrid question and shipping the deployable loop it justifies.

**`f5f6455ce` — hybrid-candidate null + wiki-density certainty gradient + gap-target emitter**
- `hybrid_candidates.py`: measurement harness (no fitted combiner). (A) budget-matched candidate generation; (B) the precondition test — μ must beat e5 at least where training is dense. Reproduces the standing e5@50 = 0.680 exactly (manifest sha `fcf5e1d6`).
- Results (`REPORT_hybrid_candidates.md`): the recall "ceiling" is pure K-truncation (e5@100 = 0.801, e5@150 = 0.870); at matched pool size pure e5 beats every μ/graph-augmented pool. μ loses to e5 in every stratum — but on the corrected density axis (e5 proximity to the 8,964 wiki training titles) the cross-corpus transfer gradient is REAL: MRR_μ 0.074 far → 0.175 near → 0.219 both-near (μ/e5 ratio 0.26 → 0.53). The certainty gate is correctly ordered but never opens — the lever is training-cloud coverage, not weighting.
- `emit_gap_targets.py`: materializes that into the #3936 work order (farthest-first target list → private `~/mu_data`, never committed). List findings: the gap mass is news/politics/current-events, NOT STEM; the training cloud contains Wikipedia admin/maintenance categories (predates the correct-ingest rule) — cloud rebuild on the correct subtree is the clean upgrade.

**`01f431137` — filing assistant v1 (`filing_assistant.py`)**
- `eval` mode: standing manifest reproduced (e5@50 MRR 0.291 vs 0.294); K lever measured honestly — recall@100 = 0.801 while MRR stays 0.292 (K raises the routing ceiling, not the headline rank). Margin routing: t=0.05 keeps 4% at R@1 0.714; t=0.01–0.03 trades 38–77% routed for kept-R@1 0.23–0.27 (descriptive grid).
- `suggest` mode: files new bookmark titles against all in-use folders (dup-title merge, tree ids, auto-file vs route-to-review verdict). Catalog hygiene: degenerate no-alnum titles dropped (a "?" folder ranked #1 for every query).

## Scope
Tools + report only; no data committed (gap list and harvested data stay in private `~/mu_data` / `.local`). No μ/blend/diffusion in the deployed path — nulls as rankers on this task; revisit via gap-directed training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fB4ZfA4bW4XNEnboUncgc