### PR TITLE
mu_cosine: harden routed filing privacy, provenance, and frozen policy

### DIFF
--- a/prototypes/mu_cosine/PROTOCOL_filing_ranker_eval.md
+++ b/prototypes/mu_cosine/PROTOCOL_filing_ranker_eval.md
@@ -165,6 +165,42 @@ once on the outer test.  Report risk/coverage or AURC against e5 and a matched-c
 paired node-block interval.  No claim of judge rescue, cost savings, or deployment benefit is permitted
 without labeled routed outcomes and a matched-cost analysis.
 
+The historical three-tier routed policy (margin <0.02: Sonnet-family judge with N=10 lineage menu;
+0.02≤margin<0.03: the same judge with N=20 lineage menu; margin≥0.03: e5 top-1) was developed on
+the standing 1,200-row benchmark and is therefore exploratory/transductive there.  Its frozen
+prospective definition is `ROUTED_POLICY_three_tier_v1.json`.  A decision-bearing follow-up must
+apply that artifact without modification to a later cohort or one untouched outer node-disjoint
+test; any threshold, menu, judge, prompt, or lineage change restarts selection inside outer-train.
+Repeated judge draws are required to expose judge variance. Task emission on that untouched set
+must not report a rescue ceiling or any other placement-label-derived diagnostic before the
+frozen judge outputs have been sealed.
+
+Any task sent outside the local machine must be rebuilt from the certified-public Pearltrees
+population.  Candidate folders and emitted lineage ancestors require explicit public node
+visibility under `pearltrees-public-only-v1`; missing node visibility is quarantined and privacy
+propagates down typed containment.  A bookmark is eligible only as content of a certified-public
+folder and only when it has no private-title or restricted-visibility signal. Candidate and query
+eligibility also use the frozen, outcome-blind
+`pearltrees-public-alphanumeric-title-v1` rule: a destination title must contain at least one
+letter or number, and queries recorded only in an excluded destination leave the evaluation
+population. The task envelope
+must bind the source inventory, privacy index, catalog, population, ranking, exact selection band,
+and task rows. Exact score ties are broken by ascending frozen catalog column, matching the
+exact-destination rank computation. Picks must bind the exact task bytes and declared judge/prompt provenance.
+Missing, extra, duplicate, legacy headerless, cross-task, or tampered rows fail closed.  Content
+hashes establish integrity, not provider authentication.
+
+The current v2 tool binds exactly one complete response artifact per judge tier. It does not yet
+represent multiple provider-call chunks or repeated judge draws. Before the next decision-bearing
+run, add a parent-task manifest that binds every chunk, provider run, and draw to the same task ID,
+plus a frozen aggregation rule. Manually concatenating partial responses is not an acceptable
+substitute.
+
+The current ranker receipt binds the e5 model name and exact candidate/query embedding arrays, so
+upstream model drift fails reproduction rather than silently changing a result. Before a future
+decision-bearing task is emitted, replace the `unresolved` Hub revision with an immutable e5
+revision so those bound arrays can also be regenerated long-term.
+
 ## 8. Reproducibility and fail-closed audit
 
 The run fingerprint must cover, by content rather than machine-local paths:

--- a/prototypes/mu_cosine/REPORT_routed_queries.md
+++ b/prototypes/mu_cosine/REPORT_routed_queries.md
@@ -1,45 +1,79 @@
-# Routed-queries loop: the first confirmed end-to-end filing win
+# Routed-queries loop: exploratory end-to-end filing evidence and frozen follow-up
 
-**Result: rank → route → judge → place beats rank-alone, confirmatory.** On the standing 1200-query
-manifest (sha `fcf5e1d6…`, e5 @ K=100, title-equivalence grading), routing low-margin queries
-(t = 0.02 → 695/1200 routed) to a cheap judge (Haiku, title-only 10-item menus) yields
+**Evidence status: strong exploratory/transductive result, not confirmatory.** On the historical
+1200-query manifest (sha `fcf5e1d6…`, e5 @ K=100, title-equivalence grading), routing low-margin
+queries (t = 0.02 → 695/1200 routed) to a cheap judge (Haiku, title-only 10-item menus) produced
 
 - policy R@1 **0.258** vs no-routing baseline **0.203**
 - **delta +0.055, paired bootstrap 95% CI [+0.037, +0.072] — EXCLUDES ZERO.**
 
-This is the filing program's first intervention with a confirmatory CI excluding zero (every
-ranker-side blend was null). It lands where the ceilings said the value lives: the perfect-judge
-ceiling at (t=0.02, N=10) is 0.389 (+0.186); Haiku captured ~30% of that headroom, rescuing
-193 of the 351 menus that contained the true folder (55% rescue-pool conversion; 87/695 nulls).
+The finite-benchmark arithmetic is reproducible, but the interval is conditional on a policy chosen
+after inspecting this same benchmark. The threshold/menu grid, judge/context choice, and second
+margin band were all selected with these 1200 placement labels available. The interval also
+resampled individual queries, omitting destination-folder dependence, selection multiplicity, and
+judge-draw variance. It therefore does not authorize a deployment or generalization claim.
 
-## Protocol (routed_queries.py)
+As an engineering result, the signal is useful: the perfect-judge ceiling at (t=0.02, N=10) was
+0.389 (+0.186), and the stored Haiku picks rescued 193 of the 351 menus containing the recorded
+folder (55% rescue-pool conversion; 87/695 nulls).
+
+## Historical protocol and prospective v2 contract
 
 - `ceilings`: perfect-judge upper bounds over (t × N). Baseline 0.203; 0.389 @ t=0.02/N=10;
   0.512 @ t=0.03/N=20 — routing, not ranking, is where filing performance lives.
