### PR TITLE
plawk: print a double-valued scalar in a rule body

### DIFF
--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -17546,6 +17546,16 @@ plawk_emit_print_expr_for_context(ssa(Value), FieldSeparator, Context,
     plawk_print_expr_output_names(Context, int, FmtPrefix, PrintPrefix),
     plawk_i64_expr_ir(ssa(Value), FieldSeparator, Base, Base,
         ValueIR, GlobalParts, SetupParts).
+% a substituted DOUBLE-scalar read (var(Name) -> ssa_f64(SlotValue)): print the
+% double SSA value with %g, mirroring the END-print double branch. This makes
+% `print x` work for a float-valued scalar slot in a rule body (the i64 `ssa`
+% clause above handles the counter case; ssa_f64 is functor-distinct).
+plawk_emit_print_expr_for_context(ssa_f64(Value), FieldSeparator, Context,
+        f64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
+    plawk_print_expr_value_base(Context, f64, Base),
+    plawk_print_expr_output_names(Context, f64, FmtPrefix, PrintPrefix),
+    plawk_f64_expr_ir(ssa_f64(Value), FieldSeparator, Base, Base,
+        ValueIR, GlobalParts, SetupParts).
 % a substituted STRING-scalar read (var(Name) -> ssa_str(SlotValue)): the slot
 % holds an atom id; resolve it to text (id 0 is the unset sentinel, printed as
 % empty). A select keeps it straight-line -- wam_atom_to_string is always called

--- a/tests/test_plawk_surface_float_exprs.pl
+++ b/tests/test_plawk_surface_float_exprs.pl
@@ -115,6 +115,37 @@ test(surface_float_composes_with_guards) :-
         "ERROR disk 10\nWARN cpu 4\nERROR net 3\n",
         "15\n4.5\n").
 
+% A double-valued scalar prints with %g in a rule body (previously only END
+% print handled a double scalar; a rule-body `print x` was rejected).
+test(surface_rule_body_double_scalar_print) :-
+    run_float_print_smoke("{ x = 1.5; print x }\n",
+        "a\nb\n",
+        "1.5\n1.5\n").
+
+% ... in a comma list beside a field.
+test(surface_rule_body_double_scalar_comma) :-
+    run_float_print_smoke("{ x = 1.5; print x, $1 }\n",
+        "7\n",
+        "1.5 7\n").
+
+% ... and glued by juxtaposition-concat.
+test(surface_rule_body_double_scalar_concat) :-
+    run_float_print_smoke("{ x = 1.5; print x $1 }\n",
+        "7\n",
+        "1.57\n").
+
+% ... and after a string-literal prefix.
+test(surface_rule_body_double_scalar_prefix) :-
+    run_float_print_smoke("{ x = 2.5; print \"v=\" x }\n",
+        "a\n",
+        "v=2.5\n").
+
+% An integer-valued double still prints without a decimal point (%g).
+test(surface_rule_body_double_scalar_integral) :-
+    run_float_print_smoke("{ x = 2.0 * $1; print x }\n",
+        "5\n",
+        "10\n").
+
 run_float_print_smoke(Source, Input, ExpectedOutput) :-
     tmp_root(Root),
     directory_file_path(Root, 'uw_plawk_surface_float_exprs', Dir),


### PR DESCRIPTION
## Summary

**Stack 1 of 2** — the prerequisite for making `/` floating-point. A float-valued (`scalar_double`) variable can now be printed in a **rule body** (`{ x = 1.5; print x }`), which previously fell outside the compilable surface. Only END-block print handled a double scalar; the rule-body path lacked the corresponding emit clause.

### Root cause
A scalar read substitutes to `ssa(Value)` for an i64/counter slot (handled) or `ssa_f64(Value)` for a double slot — and `plawk_emit_print_expr_for_context/6` had **no `ssa_f64` clause**, so print-IR generation failed and the single-rule driver fell through to the "outside the compilable surface" rejection. The surface gate itself already accepted it.

### Fix
Add the missing clause, mirroring the i64 `ssa` clause but using the f64 machinery (`plawk_f64_expr_ir` + the `%g` `@.plawk_surface_print_f64` global) — the same shape the END-print double branch already uses. The one clause covers bare `print x`, comma lists (`print x, $1`), juxtaposition concat (`print x $1`), and a string-literal prefix, since they share the substitution + prefixed-print emitter.

### Why it's the prerequisite
Without rule-body double printing, the next PR (making `/` floating-point) would *regress* `{ x = 7/2; print x }` from printing an integer to a build failure — because `7/2` would become a double and hit exactly this gap.

## Changes
- **codegen** (`plawk_native_codegen.pl`): one new `plawk_emit_print_expr_for_context/6` clause for `ssa_f64`.
- **tests**: 5 new cases in `test_plawk_surface_float_exprs` (bare / comma / concat / prefix / integer-valued). Verified against gawk.

## Verification
`plawk_surface_float_exprs` — **All 22 tests passed** (5 new + 17 existing, no regression).

## Stack
Next on top: **`/` is always floating-point division** (`7/2` = 3.5; `avg = sum/NR` → double), which builds on this so it doesn't regress rule-body prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_