### PR TITLE
mu_cosine: lever 1 — Sonnet judge + lineage menus (+0.087 R@1, CI excludes zero)

### DIFF
--- a/prototypes/mu_cosine/REPORT_routed_queries.md
+++ b/prototypes/mu_cosine/REPORT_routed_queries.md
@@ -40,3 +40,21 @@ The deployed loop is filing_assistant (e5 @ K=100 + margin gate) + judge escalat
 confirmed +0.055 R@1 today. Remaining levers, in ceiling order: stronger/contextual judge
 (up to +0.13 more at this t/N), larger menus (N=20 ceiling 0.512 at t=0.03), DAG completion
 (the `missing` stratum), and gap-directed training (REPORT_hybrid_candidates §B′/B″).
+
+## Lever 1 result: Sonnet judge + lineage-context menus (2026-07-23)
+
+Same manifest, same routed set (t=0.02, N=10), menus augmented with each folder's principal-path
+context (`--lineage`, §7 machinery, folder-side only / outcome-blind). Judge = Sonnet subagents
+(4 disjoint chunks; null rates 13/11/11/14 — far steadier than Haiku's 9/15/49/14).
+
+- **Policy R@1 0.290 vs 0.203 baseline: +0.087, 95% CI [+0.070, +0.107] — excludes zero.**
+- **Paired vs Haiku (same queries): +0.056, 95% CI [+0.032, +0.084] — excludes zero.**
+  232/351 rescuable menus converted (66% vs Haiku's 55%); ~47% of the perfect-judge headroom.
+  Pick agreement with Haiku only 0.60 — a genuinely different policy, not noise on the same one.
+- Confound note: this pass upgrades judge AND menu context together (deliberate — one redundant
+  full pass to pick the production judge); the components are not separated.
+
+**Coverage-efficiency rule (owner, standing):** full same-data re-scores are a one-time spend for
+judge selection only. All future judge spends are coverage-first — calibrate judges/prompts on
+~150–200-query subsamples; put the bulk of tokens on NEW queries (e.g. the t=0.03 increment) or
+NEW menu tail (positions 11–20 where the N=10 menu missed), never on re-scoring covered rows.

--- a/prototypes/mu_cosine/routed_queries.py
+++ b/prototypes/mu_cosine/routed_queries.py
@@ -92,19 +92,30 @@ def run_ceilings(a):
 
 
 def task_path(a):
-    return os.path.expanduser(f"~/mu_data/routed_tasks_t{a.margin}_n{a.menu}.jsonl")
+    suf = "_lin" if getattr(a, "lineage", False) else ""
+    return os.path.expanduser(f"~/mu_data/routed_tasks_t{a.margin}_n{a.menu}{suf}.jsonl")
 
 
 def run_emit(a):
     q_titles, f_titles, truepos, cos, ranks, margin, order, qman = build(a)
     routed = np.where(margin < a.margin)[0]
+    lin = {}
+    if a.lineage:
+        # folder principal-path context (§7 machinery): outcome-blind — uses only the folder's own
+        # pre-existing folder→parent lineage, never the bookmark's placement
+        from eval_pearltrees_filing import folder_lineage
+        _, cand = load_filing(TREES, a.min_bm)
+        parents_title, _ = folder_lineage(cand, depth=a.lineage_depth)
+        lin = parents_title
     out = task_path(a)
     os.makedirs(os.path.dirname(out), exist_ok=True)
     with open(out, "w", encoding="utf-8") as f:
         f.write(json.dumps({"manifest": qman, "margin": a.margin, "menu": a.menu,
-                            "n_routed": len(routed)}) + "\n")
+                            "n_routed": len(routed), "lineage": bool(a.lineage)}) + "\n")
         for b in routed:
-            menu = [{"pos": p, "title": f_titles[int(order[b][p])]} for p in range(a.menu)]
+            menu = [{"pos": p, "title": f_titles[int(order[b][p])],
+                     **({"path": " > ".join(reversed(lin.get(f_titles[int(order[b][p])], [])))}
+                        if a.lineage else {})} for p in range(a.menu)]
             f.write(json.dumps({"qid": int(b), "bookmark": q_titles[b], "menu": menu},
                                ensure_ascii=False) + "\n")
     hit = sum(menu_hit(order, truepos, b, a.menu) for b in routed)
@@ -176,6 +187,9 @@ def main(argv=None):
     em = sub.add_parser("emit")
     em.add_argument("--margin", type=float, default=0.02)
     em.add_argument("--menu", type=int, default=10)
+    em.add_argument("--lineage", action="store_true",
+                    help="include each folder's principal-path context in the menu")
+    em.add_argument("--lineage-depth", type=int, default=3)
     sc = sub.add_parser("score")
     sc.add_argument("--picks", required=True)
     sc.add_argument("--margin", type=float, default=0.02)


### PR DESCRIPTION
Policy R@1 0.290 vs 0.203 baseline (+0.087, 95% CI [+0.070,+0.107]); paired vs Haiku +0.056 [+0.032,+0.084]; 232/351 rescuable converted (~47% of perfect-judge headroom); agreement 0.60. Adds --lineage emit option + records the standing coverage-first spend rule. Judge+context confounded by design (one-time judge-selection pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fB4ZfA4bW4XNEnboUncgc