-- `emit`: outcome-blind task JSONL (menus in e5 order, truth never marked) → private `~/mu_data`.
+- Historical `emit`: outcome-blind task JSONL (menus in e5 order, truth never marked) → private
+  `~/mu_data`.
 - Judge spend: 4 parallel Haiku subagents (the roster's cheap judge), strict `{qid, pick|null}`
   contract, 695/695 scored.
-- `score`: fail-closed ingest (manifest match, each routed qid exactly once, range-checked),
-  policy R@1 with paired per-query bootstrap (2000 draws) on Δ(correct) vs the no-routing
-  baseline.
+- Historical `score`: required every routed qid but did **not** require a manifest header, reject
+  extra qids, bind the menu/task bytes, or bind judge/prompt provenance. The stored pick files are
+  consequently `legacy_unbound`; they remain descriptive and cannot be upgraded retroactively.
+- Prospective v2 `emit` rebuilds a certified-public population and binds source inventory, privacy
+  index, catalog, sampled population, ranking, exact band/menu/lineage selection, and task rows.
+  It also freezes the exact declared provider/model/revision/interface/temperature and committed
+  prompt before labels are returned. Raw output must echo the exact task ID before `seal-picks`
+  will bind it, preventing a response from being reassigned to a same-QID task with different
+  menus. Duplicate-title score ties use ascending frozen catalog column, the same rule as the
+  exact-rank calculation. They therefore have zero margin and route to review rather than being
+  silently merged; ID-specific ancestor lineage gives the judge context that title embeddings
+  cannot supply. `score` rejects missing, extra, duplicate, cross-task, or tampered rows and uses
+  exact destination ID as the primary grade (best title-equivalent destination is
+  sensitivity-only) with a paired bookmark/folder connected-component bootstrap.
+- `ROUTED_POLICY_three_tier_v1.json` freezes the current policy for a later cohort or one untouched
+  outer node-disjoint test. No result on the development benchmark becomes confirmatory merely
+  because the policy is now frozen.
+- V2 currently seals one complete response artifact per tier. Large-call chunking and repeated
+  judge draws need a bound parent-task/chunk/draw manifest before the future decision test; manual
+  concatenation would lose per-call provenance and is not supported.
 
 ## Honest caveats
 
-- Ground truth = recorded placement; a judge pick that is topically defensible but differs from
-  the recorded folder scores as wrong — 0.258 is a LOWER bound on subjective quality.
+- Ground truth = recorded placement. A topically defensible alternative scores as wrong, while a
+  historically recorded but subjectively suboptimal placement scores as right. The metric measures
+  agreement with the recorded destination and may undercount acceptable alternatives; its
+  direction relative to subjective best-choice quality is not identified.
 - Single judge pass; per-chunk null rates varied (9/15/49/14 across the 4 subagent chunks) —
   judge-draw variance is not in the CI (which is over queries). A second judge/seed pass and a
   stronger judge (sonnet-tier) are the obvious next spends.
 - Menus are title-only. Judge cards / folder lineage context (the §7 candidate-lineage machinery)
   are unexploited headroom, as is menu size (ceiling at N=20 is 0.453 for this t).
-- Thresholds t, N chosen from the descriptive ceiling grid before judging, but not preregistered.
+- Thresholds t and N were chosen from an outcome-revealing ceiling grid and were not preregistered.
+  The later judge/context and band choices were also selected on this benchmark.
+- Privacy audit found nonpublic candidate titles in 67/695 historical low-band menus and 50/227
+  middle-band menus, plus one nonpublic-source query in the middle band. No such titles were
+  committed to Git, but externally processed legacy artifacts must not be reused. V2 requires
+  explicit-public visibility certificates for candidate and lineage nodes. A bookmark is eligible
+  only inside a certified-public folder and only without a private-title or restricted-visibility
+  signal; missing node visibility is quarantined.
 
 ## Where this leaves the program
 
-The deployed loop is filing_assistant (e5 @ K=100 + margin gate) + judge escalation, worth a
-confirmed +0.055 R@1 today. Remaining levers, in ceiling order: stronger/contextual judge
-(up to +0.13 more at this t/N), larger menus (N=20 ceiling 0.512 at t=0.03), DAG completion
-(the `missing` stratum), and gap-directed training (REPORT_hybrid_candidates §B′/B″).
+The candidate loop is filing_assistant (e5 @ K=100 + margin gate) + judge escalation. On the
+historical development benchmark it improved R@1 by +0.055 with Haiku and +0.113 under the final
+three-tier policy. The next decision-bearing read must keep that policy fixed and use a later
+bookmark cohort or one untouched outer node-disjoint split, public-only tasks, repeated judge
+draws, and node-block inference. Remaining engineering levers are hypotheses, not authorized
+post-hoc changes to that test.
 
 ## Lever 1 result: Sonnet judge + lineage-context menus (2026-07-23)
 
@@ -48,9 +82,11 @@ context (`--lineage`, §7 machinery, folder-side only / outcome-blind). Judge = 
 (4 disjoint chunks; null rates 13/11/11/14 — far steadier than Haiku's 9/15/49/14).
 
 - **Policy R@1 0.290 vs 0.203 baseline: +0.087, 95% CI [+0.070, +0.107] — excludes zero.**
-- **Paired vs Haiku (same queries): +0.056, 95% CI [+0.032, +0.084] — excludes zero.**
+- **Paired vs Haiku on the 695 routed rows: +0.056, 95% conditional iid-bootstrap CI
+  [+0.032, +0.084].** The corresponding whole-policy increment is 39/1200 = **+0.0325**.
   232/351 rescuable menus converted (66% vs Haiku's 55%); ~47% of the perfect-judge headroom.
-  Pick agreement with Haiku only 0.60 — a genuinely different policy, not noise on the same one.
+  Pick agreement with Haiku was 0.60; one judge draw plus a simultaneous context change cannot
+  separate model, lineage-context, and draw-variance effects.
 - Confound note: this pass upgrades judge AND menu context together (deliberate — one redundant
   full pass to pick the production judge); the components are not separated.
 
@@ -61,12 +97,17 @@ NEW menu tail (positions 11–20 where the N=10 menu missed), never on re-scorin
 
 ## Lever 2 result: three-tier policy — margin-banded menus (coverage-first)
 
-Per the standing rule, zero re-scoring: the 0.02≤margin<0.03 band (227 NEW queries, N=20 lineage
-menus, rescue ceiling 113/227) was judged once by Sonnet (nulls 13/5). Deployed policy:
+Per the standing rule, zero re-scoring: the 0.02≤margin<0.03 band (227 newly judged queries, but
+not new or untouched evaluation rows; N=20 lineage menus, rescue ceiling 113/227) was judged once
+by Sonnet (nulls 13/5). Frozen exploratory policy:
 margin<0.02 → judge@N10; 0.02–0.03 → judge@N20; ≥0.03 → auto-file e5 top-1.
 
 - **Policy R@1 0.316 vs 0.203 baseline: +0.113, 95% CI [+0.093, +0.134].**
 - Paired vs lever-1 (band auto-filed): **+0.026, CI [+0.017, +0.036] — excludes zero.**
 - In-band: judge 72/227 correct vs auto-file 41/227 — judging the band beats auto-filing it.
 
-Arc total: R@1 0.203 → 0.316 (+56% relative) via routing alone; ranker untouched.
+Historical development arc: R@1 0.203 → 0.316 (+56% relative) via routing alone; ranker
+untouched. This exact numeric result belongs to the legacy, private-inclusive population. The
+prospective public-only population has a new privacy/catalog/population fingerprint and the
+outcome-blind `pearltrees-public-alphanumeric-title-v1` eligibility rule. It must be reported
+separately rather than compared as though its rows were unchanged.

--- a/prototypes/mu_cosine/ROUTED_JUDGE_PROMPT_three_tier_v1.md
+++ b/prototypes/mu_cosine/ROUTED_JUDGE_PROMPT_three_tier_v1.md
@@ -1,0 +1,19 @@
+You are a bookmark-filing reviewer.
+
+For each task, choose the single candidate folder that best matches the bookmark.
+Candidate order is only a retrieval order; do not prefer an item merely because it
+appears earlier. Use the folder title and, when present, its ancestor path. Prefer
+the most specific candidate that is genuinely appropriate. If none of the
+candidates is appropriate, choose `null`.
+
+The task envelope supplies a `task_id`. Return JSONL with no prose. The first
+line must bind your response to that exact task:
+
+`{"schema":"unifyweaver.raw-routed-picks.v1","record_type":"raw_pick_header","task_id":"<exact task_id>"}`
+
+Then return exactly one JSON object per input task:
+
+`{"qid": <the input integer qid>, "pick": <zero-based menu position or null>}`
+
+Do not infer or request the recorded destination, and do not reproduce task titles
+outside the required JSON output.

--- a/prototypes/mu_cosine/ROUTED_POLICY_three_tier_v1.json
+++ b/prototypes/mu_cosine/ROUTED_POLICY_three_tier_v1.json
@@ -1,0 +1,72 @@
+{
+  "schema": "unifyweaver.routed-policy.v1",
+  "record_type": "policy_envelope",
+  "policy_id": "4e38b7e5c9420fdf7c400416a7b16004ce686dc3bc730418225e2f9c38733df3",
+  "policy_core": {
+    "name": "three-tier-margin-v1",
+    "evidence_status": "exploratory_transductive",
+    "frozen_date": "2026-07-23",
+    "privacy_policy_id": "pearltrees-public-only-v1",
+    "catalog_policy_id": "pearltrees-public-alphanumeric-title-v1",
+    "primary_grading": "exact_destination_id",
+    "sensitivity_grading": "best_title_equivalent_destination",
+    "judge_prompt": {
+      "path": "ROUTED_JUDGE_PROMPT_three_tier_v1.md",
+      "sha256": "eadb767bbd71ceb0b6f6d2bfa7a2cac916ddff615979c436d6f62415c7859fb6"
+    },
+    "selection_history": "Thresholds, menu sizes, judge family, and lineage context were selected after inspecting the historical 1,200-row benchmark. Freezing them now does not convert that benchmark into confirmatory evidence. The public-only catalog and outcome-blind alphanumeric-title eligibility rule define a new prospective population and are frozen before its decision labels are used.",
+    "next_decision_test": {
+      "population": "later bookmark cohort or one untouched outer node-disjoint split",
+      "selection": "no threshold, menu, judge, prompt, or lineage changes after labels are revealed",
+      "primary_metric": "exact-destination filing recall@1",
+      "interval": "paired bookmark-folder connected-component bootstrap",
+      "judge_repeats": "repeat the frozen judge procedure to expose judge-draw variance"
+    },
+    "tiers": [
+      {
+        "tier_id": "low",
+        "band": {
+          "lower_float64_hex": null,
+          "upper_float64_hex": "0x1.47ae147ae147bp-6",
+          "semantics": "lower-inclusive_upper-exclusive"
+        },
+        "action": "judge",
+        "menu_size": 10,
+        "lineage": true,
+        "lineage_depth": 3,
+        "required_judge_family": "sonnet"
+      },
+      {
+        "tier_id": "middle",
+        "band": {
+          "lower_float64_hex": "0x1.47ae147ae147bp-6",
+          "upper_float64_hex": "0x1.eb851eb851eb8p-6",
+          "semantics": "lower-inclusive_upper-exclusive"
+        },
+        "action": "judge",
+        "menu_size": 20,
+        "lineage": true,
+        "lineage_depth": 3,
+        "required_judge_family": "sonnet"
+      },
+      {
+        "tier_id": "auto",
+        "band": {
+          "lower_float64_hex": "0x1.eb851eb851eb8p-6",
+          "upper_float64_hex": null,
+          "semantics": "lower-inclusive_upper-exclusive"
+        },
+        "action": "auto_top1"
+      }
+    ],
+    "bootstrap": {
+      "unit": "bookmark-folder-connected-component",
+      "seed": 3867001,
+      "replicates": 9999,
+      "interval": [
+        0.025,
+        0.975
+      ]
+    }
+  }
+}

--- a/prototypes/mu_cosine/eval_filing.py
+++ b/prototypes/mu_cosine/eval_filing.py
@@ -26,9 +26,11 @@ Usage:
   python3 eval_filing.py --ckpt model_nodetype.pt --trees ../../.local/data/pearltrees_api/trees \
       --min-bm 3 --max-queries 500 [--seed 7]
 """
-import argparse, glob, json, os, random, collections
+import argparse, json, os, random, collections
 import torch
 from mu_attention import build_e5_tables, Tokenizer, MuAttention, OPS, load_dag, GRAPH
+from filing_privacy import build_pearltrees_privacy_index
+from privacy import is_private_title, vis_private
 
 
 import re
@@ -66,28 +68,39 @@ def load_membership(graph_path, min_bm, holdout=None, drop_admin=None):
     return queries, cand
 
 
-def load_filing(trees_dir, min_bm):
-    """Parse harvested tree JSONs → (queries, folders). A folder = a tree; its bookmarks (contentType 1)
-    are filed in it. Candidate folders = those with >= min_bm bookmarks; queries = the bookmarks therein."""
+def load_filing(trees_dir, min_bm, *, return_privacy=False, paths_jsonl=None):
+    """Parse a certified-public harvested snapshot into filing queries/folders.
+
+    Privacy filtering is unconditional: there is deliberately no
+    ``include_private`` escape hatch.  Candidate eligibility and ``min_bm`` are
+    computed *after* private-title bookmarks and private/quarantined folders
+    have been removed, so excluded content cannot influence ranking margins or
+    routing.  With ``return_privacy=True`` the exact privacy index used for the
+    population is returned as a third value.
+    """
+    privacy = build_pearltrees_privacy_index(trees_dir, paths_jsonl=paths_jsonl)
     folders = {}                                  # tid -> title
     by_folder = collections.defaultdict(list)     # tid -> [bookmark_title, ...]
-    for f in glob.glob(os.path.join(trees_dir, "*.json")):
-        try:
-            d = json.load(open(f, encoding="utf-8"))
-        except Exception:
+    for tid_key, t in privacy.tree_payloads.items():
+        if tid_key not in privacy.public_ids:
             continue
-        t = d.get("api_response", {}).get("tree", {}) if isinstance(d, dict) else {}
-        if not isinstance(t, dict):
-            continue
-        tid, ttitle = t.get("id"), t.get("title")
+        tid, ttitle = privacy.tree_value_ids[tid_key], t.get("title")
         if tid is None or not ttitle:
-            continue
+            raise ValueError(f"certified-public tree {tid_key} lacks a title")
         folders[tid] = ttitle
         for p in t.get("pearls", []) if isinstance(t.get("pearls"), list) else []:
-            if isinstance(p, dict) and p.get("contentType") == 1 and p.get("title"):
+            if (
+                isinstance(p, dict)
+                and str(p.get("contentType")) == "1"
+                and p.get("title")
+                and not is_private_title(p["title"])
+                and not vis_private(p.get("visibility"))
+            ):
                 by_folder[tid].append(p["title"])
     cand = {tid: folders[tid] for tid, bms in by_folder.items() if len(bms) >= min_bm and tid in folders}
     queries = [(bt, tid) for tid in cand for bt in by_folder[tid]]   # (bookmark_title, true_folder_tid)
+    if return_privacy:
+        return queries, cand, privacy
     return queries, cand
 
 

--- a/prototypes/mu_cosine/eval_pearltrees_filing.py
+++ b/prototypes/mu_cosine/eval_pearltrees_filing.py
@@ -29,6 +29,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from eval_filing import load_filing, metrics, score_mu
 from fine_tune_pearltrees_filing import load_with_lineage_ops
 from mu_attention import CORPORA, JUDGES, NODETYPE, OPS, Tokenizer, build_e5_tables
+from privacy import is_private_title
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 PT_API = os.path.join(ROOT, "..", "..", ".local", "data", "pearltrees_api")
@@ -40,7 +41,14 @@ TITLES = os.path.join(PT_API, "assembled_titles.tsv")
 PATHS_JSONL = os.path.join(PT_API, "..", "api_tree_paths_v8.jsonl")
 
 
-def folder_lineage(cand, depth=5, shuffle_seed=None):
+def folder_lineage(
+    cand,
+    depth=5,
+    shuffle_seed=None,
+    *,
+    public_tree_titles=None,
+    return_id_chains=False,
+):
     """Build {folder_title: [parent_title,...]} PRINCIPAL paths for candidate folders.
 
     Principal parent = the OBSERVATION-MAJORITY parent across the account's recorded path_ids (the
@@ -51,9 +59,28 @@ def folder_lineage(cand, depth=5, shuffle_seed=None):
     boundary — never the evaluated bookmark's placement or the folder's bookmark children).
     `shuffle_seed` permutes which folder receives which lineage, SUPPORT-PRESERVING: chains permute
     only among folders that HAVE a chain (audit finding 6 — a naive permutation also changes which
-    folders get any lineage at all, confounding the control)."""
+    folders get any lineage at all, confounding the control).
+
+    Hosted-task callers must pass ``public_tree_titles`` from the same privacy
+    index that built ``cand``.  In that mode unsafe path rows are excluded
+    before parent voting, every emitted ancestor is certified public, and the
+    visibility-free assembled-DAG and assembled-title fallbacks are disabled.
+    """
     import json as _json
     from collections import Counter, defaultdict
+
+    allowed = (
+        None
+        if public_tree_titles is None
+        else {str(x) for x in public_tree_titles}
+    )
+    if allowed is not None:
+        blocked = sorted(str(tid) for tid in cand if str(tid) not in allowed)
+        if blocked:
+            raise ValueError(
+                f"candidate catalog contains {len(blocked)} uncertified tree ids "
+                f"(first: {blocked[:5]})"
+            )
 
     votes = defaultdict(Counter)
     with open(PATHS_JSONL, encoding="utf-8") as f:
@@ -61,20 +88,34 @@ def folder_lineage(cand, depth=5, shuffle_seed=None):
             if not ln.strip():
                 continue
             r = _json.loads(ln)
-            ids = [str(x).split(":")[-1] for x in (r.get("path_ids") or [])]
+            ids = [
+                str(x)
+                for x in (r.get("path_ids") or [])
+                if str(x) and not str(x).startswith("account:")
+            ]
+            if allowed is not None and (
+                is_private_title(r.get("title"))
+                or is_private_title(r.get("target_text"))
+                or any(node not in allowed for node in ids)
+            ):
+                continue
             for p, c in zip(ids, ids[1:]):
                 if p != c:
                     votes[c][p] += 1
     principal = {c: max(cnt.items(), key=lambda kv: (kv[1], kv[0]))[0] for c, cnt in votes.items()}
     dag_first = {}
-    for ln in open(DAG, encoding="utf-8"):
-        p, c = ln.split()
-        dag_first.setdefault(c, p)
-    titles = {}
-    for ln in open(TITLES, encoding="utf-8"):
-        parts = ln.rstrip("\n").split("\t")
-        if len(parts) >= 2:
-            titles[parts[0]] = parts[1]
+    if allowed is None:
+        for ln in open(DAG, encoding="utf-8"):
+            p, c = ln.split()
+            dag_first.setdefault(c, p)
+    if public_tree_titles is None:
+        titles = {}
+        for ln in open(TITLES, encoding="utf-8"):
+            parts = ln.rstrip("\n").split("\t")
+            if len(parts) >= 2:
+                titles[parts[0]] = parts[1]
+    else:
+        titles = {str(tid): title for tid, title in public_tree_titles.items()}
 
     n_rec, n_dag = 0, 0
 
@@ -89,6 +130,8 @@ def folder_lineage(cand, depth=5, shuffle_seed=None):
                 nxt = dag_first[cur]
                 n_dag += 1
             else:
+                break
+            if allowed is not None and nxt not in allowed:
                 break
             if nxt in seen:
                 break
@@ -120,6 +163,10 @@ def folder_lineage(cand, depth=5, shuffle_seed=None):
             parents_title.setdefault(prev, [p])
             anc_titles.add(p)
             prev = p
+    if return_id_chains:
+        return parents_title, anc_titles, {
+            str(tid): list(ch) for tid, ch in zip(tids, chains)
+        }
     return parents_title, anc_titles
 
 

--- a/prototypes/mu_cosine/filing_assistant.py
+++ b/prototypes/mu_cosine/filing_assistant.py
@@ -16,9 +16,11 @@ confident placements auto-suggested, low-margin ones routed to review (a human o
   suggest mode  python3 filing_assistant.py suggest "Some new bookmark title" [--top-n 5]
       Rank folders for new bookmark title(s) (repeatable arg, or --from-file, one per line).
       Catalog = folders with ≥ --min-bm recorded bookmarks (default 1: every folder actually in
-      use as a filing destination). Duplicate titles are merged (all tree ids shown). Each
-      suggestion prints e5 cosine; the query prints its top-2 margin and a routing verdict at
-      --margin (default 0.05 — see the eval routing table for the measured kept-R@1 tradeoff).
+      use as a filing destination). Folder IDs remain distinct even when titles match, so exact
+      score ties have the same ascending-catalog-column rule as evaluation and correctly produce
+      zero margin. Each suggestion prints the exact tree ID and e5 cosine; the query prints its
+      top-2 ID-level margin and a routing verdict at --margin (default 0.05 — see the eval routing
+      table for the measured kept-R@1 tradeoff).
 
 No μ, no blend, no diffusion — those are nulls as rankers on this task (REPORTs); revisit only if
 a future head beats e5 somewhere (gap-directed training is the demonstrated path — §B′/B″).
@@ -34,23 +36,50 @@ import numpy as np
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from eval_filing import load_filing, metrics
+from filing_privacy import public_catalog_title_eligible
 from mu_attention import E5_MODEL, build_e5_tables
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 TREES = os.path.join(ROOT, "..", "..", ".local", "data", "pearltrees_api", "trees")
 
 
-def catalog_tables(min_bm, cache_tag):
-    """Folder catalog + unit e5 passage vectors (cached per catalog)."""
-    queries, cand = load_filing(TREES, min_bm)
+def apply_public_catalog_policy(queries, candidates):
+    """Apply the one shared outcome-blind folder eligibility rule."""
+    eligible = {
+        folder_id: title
+        for folder_id, title in candidates.items()
+        if public_catalog_title_eligible(title)
+    }
+    filtered_queries = [
+        (bookmark, folder_id)
+        for bookmark, folder_id in queries
+        if folder_id in eligible
+    ]
+    return filtered_queries, eligible
+
+
+def catalog_tables(min_bm, cache_tag, *, return_privacy=False):
+    """Certified-public folder catalog + unit e5 passage vectors.
+
+    ``return_privacy`` exposes the exact privacy index used to construct the
+    catalog so hosted-task emitters can bind it into their provenance.
+    """
+    queries, cand, privacy = load_filing(TREES, min_bm, return_privacy=True)
+    queries, cand = apply_public_catalog_policy(queries, cand)
     f_ids = sorted(cand)
     f_titles = [cand[fid] for fid in f_ids]
     names = sorted(set(f_titles))
-    cache = f"/tmp/mu_data/filing_assistant_e5_{cache_tag}.pt"
+    cache_root = os.environ.get("MU_COSINE_CACHE_DIR", "/tmp/mu_data")
+    os.makedirs(cache_root, exist_ok=True)
+    cache = os.path.join(
+        cache_root,
+        f"filing_assistant_e5_{cache_tag}_{privacy.manifest_sha256[:12]}.pt",
+    )
     _, ptbl, idx = build_e5_tables(names, cache_path=cache, batch_size=128)
     P = ptbl.numpy()
     cand_vec = np.stack([P[idx[t]] for t in f_titles])
-    return queries, f_ids, f_titles, cand_vec
+    result = (queries, f_ids, f_titles, cand_vec)
+    return (*result, privacy) if return_privacy else result
 
 
 def encode_queries(titles):
@@ -62,8 +91,12 @@ def encode_queries(titles):
 
 
 def ranks_np(cos, truepos):
-    """1-based rank of the best acceptable folder (title-equivalence; ties broken pessimistically
-    against later columns, matching eval_pearltrees_filing.ranks_from)."""
+    """1-based rank of the best supplied acceptable column.
+
+    ``truepos`` determines exact-ID versus title-equivalence grading. Exact
+    ties favor the lower catalog column, matching ``stable_score_order`` and
+    ``eval_pearltrees_filing.ranks_from``.
+    """
     out = []
     for r in range(cos.shape[0]):
         best = None
@@ -73,6 +106,11 @@ def ranks_np(cos, truepos):
             best = rank if best is None else min(best, rank)
         out.append(best)
     return np.array(out)
+
+
+def stable_score_order(cos):
+    """Descending score order with exact ties broken by lower catalog column."""
+    return np.argsort(-np.asarray(cos), axis=-1, kind="stable")
 
 
 def run_eval(a):
@@ -124,37 +162,19 @@ def run_suggest(a):
         print("no titles given — pass positional titles or --from-file", file=sys.stderr)
         sys.exit(2)
     _, f_ids, f_titles, cand_vec = catalog_tables(a.min_bm, f"sugg{a.min_bm}")
-    # catalog hygiene (suggest only — eval keeps the standing manifest): drop degenerate titles
-    # with no letters/digits ("?", "-", …) — e5 places them near everything (observed: a "?"
-    # folder ranked #1 for every query)
-    keep = [j for j, t in enumerate(f_titles) if any(c.isalnum() for c in t)]
-    dropped = len(f_titles) - len(keep)
-    if dropped:
-        print(f"(catalog hygiene: dropped {dropped} degenerate folder title(s))")
-    f_ids = [f_ids[j] for j in keep]
-    cand_vec = cand_vec[keep]
-    f_titles = [f_titles[j] for j in keep]
-    by_title = {}
-    for j, t in enumerate(f_titles):
-        by_title.setdefault(t, []).append(f_ids[j])
-    uniq_titles = sorted(by_title)
-    tvec = {}
-    for j, t in enumerate(f_titles):
-        tvec.setdefault(t, cand_vec[j])
-    U = np.stack([tvec[t] for t in uniq_titles])
-
     qv = encode_queries(titles)
-    cos = qv @ U.T
+    cos = qv @ cand_vec.T
     for i, bt in enumerate(titles):
-        order = np.argsort(-cos[i])
+        order = stable_score_order(cos[i])
         margin = float(cos[i][order[0]] - cos[i][order[1]]) if len(order) > 1 else float("inf")
         verdict = "AUTO-FILE candidate" if margin >= a.margin else "ROUTE TO REVIEW (low margin)"
         print(f"\n» {bt}")
         print(f"  margin {margin:.3f} → {verdict} (t={a.margin})")
         for r, j in enumerate(order[:a.top_n], 1):
-            t = uniq_titles[j]
-            ids = ",".join(str(x) for x in by_title[t][:4])
-            print(f"  {r}. {cos[i][j]:.3f}  {t}   [tree {ids}]")
+            print(
+                f"  {r}. {cos[i][j]:.3f}  {f_titles[j]}   "
+                f"[tree {f_ids[j]}]"
+            )
 
 
 def main(argv=None):

--- a/prototypes/mu_cosine/filing_privacy.py
+++ b/prototypes/mu_cosine/filing_privacy.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Fail-closed privacy index for harvested Pearltrees filing data.
+
+The filing tools may send bookmark and folder titles to a hosted judge.  They
+therefore need stronger evidence than "not explicitly private": a node is
+eligible only when the harvest contains an explicit public claim, no private
+claim or private-title marker, and no private/unknown containment ancestor.
+
+Unknown nodes are quarantined, not relabelled private.  The distinction is
+preserved in the manifest while both classes remain ineligible for external
+tasks.  See ``privacy.py`` for the repository-wide scrub-everywhere rule.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+from privacy import is_private_title, propagate, vis_public
+
+
+POLICY_ID = "pearltrees-public-only-v1"
+PUBLIC_CATALOG_POLICY_ID = "pearltrees-public-alphanumeric-title-v1"
+SCHEMA = "unifyweaver.pearltrees-privacy-index.v1"
+
+
+class FilingPrivacyError(ValueError):
+    """The harvested snapshot cannot be certified for public-only use."""
+
+
+def public_catalog_title_eligible(title: Any) -> bool:
+    """Outcome-blind folder-title eligibility shared by eval and suggestion."""
+    return isinstance(title, str) and any(character.isalnum() for character in title)
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        + b"\n"
+    )
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _strict_object(pairs):
+    out = {}
+    for key, value in pairs:
+        if key in out:
+            raise FilingPrivacyError(f"duplicate JSON key: {key!r}")
+        out[key] = value
+    return out
+
+
+def _strict_json(data: bytes, source: str):
+    try:
+        return json.loads(data.decode("utf-8"), object_pairs_hook=_strict_object)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise FilingPrivacyError(f"malformed JSON in {source}: {exc}") from exc
+
+
+def canonical_tree_id(value: Any) -> str:
+    """Return a decimal tree id, rejecting bools and malformed identifiers."""
+    if isinstance(value, bool) or value is None:
+        raise FilingPrivacyError(f"invalid tree id: {value!r}")
+    text = str(value).strip()
+    if not text.isdecimal():
+        raise FilingPrivacyError(f"invalid tree id: {value!r}")
+    return str(int(text))
+
+
+def visibility_claim(value: Any) -> str:
+    """Map a Pearltrees visibility value to public/private/unknown.
+
+    Canonical integer-like values are accepted.  A malformed nonempty value is
+    not silently quarantined because it may reflect a changed upstream schema.
+    """
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return "unknown"
+    if isinstance(value, bool):
+        raise FilingPrivacyError(f"malformed visibility: {value!r}")
+    text = str(value).strip()
+    try:
+        numeric = int(text)
+    except ValueError as exc:
+        raise FilingPrivacyError(f"malformed visibility: {value!r}") from exc
+    if str(numeric) != text:
+        raise FilingPrivacyError(f"noncanonical visibility: {value!r}")
+    return "public" if vis_public(value) else "private"
+
+
+def merge_visibility_claims(claims) -> str:
+    claims = tuple(claims)
+    if any(claim == "private" for claim in claims):
+        return "private"
+    if any(claim == "public" for claim in claims):
+        return "public"
+    return "unknown"
+
+
+@dataclass(frozen=True)
+class PearltreesPrivacyIndex:
+    status_by_id: Mapping[str, str]
+    reason_by_id: Mapping[str, tuple[str, ...]]
+    public_ids: frozenset[str]
+    private_ids: frozenset[str]
+    quarantined_ids: frozenset[str]
+    manifest_sha256: str
+    source_snapshot: Mapping[str, Any]
+    tree_payloads: Mapping[str, Mapping[str, Any]]
+    tree_value_ids: Mapping[str, Any]
+    tree_file_sha256: Mapping[str, str]
+    public_title_by_id: Mapping[str, str]
+
+    def receipt(self) -> dict[str, Any]:
+        """Non-sensitive aggregate record suitable for a hosted-task header."""
+        return {
+            "schema": SCHEMA,
+            "policy_id": POLICY_ID,
+            "manifest_sha256": self.manifest_sha256,
+            "source_snapshot": dict(self.source_snapshot),
+            "counts": {
+                "public": len(self.public_ids),
+                "private": len(self.private_ids),
+                "quarantined": len(self.quarantined_ids),
+                "observed": len(self.status_by_id),
+            },
+        }
+
+
+def _infer_paths_jsonl(trees_dir: Path) -> Path | None:
+    # .../.local/data/pearltrees_api/trees -> .../.local/data/api_tree_paths_v8.jsonl
+    candidate = trees_dir.parent.parent / "api_tree_paths_v8.jsonl"
+    return candidate if candidate.is_file() else None
+
+
+def build_pearltrees_privacy_index(
+    trees_dir: str | os.PathLike[str],
+    *,
+    paths_jsonl: str | os.PathLike[str] | None = None,
+) -> PearltreesPrivacyIndex:
+    """Certify the public subset of a Pearltrees API snapshot.
+
+    Containment is limited to typed API parent/collection edges and validated
+    materialized paths.  Shortcut/alias/cross-link pearls are deliberately not
+    privacy-propagation edges.
+    """
+    root = Path(trees_dir)
+    if not root.is_dir():
+        raise FilingPrivacyError(f"trees directory does not exist: {root}")
+    path_file = Path(paths_jsonl) if paths_jsonl is not None else _infer_paths_jsonl(root)
+
+    observations: dict[str, list[str]] = defaultdict(list)
+    title_private: dict[str, bool] = defaultdict(bool)
+    title_claims: dict[str, list[tuple[int, str]]] = defaultdict(list)
+    reasons: dict[str, set[str]] = defaultdict(set)
+    children: dict[str, set[str]] = defaultdict(set)
+    anchored_nodes: set[str] = set()
+    explicit_user_roots: set[str] = set()
+    tree_payloads: dict[str, Mapping[str, Any]] = {}
+    tree_value_ids: dict[str, Any] = {}
+    tree_file_sha256: dict[str, str] = {}
+    inventory: list[dict[str, Any]] = []
+
+    def observe(raw_id, title, visibility, source):
+        tid = canonical_tree_id(raw_id)
+        claim = visibility_claim(visibility)
+        observations[tid].append(claim)
+        reasons[tid].add(f"{source}:{claim}")
+        if isinstance(title, str) and title:
+            priority = {"tree": 0, "parentTree": 1, "contentTree": 2}.get(source, 9)
+            title_claims[tid].append((priority, title))
+        if is_private_title(title):
+            title_private[tid] = True
+            reasons[tid].add(f"{source}:private-title")
+        return tid
+
+    # The directory also carries queue/priority metadata JSON.  Only numeric
+    # names are per-tree source records; malformed *numeric* records fail below.
+    files = sorted(
+        (path for path in root.glob("*.json") if path.stem.isdecimal()),
+        key=lambda path: path.name,
+    )
+    if not files:
+        raise FilingPrivacyError(f"no harvested tree JSON files in {root}")
+    for path in files:
+        raw = path.read_bytes()
+        digest = _sha256(raw)
+        inventory.append(
+            {
+                "name": f"trees/{path.name}",
+                "size_bytes": len(raw),
+                "sha256": digest,
+            }
+        )
+        doc = _strict_json(raw, str(path))
+        if not isinstance(doc, dict):
+            raise FilingPrivacyError(f"tree file is not an object: {path}")
+        api = doc.get("api_response")
+        if not isinstance(api, dict):
+            raise FilingPrivacyError(f"missing api_response object: {path}")
+        tree = api.get("tree")
+        if not isinstance(tree, dict):
+            raise FilingPrivacyError(f"missing tree object: {path}")
+        tid = observe(tree.get("id"), tree.get("title"), tree.get("visibility"), "tree")
+        if tid != canonical_tree_id(path.stem):
+            raise FilingPrivacyError(
+                f"filename/payload tree id mismatch: {path.name} != {tree.get('id')!r}"
+            )
+        if tid in tree_payloads:
+            raise FilingPrivacyError(f"duplicate harvested tree id: {tid}")
+        tree_payloads[tid] = tree
+        tree_value_ids[tid] = tree.get("id")
+        tree_file_sha256[tid] = digest
+        if tree.get("isUserRoot") in (1, "1", True):
+            explicit_user_roots.add(tid)
+
+        info = api.get("info")
+        parent = info.get("parentTree") if isinstance(info, dict) else None
+        if isinstance(parent, dict) and parent.get("id") is not None:
+            pid = observe(
+                parent.get("id"),
+                parent.get("title"),
+                parent.get("visibility"),
+                "parentTree",
+            )
+            if pid != tid:
+                children[pid].add(tid)
+
+        pearls = tree.get("pearls")
+        if pearls is None:
+            pearls = []
+        if not isinstance(pearls, list):
+            raise FilingPrivacyError(f"tree.pearls is not a list: {path}")
+        for pearl in pearls:
+            if not isinstance(pearl, dict) or str(pearl.get("contentType")) != "2":
+                continue
+            child = pearl.get("contentTree")
+            if not isinstance(child, dict) or child.get("id") is None:
+                raise FilingPrivacyError(f"collection pearl lacks contentTree id: {path}")
+            cid = observe(
+                child.get("id"),
+                child.get("title") or pearl.get("title"),
+                child.get("visibility"),
+                "contentTree",
+            )
+            if is_private_title(pearl.get("title")):
+                title_private[cid] = True
+                reasons[cid].add("collectionPearl:private-title")
+            if cid != tid:
+                children[tid].add(cid)
+
+    if path_file is None:
+        raise FilingPrivacyError(
+            "api_tree_paths_v8.jsonl is required for public-only ancestry certification"
+        )
+    if path_file is not None:
+        raw_paths = path_file.read_bytes()
+        inventory.append(
+            {
+                "name": path_file.name,
+                "size_bytes": len(raw_paths),
+                "sha256": _sha256(raw_paths),
+            }
+        )
+        for line_no, line in enumerate(raw_paths.splitlines(), 1):
+            if not line.strip():
+                continue
+            row = _strict_json(line, f"{path_file}:{line_no}")
+            if not isinstance(row, dict):
+                raise FilingPrivacyError(f"path row is not an object: {path_file}:{line_no}")
+            raw_ids = row.get("path_ids")
+            if not isinstance(raw_ids, list):
+                raise FilingPrivacyError(f"path_ids is not a list: {path_file}:{line_no}")
+            target = canonical_tree_id(row.get("tree_id"))
+            account_rooted = bool(
+                raw_ids
+                and isinstance(raw_ids[0], str)
+                and raw_ids[0].startswith("account:")
+            )
+            numeric_user_root = bool(
+                len(raw_ids) == 1
+                and row.get("parent_tree_id") is None
+                and canonical_tree_id(raw_ids[0]) == target
+            )
+            if not account_rooted and not numeric_user_root:
+                raise FilingPrivacyError(
+                    f"path row lacks an account root: {path_file}:{line_no}"
+                )
+            if row.get("path_depth") is not None:
+                depth = row["path_depth"]
+                if isinstance(depth, bool) or not isinstance(depth, int) or depth != len(raw_ids):
+                    raise FilingPrivacyError(
+                        f"path_depth mismatch at {path_file}:{line_no}"
+                    )
+            ids = []
+            for raw_id in raw_ids:
+                text = str(raw_id)
+                if text.startswith("account:"):
+                    continue
+                ids.append(canonical_tree_id(raw_id))
+            if not ids:
+                raise FilingPrivacyError(f"path row has no numeric ids: {path_file}:{line_no}")
+            if ids[-1] != target:
+                raise FilingPrivacyError(
+                    f"path target mismatch at {path_file}:{line_no}: {ids[-1]} != {target}"
+                )
+            parent = row.get("parent_tree_id")
+            if parent is not None:
+                if len(ids) < 2:
+                    raise FilingPrivacyError(
+                        f"path parent has no preceding id: {path_file}:{line_no}"
+                    )
+                if canonical_tree_id(parent) != ids[-2]:
+                    raise FilingPrivacyError(f"path parent mismatch: {path_file}:{line_no}")
+            for parent_id, child_id in zip(ids, ids[1:]):
+                if parent_id != child_id:
+                    children[parent_id].add(child_id)
+            anchored_nodes.update(ids)
+            # A private marker anywhere in the materialized display path means
+            # the target is below a private ancestor.  When the display lines
+            # align with path_ids, seed the exact marked numeric node; otherwise
+            # conservatively seed the target.
+            if is_private_title(row.get("title")) or is_private_title(row.get("target_text")):
+                display = []
+                for line in str(row.get("target_text") or "").splitlines():
+                    stripped = line.strip()
+                    if stripped.startswith("- "):
+                        display.append(stripped[2:].strip())
+                marked = False
+                if len(display) == len(raw_ids):
+                    for raw_id, title in zip(raw_ids, display):
+                        if (
+                            not str(raw_id).startswith("account:")
+                            and is_private_title(title)
+                        ):
+                            marked_id = canonical_tree_id(raw_id)
+                            title_private[marked_id] = True
+                            reasons[marked_id].add("path:private-marker")
+                            marked = True
+                if not marked:
+                    title_private[target] = True
+                    reasons[target].add("path:private-marker")
+
+    direct_private = {
+        tid
+        for tid, claims in observations.items()
+        if merge_visibility_claims(claims) == "private" or title_private[tid]
+    }
+    direct_unknown = {
+        tid
+        for tid, claims in observations.items()
+        if tid not in direct_private and merge_visibility_claims(claims) == "unknown"
+    }
+    # Paths can mention nodes absent from API summaries.  Such nodes are
+    # uncertified and quarantine their descendants.
+    all_nodes = set(observations) | set(children)
+    for values in children.values():
+        all_nodes.update(values)
+    direct_unknown.update(all_nodes - set(observations) - direct_private)
+    ancestry_reachable = propagate(anchored_nodes | explicit_user_roots, children)
+    direct_unknown.update(
+        tid
+        for tid, claims in observations.items()
+        if merge_visibility_claims(claims) == "public"
+        and tid not in ancestry_reachable
+        and tid not in direct_private
+    )
+    for tid in direct_unknown:
+        if tid in observations and merge_visibility_claims(observations[tid]) == "public":
+            reasons[tid].add("uncertified-ancestry")
+
+    private_closure = propagate(direct_private, children)
+    quarantine_closure = propagate(direct_unknown, children) - private_closure
+    public_ids = {
+        tid
+        for tid, claims in observations.items()
+        if merge_visibility_claims(claims) == "public"
+        and tid not in private_closure
+        and tid not in quarantine_closure
+    }
+
+    status_by_id = {}
+    reason_by_id = {}
+    for tid in sorted(all_nodes, key=lambda value: int(value)):
+        if tid in private_closure:
+            status = "private"
+            if tid not in direct_private:
+                reasons[tid].add("private-ancestor")
+        elif tid in quarantine_closure:
+            status = "unknown"
+            if tid not in direct_unknown:
+                reasons[tid].add("unknown-ancestor")
+        elif tid in public_ids:
+            status = "public"
+        else:
+            status = "unknown"
+            reasons[tid].add("no-public-evidence")
+        status_by_id[tid] = status
+        reason_by_id[tid] = tuple(sorted(reasons[tid]))
+
+    decision_rows = [
+        {
+            "tree_id": tid,
+            "status": status_by_id[tid],
+            "reasons": list(reason_by_id[tid]),
+        }
+        for tid in sorted(status_by_id, key=lambda value: int(value))
+    ]
+    inventory = sorted(inventory, key=lambda row: row["name"])
+    source_snapshot = {
+        "schema": "unifyweaver.pearltrees-source-snapshot.v1",
+        "file_count": len(inventory),
+        "total_size_bytes": sum(row["size_bytes"] for row in inventory),
+        "members_sha256": _sha256(b"".join(canonical_json_bytes(row) for row in inventory)),
+    }
+    manifest_core = {
+        "schema": SCHEMA,
+        "policy_id": POLICY_ID,
+        "source_snapshot": source_snapshot,
+        "decisions_sha256": _sha256(
+            b"".join(canonical_json_bytes(row) for row in decision_rows)
+        ),
+    }
+    manifest_sha256 = _sha256(canonical_json_bytes(manifest_core))
+    public_title_by_id = {
+        tid: sorted(title_claims[tid], key=lambda item: (item[0], item[1]))[0][1]
+        for tid in public_ids
+        if title_claims.get(tid)
+    }
+    return PearltreesPrivacyIndex(
+        status_by_id=status_by_id,
+        reason_by_id=reason_by_id,
+        public_ids=frozenset(public_ids),
+        private_ids=frozenset(private_closure),
+        quarantined_ids=frozenset(quarantine_closure),
+        manifest_sha256=manifest_sha256,
+        source_snapshot=source_snapshot,
+        tree_payloads=tree_payloads,
+        tree_value_ids=tree_value_ids,
+        tree_file_sha256=tree_file_sha256,
+        public_title_by_id=public_title_by_id,
+    )

--- a/prototypes/mu_cosine/privacy.py
+++ b/prototypes/mu_cosine/privacy.py
@@ -23,6 +23,15 @@ def vis_private(v):
     return v is not None and str(v).strip() not in ("", "0")
 
 
+def vis_public(v):
+    """True only for Pearltrees' explicit public value.
+
+    This deliberately is not ``not vis_private(v)``: missing visibility is
+    *unknown*, not evidence that a node is safe to send to an external service.
+    """
+    return v is not None and str(v).strip() == "0"
+
+
 def propagate(private_seed, children_of):
     """Inherit privacy DOWN a containment graph: given a seed set of private keys and a
     parent_key -> iterable(child_key) map, return the full set including all descendants."""

--- a/prototypes/mu_cosine/routed_policy.py
+++ b/prototypes/mu_cosine/routed_policy.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""Integrity primitives for public-only routed filing tasks and policies.
+
+The hashes below provide content binding, not provider authentication.  Judge
+identity remains declared provenance, but changing a task, menu, pick, policy,
+or provenance field necessarily changes the corresponding identifier.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, Iterable, Mapping, Sequence
+
+import numpy as np
+
+from filing_privacy import (
+    POLICY_ID as PRIVACY_POLICY_ID,
+    PUBLIC_CATALOG_POLICY_ID,
+)
+
+
+TASK_SCHEMA = "unifyweaver.routed-task.v2"
+RAW_PICKS_SCHEMA = "unifyweaver.raw-routed-picks.v1"
+PICKS_SCHEMA = "unifyweaver.routed-picks.v2"
+POLICY_SCHEMA = "unifyweaver.routed-policy.v1"
+
+
+class RoutedPolicyError(ValueError):
+    """A routed task/pick/policy artifact failed closed."""
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        + b"\n"
+    )
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def content_record_bytes(data: bytes) -> dict[str, Any]:
+    return {"size_bytes": len(data), "sha256": sha256_bytes(data)}
+
+
+def file_content_record(path: str | os.PathLike[str]) -> dict[str, Any]:
+    return content_record_bytes(Path(path).read_bytes())
+
+
+def _strict_object(pairs):
+    out = {}
+    for key, value in pairs:
+        if key in out:
+            raise RoutedPolicyError(f"duplicate JSON key: {key!r}")
+        out[key] = value
+    return out
+
+
+def _bad_constant(value):
+    raise RoutedPolicyError(f"non-finite JSON number: {value}")
+
+
+def strict_json_loads(data: bytes | str, source="<json>"):
+    try:
+        text = data.decode("utf-8") if isinstance(data, bytes) else data
+        return json.loads(
+            text,
+            object_pairs_hook=_strict_object,
+            parse_constant=_bad_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RoutedPolicyError(f"malformed JSON in {source}: {exc}") from exc
+
+
+def _require_int(value, label):
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RoutedPolicyError(f"{label} must be an integer")
+    return value
+
+
+def _ordered_qid_record(qids: Sequence[int]) -> dict[str, Any]:
+    for qid in qids:
+        _require_int(qid, "qid")
+    data = b"".join(canonical_json_bytes(qid) for qid in qids)
+    return {"count": len(qids), "sha256": sha256_bytes(data)}
+
+
+def _rows_record(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    data = b"".join(canonical_json_bytes(dict(row)) for row in rows)
+    return {
+        "count": len(rows),
+        "qid_sha256": _ordered_qid_record([row["qid"] for row in rows])["sha256"],
+        "sha256": sha256_bytes(data),
+    }
+
+
+def _id_for(core: Mapping[str, Any]) -> str:
+    return sha256_bytes(canonical_json_bytes(dict(core)))
+
+
+def float64_hex(value: float | None) -> str | None:
+    if value is None:
+        return None
+    value = float(value)
+    if not math.isfinite(value):
+        raise RoutedPolicyError("band boundary must be finite")
+    return value.hex()
+
+
+def parse_float64_hex(value: str | None) -> float | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise RoutedPolicyError("band boundary must be a float.hex string or null")
+    try:
+        parsed = float.fromhex(value)
+    except ValueError as exc:
+        raise RoutedPolicyError(f"invalid float.hex boundary: {value!r}") from exc
+    if not math.isfinite(parsed) or parsed.hex() != value:
+        raise RoutedPolicyError(f"noncanonical float.hex boundary: {value!r}")
+    return parsed
+
+
+def make_band(lower: float | None, upper: float | None) -> dict[str, Any]:
+    low = None if lower is None else float(lower)
+    high = None if upper is None else float(upper)
+    if low is not None and high is not None and not low < high:
+        raise RoutedPolicyError("band lower boundary must be smaller than upper")
+    return {
+        "lower_float64_hex": float64_hex(low),
+        "upper_float64_hex": float64_hex(high),
+        "semantics": "lower-inclusive_upper-exclusive",
+    }
+
+
+def parse_band(band: Mapping[str, Any]) -> tuple[float | None, float | None]:
+    if not isinstance(band, Mapping):
+        raise RoutedPolicyError("band must be an object")
+    if band.get("semantics") != "lower-inclusive_upper-exclusive":
+        raise RoutedPolicyError("unsupported band semantics")
+    low = parse_float64_hex(band.get("lower_float64_hex"))
+    high = parse_float64_hex(band.get("upper_float64_hex"))
+    if low is not None and high is not None and not low < high:
+        raise RoutedPolicyError("band is empty or reversed")
+    return low, high
+
+
+def in_band(value: float, band: Mapping[str, Any]) -> bool:
+    value = float(value)
+    if not math.isfinite(value):
+        raise RoutedPolicyError("margin must be finite")
+    low, high = parse_band(band)
+    return (low is None or value >= low) and (high is None or value < high)
+
+
+def band_qids(margins: Sequence[float], band: Mapping[str, Any]) -> tuple[int, ...]:
+    return tuple(qid for qid, margin in enumerate(margins) if in_band(float(margin), band))
+
+
+def _validate_task_row(row: Mapping[str, Any]):
+    if not isinstance(row, Mapping) or row.get("record_type") != "task":
+        raise RoutedPolicyError("task row has wrong record_type")
+    _require_int(row.get("qid"), "task qid")
+    if not isinstance(row.get("bookmark"), str) or not row["bookmark"]:
+        raise RoutedPolicyError("task bookmark must be a nonempty string")
+    menu = row.get("menu")
+    if not isinstance(menu, list) or not menu:
+        raise RoutedPolicyError("task menu must be a nonempty list")
+    for expected, item in enumerate(menu):
+        if not isinstance(item, Mapping):
+            raise RoutedPolicyError("menu item must be an object")
+        if _require_int(item.get("pos"), "menu position") != expected:
+            raise RoutedPolicyError("menu positions must be contiguous and zero based")
+        if not isinstance(item.get("title"), str) or not item["title"]:
+            raise RoutedPolicyError("menu title must be a nonempty string")
+        if not isinstance(item.get("folder_id"), str) or not item["folder_id"]:
+            raise RoutedPolicyError("menu folder_id must be a nonempty string")
+        if "path" in item and not isinstance(item["path"], str):
+            raise RoutedPolicyError("menu path must be a string")
+
+
+def build_task_envelope(
+    task_core: Mapping[str, Any], rows: Sequence[Mapping[str, Any]]
+) -> dict[str, Any]:
+    rows = [dict(row) for row in rows]
+    seen = set()
+    for row in rows:
+        _validate_task_row(row)
+        if row["qid"] in seen:
+            raise RoutedPolicyError(f"duplicate task qid: {row['qid']}")
+        seen.add(row["qid"])
+    core = dict(task_core)
+    if "task_rows" in core:
+        raise RoutedPolicyError("caller must not prepopulate task_rows")
+    selection = core.get("selection")
+    if not isinstance(selection, Mapping):
+        raise RoutedPolicyError("task selection is missing")
+    expected_menu_size = _require_int(selection.get("menu_size"), "menu_size")
+    if expected_menu_size <= 0:
+        raise RoutedPolicyError("menu_size must be positive")
+    for row in rows:
+        if len(row["menu"]) != expected_menu_size:
+            raise RoutedPolicyError(
+                f"qid {row['qid']} has {len(row['menu'])} menu items, "
+                f"expected {expected_menu_size}"
+            )
+    core["task_rows"] = _rows_record(rows)
+    return {
+        "schema": TASK_SCHEMA,
+        "record_type": "task_envelope",
+        "task_id": _id_for(core),
+        "task_core": core,
+    }
+
+
+def _atomic_write_jsonl(
+    path: str | os.PathLike[str],
+    header: Mapping[str, Any],
+    rows: Sequence[Mapping[str, Any]],
+):
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{target.name}.", dir=str(target.parent))
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(canonical_json_bytes(dict(header)))
+            for row in rows:
+                handle.write(canonical_json_bytes(dict(row)))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, target)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+        raise
+    return file_content_record(target)
+
+
+def write_task_file(path, task_core, rows):
+    header = build_task_envelope(task_core, rows)
+    record = _atomic_write_jsonl(path, header, rows)
+    return header, record
+
+
+def _read_jsonl(path):
+    rows = []
+    for line_no, line in enumerate(Path(path).read_bytes().splitlines(), 1):
+        if not line.strip():
+            continue
+        rows.append(strict_json_loads(line, f"{path}:{line_no}"))
+    if not rows:
+        raise RoutedPolicyError(f"empty JSONL file: {path}")
+    return rows
+
+
+def read_task_file(path):
+    records = _read_jsonl(path)
+    header, rows = records[0], records[1:]
+    if (
+        not isinstance(header, Mapping)
+        or header.get("schema") != TASK_SCHEMA
+        or header.get("record_type") != "task_envelope"
+    ):
+        raise RoutedPolicyError("legacy or malformed task file; v2 envelope required")
+    core = header.get("task_core")
+    if not isinstance(core, Mapping):
+        raise RoutedPolicyError("task_core is missing")
+    rebuilt = build_task_envelope(
+        {key: value for key, value in core.items() if key != "task_rows"}, rows
+    )
+    if dict(header) != rebuilt:
+        raise RoutedPolicyError("task envelope/content hash mismatch")
+    return dict(header), [dict(row) for row in rows], file_content_record(path)
+
+
+def _validate_pick_rows(task_rows, pick_rows):
+    menu_len = {row["qid"]: len(row["menu"]) for row in task_rows}
+    expected = tuple(row["qid"] for row in task_rows)
+    picks = {}
+    for row in pick_rows:
+        if not isinstance(row, Mapping) or row.get("record_type") != "pick":
+            raise RoutedPolicyError("pick row has wrong record_type")
+        qid = _require_int(row.get("qid"), "pick qid")
+        if qid in picks:
+            raise RoutedPolicyError(f"duplicate pick qid: {qid}")
+        pick = row.get("pick")
+        if pick is not None:
+            pick = _require_int(pick, f"pick for qid {qid}")
+        picks[qid] = pick
+    actual = tuple(row["qid"] for row in pick_rows)
+    if set(actual) != set(expected):
+        missing = sorted(set(expected) - set(actual))
+        extras = sorted(set(actual) - set(expected))
+        raise RoutedPolicyError(
+            f"pick qids do not exactly match task; missing={missing[:5]}, extras={extras[:5]}"
+        )
+    for qid, pick in picks.items():
+        if pick is not None and not 0 <= pick < menu_len[qid]:
+            raise RoutedPolicyError(f"pick out of range for qid {qid}: {pick}")
+    return picks
+
+
+def read_raw_picks(path, task_header, task_rows):
+    records = _read_jsonl(path)
+    raw_header, records = records[0], records[1:]
+    if (
+        not isinstance(raw_header, Mapping)
+        or raw_header.get("schema") != RAW_PICKS_SCHEMA
+        or raw_header.get("record_type") != "raw_pick_header"
+        or raw_header.get("task_id") != task_header["task_id"]
+        or set(raw_header) != {"schema", "record_type", "task_id"}
+    ):
+        raise RoutedPolicyError(
+            "raw picks require an exact task_id header; unbound legacy rows cannot be sealed"
+        )
+    rows = []
+    for record in records:
+        if not isinstance(record, Mapping) or set(record) != {"qid", "pick"}:
+            raise RoutedPolicyError(
+                "raw picks must contain exactly {qid,pick}; legacy headers require an explicit migration"
+            )
+        rows.append(
+            {
+                "record_type": "pick",
+                "qid": record["qid"],
+                "pick": record["pick"],
+            }
+        )
+    _validate_pick_rows(task_rows, rows)
+    return rows
+
+
+def build_pick_envelope(
+    task_header,
+    task_file_record,
+    task_rows,
+    pick_rows,
+    judge_provenance,
+):
+    _validate_pick_rows(task_rows, pick_rows)
+    expected = _ordered_qid_record([row["qid"] for row in task_rows])
+    core = {
+        "task_id": task_header["task_id"],
+        "task_file": dict(task_file_record),
+        "expected_qids": expected,
+        "judge": dict(judge_provenance),
+        "pick_rows": _rows_record(pick_rows),
+    }
+    return {
+        "schema": PICKS_SCHEMA,
+        "record_type": "pick_envelope",
+        "pick_id": _id_for(core),
+        "pick_core": core,
+    }
+
+
+def seal_pick_file(task_path, raw_picks_path, out_path, judge_provenance):
+    task_header, task_rows, task_file_record = read_task_file(task_path)
+    pick_rows = read_raw_picks(raw_picks_path, task_header, task_rows)
+    header = build_pick_envelope(
+        task_header,
+        task_file_record,
+        task_rows,
+        pick_rows,
+        judge_provenance,
+    )
+    record = _atomic_write_jsonl(out_path, header, pick_rows)
+    return header, record
+
+
+def read_pick_file(path, task_path):
+    task_header, task_rows, task_file_record = read_task_file(task_path)
+    records = _read_jsonl(path)
+    header, pick_rows = records[0], records[1:]
+    if (
+        not isinstance(header, Mapping)
+        or header.get("schema") != PICKS_SCHEMA
+        or header.get("record_type") != "pick_envelope"
+    ):
+        raise RoutedPolicyError("legacy or malformed picks; v2 envelope required")
+    core = header.get("pick_core")
+    if not isinstance(core, Mapping):
+        raise RoutedPolicyError("pick_core is missing")
+    rebuilt = build_pick_envelope(
+        task_header,
+        task_file_record,
+        task_rows,
+        pick_rows,
+        core.get("judge", {}),
+    )
+    if dict(header) != rebuilt:
+        raise RoutedPolicyError("pick envelope/content hash mismatch")
+    return dict(header), [dict(row) for row in pick_rows], dict(
+        _validate_pick_rows(task_rows, pick_rows)
+    )
+
+
+def build_policy_envelope(policy_core):
+    core = dict(policy_core)
+    return {
+        "schema": POLICY_SCHEMA,
+        "record_type": "policy_envelope",
+        "policy_id": _id_for(core),
+        "policy_core": core,
+    }
+
+
+def read_policy_file(path):
+    envelope = strict_json_loads(Path(path).read_bytes(), str(path))
+    if (
+        not isinstance(envelope, Mapping)
+        or envelope.get("schema") != POLICY_SCHEMA
+        or envelope.get("record_type") != "policy_envelope"
+    ):
+        raise RoutedPolicyError("malformed routed policy")
+    core = envelope.get("policy_core")
+    if not isinstance(core, Mapping) or dict(envelope) != build_policy_envelope(core):
+        raise RoutedPolicyError("policy envelope/content hash mismatch")
+    validate_policy_core(core)
+    return dict(envelope)
+
+
+def validate_policy_core(core):
+    if core.get("evidence_status") != "exploratory_transductive":
+        raise RoutedPolicyError("current routed policy must remain exploratory_transductive")
+    if core.get("primary_grading") != "exact_destination_id":
+        raise RoutedPolicyError("primary grading must be exact_destination_id")
+    if core.get("privacy_policy_id") != PRIVACY_POLICY_ID:
+        raise RoutedPolicyError("policy must bind the public-only privacy policy")
+    if core.get("catalog_policy_id") != PUBLIC_CATALOG_POLICY_ID:
+        raise RoutedPolicyError("policy must bind the public catalog eligibility rule")
+    prompt = core.get("judge_prompt")
+    if (
+        not isinstance(prompt, Mapping)
+        or not isinstance(prompt.get("path"), str)
+        or not isinstance(prompt.get("sha256"), str)
+        or len(prompt["sha256"]) != 64
+    ):
+        raise RoutedPolicyError("policy must bind the frozen judge prompt")
+    tiers = core.get("tiers")
+    if not isinstance(tiers, list) or not tiers:
+        raise RoutedPolicyError("policy tiers are missing")
+    seen_ids = set()
+    previous_upper = None
+    for index, tier in enumerate(tiers):
+        if not isinstance(tier, Mapping):
+            raise RoutedPolicyError("policy tier must be an object")
+        tier_id = tier.get("tier_id")
+        if not isinstance(tier_id, str) or not tier_id or tier_id in seen_ids:
+            raise RoutedPolicyError("policy tier ids must be unique nonempty strings")
+        seen_ids.add(tier_id)
+        low, high = parse_band(tier.get("band", {}))
+        if index == 0 and low is not None:
+            raise RoutedPolicyError("first policy tier must start at -infinity")
+        if index > 0 and low is None:
+            raise RoutedPolicyError("only the first policy tier may start at -infinity")
+        if index < len(tiers) - 1 and high is None:
+            raise RoutedPolicyError("only the final policy tier may end at +infinity")
+        if index and low != previous_upper:
+            raise RoutedPolicyError("policy tiers overlap or leave a gap")
+        action = tier.get("action")
+        if action not in ("judge", "auto_top1"):
+            raise RoutedPolicyError(f"unsupported tier action: {action!r}")
+        if action == "judge":
+            if _require_int(tier.get("menu_size"), "menu_size") <= 0:
+                raise RoutedPolicyError("judge menu_size must be positive")
+            if not tier.get("lineage") or not isinstance(
+                tier.get("required_judge_family"), str
+            ):
+                raise RoutedPolicyError("judge tier must freeze lineage and required_judge")
+        previous_upper = high
+    if previous_upper is not None:
+        raise RoutedPolicyError("last policy tier must end at +infinity")
+    bootstrap = core.get("bootstrap")
+    if not isinstance(bootstrap, Mapping):
+        raise RoutedPolicyError("policy bootstrap contract is missing")
+    if bootstrap.get("unit") != "bookmark-folder-connected-component":
+        raise RoutedPolicyError("unsupported bootstrap unit")
+    if _require_int(bootstrap.get("replicates"), "bootstrap replicates") <= 0:
+        raise RoutedPolicyError("bootstrap replicates must be positive")
+    _require_int(bootstrap.get("seed"), "bootstrap seed")
+    interval = bootstrap.get("interval")
+    if interval != [0.025, 0.975]:
+        raise RoutedPolicyError("policy interval must be the frozen [0.025,0.975]")
+
+
+def policy_tier_for_margin(core, margin):
+    matched = [tier for tier in core["tiers"] if in_band(margin, tier["band"])]
+    if len(matched) != 1:
+        raise RoutedPolicyError(f"margin matched {len(matched)} policy tiers")
+    return matched[0]
+
+
+def paired_node_block_bootstrap(
+    policy_correct: Sequence[bool],
+    baseline_correct: Sequence[bool],
+    bookmark_nodes: Sequence[str],
+    folder_nodes: Sequence[str],
+    *,
+    replicates=9999,
+    seed=3867001,
+):
+    """Paired bootstrap over bookmark/folder connected components.
+
+    Rows sharing either a bookmark-title node or destination-folder node remain
+    together, so repeated destinations and duplicate bookmark titles cannot be
+    split across resampled blocks.
+    """
+    policy = np.asarray(policy_correct, dtype=float)
+    baseline = np.asarray(baseline_correct, dtype=float)
+    if not (
+        len(policy)
+        == len(baseline)
+        == len(bookmark_nodes)
+        == len(folder_nodes)
+        and len(policy) > 0
+    ):
+        raise RoutedPolicyError("bootstrap inputs must have equal nonzero length")
+    if replicates <= 0:
+        raise RoutedPolicyError("bootstrap replicates must be positive")
+
+    parent = list(range(len(policy)))
+
+    def find(i):
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    first = {}
+    for index, (bookmark, folder) in enumerate(zip(bookmark_nodes, folder_nodes)):
+        for node in (f"B:{bookmark}", f"F:{folder}"):
+            if node in first:
+                union(index, first[node])
+            else:
+                first[node] = index
+    blocks = defaultdict(list)
+    for index in range(len(policy)):
+        blocks[find(index)].append(index)
+    block_rows = [np.asarray(rows, dtype=int) for _, rows in sorted(blocks.items())]
+    delta = policy - baseline
+    rng = np.random.default_rng(seed)
+    samples = np.empty(replicates, dtype=float)
+    for draw in range(replicates):
+        chosen = rng.integers(0, len(block_rows), len(block_rows))
+        rows = np.concatenate([block_rows[index] for index in chosen])
+        samples[draw] = float(delta[rows].mean())
+    lo, hi = np.quantile(samples, [0.025, 0.975])
+    return {
+        "point": float(delta.mean()),
+        "lower_0.025": float(lo),
+        "upper_0.975": float(hi),
+        "bootstrap_mean": float(samples.mean()),
+        "replicates": int(replicates),
+        "seed": int(seed),
+        "block_count": len(block_rows),
+        "unit": "bookmark-folder-connected-component",
+    }

--- a/prototypes/mu_cosine/routed_queries.py
+++ b/prototypes/mu_cosine/routed_queries.py
@@ -1,201 +1,890 @@
 #!/usr/bin/env python3
-"""Routed-queries loop, step 1: rescue ceilings + the judge task file.
+"""Public-only routed filing tasks with content-bound provenance.
 
-filing_assistant.py routes low-margin queries to review. This is the policy evaluation that the
-escalation tables always deferred ("needs judge labels on the routed queries"). Three modes:
+The historical routed-query passes established useful exploratory engineering
+evidence, but their task and pick files were not cryptographically bound and
+the catalog did not enforce privacy.  This v2 interface is the prospective
+contract for any further hosted judging:
 
-  ceilings   python3 routed_queries.py ceilings
-      No judge needed: for a grid of margin thresholds t and judge menus of size N, report the
-      POLICY CEILING — overall R@1 if the judge picked perfectly whenever the true folder is in
-      the top-N menu of a routed query (auto-filed kept queries keep their e5 top-1). This bounds
-      what any judge spend can buy and locates the useful (t, N) region.
+  ceilings
+      Recompute descriptive perfect-judge ceilings on the certified-public
+      population.
 
-  emit       python3 routed_queries.py emit --margin 0.02 --menu 10
-      Write the OUTCOME-BLIND judge task file for the routed set at t: one JSONL row per routed
-      query {qid, bookmark, menu:[{pos, title}]} (no truth marked, menu in e5 order) →
-      ~/mu_data/routed_tasks_t{t}_n{N}.jsonl (PRIVATE — personal titles). A judge (cheap LLM or
-      human) fills {qid, pick: pos|null}. Contract mirrors the campaign judge files: strict rows,
-      one pick per qid.
+  emit --margin 0.02 --menu 10 --lineage --tier-id low
+      Emit an outcome-blind v2 task.  Catalog, population, ranking, privacy
+      index, selection band, menus, and lineage mode are all content-bound.
 
-  score      python3 routed_queries.py score --picks <file> --margin 0.02 --menu 10
-      Ingest judge picks (JSONL {qid, pick}) fail-closed (every routed qid exactly once, pick in
-      menu range or null) and report the POLICY result: R@1 of [auto-filed kept + judge-picked
-      routed] vs the no-routing baseline, with a paired bootstrap CI on the delta.
+  seal-picks --task TASK --raw-picks RAW ...
+      Convert strict raw ``{qid,pick}`` rows into a v2 pick artifact that binds
+      the exact task bytes and declared judge provenance.  This does not
+      authenticate the provider; it prevents later provenance drift.
 
-Population/manifest identical to filing_assistant eval (seed 7, ≤1200 queries, min_bm=3 catalog,
-manifest sha printed). Ranking = e5 @ K=100. Title-equivalence grading.
+  score --task TASK --picks PICKS
+      Rebuild and byte-compare the task, require an exact QID join, then report
+      a paired bookmark/folder node-block interval.
+
+  score-policy --policy POLICY --tier ID TASK PICKS [...]
+      Reproduce a complete frozen multi-tier policy.  Each population row must
+      match exactly one tier and every judge tier must have one bound task/pick
+      pair.
+
+Legacy unbound artifacts are intentionally rejected.  They remain valid only
+as descriptive historical evidence and cannot be upgraded retroactively.
+This version binds one response artifact per tier; provenance-safe provider-call
+chunking and repeated-draw aggregation require a future parent-task/chunk
+manifest and are not silently emulated by concatenating responses.
 """
+from __future__ import annotations
+
 import argparse
+from dataclasses import dataclass
 import hashlib
-import json
 import os
+from pathlib import Path
 import random
+import subprocess
 import sys
+from typing import Mapping
 
 import numpy as np
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from eval_filing import load_filing
-from filing_assistant import TREES, catalog_tables, encode_queries, ranks_np
+from filing_privacy import PUBLIC_CATALOG_POLICY_ID
+from filing_assistant import (
+    TREES,
+    catalog_tables,
+    encode_queries,
+    ranks_np,
+    stable_score_order,
+)
+from mu_attention import E5_MODEL
+from routed_policy import (
+    RoutedPolicyError,
+    band_qids,
+    build_task_envelope,
+    canonical_json_bytes,
+    file_content_record,
+    make_band,
+    paired_node_block_bootstrap,
+    policy_tier_for_margin,
+    read_pick_file,
+    read_policy_file,
+    read_task_file,
+    seal_pick_file,
+    sha256_bytes,
+    write_task_file,
+)
+
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_POLICY = ROOT / "ROUTED_POLICY_three_tier_v1.json"
+EVIDENCE_STATUS = "exploratory_transductive"
+JUDGE_CONTRACT_FIELDS = {
+    "provider",
+    "family",
+    "model",
+    "model_revision",
+    "interface",
+    "prompt_sha256",
+    "temperature",
+}
+PRIVACY_NOTE = (
+    "Only bookmarks retained inside certified-public folders, certified-public "
+    "candidate folders, and certified-public lineage nodes may enter hosted "
+    "tasks; private markers/restrictions are removed and unknown node visibility "
+    "is quarantined."
+)
+
+
+def _frozen_policy():
+    envelope = read_policy_file(DEFAULT_POLICY)
+    prompt = envelope["policy_core"]["judge_prompt"]
+    prompt_path = ROOT / prompt["path"]
+    if sha256_bytes(prompt_path.read_bytes()) != prompt["sha256"]:
+        raise RoutedPolicyError("frozen judge prompt does not match the policy hash")
+    return envelope
+
+
+def _validate_selection_against_tier(policy_envelope, selection):
+    """Require a task selection to be one exact judge tier of the policy."""
+    if not isinstance(selection, Mapping):
+        raise RoutedPolicyError("task selection is missing")
+    core = policy_envelope["policy_core"]
+    matching = [
+        tier
+        for tier in core["tiers"]
+        if tier["tier_id"] == selection.get("tier_id")
+    ]
+    if len(matching) != 1 or matching[0]["action"] != "judge":
+        raise RoutedPolicyError("task selection is not a frozen judge tier")
+    tier = matching[0]
+    for field in ("band", "menu_size", "lineage", "lineage_depth"):
+        if selection.get(field) != tier[field]:
+            raise RoutedPolicyError(
+                f"task selection {field} differs from frozen tier {tier['tier_id']}"
+            )
+    judge = selection.get("required_judge")
+    if not isinstance(judge, Mapping) or set(judge) != JUDGE_CONTRACT_FIELDS:
+        raise RoutedPolicyError("task must bind the complete declared judge contract")
+    for field in ("provider", "family", "model", "model_revision", "interface"):
+        if not isinstance(judge.get(field), str) or not judge[field]:
+            raise RoutedPolicyError(f"required judge {field} must be a nonempty string")
+    if judge["family"] != tier["required_judge_family"]:
+        raise RoutedPolicyError("task judge family differs from frozen tier")
+    if judge["prompt_sha256"] != core["judge_prompt"]["sha256"]:
+        raise RoutedPolicyError("task prompt differs from frozen policy prompt")
+    temperature = judge["temperature"]
+    if (
+        temperature is not None
+        and (
+            isinstance(temperature, bool)
+            or not isinstance(temperature, (int, float))
+            or not np.isfinite(temperature)
+        )
+    ):
+        raise RoutedPolicyError("required judge temperature must be finite or null")
+    return tier
+
+
+@dataclass
+class BuildState:
+    queries: list[tuple[str, object]]
+    q_titles: list[str]
+    f_ids: list[object]
+    f_titles: list[str]
+    truepos: list[list[int]]
+    alias_truepos: list[list[int]]
+    cos: np.ndarray
+    ranks: np.ndarray
+    alias_ranks: np.ndarray
+    margin: np.ndarray
+    order: np.ndarray
+    legacy_manifest: str
+    privacy: object
+    receipt: dict
+
+
+def _hash_rows(rows):
+    return sha256_bytes(b"".join(canonical_json_bytes(row) for row in rows))
+
+
+def _array_record(array):
+    contiguous = np.ascontiguousarray(array)
+    return {
+        "dtype": contiguous.dtype.str,
+        "shape": list(contiguous.shape),
+        "sha256": sha256_bytes(contiguous.tobytes(order="C")),
+    }
+
+
+def _implementation_record():
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        commit = "unknown"
+    files = [
+        "routed_queries.py",
+        "routed_policy.py",
+        "filing_privacy.py",
+        "eval_filing.py",
+        "eval_pearltrees_filing.py",
+        "filing_assistant.py",
+        "mu_attention.py",
+    ]
+    rows = []
+    for name in files:
+        data = (ROOT / name).read_bytes()
+        rows.append({"name": name, "sha256": sha256_bytes(data)})
+    return {
+        "git_commit": commit,
+        "files_sha256": _hash_rows(rows),
+    }
 
 
 def build(a):
-    queries, f_ids, f_titles, cand_vec = catalog_tables(a.min_bm, f"eval{a.min_bm}")
+    queries, f_ids, f_titles, cand_vec, privacy = catalog_tables(
+        a.min_bm, f"eval{a.min_bm}", return_privacy=True
+    )
     by_title = {}
-    for j, t in enumerate(f_titles):
-        by_title.setdefault(t, []).append(j)
+    for column, title in enumerate(f_titles):
+        by_title.setdefault(title, []).append(column)
     queries = sorted(queries)
     if len(queries) > a.max_queries:
         queries = random.Random(a.seed).sample(queries, a.max_queries)
-    q_titles = [q for q, _ in queries]
+    q_titles = [title for title, _ in queries]
     cand_by_id = dict(zip(f_ids, f_titles))
-    truepos = [sorted(by_title[cand_by_id[fid]]) for _, fid in queries]
-    qman = hashlib.sha256("\n".join(f"{q}\t{fid}" for q, fid in queries).encode()).hexdigest()
+    position_by_id = {folder_id: column for column, folder_id in enumerate(f_ids)}
+    truepos = [[position_by_id[folder_id]] for _, folder_id in queries]
+    alias_truepos = [
+        sorted(by_title[cand_by_id[folder_id]]) for _, folder_id in queries
+    ]
+    legacy_manifest = hashlib.sha256(
+        "\n".join(f"{title}\t{folder_id}" for title, folder_id in queries).encode()
+    ).hexdigest()
     qv = encode_queries(q_titles)
     cos = qv @ cand_vec.T
     ranks = ranks_np(cos, truepos)
-    srt = np.sort(cos, axis=1)
-    margin = srt[:, -1] - srt[:, -2]
-    order = np.argsort(-cos, axis=1)
-    print(f"population: {len(queries)} queries (manifest sha {qman[:16]}), "
-          f"{len(f_ids)} folders, K={a.top_k}")
-    return q_titles, f_titles, truepos, cos, ranks, margin, order, qman
+    alias_ranks = ranks_np(cos, alias_truepos)
+    if cos.shape[1] < 2:
+        raise RoutedPolicyError("at least two public candidate folders are required")
+    sorted_scores = np.sort(cos, axis=1)
+    margin = sorted_scores[:, -1] - sorted_scores[:, -2]
+    order = stable_score_order(cos)
+
+    catalog_rows = [
+        {"folder_id": str(folder_id), "title": title}
+        for folder_id, title in zip(f_ids, f_titles)
+    ]
+    population_rows = [
+        {
+            "qid": qid,
+            "bookmark": title,
+            "true_folder_id": str(folder_id),
+        }
+        for qid, (title, folder_id) in enumerate(queries)
+    ]
+    ranking_rows = [
+        {
+            "qid": qid,
+            "margin_float64_hex": float(margin[qid]).hex(),
+            "top_k_folder_ids": [
+                str(f_ids[int(column)]) for column in order[qid, : a.top_k]
+            ],
+        }
+        for qid in range(len(queries))
+    ]
+    privacy_receipt = privacy.receipt()
+    receipt = {
+        "source": dict(privacy.source_snapshot),
+        "privacy": {
+            "schema": privacy_receipt["schema"],
+            "policy_id": privacy_receipt["policy_id"],
+            "manifest_sha256": privacy.manifest_sha256,
+            "counts": privacy_receipt["counts"],
+        },
+        "catalog": {
+            "policy_id": PUBLIC_CATALOG_POLICY_ID,
+            "min_bm": a.min_bm,
+            "folder_count": len(f_ids),
+            "sha256": _hash_rows(catalog_rows),
+        },
+        "population": {
+            "count": len(queries),
+            "seed": a.seed,
+            "max_queries": a.max_queries,
+            "sha256": _hash_rows(population_rows),
+            "legacy_sha256": legacy_manifest,
+            "primary_grading": "exact_destination_id",
+            "sensitivity_grading": "best_title_equivalent_destination",
+        },
+        "ranker": {
+            "name": "e5-cos",
+            "model_id": E5_MODEL,
+            "model_revision": "unresolved",
+            "model_revision_status": "name-plus-output-bound",
+            "top_k": a.top_k,
+            "tie_break": "candidate_catalog_column_ascending",
+            "candidate_embeddings": _array_record(cand_vec),
+            "query_embeddings": _array_record(qv),
+            "ranking_sha256": _hash_rows(ranking_rows),
+            "implementation": _implementation_record(),
+        },
+    }
+    print(
+        f"population: {len(queries)} public-only queries "
+        f"(manifest {legacy_manifest[:16]}, privacy {privacy.manifest_sha256[:16]}), "
+        f"{len(f_ids)} folders, K={a.top_k}"
+    )
+    return BuildState(
+        queries=queries,
+        q_titles=q_titles,
+        f_ids=f_ids,
+        f_titles=f_titles,
+        truepos=truepos,
+        alias_truepos=alias_truepos,
+        cos=cos,
+        ranks=ranks,
+        alias_ranks=alias_ranks,
+        margin=margin,
+        order=order,
+        legacy_manifest=legacy_manifest,
+        privacy=privacy,
+        receipt=receipt,
+    )
 
 
-def menu_hit(order, truepos, b, N):
-    """True folder (title-equivalent) inside the top-N menu?"""
-    tp = set(truepos[b])
-    return any(int(c) in tp for c in order[b][:N])
+def menu_hit(state, qid, menu_size):
+    truth = set(state.truepos[qid])
+    return any(int(column) in truth for column in state.order[qid, :menu_size])
 
 
 def run_ceilings(a):
-    q_titles, f_titles, truepos, cos, ranks, margin, order, _ = build(a)
-    B = len(q_titles)
-    base_r1 = float(np.mean(ranks <= 1))
-    print(f"\nno-routing baseline R@1: {base_r1:.3f}")
-    print(f"{'t':>7s} {'routed':>7s} {'kept R@1':>9s} " +
-          " ".join(f"ceil@N={n:<3d}" for n in a.menus))
-    for t in a.grid:
-        routed = margin < t
+    state = build(a)
+    baseline = float(np.mean(state.ranks <= 1))
+    print(f"\nno-routing baseline R@1: {baseline:.3f}")
+    print(
+        f"{'t':>7s} {'routed':>7s} {'kept R@1':>9s} "
+        + " ".join(f"ceil@N={n:<3d}" for n in a.menus)
+    )
+    for threshold in a.grid:
+        routed = state.margin < threshold
         kept = ~routed
-        kept_r1 = float(np.mean(ranks[kept] <= 1)) if kept.any() else float("nan")
+        kept_r1 = float(np.mean(state.ranks[kept] <= 1)) if kept.any() else float("nan")
         cells = []
-        for N in a.menus:
-            resc = sum(menu_hit(order, truepos, b, N) for b in np.where(routed)[0])
-            pol = (int((ranks[kept] <= 1).sum()) + resc) / B
-            cells.append(f"{pol:9.3f}")
-        print(f"{t:7.3f} {routed.mean():7.2f} {kept_r1:9.3f} " + " ".join(cells))
-    print("\nCEILINGS assume a perfect judge over the menu (upper bounds, not predictions). "
-          "Judge value = ceiling − baseline at the chosen (t, N); real judges land in between — "
-          "emit + score to measure.")
+        for menu_size in a.menus:
+            rescued = sum(
+                menu_hit(state, int(qid), menu_size) for qid in np.where(routed)[0]
+            )
+            policy = (int((state.ranks[kept] <= 1).sum()) + rescued) / len(state.q_titles)
+            cells.append(f"{policy:9.3f}")
+        print(
+            f"{threshold:7.3f} {routed.mean():7.2f} {kept_r1:9.3f} "
+            + " ".join(cells)
+        )
+    print(
+        "\nDESCRIPTIVE public-only ceilings only. Threshold/menu selection here "
+        "cannot be called confirmatory on this population."
+    )
 
 
-def task_path(a):
-    suf = "_lin" if getattr(a, "lineage", False) else ""
-    return os.path.expanduser(f"~/mu_data/routed_tasks_t{a.margin}_n{a.menu}{suf}.jsonl")
+def _selection(
+    *,
+    tier_id,
+    margin_low,
+    margin_high,
+    menu_size,
+    lineage,
+    lineage_depth,
+    required_judge,
+):
+    if not isinstance(tier_id, str) or not tier_id:
+        raise RoutedPolicyError("tier_id is required")
+    if menu_size <= 0:
+        raise RoutedPolicyError("menu size must be positive")
+    return {
+        "tier_id": tier_id,
+        "band": make_band(margin_low, margin_high),
+        "menu_size": int(menu_size),
+        "lineage": bool(lineage),
+        "lineage_depth": int(lineage_depth),
+        "required_judge": dict(required_judge),
+    }
+
+
+def _task_core(state, selection):
+    policy = _frozen_policy()
+    return {
+        **state.receipt,
+        "selection": dict(selection),
+        "policy_provenance": {
+            "policy_name": "three-tier-margin-v1",
+            "policy_id": policy["policy_id"],
+            "evidence_status": EVIDENCE_STATUS,
+            "selection_note": (
+                "Thresholds, menu sizes, judge family, and lineage context were "
+                "selected on the historical 1,200-row transductive benchmark."
+            ),
+        },
+        "judge_contract": {
+            "pick_semantics": "zero-based-menu-position-or-null",
+            "required_context": "title-plus-lineage"
+            if selection["lineage"]
+            else "title-only",
+            "privacy": PRIVACY_NOTE,
+            "required_judge": dict(selection["required_judge"]),
+        },
+        "execution_contract": {
+            "response_artifacts_per_tier": 1,
+            "chunked_provider_calls": "unsupported-requires-bound-chunk-manifest",
+            "repeated_draw_aggregation": "unsupported-requires-bound-draw-manifest",
+        },
+    }
+
+
+def _task_rows(state, selection):
+    qids = band_qids(state.margin, selection["band"])
+    maximum_menu = min(len(state.f_ids), state.receipt["ranker"]["top_k"])
+    if selection["menu_size"] > maximum_menu:
+        raise RoutedPolicyError(
+            f"menu_size {selection['menu_size']} exceeds ranked public pool {maximum_menu}"
+        )
+    lineage = {}
+    if selection["lineage"]:
+        from eval_pearltrees_filing import folder_lineage
+
+        _, candidates, privacy = load_filing(TREES, state.receipt["catalog"]["min_bm"],
+                                             return_privacy=True)
+        if privacy.manifest_sha256 != state.privacy.manifest_sha256:
+            raise RoutedPolicyError("privacy index drifted while constructing lineage")
+        _, _, lineage_by_id = folder_lineage(
+            candidates,
+            depth=selection["lineage_depth"],
+            public_tree_titles=privacy.public_title_by_id,
+            return_id_chains=True,
+        )
+        lineage = lineage_by_id
+    rows = []
+    for qid in qids:
+        menu = []
+        for position, column in enumerate(
+            state.order[qid, : selection["menu_size"]]
+        ):
+            column = int(column)
+            title = state.f_titles[column]
+            item = {
+                "pos": position,
+                "folder_id": str(state.f_ids[column]),
+                "title": title,
+            }
+            if selection["lineage"]:
+                item["path"] = " > ".join(
+                    reversed(lineage.get(str(state.f_ids[column]), []))
+                )
+            menu.append(item)
+        rows.append(
+            {
+                "record_type": "task",
+                "qid": int(qid),
+                "bookmark": state.q_titles[qid],
+                "menu": menu,
+            }
+        )
+    return rows
+
+
+def _default_task_path(a):
+    low = "min" if a.margin_low is None else str(a.margin_low)
+    high = "max" if a.margin is None else str(a.margin)
+    suffix = "_lin" if a.lineage else ""
+    return os.path.expanduser(
+        f"~/mu_data/routed_tasks_{a.tier_id}_{low}_{high}_n{a.menu}{suffix}.jsonl"
+    )
 
 
 def run_emit(a):
-    q_titles, f_titles, truepos, cos, ranks, margin, order, qman = build(a)
-    routed = np.where(margin < a.margin)[0]
-    lin = {}
-    if a.lineage:
-        # folder principal-path context (§7 machinery): outcome-blind — uses only the folder's own
-        # pre-existing folder→parent lineage, never the bookmark's placement
-        from eval_pearltrees_filing import folder_lineage
-        _, cand = load_filing(TREES, a.min_bm)
-        parents_title, _ = folder_lineage(cand, depth=a.lineage_depth)
-        lin = parents_title
-    out = task_path(a)
-    os.makedirs(os.path.dirname(out), exist_ok=True)
-    with open(out, "w", encoding="utf-8") as f:
-        f.write(json.dumps({"manifest": qman, "margin": a.margin, "menu": a.menu,
-                            "n_routed": len(routed), "lineage": bool(a.lineage)}) + "\n")
-        for b in routed:
-            menu = [{"pos": p, "title": f_titles[int(order[b][p])],
-                     **({"path": " > ".join(reversed(lin.get(f_titles[int(order[b][p])], [])))}
-                        if a.lineage else {})} for p in range(a.menu)]
-            f.write(json.dumps({"qid": int(b), "bookmark": q_titles[b], "menu": menu},
-                               ensure_ascii=False) + "\n")
-    hit = sum(menu_hit(order, truepos, b, a.menu) for b in routed)
-    print(f"emitted {len(routed)} routed tasks -> {out} (PRIVATE)")
-    print(f"rescue ceiling on this set: {hit}/{len(routed)} menus contain the true folder")
-    print("judge contract: JSONL rows {\"qid\": int, \"pick\": pos-int or null}; one row per qid; "
-          "pick = the menu position to file into, null = none fits.")
+    state = build(a)
+    policy = _frozen_policy()
+    prompt = policy["policy_core"]["judge_prompt"]
+    required_judge = {
+        "provider": a.required_judge_provider,
+        "family": a.required_judge_family,
+        "model": a.required_judge_model,
+        "model_revision": a.required_model_revision,
+        "interface": a.required_interface,
+        "prompt_sha256": prompt["sha256"],
+        "temperature": a.required_temperature,
+    }
+    selection = _selection(
+        tier_id=a.tier_id,
+        margin_low=a.margin_low,
+        margin_high=a.margin,
+        menu_size=a.menu,
+        lineage=a.lineage,
+        lineage_depth=a.lineage_depth,
+        required_judge=required_judge,
+    )
+    _validate_selection_against_tier(policy, selection)
+    rows = _task_rows(state, selection)
+    out = a.out or _default_task_path(a)
+    header, record = write_task_file(out, _task_core(state, selection), rows)
+    print(
+        f"emitted {len(rows)} certified-public tasks -> {out}\n"
+        f"task_id {header['task_id']}  file_sha256 {record['sha256']}"
+    )
+    print(
+        f"Raw judge output must begin with a header binding task_id "
+        f"{header['task_id']}, then contain exactly one {{qid,pick}} row per task; "
+        "run seal-picks before score."
+    )
+    print(
+        "Current v2 sealing accepts one complete response artifact for this tier; "
+        "do not concatenate unbound provider-call chunks or repeated draws."
+    )
+
+
+def _verify_task_rebuild(state, task_path):
+    header, rows, file_record = read_task_file(task_path)
+    core = header["task_core"]
+    selection = core.get("selection")
+    if not isinstance(selection, dict):
+        raise RoutedPolicyError("task selection is missing")
+    expected_rows = _task_rows(state, selection)
+    expected = build_task_envelope(_task_core(state, selection), expected_rows)
+    if header != expected or rows != expected_rows:
+        raise RoutedPolicyError(
+            "task does not reproduce from the current source/privacy/catalog/ranking state"
+        )
+    return header, rows, file_record, selection
+
+
+def run_seal_picks(a):
+    task_header, _, _ = read_task_file(a.task)
+    required = task_header["task_core"]["selection"]["required_judge"]
+    prompt = Path(a.prompt_file).read_bytes()
+    provenance = {
+        "provider": a.judge_provider,
+        "family": a.judge_family,
+        "model": a.judge_model,
+        "model_revision": a.model_revision,
+        "interface": a.interface,
+        "prompt_sha256": sha256_bytes(prompt),
+        "temperature": a.temperature,
+        "run_id": a.run_id,
+        "provenance_status": "declared",
+    }
+    for field, expected in required.items():
+        if provenance.get(field) != expected:
+            raise RoutedPolicyError(
+                f"declared judge {field}={provenance.get(field)!r} "
+                f"!= task requirement {expected!r}"
+            )
+    header, record = seal_pick_file(
+        a.task, a.raw_picks, a.out, provenance
+    )
+    print(
+        f"sealed picks -> {a.out}\n"
+        f"pick_id {header['pick_id']}  file_sha256 {record['sha256']}"
+    )
+    print("Judge identity is declared and content-bound; it is not provider-authenticated.")
+
+
+def _policy_correct(state, task_rows, picks, *, title_equivalence=False):
+    ranks = state.alias_ranks if title_equivalence else state.ranks
+    true_positions = state.alias_truepos if title_equivalence else state.truepos
+    correct = np.array(ranks <= 1, dtype=bool)
+    for task in task_rows:
+        qid = task["qid"]
+        correct[qid] = False
+        pick = picks[qid]
+        if pick is not None:
+            column = int(state.order[qid, pick])
+            if column in set(true_positions[qid]):
+                correct[qid] = True
+    return correct
+
+
+def _result_receipt(
+    state,
+    correct,
+    baseline,
+    interval,
+    artifacts,
+    policy_id,
+    *,
+    evaluation_scope,
+    frozen_policy_id=None,
+    task_id=None,
+    alias_correct=None,
+):
+    receipt = {
+        "schema": "unifyweaver.routed-result.v1",
+        "evidence_status": EVIDENCE_STATUS,
+        "policy_id": policy_id,
+        "evaluation_scope": evaluation_scope,
+        "primary_grading": "exact_destination_id",
+        "population": state.receipt["population"],
+        "privacy": state.receipt["privacy"],
+        "ranker": state.receipt["ranker"],
+        "artifacts": artifacts,
+        "baseline_correct": int(baseline.sum()),
+        "policy_correct": int(correct.sum()),
+        "query_count": len(correct),
+        "baseline_r1": float(baseline.mean()),
+        "policy_r1": float(correct.mean()),
+        "delta": float(correct.mean() - baseline.mean()),
+        "paired_node_block_interval": interval,
+    }
+    if frozen_policy_id is not None:
+        receipt["frozen_policy_id"] = frozen_policy_id
+    if task_id is not None:
+        receipt["task_id"] = task_id
+    if alias_correct is not None:
+        receipt["title_equivalence_sensitivity"] = {
+            "policy_correct": int(alias_correct.sum()),
+            "baseline_correct": int((state.alias_ranks <= 1).sum()),
+            "policy_r1": float(alias_correct.mean()),
+            "baseline_r1": float(np.mean(state.alias_ranks <= 1)),
+        }
+    core = dict(receipt)
+    receipt["result_id"] = sha256_bytes(canonical_json_bytes(core))
+    return receipt
+
+
+def _write_result(path, receipt):
+    if path:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_bytes(canonical_json_bytes(receipt))
+        print(f"result receipt -> {path}")
+
+
+def _print_result(receipt):
+    ci = receipt["paired_node_block_interval"]
+    print(
+        f"\npolicy R@1 {receipt['policy_r1']:.3f} vs baseline "
+        f"{receipt['baseline_r1']:.3f} (delta {receipt['delta']:+.3f})"
+    )
+    print(
+        "paired bookmark/folder node-block 95% interval: "
+        f"[{ci['lower_0.025']:+.3f}, {ci['upper_0.975']:+.3f}] "
+        f"({ci['block_count']} blocks, {ci['replicates']} draws)"
+    )
+    print("EVIDENCE STATUS: exploratory/transductive; not a confirmatory deployment claim.")
 
 
 def run_score(a):
-    q_titles, f_titles, truepos, cos, ranks, margin, order, qman = build(a)
-    routed = np.where(margin < a.margin)[0]
-    picks = {}
-    with open(a.picks, encoding="utf-8") as f:
-        for ln in f:
-            if not ln.strip():
-                continue
-            r = json.loads(ln)
-            if "manifest" in r:
-                if r["manifest"] != qman:
-                    sys.exit(f"FAIL-CLOSED: picks manifest {r['manifest'][:16]} != population "
-                             f"{qman[:16]}")
-                continue
-            q = int(r["qid"])
-            if q in picks:
-                sys.exit(f"FAIL-CLOSED: duplicate pick for qid {q}")
-            p = r["pick"]
-            if p is not None and not (0 <= int(p) < a.menu):
-                sys.exit(f"FAIL-CLOSED: pick {p} out of menu range for qid {q}")
-            picks[q] = None if p is None else int(p)
-    missing = [int(b) for b in routed if int(b) not in picks]
-    if missing:
-        sys.exit(f"FAIL-CLOSED: {len(missing)} routed qids unscored (first: {missing[:5]})")
+    state = build(a)
+    task_header, task_rows, task_record, selection = _verify_task_rebuild(
+        state, a.task
+    )
+    frozen = _frozen_policy()
+    _validate_selection_against_tier(frozen, selection)
+    pick_header, _, picks = read_pick_file(a.picks, a.task)
+    judge = pick_header["pick_core"]["judge"]
+    for field, expected in selection["required_judge"].items():
+        if judge.get(field) != expected:
+            raise RoutedPolicyError(f"sealed judge {field} differs from task requirement")
+    correct = _policy_correct(state, task_rows, picks)
+    alias_correct = _policy_correct(
+        state, task_rows, picks, title_equivalence=True
+    )
+    baseline = np.array(state.ranks <= 1, dtype=bool)
+    interval = paired_node_block_bootstrap(
+        correct,
+        baseline,
+        state.q_titles,
+        [str(folder_id) for _, folder_id in state.queries],
+        replicates=a.bootstrap_replicates,
+        seed=a.bootstrap_seed,
+    )
+    partial_policy_id = sha256_bytes(
+        canonical_json_bytes(
+            {
+                "scope": "single-tier-plus-auto-baseline",
+                "frozen_policy_id": frozen["policy_id"],
+                "task_id": task_header["task_id"],
+            }
+        )
+    )
+    receipt = _result_receipt(
+        state,
+        correct,
+        baseline,
+        interval,
+        {
+            "task": {**task_record, "task_id": task_header["task_id"]},
+            "picks": {
+                **file_content_record(a.picks),
+                "pick_id": pick_header["pick_id"],
+            },
+        },
+        partial_policy_id,
+        evaluation_scope="single-tier-plus-auto-baseline",
+        frozen_policy_id=frozen["policy_id"],
+        task_id=task_header["task_id"],
+        alias_correct=alias_correct,
+    )
+    _print_result(receipt)
+    _write_result(a.out, receipt)
 
-    kept = np.ones(len(q_titles), bool)
-    kept[routed] = False
-    correct = (ranks <= 1) & kept
-    n_resc = 0
-    for b in routed:
-        p = picks[int(b)]
-        if p is not None and int(order[b][p]) in set(truepos[b]):
-            correct[b] = True
-            n_resc += 1
-    base = (ranks <= 1)
-    pol_r1, base_r1 = float(correct.mean()), float(base.mean())
-    print(f"\njudge policy: routed {len(routed)}, judge-rescued {n_resc} "
-          f"(menus containing truth: {sum(menu_hit(order, truepos, b, a.menu) for b in routed)})")
-    print(f"policy R@1 {pol_r1:.3f} vs no-routing baseline {base_r1:.3f} "
-          f"(delta {pol_r1 - base_r1:+.3f})")
-    rng = np.random.default_rng(0)
-    d = correct.astype(float) - base.astype(float)
-    boots = [float(np.mean(d[rng.integers(0, len(d), len(d))])) for _ in range(2000)]
-    lo, hi = np.percentile(boots, [2.5, 97.5])
-    print(f"paired bootstrap 95% CI on delta: [{lo:+.3f}, {hi:+.3f}] "
-          f"({'EXCLUDES' if lo > 0 or hi < 0 else 'includes'} zero)")
+
+def _parse_tier_args(values):
+    out = {}
+    for tier_id, task, picks in values:
+        if tier_id in out:
+            raise RoutedPolicyError(f"duplicate --tier binding: {tier_id}")
+        out[tier_id] = (task, picks)
+    return out
+
+
+def run_score_policy(a):
+    state = build(a)
+    envelope = read_policy_file(a.policy)
+    frozen = _frozen_policy()
+    if envelope["policy_id"] != frozen["policy_id"]:
+        raise RoutedPolicyError("score-policy accepts only the frozen policy id")
+    core = envelope["policy_core"]
+    supplied = _parse_tier_args(a.tier)
+    expected_judge_ids = {
+        tier["tier_id"] for tier in core["tiers"] if tier["action"] == "judge"
+    }
+    if set(supplied) != expected_judge_ids:
+        raise RoutedPolicyError(
+            f"tier artifacts do not match policy; expected={sorted(expected_judge_ids)}, "
+            f"supplied={sorted(supplied)}"
+        )
+
+    baseline = np.array(state.ranks <= 1, dtype=bool)
+    correct = baseline.copy()
+    alias_correct = np.array(state.alias_ranks <= 1, dtype=bool)
+    artifacts = {"policy": {**file_content_record(a.policy), "policy_id": envelope["policy_id"]}}
+    observed_judge_qids = set()
+    for tier in core["tiers"]:
+        tier_qids = set(band_qids(state.margin, tier["band"]))
+        if tier["action"] == "auto_top1":
+            continue
+        task_path, picks_path = supplied[tier["tier_id"]]
+        task_header, task_rows, task_record, selection = _verify_task_rebuild(
+            state, task_path
+        )
+        if (
+            task_header["task_core"]["policy_provenance"]["policy_id"]
+            != envelope["policy_id"]
+        ):
+            raise RoutedPolicyError(f"task is bound to a different policy: {tier['tier_id']}")
+        try:
+            validated_tier = _validate_selection_against_tier(envelope, selection)
+        except RoutedPolicyError as exc:
+            raise RoutedPolicyError(
+                f"task selection does not match tier {tier['tier_id']}: {exc}"
+            ) from exc
+        if validated_tier["tier_id"] != tier["tier_id"]:
+            raise RoutedPolicyError(f"task selection does not match tier {tier['tier_id']}")
+        task_qids = {row["qid"] for row in task_rows}
+        if task_qids != tier_qids or observed_judge_qids & task_qids:
+            raise RoutedPolicyError(f"task qids do not exactly partition tier {tier['tier_id']}")
+        observed_judge_qids.update(task_qids)
+        pick_header, _, picks = read_pick_file(picks_path, task_path)
+        judge = pick_header["pick_core"]["judge"]
+        for field, expected in selection["required_judge"].items():
+            if judge.get(field) != expected:
+                raise RoutedPolicyError(
+                    f"wrong judge {field} for tier {tier['tier_id']}"
+                )
+        tier_correct = _policy_correct(state, task_rows, picks)
+        tier_alias_correct = _policy_correct(
+            state, task_rows, picks, title_equivalence=True
+        )
+        for qid in task_qids:
+            correct[qid] = tier_correct[qid]
+            alias_correct[qid] = tier_alias_correct[qid]
+        artifacts[tier["tier_id"]] = {
+            "task": {**task_record, "task_id": task_header["task_id"]},
+            "picks": {
+                **file_content_record(picks_path),
+                "pick_id": pick_header["pick_id"],
+            },
+        }
+
+    for qid, margin in enumerate(state.margin):
+        tier = policy_tier_for_margin(core, float(margin))
+        if tier["action"] == "judge" and qid not in observed_judge_qids:
+            raise RoutedPolicyError(f"judge tier qid {qid} lacks a bound artifact")
+        if tier["action"] == "auto_top1" and qid in observed_judge_qids:
+            raise RoutedPolicyError(f"auto tier qid {qid} appears in judge artifacts")
+
+    interval = paired_node_block_bootstrap(
+        correct,
+        baseline,
+        state.q_titles,
+        [str(folder_id) for _, folder_id in state.queries],
+        replicates=core["bootstrap"]["replicates"],
+        seed=core["bootstrap"]["seed"],
+    )
+    receipt = _result_receipt(
+        state,
+        correct,
+        baseline,
+        interval,
+        artifacts,
+        envelope["policy_id"],
+        evaluation_scope="complete-frozen-policy",
+        alias_correct=alias_correct,
+    )
+    _print_result(receipt)
+    _write_result(a.out, receipt)
+
+
+def _add_population_args(parser):
+    parser.add_argument("--min-bm", type=int, default=3)
+    parser.add_argument("--max-queries", type=int, default=1200)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--top-k", type=int, default=100)
+
+
+def _add_bootstrap_args(parser):
+    parser.add_argument("--bootstrap-replicates", type=int, default=9999)
+    parser.add_argument("--bootstrap-seed", type=int, default=3867001)
 
 
 def main(argv=None):
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--min-bm", type=int, default=3)
-    ap.add_argument("--max-queries", type=int, default=1200)
-    ap.add_argument("--seed", type=int, default=7)
-    ap.add_argument("--top-k", type=int, default=100)
-    sub = ap.add_subparsers(dest="mode", required=True)
-    ce = sub.add_parser("ceilings")
-    ce.add_argument("--grid", type=float, nargs="*",
-                    default=(0.005, 0.01, 0.02, 0.03, 0.05, 0.08))
-    ce.add_argument("--menus", type=int, nargs="*", default=(5, 10, 20, 50))
-    em = sub.add_parser("emit")
-    em.add_argument("--margin", type=float, default=0.02)
-    em.add_argument("--menu", type=int, default=10)
-    em.add_argument("--lineage", action="store_true",
-                    help="include each folder's principal-path context in the menu")
-    em.add_argument("--lineage-depth", type=int, default=3)
-    sc = sub.add_parser("score")
-    sc.add_argument("--picks", required=True)
-    sc.add_argument("--margin", type=float, default=0.02)
-    sc.add_argument("--menu", type=int, default=10)
-    a = ap.parse_args(argv)
-    {"ceilings": run_ceilings, "emit": run_emit, "score": run_score}[a.mode](a)
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    ceilings = sub.add_parser("ceilings")
+    _add_population_args(ceilings)
+    ceilings.add_argument(
+        "--grid", type=float, nargs="*", default=(0.005, 0.01, 0.02, 0.03, 0.05, 0.08)
+    )
+    ceilings.add_argument("--menus", type=int, nargs="*", default=(5, 10, 20, 50))
+
+    emit = sub.add_parser("emit")
+    _add_population_args(emit)
+    emit.add_argument("--tier-id", required=True)
+    emit.add_argument("--margin-low", type=float, default=None)
+    emit.add_argument("--margin", type=float, default=0.02, help="exclusive upper band boundary")
+    emit.add_argument("--menu", type=int, default=10)
+    emit.add_argument("--lineage", action="store_true")
+    emit.add_argument("--lineage-depth", type=int, default=3)
+    emit.add_argument("--required-judge-family", default="sonnet")
+    emit.add_argument("--required-judge-provider", required=True)
+    emit.add_argument("--required-judge-model", required=True)
+    emit.add_argument("--required-model-revision", required=True)
+    emit.add_argument("--required-interface", required=True)
+    emit.add_argument("--required-temperature", type=float, default=None)
+    emit.add_argument("--out")
+
+    seal = sub.add_parser("seal-picks")
+    seal.add_argument("--task", required=True)
+    seal.add_argument("--raw-picks", required=True)
+    seal.add_argument("--out", required=True)
+    seal.add_argument("--judge-provider", required=True)
+    seal.add_argument("--judge-family", required=True)
+    seal.add_argument("--judge-model", required=True)
+    seal.add_argument("--model-revision", required=True)
+    seal.add_argument("--interface", required=True)
+    seal.add_argument("--prompt-file", required=True)
+    seal.add_argument("--temperature", type=float, default=None)
+    seal.add_argument("--run-id", required=True)
+
+    score = sub.add_parser("score")
+    _add_population_args(score)
+    _add_bootstrap_args(score)
+    score.add_argument("--task", required=True)
+    score.add_argument("--picks", required=True)
+    score.add_argument("--out")
+
+    score_policy = sub.add_parser("score-policy")
+    _add_population_args(score_policy)
+    score_policy.add_argument("--policy", default=str(DEFAULT_POLICY))
+    score_policy.add_argument(
+        "--tier",
+        nargs=3,
+        action="append",
+        metavar=("TIER_ID", "TASK", "PICKS"),
+        default=[],
+    )
+    score_policy.add_argument("--out")
+
+    args = parser.parse_args(argv)
+    actions = {
+        "ceilings": run_ceilings,
+        "emit": run_emit,
+        "seal-picks": run_seal_picks,
+        "score": run_score,
+        "score-policy": run_score_policy,
+    }
+    try:
+        actions[args.mode](args)
+    except (OSError, RoutedPolicyError, ValueError) as exc:
+        parser.error(f"FAIL-CLOSED: {exc}")
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/test_filing_privacy.py
+++ b/prototypes/mu_cosine/test_filing_privacy.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""Privacy-contract tests for the routed filing population."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from eval_filing import load_filing
+from filing_privacy import (
+    FilingPrivacyError,
+    build_pearltrees_privacy_index,
+    merge_visibility_claims,
+    public_catalog_title_eligible,
+    visibility_claim,
+)
+import eval_pearltrees_filing as filing_eval
+
+
+def _tree(
+    tree_id,
+    title,
+    visibility,
+    *,
+    bookmarks=(),
+    parent=None,
+    collections=(),
+    other_links=(),
+):
+    pearls = [
+        {"id": 100000 + i, "contentType": 1, "title": bookmark}
+        for i, bookmark in enumerate(bookmarks)
+    ]
+    for child_id, child_title, child_visibility in collections:
+        pearls.append(
+            {
+                "id": 200000 + int(child_id),
+                "contentType": 2,
+                "title": child_title,
+                "contentTree": {
+                    "id": child_id,
+                    "title": child_title,
+                    "visibility": child_visibility,
+                },
+            }
+        )
+    for child_id, child_title, child_visibility in other_links:
+        pearls.append(
+            {
+                "id": 300000 + int(child_id),
+                "contentType": 5,
+                "title": child_title,
+                "contentTree": {
+                    "id": child_id,
+                    "title": child_title,
+                    "visibility": child_visibility,
+                },
+            }
+        )
+    info = {}
+    if parent is not None:
+        parent_id, parent_title, parent_visibility = parent
+        info["parentTree"] = {
+            "id": parent_id,
+            "title": parent_title,
+            "visibility": parent_visibility,
+        }
+    return {
+        "tree_id": tree_id,
+        "api_response": {
+            "info": info,
+            "tree": {
+                "id": tree_id,
+                "title": title,
+                "visibility": visibility,
+                "isUserRoot": 1 if parent is None else 0,
+                "pearls": pearls,
+            },
+        },
+    }
+
+
+def _write_tree(trees: Path, payload):
+    tree_id = payload["api_response"]["tree"]["id"]
+    (trees / f"{tree_id}.json").write_text(
+        json.dumps(payload, sort_keys=True), encoding="utf-8"
+    )
+
+
+def _layout(tmp_path):
+    data = tmp_path / "data"
+    trees = data / "pearltrees_api" / "trees"
+    trees.mkdir(parents=True)
+    (data / "api_tree_paths_v8.jsonl").write_text("", encoding="utf-8")
+    return data, trees
+
+
+def test_visibility_is_tri_state_and_private_wins():
+    assert visibility_claim(0) == "public"
+    assert visibility_claim("0") == "public"
+    assert visibility_claim(2) == "private"
+    assert visibility_claim(None) == "unknown"
+    assert merge_visibility_claims(["unknown", "public"]) == "public"
+    assert merge_visibility_claims(["public", "private"]) == "private"
+    with pytest.raises(FilingPrivacyError, match="malformed visibility"):
+        visibility_claim("friends")
+
+
+def test_public_catalog_title_rule_is_outcome_blind_and_explicit():
+    assert public_catalog_title_eligible("Mathematics")
+    assert public_catalog_title_eligible("C++")
+    assert not public_catalog_title_eligible("?")
+    assert not public_catalog_title_eligible("---")
+    assert not public_catalog_title_eligible("")
+
+
+def test_public_only_population_propagates_private_and_unknown(tmp_path):
+    _, trees = _layout(tmp_path)
+    _write_tree(
+        trees,
+        _tree(
+            1,
+            "Public root",
+            0,
+            bookmarks=("one", "two", "three"),
+            collections=((2, "Restricted branch", 2), (4, "Unknown branch", None)),
+        ),
+    )
+    _write_tree(
+        trees,
+        _tree(
+            2,
+            "Restricted branch",
+            2,
+            bookmarks=("secret one", "secret two", "secret three"),
+            parent=(1, "Public root", 0),
+        ),
+    )
+    _write_tree(
+        trees,
+        _tree(
+            3,
+            "Looks public below restricted",
+            0,
+            bookmarks=("a", "b", "c"),
+            parent=(2, "Restricted branch", 2),
+        ),
+    )
+    _write_tree(
+        trees,
+        _tree(
+            4,
+            "Unknown branch",
+            None,
+            bookmarks=("unknown one", "unknown two", "unknown three"),
+            parent=(1, "Public root", 0),
+        ),
+    )
+    _write_tree(
+        trees,
+        _tree(
+            5,
+            "Looks public below unknown",
+            0,
+            bookmarks=("d", "e", "f"),
+            parent=(4, "Unknown branch", None),
+        ),
+    )
+    queries, candidates, privacy = load_filing(
+        trees, 3, return_privacy=True, paths_jsonl=None
+    )
+    assert candidates == {1: "Public root"}
+    assert queries == [("one", 1), ("two", 1), ("three", 1)]
+    assert {"2", "3"} <= privacy.private_ids
+    assert {"4", "5"} <= privacy.quarantined_ids
+
+
+def test_public_claim_resolves_missing_summary_but_private_conflict_wins(tmp_path):
+    _, trees = _layout(tmp_path)
+    _write_tree(
+        trees,
+        _tree(
+            1,
+            "Parent",
+            0,
+            bookmarks=("p1", "p2", "p3"),
+            collections=((2, "Public child", None), (3, "Conflicted child", 2)),
+        ),
+    )
+    _write_tree(
+        trees,
+        _tree(
+            2,
+            "Public child",
+            0,
+            bookmarks=("a", "b", "c"),
+            parent=(1, "Parent", 0),
+        ),
+    )
+    _write_tree(
+        trees,
+        _tree(
+            3,
+            "Conflicted child",
+            0,
+            bookmarks=("x", "y", "z"),
+            parent=(1, "Parent", 0),
+        ),
+    )
+    _, candidates, privacy = load_filing(
+        trees, 3, return_privacy=True, paths_jsonl=None
+    )
+    assert set(candidates) == {1, 2}
+    assert "2" in privacy.public_ids
+    assert "3" in privacy.private_ids
+
+
+def test_private_collection_wrapper_title_wins_over_public_child_title(tmp_path):
+    _, trees = _layout(tmp_path)
+    parent = _tree(
+        1,
+        "Parent",
+        0,
+        bookmarks=("p1", "p2", "p3"),
+        collections=((2, "Economics", 0),),
+    )
+    parent["api_response"]["tree"]["pearls"][-1]["title"] = "*private*"
+    _write_tree(trees, parent)
+    _write_tree(
+        trees,
+        _tree(
+            2,
+            "Economics",
+            0,
+            bookmarks=("a", "b", "c"),
+            parent=(1, "Parent", 0),
+        ),
+    )
+    _, candidates, privacy = load_filing(trees, 3, return_privacy=True)
+    assert candidates == {1: "Parent"}
+    assert "2" in privacy.private_ids
+
+
+def test_private_bookmarks_removed_before_minimum_count(tmp_path):
+    _, trees = _layout(tmp_path)
+    _write_tree(
+        trees,
+        _tree(
+            1,
+            "Public",
+            0,
+            bookmarks=("public one", "public two", "Private equity"),
+        ),
+    )
+    queries, candidates = load_filing(trees, 3, paths_jsonl=None)
+    assert queries == []
+    assert candidates == {}
+
+
+def test_bookmark_without_visibility_inherits_certified_public_container(tmp_path):
+    _, trees = _layout(tmp_path)
+    _write_tree(
+        trees,
+        _tree(1, "Public folder", 0, bookmarks=("one", "two", "three")),
+    )
+    queries, candidates = load_filing(trees, 3, paths_jsonl=None)
+    assert candidates == {1: "Public folder"}
+    assert queries == [("one", 1), ("two", 1), ("three", 1)]
+
+
+def test_noncontainment_link_does_not_propagate_privacy(tmp_path):
+    _, trees = _layout(tmp_path)
+    _write_tree(
+        trees,
+        _tree(
+            1,
+            "Public",
+            0,
+            bookmarks=("a", "b", "c"),
+            other_links=((2, "Private shortcut", 2),),
+        ),
+    )
+    queries, candidates = load_filing(trees, 3, paths_jsonl=None)
+    assert candidates == {1: "Public"}
+    assert len(queries) == 3
+
+
+def test_private_marker_in_path_scrubs_target(tmp_path):
+    data, trees = _layout(tmp_path)
+    _write_tree(
+        trees,
+        _tree(1, "Public root", 0, bookmarks=("a", "b", "c")),
+    )
+    _write_tree(
+        trees,
+        _tree(
+            2,
+            "Target",
+            0,
+            bookmarks=("d", "e", "f"),
+            parent=(1, "Public root", 0),
+        ),
+    )
+    path_file = data / "api_tree_paths_v8.jsonl"
+    path_file.write_text(
+        json.dumps(
+            {
+                "tree_id": "2",
+                "title": "Target",
+                "target_text": "- Public root\n  - *private*\n    - Target",
+                "path_ids": ["account:test", "1", "2"],
+                "parent_tree_id": "1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _, candidates, privacy = load_filing(trees, 3, return_privacy=True)
+    assert candidates == {}
+    assert "2" in privacy.private_ids
+
+
+def test_missing_materialized_paths_fail_closed(tmp_path):
+    data, trees = _layout(tmp_path)
+    _write_tree(trees, _tree(1, "Public", 0, bookmarks=("a", "b", "c")))
+    (data / "api_tree_paths_v8.jsonl").unlink()
+    with pytest.raises(FilingPrivacyError, match="required"):
+        load_filing(trees, 3)
+
+
+def test_malformed_numeric_record_and_id_mismatch_fail_closed(tmp_path):
+    _, trees = _layout(tmp_path)
+    (trees / "1.json").write_text("{", encoding="utf-8")
+    with pytest.raises(FilingPrivacyError, match="malformed JSON"):
+        build_pearltrees_privacy_index(trees, paths_jsonl=None)
+    (trees / "1.json").write_text(
+        json.dumps(_tree(2, "Wrong", 0)), encoding="utf-8"
+    )
+    with pytest.raises(FilingPrivacyError, match="mismatch"):
+        build_pearltrees_privacy_index(trees, paths_jsonl=None)
+
+
+def test_hosted_lineage_uses_only_certified_path_and_no_dag_fallback(
+    tmp_path, monkeypatch
+):
+    paths = tmp_path / "paths.jsonl"
+    dag = tmp_path / "dag.tsv"
+    titles = tmp_path / "titles.tsv"
+    paths.write_text(
+        json.dumps(
+            {
+                "tree_id": "2",
+                "title": "Child",
+                "target_text": "- Parent\n  - *private*\n    - Child",
+                "path_ids": ["account:test", "1", "2"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    dag.write_text("1\t2\n", encoding="utf-8")
+    # Hosted mode must never read this visibility-free/stale title source.
+    titles.write_text("1\t*private stale title*\n2\tChild\n", encoding="utf-8")
+    monkeypatch.setattr(filing_eval, "PATHS_JSONL", str(paths))
+    monkeypatch.setattr(filing_eval, "DAG", str(dag))
+    monkeypatch.setattr(filing_eval, "TITLES", str(titles))
+
+    parents, ancestors = filing_eval.folder_lineage(
+        {2: "Child"},
+        depth=3,
+        public_tree_titles={"1": "Parent", "2": "Child"},
+    )
+    assert parents == {}
+    assert ancestors == set()
+
+    paths.write_text(
+        json.dumps(
+            {
+                "tree_id": "2",
+                "title": "Child",
+                "target_text": "- Parent\n  - Child",
+                "path_ids": ["account:test", "1", "2"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    parents, ancestors = filing_eval.folder_lineage(
+        {2: "Child"},
+        depth=3,
+        public_tree_titles={"1": "Parent", "2": "Child"},
+    )
+    assert parents == {"Child": ["Parent"]}
+    assert ancestors == {"Parent"}
+
+
+def test_hosted_lineage_keeps_duplicate_title_paths_distinct(tmp_path, monkeypatch):
+    paths = tmp_path / "paths.jsonl"
+    dag = tmp_path / "dag.tsv"
+    titles = tmp_path / "titles.tsv"
+    records = [
+        {
+            "tree_id": "2",
+            "title": "Same",
+            "target_text": "- Root A\n  - Same",
+            "path_ids": ["account:test", "1", "2"],
+        },
+        {
+            "tree_id": "4",
+            "title": "Same",
+            "target_text": "- Root B\n  - Same",
+            "path_ids": ["account:test", "3", "4"],
+        },
+    ]
+    paths.write_text(
+        "".join(json.dumps(row) + "\n" for row in records), encoding="utf-8"
+    )
+    dag.write_text("", encoding="utf-8")
+    titles.write_text("", encoding="utf-8")
+    monkeypatch.setattr(filing_eval, "PATHS_JSONL", str(paths))
+    monkeypatch.setattr(filing_eval, "DAG", str(dag))
+    monkeypatch.setattr(filing_eval, "TITLES", str(titles))
+    _, _, by_id = filing_eval.folder_lineage(
+        {2: "Same", 4: "Same"},
+        depth=3,
+        public_tree_titles={
+            "1": "Root A",
+            "2": "Same",
+            "3": "Root B",
+            "4": "Same",
+        },
+        return_id_chains=True,
+    )
+    assert by_id == {"2": ["Root A"], "4": ["Root B"]}

--- a/prototypes/mu_cosine/test_routed_policy.py
+++ b/prototypes/mu_cosine/test_routed_policy.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Integrity and inference tests for routed-task v2."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from routed_policy import (
+    RAW_PICKS_SCHEMA,
+    RoutedPolicyError,
+    band_qids,
+    build_pick_envelope,
+    build_policy_envelope,
+    build_task_envelope,
+    file_content_record,
+    in_band,
+    make_band,
+    paired_node_block_bootstrap,
+    policy_tier_for_margin,
+    read_pick_file,
+    read_policy_file,
+    read_raw_picks,
+    read_task_file,
+    seal_pick_file,
+    validate_policy_core,
+    write_task_file,
+)
+import routed_queries
+from filing_assistant import apply_public_catalog_policy
+
+
+def _rows(qids=(0, 1)):
+    return [
+        {
+            "record_type": "task",
+            "qid": qid,
+            "bookmark": f"bookmark {qid}",
+            "menu": [
+                {"pos": 0, "folder_id": "10", "title": "first"},
+                {"pos": 1, "folder_id": "11", "title": "second", "path": "root"},
+            ],
+        }
+        for qid in qids
+    ]
+
+
+def _task_core():
+    return {
+        "source": {"members_sha256": "a" * 64},
+        "privacy": {
+            "policy_id": "pearltrees-public-only-v1",
+            "manifest_sha256": "b" * 64,
+        },
+        "catalog": {"sha256": "c" * 64},
+        "population": {"sha256": "d" * 64},
+        "ranker": {"ranking_sha256": "e" * 64},
+        "selection": {
+            "tier_id": "low",
+            "band": make_band(None, 0.02),
+            "menu_size": 2,
+            "lineage": True,
+            "lineage_depth": 3,
+            "required_judge_family": "sonnet",
+        },
+        "policy_provenance": {"evidence_status": "exploratory_transductive"},
+    }
+
+
+def _judge():
+    return {
+        "provider": "test",
+        "family": "sonnet",
+        "model": "test-model",
+        "model_revision": "r1",
+        "interface": "fixture",
+        "prompt_sha256": "f" * 64,
+        "temperature": 0.0,
+        "run_id": "test-run",
+        "provenance_status": "declared",
+    }
+
+
+def _raw_picks(path, task_header, values=((0, 0), (1, None))):
+    path.write_text(
+        json.dumps(
+            {
+                "schema": RAW_PICKS_SCHEMA,
+                "record_type": "raw_pick_header",
+                "task_id": task_header["task_id"],
+            }
+        )
+        + "\n"
+        + "".join(
+            json.dumps({"qid": qid, "pick": pick}) + "\n" for qid, pick in values
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_band_boundaries_are_exact_and_half_open():
+    band = make_band(0.02, 0.03)
+    assert not in_band(np.nextafter(0.02, 0.0), band)
+    assert in_band(0.02, band)
+    assert in_band(np.nextafter(0.03, 0.0), band)
+    assert not in_band(0.03, band)
+    assert band_qids([0.019, 0.02, 0.025, 0.03], band) == (1, 2)
+
+
+def test_task_and_pick_round_trip_bind_exact_bytes(tmp_path):
+    task = tmp_path / "task.jsonl"
+    raw = tmp_path / "raw.jsonl"
+    picks = tmp_path / "picks.jsonl"
+    task_header, task_record = write_task_file(task, _task_core(), _rows())
+    _raw_picks(raw, task_header)
+    pick_header, _ = seal_pick_file(task, raw, picks, _judge())
+
+    loaded_task, loaded_rows, loaded_record = read_task_file(task)
+    loaded_pick, _, mapping = read_pick_file(picks, task)
+    assert loaded_task == task_header
+    assert loaded_rows == _rows()
+    assert loaded_record == task_record
+    assert loaded_pick == pick_header
+    assert mapping == {0: 0, 1: None}
+    assert loaded_pick["pick_core"]["task_id"] == loaded_task["task_id"]
+
+
+def test_task_row_tampering_is_rejected(tmp_path):
+    task = tmp_path / "task.jsonl"
+    write_task_file(task, _task_core(), _rows())
+    lines = task.read_text(encoding="utf-8").splitlines()
+    row = json.loads(lines[1])
+    row["menu"][0]["title"] = "tampered"
+    lines[1] = json.dumps(row)
+    task.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    with pytest.raises(RoutedPolicyError, match="hash mismatch"):
+        read_task_file(task)
+
+
+def test_raw_picks_reject_missing_extra_duplicate_bool_and_legacy_header(tmp_path):
+    rows = _rows()
+    task_header = build_task_envelope(_task_core(), rows)
+    raw = tmp_path / "raw.jsonl"
+
+    _raw_picks(raw, task_header, ((0, 0), (2, 1)))
+    with pytest.raises(RoutedPolicyError, match="exactly match"):
+        read_raw_picks(raw, task_header, rows)
+
+    _raw_picks(raw, task_header, ((0, 0), (0, 1), (1, None)))
+    with pytest.raises(RoutedPolicyError, match="duplicate"):
+        read_raw_picks(raw, task_header, rows)
+
+    _raw_picks(raw, task_header, ((0, True), (1, None)))
+    with pytest.raises(RoutedPolicyError, match="integer"):
+        read_raw_picks(raw, task_header, rows)
+
+    raw.write_text(
+        json.dumps({"manifest": "legacy"}) + "\n"
+        + json.dumps({"qid": 0, "pick": 0}) + "\n"
+        + json.dumps({"qid": 1, "pick": None}) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(RoutedPolicyError, match="task_id header"):
+        read_raw_picks(raw, task_header, rows)
+
+
+def test_cross_task_pick_substitution_is_rejected(tmp_path):
+    task_a = tmp_path / "a.jsonl"
+    task_b = tmp_path / "b.jsonl"
+    raw = tmp_path / "raw.jsonl"
+    picks = tmp_path / "picks.jsonl"
+    task_a_header, _ = write_task_file(task_a, _task_core(), _rows())
+    changed = _task_core()
+    changed["selection"] = {
+        **changed["selection"],
+        "menu_size": 3,
+    }
+    rows_b = _rows()
+    for row in rows_b:
+        row["menu"].append({"pos": 2, "folder_id": "12", "title": "third"})
+    write_task_file(task_b, changed, rows_b)
+    _raw_picks(raw, task_a_header)
+    seal_pick_file(task_a, raw, picks, _judge())
+    with pytest.raises(RoutedPolicyError, match="hash mismatch"):
+        read_pick_file(picks, task_b)
+
+
+def test_raw_response_cannot_be_rebound_before_sealing(tmp_path):
+    task_a = tmp_path / "a.jsonl"
+    task_b = tmp_path / "b.jsonl"
+    raw = tmp_path / "raw.jsonl"
+    picks = tmp_path / "picks.jsonl"
+    header_a, _ = write_task_file(task_a, _task_core(), _rows())
+    swapped = _rows()
+    for row in swapped:
+        row["menu"] = [
+            {**row["menu"][1], "pos": 0},
+            {**row["menu"][0], "pos": 1},
+        ]
+    write_task_file(task_b, _task_core(), swapped)
+    _raw_picks(raw, header_a)
+    with pytest.raises(RoutedPolicyError, match="task_id header"):
+        seal_pick_file(task_b, raw, picks, _judge())
+
+
+def test_empty_task_and_header_only_raw_picks_round_trip(tmp_path):
+    task = tmp_path / "task.jsonl"
+    raw = tmp_path / "raw.jsonl"
+    picks = tmp_path / "picks.jsonl"
+    header, _ = write_task_file(task, _task_core(), [])
+    _raw_picks(raw, header, ())
+    seal_pick_file(task, raw, picks, _judge())
+    _, rows, mapping = read_pick_file(picks, task)
+    assert rows == []
+    assert mapping == {}
+
+
+def _policy_core():
+    return {
+        "name": "three-tier-margin-v1",
+        "evidence_status": "exploratory_transductive",
+        "privacy_policy_id": "pearltrees-public-only-v1",
+        "catalog_policy_id": "pearltrees-public-alphanumeric-title-v1",
+        "primary_grading": "exact_destination_id",
+        "judge_prompt": {
+            "path": "prompt.md",
+            "sha256": "f" * 64,
+        },
+        "tiers": [
+            {
+                "tier_id": "low",
+                "band": make_band(None, 0.02),
+                "action": "judge",
+                "menu_size": 10,
+                "lineage": True,
+                "lineage_depth": 3,
+                "required_judge_family": "sonnet",
+            },
+            {
+                "tier_id": "middle",
+                "band": make_band(0.02, 0.03),
+                "action": "judge",
+                "menu_size": 20,
+                "lineage": True,
+                "lineage_depth": 3,
+                "required_judge_family": "sonnet",
+            },
+            {
+                "tier_id": "auto",
+                "band": make_band(0.03, None),
+                "action": "auto_top1",
+            },
+        ],
+        "bootstrap": {
+            "unit": "bookmark-folder-connected-component",
+            "seed": 3867001,
+            "replicates": 9999,
+            "interval": [0.025, 0.975],
+        },
+    }
+
+
+def test_policy_requires_exact_nonoverlapping_complete_partition():
+    core = _policy_core()
+    validate_policy_core(core)
+    assert policy_tier_for_margin(core, 0.019)["tier_id"] == "low"
+    assert policy_tier_for_margin(core, 0.02)["tier_id"] == "middle"
+    assert policy_tier_for_margin(core, 0.03)["tier_id"] == "auto"
+
+    gapped = _policy_core()
+    gapped["tiers"][1]["band"] = make_band(0.021, 0.03)
+    with pytest.raises(RoutedPolicyError, match="gap"):
+        validate_policy_core(gapped)
+
+    promoted = _policy_core()
+    promoted["evidence_status"] = "confirmatory"
+    with pytest.raises(RoutedPolicyError, match="exploratory"):
+        validate_policy_core(promoted)
+
+    premature_infinity = _policy_core()
+    premature_infinity["tiers"][0]["band"] = make_band(None, None)
+    with pytest.raises(RoutedPolicyError, match="final"):
+        validate_policy_core(premature_infinity)
+
+
+def test_committed_policy_has_valid_content_id():
+    envelope = read_policy_file(ROOT / "ROUTED_POLICY_three_tier_v1.json")
+    assert envelope == build_policy_envelope(envelope["policy_core"])
+    assert envelope["policy_core"]["evidence_status"] == "exploratory_transductive"
+    assert routed_queries._frozen_policy() == envelope
+
+
+def test_task_selection_must_match_frozen_tier_and_prompt():
+    envelope = read_policy_file(ROOT / "ROUTED_POLICY_three_tier_v1.json")
+    tier = envelope["policy_core"]["tiers"][0]
+    selection = {
+        "tier_id": tier["tier_id"],
+        "band": tier["band"],
+        "menu_size": tier["menu_size"],
+        "lineage": tier["lineage"],
+        "lineage_depth": tier["lineage_depth"],
+        "required_judge": {
+            "provider": "fixture",
+            "family": tier["required_judge_family"],
+            "model": "fixture-sonnet",
+            "model_revision": "r1",
+            "interface": "fixture",
+            "prompt_sha256": envelope["policy_core"]["judge_prompt"]["sha256"],
+            "temperature": None,
+        },
+    }
+    assert routed_queries._validate_selection_against_tier(
+        envelope, selection
+    ) == tier
+
+    wrong_prompt = {
+        **selection,
+        "required_judge": {
+            **selection["required_judge"],
+            "prompt_sha256": "0" * 64,
+        },
+    }
+    with pytest.raises(RoutedPolicyError, match="prompt"):
+        routed_queries._validate_selection_against_tier(envelope, wrong_prompt)
+
+    wrong_band = {**selection, "band": make_band(None, 0.01)}
+    with pytest.raises(RoutedPolicyError, match="band"):
+        routed_queries._validate_selection_against_tier(envelope, wrong_band)
+
+
+def test_node_block_bootstrap_is_deterministic_and_clusters_shared_nodes():
+    policy = [True, False, True, True]
+    baseline = [False, False, False, True]
+    bookmarks = ["same", "same", "other", "last"]
+    folders = ["A", "B", "B", "C"]
+    # Rows 0-2 form one connected component (shared bookmark then shared
+    # folder); row 3 is the second component.
+    first = paired_node_block_bootstrap(
+        policy, baseline, bookmarks, folders, replicates=200, seed=11
+    )
+    second = paired_node_block_bootstrap(
+        policy, baseline, bookmarks, folders, replicates=200, seed=11
+    )
+    assert first == second
+    assert first["block_count"] == 2
+    assert first["point"] == pytest.approx(0.5)
+
+
+def test_exact_destination_is_primary_and_title_alias_is_sensitivity_only():
+    state = SimpleNamespace(
+        ranks=np.array([2]),
+        alias_ranks=np.array([1]),
+        order=np.array([[1, 0]]),
+        truepos=[[0]],
+        alias_truepos=[[0, 1]],
+    )
+    task_rows = [{"qid": 0}]
+    picks = {0: 0}  # chooses column 1: same title, wrong destination id
+    exact = routed_queries._policy_correct(state, task_rows, picks)
+    alias = routed_queries._policy_correct(
+        state, task_rows, picks, title_equivalence=True
+    )
+    assert exact.tolist() == [False]
+    assert alias.tolist() == [True]
+
+
+def test_duplicate_title_score_ties_match_exact_rank_tie_break():
+    cos = np.array([[0.9, 0.9, 0.2], [0.4, 0.8, 0.8]])
+    order = routed_queries.stable_score_order(cos)
+    assert order.tolist() == [[0, 1, 2], [1, 2, 0]]
+    assert routed_queries.ranks_np(cos, [[0], [1]]).tolist() == [1, 1]
+    assert [
+        int(order[row, 0]) == truth
+        for row, truth in enumerate((0, 1))
+    ] == [True, True]
+
+
+def test_eval_and_suggest_share_one_public_catalog_policy():
+    queries, candidates = apply_public_catalog_policy(
+        [("kept bookmark", 1), ("excluded bookmark", 2)],
+        {1: "Mathematics", 2: "?"},
+    )
+    assert candidates == {1: "Mathematics"}
+    assert queries == [("kept bookmark", 1)]


### PR DESCRIPTION
## Summary

- enforce a fail-closed, tri-state Pearltrees privacy boundary for hosted filing tasks:
  explicit-public folder/lineage nodes only, private/unknown containment propagation, and
  private-title/restricted bookmark filtering
- apply one outcome-blind public catalog rule to both evaluation and interactive suggestion;
  preserve folder IDs, use stable catalog-column tie-breaking, and route duplicate-title ties to
  lineage-aware review
- freeze the exploratory three-tier margin policy and judge prompt while binding exact
  source/privacy/catalog/population/ranking/task bytes, policy ID, prompt, and declared judge
  provenance
- require raw responses to echo the exact task ID, seal exact QID joins, and reject legacy,
  missing, extra, duplicate, cross-task, or tampered rows
- make exact destination ID the primary endpoint, retain title equivalence as sensitivity only,
  and replace the iid query interval with a paired bookmark/folder connected-component bootstrap
- correct the historical report: the stored `0.203 → 0.290 → 0.316` arc is reproducible
  exploratory/transductive evidence, not a confirmatory deployment result

No new hosted judge calls or placement-label tuning were performed.

## Prospective population

The current certified-public snapshot yields 131 eligible candidate folders under
`pearltrees-public-alphanumeric-title-v1`. This is a new privacy/catalog/population fingerprint;
its future results must not be compared as though they came from the legacy private-inclusive
1,200-row population.

## Verification

- Python compilation checks passed for all changed modules.
- `149 passed` across the new privacy/policy tests and the existing filing, snapshot,
  diffusion-consensus, HOP-plan, and STEM-harvest-plan suites.
- A real local 20-query public-data smoke test completed `emit → seal-picks → score`.
- On the 1,200-row public sample, stable ID-level top-1 and exact-rank top-1 disagree on `0` rows.
- `git diff --check` passes.

## Deliberate follow-ons

- v2 currently seals one complete response artifact per tier. A parent task/chunk/draw manifest
  and frozen aggregation rule are required before chunked calls or repeated judge draws can support
  a decision-bearing test.
- the e5 output arrays are content-bound and drift fails closed, but the immutable Hub revision
  still needs to replace `unresolved` before the future untouched run.

## Review focus

The highest-risk surfaces are the containment/privacy closure, hosted lineage filtering,
task/pick content binding, stable duplicate-title tie semantics, and the distinction between a
single-tier descriptive score and the complete frozen-policy score.
