### PR TITLE
mu_cosine: lever 2 — three-tier policy R@1 0.316 (+0.113, CI excludes zero)

### DIFF
--- a/prototypes/mu_cosine/REPORT_routed_queries.md
+++ b/prototypes/mu_cosine/REPORT_routed_queries.md
@@ -58,3 +58,15 @@ context (`--lineage`, §7 machinery, folder-side only / outcome-blind). Judge = 
 judge selection only. All future judge spends are coverage-first — calibrate judges/prompts on
 ~150–200-query subsamples; put the bulk of tokens on NEW queries (e.g. the t=0.03 increment) or
 NEW menu tail (positions 11–20 where the N=10 menu missed), never on re-scoring covered rows.
+
+## Lever 2 result: three-tier policy — margin-banded menus (coverage-first)
+
+Per the standing rule, zero re-scoring: the 0.02≤margin<0.03 band (227 NEW queries, N=20 lineage
+menus, rescue ceiling 113/227) was judged once by Sonnet (nulls 13/5). Deployed policy:
+margin<0.02 → judge@N10; 0.02–0.03 → judge@N20; ≥0.03 → auto-file e5 top-1.
+
+- **Policy R@1 0.316 vs 0.203 baseline: +0.113, 95% CI [+0.093, +0.134].**
+- Paired vs lever-1 (band auto-filed): **+0.026, CI [+0.017, +0.036] — excludes zero.**
+- In-band: judge 72/227 correct vs auto-file 41/227 — judging the band beats auto-filing it.
+
+Arc total: R@1 0.203 → 0.316 (+56% relative) via routing alone; ranker untouched.


### PR DESCRIPTION
Coverage-first band extension (227 new queries, N=20 lineage menus): policy R@1 0.316 vs 0.203 (+0.113, CI [+0.093,+0.134]); paired vs lever-1 +0.026 [+0.017,+0.036]; band judge 72/227 vs auto-file 41/227. Arc total: 0.203 → 0.316 via routing alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fB4ZfA4bW4XNEnboUncgc