### PR TITLE
PERF-R-CA-IDDFS: integer-ID traversal and downward hops for R CA kernel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,15 +246,6 @@ jobs:
         run: |
           swipl -q -f init.pl -s tests/test_wam_r_ca_direct_lookup.pl -g "run_tests, halt" -t "halt(1)"
 
-      # Review-only measurement on the same hosted runner class as the
-      # documented post-PERF-R-CA-DIRECT baseline. Remove after recording.
-      - name: Measure PERF-R-CA-IDDFS scale-300 timing
-        run: |
-          OUT="$RUNNER_TEMP/wam-r-ed-300"
-          swipl -q -s examples/benchmark/generate_wam_r_effective_distance_benchmark.pl -- data/benchmark/300/facts.pl "$OUT" kernels_on functions
-          ( cd "$OUT/R" && Rscript run_effective_distance.R "$GITHUB_WORKSPACE/data/benchmark/300" 3 ) > "$RUNNER_TEMP/wam-r-ed-300.tsv" 2> "$RUNNER_TEMP/wam-r-ed-300.metrics"
-          cat "$RUNNER_TEMP/wam-r-ed-300.metrics"
-
       - name: Run full R classic conformance
         run: |
           swipl -q -f init.pl -s tests/test_wam_cross_target_conformance.pl -g "run_tests" -t halt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,6 +246,15 @@ jobs:
         run: |
           swipl -q -f init.pl -s tests/test_wam_r_ca_direct_lookup.pl -g "run_tests, halt" -t "halt(1)"
 
+      # Review-only measurement on the same hosted runner class as the
+      # documented post-PERF-R-CA-DIRECT baseline. Remove after recording.
+      - name: Measure PERF-R-CA-IDDFS scale-300 timing
+        run: |
+          OUT="$RUNNER_TEMP/wam-r-ed-300"
+          swipl -q -s examples/benchmark/generate_wam_r_effective_distance_benchmark.pl -- data/benchmark/300/facts.pl "$OUT" kernels_on functions
+          ( cd "$OUT/R" && Rscript run_effective_distance.R "$GITHUB_WORKSPACE/data/benchmark/300" 3 ) > "$RUNNER_TEMP/wam-r-ed-300.tsv" 2> "$RUNNER_TEMP/wam-r-ed-300.metrics"
+          cat "$RUNNER_TEMP/wam-r-ed-300.metrics"
+
       - name: Run full R classic conformance
         run: |
           swipl -q -f init.pl -s tests/test_wam_cross_target_conformance.pl -g "run_tests" -t halt

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -833,7 +833,7 @@ Add each target to the scale-300 effective-distance matrix in
 
 ### BENCH-R: Add R row to effective-distance scale-300 matrix ✅
 - **Lever:** Effective-distance benchmark rows  **Target:** R  **Size:** L  **Depends on:** —
-- **Status:** Done — `examples/benchmark/generate_wam_r_effective_distance_benchmark.pl`, guarded Rscript harness block, scale-300 matrix row + subsection in `WAM_CROSS_TARGET_BENCHMARK_RESULTS.md` (hosted-CI query_ms=10307 median / total_ms=11103 from process start after capability-gated direct arg1 lookup; reference parity match). Initial BENCH-R branch `cursor/bench-r-effective-distance-f421`; optimized by PERF-R-CA-DIRECT.
+- **Status:** Done — `examples/benchmark/generate_wam_r_effective_distance_benchmark.pl`, guarded Rscript harness block, scale-300 matrix row + subsection in `WAM_CROSS_TARGET_BENCHMARK_RESULTS.md` (hosted-CI query_ms=7521 median / total_ms=8341 from process start after direct arg1 lookup plus integer-ID DFS/downward hops; reference parity match). Initial BENCH-R branch `cursor/bench-r-effective-distance-f421`; optimized by PERF-R-CA-DIRECT and PERF-R-CA-IDDFS.
 
 ---
 

--- a/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
+++ b/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
@@ -22,7 +22,7 @@ All primary measurements at **scale 300** (6004 `category_parent` facts,
 | **F# WAM + FFI (functions mode)** | **11** | **159** | **1** | **Yes** | Lowered predicates; .NET 8 Release build |
 | **F# LMDB cached (two-level L1/L2)** | **2** | -- | **1** | **Yes** | Fact-access only (no WAM overhead); see below |
 | Python WAM | 215 | 689 | 1 | Yes | CPython 3.12; WAM interpreter, FFI for `category_parent/2` |
-| R WAM (functions, kernels_on) | 10307 | 11103 | 1 | Yes | Hosted Ubuntu 24.04 CI, R 4.3.3; auto `category_ancestor/4` kernel + direct indexed FactSource lookup; 3-rep median query |
+| R WAM (functions, kernels_on) | 7521 | 8341 | 1 | Yes | Hosted Ubuntu 24.04 CI, R 4.3.3; direct indexed lookup + integer-ID CA DFS/downward hops; 3-rep median query |
 | Go WAM | -- | -- | -- | Yes | Build OK; benchmark driver in progress |
 
 **Key takeaway:** Atom interning (replacing `HashMap<String, Vec<String>>` with
@@ -354,22 +354,23 @@ R 4.3.3, single-core.
 
 | Scale | query_ms | total_ms | rows | Cores | vs reference |
 |-------|----------|----------|------|-------|--------------|
-| 300 | 10307 | 11103 | 271 | 1 | match (`normalize_three_column_float_rows`, 6 dp) |
+| 300 | 7521 | 8341 | 271 | 1 | match (`normalize_three_column_float_rows`, 6 dp) |
 
 `query_ms` is the 3-run median of article×root enumeration only
-(samples: 11038, 10307, 10296). `total_ms` is setup (Rscript startup +
+(samples: 8260, 7509, 7521). `total_ms` is setup (Rscript startup +
 generated-program / FactSource load + article/root TSV load) plus that
 median query. Output validated against
 `data/benchmark/300/reference_output.tsv` with canonical sort and 6-decimal
 float tolerance (not row-count-only).
 
-PERF-R-CA-DIRECT reduced the same hosted-runner query baseline from 62595 ms
-to 10307 ms (6.07x) by giving the native CA kernel a capability-gated bound-
-arg1 lookup over the existing FactSource index. Sources without the
-capability retain the generic `iterate_goal` fallback. The R path remains
-slower than compiled FFI targets; its remaining cost is inside interpreted R
-DFS/result handling and the lowered power-sum orchestration rather than
-generic WAM fact dispatch.
+PERF-R-CA-DIRECT reduced the hosted-runner query baseline from 62595 ms to
+10307 ms (6.07x) by giving the native CA kernel a capability-gated bound-arg1
+lookup over the existing FactSource index. PERF-R-CA-IDDFS then reduced it to
+7521 ms (a further 1.37x; 8.32x cumulative) by traversing intern IDs, carrying
+depth downward, and constructing `IntTerm` results only at the WAM boundary.
+Sources without these capabilities retain the TermValue and generic
+`iterate_goal` fallbacks. The remaining cost is interpreted R lookup/DFS and
+lowered power-sum orchestration rather than generic WAM fact dispatch.
 
 #### Reproduction
 

--- a/templates/targets/r_wam/program.R.mustache
+++ b/templates/targets/r_wam/program.R.mustache
@@ -102,12 +102,12 @@ shared_program <- list(
   # the fact_in_range/5 builtin via binary-search + the existing
   # fact_table_iter_subset enumeration path.
   fact_range_indexes = new.env(parent = emptyenv()),
-  # Bound-arg1 parent-lookup capability registry (PERF-R-CA-DIRECT).
-  # Keyed by "pred/arity"; value is a closure key_term -> list of
-  # atom parent TermValues (arg2). Registered explicitly at FactSource
-  # / fact-table emit time — kernels never guess generated R names.
-  # category_ancestor/4 uses this when present; otherwise falls back
-  # to iterate_goal over the edge predicate.
+  # Bound-arg1 parent-lookup capability registry (PERF-R-CA-DIRECT /
+  # PERF-R-CA-IDDFS). Keyed by "pred/arity"; value is
+  # list(lookup, lookup_ids) registered at FactSource / fact-table
+  # emit time — kernels never guess generated R names.
+  # lookup_ids enables integer-ID DFS; lookup alone keeps TermValue
+  # DFS; neither falls back to iterate_goal.
   arg1_lookups = new.env(parent = emptyenv())
 )
 

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3234,15 +3234,16 @@ WamRuntime$category_ancestor <- function(program, state, key, edge_pred,
   out_terms <- list()
   if (!is.null(lookup_ids)) {
     # ID-native path: convert Visited once, downward depth, integer buffer.
-    vlen0 <- 0L
-    visited_ids <- integer(max(8L, length(visited_elems)))
-    for (elem in visited_elems) {
+    # Depth is the full Prolog list length, even though only atom entries
+    # participate in cycle membership. Keep non-atoms as the zero sentinel
+    # so this fast path has the same max_depth semantics as the TermValue
+    # and iterate_goal paths.
+    vlen0 <- length(visited_elems)
+    visited_ids <- integer(max(8L, vlen0))
+    for (i in seq_along(visited_elems)) {
+      elem <- visited_elems[[i]]
       if (!is.null(elem) && !is.null(elem$tag) && elem$tag == "atom") {
-        vlen0 <- vlen0 + 1L
-        if (vlen0 > length(visited_ids)) {
-          length(visited_ids) <- as.integer(length(visited_ids) * 2L)
-        }
-        visited_ids[[vlen0]] <- as.integer(elem$id)
+        visited_ids[[i]] <- as.integer(elem$id)
       }
     }
     out <- new.env(parent = emptyenv())

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3132,13 +3132,13 @@ WamRuntime$category_ancestor_collect_parents <- function(program, state,
   parents
 }
 
+# TermValue / iterate_goal DFS (PERF-R-CA-DIRECT fallback path).
+# Upward hop rewrite preserved for sources without lookup_ids.
 WamRuntime$category_ancestor_hops_rec <- function(program, state, edge_atom_id,
                                                    parent_lookup,
                                                    cat, root_id, visited_env,
                                                    visited_len, max_depth, out) {
   root_seen <- exists(as.character(root_id), envir = visited_env, inherits = FALSE)
-  # Prefer an explicit bound-arg1 parent lookup when the edge FactSource
-  # registered one; otherwise keep the iterate_goal semantic fallback.
   parents <- if (!is.null(parent_lookup)) {
     parent_lookup(cat)
   } else {
@@ -3172,6 +3172,37 @@ WamRuntime$category_ancestor_hops_rec <- function(program, state, edge_atom_id,
   invisible(NULL)
 }
 
+# Integer-ID DFS with downward depth (PERF-R-CA-IDDFS). Mirrors Rust
+# accumulator-passing: emit depth+1 when root is among parents; traverse
+# parents/visited as intern IDs; grow an integer buffer (IntTerm only at exit).
+WamRuntime$category_ancestor_hops_rec_ids <- function(lookup_ids, cat_id, root_id,
+                                                       visited, vlen, max_depth,
+                                                       depth, out) {
+  root_seen <- if (vlen < 1L) FALSE else any(visited[seq_len(vlen)] == root_id)
+  parents <- lookup_ids(cat_id)
+  if (!root_seen && length(parents) > 0L && any(parents == root_id)) {
+    n <- out$n + 1L
+    if (n > length(out$buf)) {
+      length(out$buf) <- as.integer(max(8L, length(out$buf) * 2L))
+    }
+    out$buf[[n]] <- as.integer(depth + 1L)
+    out$n <- n
+  }
+  if (vlen >= max_depth) return(invisible(NULL))
+  for (pid in parents) {
+    if (vlen > 0L && any(visited[seq_len(vlen)] == pid)) next
+    nv <- vlen + 1L
+    if (nv > length(visited)) {
+      length(visited) <- as.integer(max(8L, length(visited) * 2L))
+    }
+    visited[[nv]] <- as.integer(pid)
+    WamRuntime$category_ancestor_hops_rec_ids(
+      lookup_ids, as.integer(pid), root_id, visited, nv, max_depth,
+      depth + 1L, out)
+  }
+  invisible(NULL)
+}
+
 WamRuntime$category_ancestor <- function(program, state, key, edge_pred,
                                             edge_key, max_depth, source,
                                             root, hops, visited, resume_pc) {
@@ -3196,18 +3227,48 @@ WamRuntime$category_ancestor <- function(program, state, key, edge_pred,
   snap_build <- state$build_stack
 
   edge_atom_id <- WamRuntime$intern(table, edge_pred)
-  parent_lookup <- WamRuntime$get_arg1_parent_lookup(program, edge_key)
-  visited_env <- new.env(parent = emptyenv())
-  for (elem in visited_elems) {
-    if (!is.null(elem) && !is.null(elem$tag) && elem$tag == "atom") {
-      assign(as.character(elem$id), TRUE, envir = visited_env)
+  cap <- WamRuntime$get_arg1_capability(program, edge_key)
+  lookup_ids <- if (!is.null(cap)) cap$lookup_ids else NULL
+  parent_lookup <- if (!is.null(cap)) cap$lookup else NULL
+
+  out_terms <- list()
+  if (!is.null(lookup_ids)) {
+    # ID-native path: convert Visited once, downward depth, integer buffer.
+    vlen0 <- 0L
+    visited_ids <- integer(max(8L, length(visited_elems)))
+    for (elem in visited_elems) {
+      if (!is.null(elem) && !is.null(elem$tag) && elem$tag == "atom") {
+        vlen0 <- vlen0 + 1L
+        if (vlen0 > length(visited_ids)) {
+          length(visited_ids) <- as.integer(length(visited_ids) * 2L)
+        }
+        visited_ids[[vlen0]] <- as.integer(elem$id)
+      }
     }
+    out <- new.env(parent = emptyenv())
+    out$buf <- integer(8L)
+    out$n <- 0L
+    WamRuntime$category_ancestor_hops_rec_ids(
+      lookup_ids, as.integer(src_v$id), as.integer(root_v$id),
+      visited_ids, vlen0, as.integer(max_depth), 0L, out)
+    if (out$n > 0L) {
+      out_terms <- vector("list", out$n)
+      for (i in seq_len(out$n)) out_terms[[i]] <- IntTerm(out$buf[[i]])
+    }
+  } else {
+    visited_env <- new.env(parent = emptyenv())
+    for (elem in visited_elems) {
+      if (!is.null(elem) && !is.null(elem$tag) && elem$tag == "atom") {
+        assign(as.character(elem$id), TRUE, envir = visited_env)
+      }
+    }
+    out <- new.env(parent = emptyenv())
+    out$hops <- list()
+    WamRuntime$category_ancestor_hops_rec(
+      program, state, edge_atom_id, parent_lookup, src_v, root_v$id,
+      visited_env, length(visited_elems), as.integer(max_depth), out)
+    out_terms <- out$hops
   }
-  out <- new.env(parent = emptyenv())
-  out$hops <- list()
-  WamRuntime$category_ancestor_hops_rec(
-    program, state, edge_atom_id, parent_lookup, src_v, root_v$id,
-    visited_env, length(visited_elems), as.integer(max_depth), out)
 
   if (length(state$cps) > snap_cps) {
     state$cps <- state$cps[seq_len(snap_cps)]
@@ -3227,8 +3288,8 @@ WamRuntime$category_ancestor <- function(program, state, key, edge_pred,
   state$mode        <- snap_mode
   state$build_stack <- snap_build
 
-  if (length(out$hops) == 0L) return(FALSE)
-  WamRuntime$kernel_stream_iter(program, state, key, out$hops, hops,
+  if (length(out_terms) == 0L) return(FALSE)
+  WamRuntime$kernel_stream_iter(program, state, key, out_terms, hops,
                                   1L, resume_pc)
 }
 
@@ -4265,12 +4326,15 @@ WamRuntime$build_fact_indexes <- function(facts, arity) {
 }
 
 # ----------------------------------------------------------
-# Bound-arg1 parent-lookup capability (PERF-R-CA-DIRECT)
+# Bound-arg1 parent-lookup capability (PERF-R-CA-DIRECT / IDDFS)
 # ----------------------------------------------------------
-# Explicit registry on program$arg1_lookups ("pred/arity" -> closure).
-# Closures are installed by codegen after fact tables / FactSources are
-# built — never by guessing pred_*_indexes names from a kernel.
-# Atom-only parents match category_ancestor_collect_parents filtering.
+# Registry: program$arg1_lookups["pred/arity"] -> capability list:
+#   list(lookup = function(key_term) -> list(atom TermValues) | NULL,
+#        lookup_ids = function(atom_id) -> integer vector of parent ids | NULL)
+# Installed by codegen after fact tables / FactSources are built — never
+# by guessing pred_*_indexes names from a kernel. lookup_ids enables the
+# integer-ID DFS; lookup alone keeps the TermValue path; neither falls
+# back to iterate_goal. Atom-only parents match collect_parents filtering.
 WamRuntime$arg1_parent_terms_from_tuples <- function(tuples) {
   n <- length(tuples)
   if (n == 0L) return(list())
@@ -4285,6 +4349,22 @@ WamRuntime$arg1_parent_terms_from_tuples <- function(tuples) {
     }
   }
   if (k == 0L) list() else if (k == n) parents else parents[seq_len(k)]
+}
+
+WamRuntime$arg1_parent_ids_from_tuples <- function(tuples) {
+  n <- length(tuples)
+  if (n == 0L) return(integer(0))
+  ids <- integer(n)
+  k <- 0L
+  for (tup in tuples) {
+    if (length(tup) < 2L) next
+    p <- tup[[2L]]
+    if (!is.null(p) && !is.null(p$tag) && identical(p$tag, "atom")) {
+      k <- k + 1L
+      ids[[k]] <- as.integer(p$id)
+    }
+  }
+  if (k == 0L) integer(0) else if (k == n) ids else ids[seq_len(k)]
 }
 
 WamRuntime$make_indexed_arg1_parent_lookup <- function(facts, indexes) {
@@ -4314,44 +4394,115 @@ WamRuntime$make_indexed_arg1_parent_lookup <- function(facts, indexes) {
   }
 }
 
-WamRuntime$register_arg1_parent_lookup_fn <- function(program, key, fn) {
-  if (is.null(program$arg1_lookups) || is.null(fn)) return(invisible(NULL))
-  assign(key, fn, envir = program$arg1_lookups)
+WamRuntime$make_indexed_arg1_parent_lookup_ids <- function(facts, indexes) {
+  if (is.null(indexes) || length(indexes) < 1L) return(NULL)
+  idx0 <- indexes[[1L]]
+  function(atom_id) {
+    bk <- paste0("a", as.integer(atom_id))
+    if (!exists(bk, envir = idx0, inherits = FALSE)) return(integer(0))
+    tidxs <- get(bk, envir = idx0, inherits = FALSE)
+    n <- length(tidxs)
+    if (n == 0L) return(integer(0))
+    ids <- integer(n)
+    k <- 0L
+    for (ti in tidxs) {
+      tup <- facts[[ti]]
+      if (length(tup) < 2L) next
+      p <- tup[[2L]]
+      if (!is.null(p) && !is.null(p$tag) && identical(p$tag, "atom")) {
+        k <- k + 1L
+        ids[[k]] <- as.integer(p$id)
+      }
+    }
+    if (k == 0L) integer(0) else if (k == n) ids else ids[seq_len(k)]
+  }
+}
+
+WamRuntime$normalize_arg1_capability <- function(cap) {
+  if (is.null(cap)) return(NULL)
+  # Legacy: bare function treated as TermValue-only lookup.
+  if (is.function(cap)) return(list(lookup = cap, lookup_ids = NULL))
+  if (!is.list(cap)) return(NULL)
+  list(
+    lookup = if (!is.null(cap$lookup)) cap$lookup else NULL,
+    lookup_ids = if (!is.null(cap$lookup_ids)) cap$lookup_ids else NULL
+  )
+}
+
+WamRuntime$register_arg1_capability <- function(program, key, cap) {
+  if (is.null(program$arg1_lookups) || is.null(cap)) return(invisible(NULL))
+  assign(key, WamRuntime$normalize_arg1_capability(cap),
+         envir = program$arg1_lookups)
   invisible(NULL)
+}
+
+# Back-compat: register a TermValue-only (or full) capability via fn args.
+WamRuntime$register_arg1_parent_lookup_fn <- function(program, key, fn,
+                                                       lookup_ids = NULL) {
+  WamRuntime$register_arg1_capability(
+    program, key, list(lookup = fn, lookup_ids = lookup_ids))
 }
 
 WamRuntime$register_indexed_arg1_parent_lookup <- function(program, key,
                                                             facts, indexes) {
-  fn <- WamRuntime$make_indexed_arg1_parent_lookup(facts, indexes)
-  WamRuntime$register_arg1_parent_lookup_fn(program, key, fn)
+  WamRuntime$register_arg1_capability(program, key, list(
+    lookup = WamRuntime$make_indexed_arg1_parent_lookup(facts, indexes),
+    lookup_ids = WamRuntime$make_indexed_arg1_parent_lookup_ids(facts, indexes)
+  ))
 }
 
 WamRuntime$register_lmdb_arg1_parent_lookup <- function(program, key, path,
                                                          arity) {
   # On-demand: each key hits lmdb_arg1_v1_lookup — no full materialize.
   table <- program$intern_table
-  WamRuntime$register_arg1_parent_lookup_fn(program, key, function(key_term) {
-    rows <- WamRuntime$lmdb_arg1_v1_lookup(path, key_term, arity, table)
-    WamRuntime$arg1_parent_terms_from_tuples(rows)
-  })
+  WamRuntime$register_arg1_capability(program, key, list(
+    lookup = function(key_term) {
+      rows <- WamRuntime$lmdb_arg1_v1_lookup(path, key_term, arity, table)
+      WamRuntime$arg1_parent_terms_from_tuples(rows)
+    },
+    lookup_ids = function(atom_id) {
+      rows <- WamRuntime$lmdb_arg1_v1_lookup(
+        path, Atom(as.integer(atom_id)), arity, table)
+      WamRuntime$arg1_parent_ids_from_tuples(rows)
+    }
+  ))
 }
 
 WamRuntime$register_lmdb_cached_arg1_parent_lookup <- function(program, key,
                                                                 path, arity,
                                                                 cache) {
   table <- program$intern_table
-  WamRuntime$register_arg1_parent_lookup_fn(program, key, function(key_term) {
-    rows <- WamRuntime$lmdb_arg1_v1_cached_lookup(
-      cache, path, key_term, arity, table)
-    WamRuntime$arg1_parent_terms_from_tuples(rows)
-  })
+  WamRuntime$register_arg1_capability(program, key, list(
+    lookup = function(key_term) {
+      rows <- WamRuntime$lmdb_arg1_v1_cached_lookup(
+        cache, path, key_term, arity, table)
+      WamRuntime$arg1_parent_terms_from_tuples(rows)
+    },
+    lookup_ids = function(atom_id) {
+      rows <- WamRuntime$lmdb_arg1_v1_cached_lookup(
+        cache, path, Atom(as.integer(atom_id)), arity, table)
+      WamRuntime$arg1_parent_ids_from_tuples(rows)
+    }
+  ))
 }
 
-WamRuntime$get_arg1_parent_lookup <- function(program, key) {
+WamRuntime$get_arg1_capability <- function(program, key) {
   env <- program$arg1_lookups
   if (is.null(env)) return(NULL)
   if (!exists(key, envir = env, inherits = FALSE)) return(NULL)
-  get(key, envir = env, inherits = FALSE)
+  WamRuntime$normalize_arg1_capability(get(key, envir = env, inherits = FALSE))
+}
+
+WamRuntime$get_arg1_parent_lookup <- function(program, key) {
+  cap <- WamRuntime$get_arg1_capability(program, key)
+  if (is.null(cap)) return(NULL)
+  cap$lookup
+}
+
+WamRuntime$get_arg1_parent_lookup_ids <- function(program, key) {
+  cap <- WamRuntime$get_arg1_capability(program, key)
+  if (is.null(cap)) return(NULL)
+  cap$lookup_ids
 }
 
 # Binary-search a sorted-by-value index for tuple indices whose value

--- a/tests/test_wam_r_ca_direct_lookup.pl
+++ b/tests/test_wam_r_ca_direct_lookup.pl
@@ -143,8 +143,9 @@ collect_hops <- function(cat, root, visited_chars, sorted = TRUE) {
   state <- WamRuntime$new_state()
   WamRuntime$promote_regs(state)
   hops <- Unbound("H")
-  vis_elems <- lapply(visited_chars, function(nm)
-    Atom(WamRuntime$intern(intern_table, nm)))
+  vis_elems <- if (is.list(visited_chars)) visited_chars else
+    lapply(visited_chars, function(nm)
+      Atom(WamRuntime$intern(intern_table, nm)))
   vis <- WamRuntime$wam_list_build(vis_elems, intern_table)
   WamRuntime$put_reg(state, 1L, Atom(WamRuntime$intern(intern_table, cat)))
   WamRuntime$put_reg(state, 2L, Atom(WamRuntime$intern(intern_table, root)))
@@ -172,7 +173,8 @@ d_root_vis  <- collect_hops("a", "d", c("d"))
 d_depth     <- collect_hops("deep0", "deep3", character(0))
 d_num       <- collect_hops("1827", "9001", character(0))
 d_num_miss  <- collect_hops("1827", "nope", character(0))
-d_order     <- collect_hops("a", "d", character(0), sorted = FALSE)
+d_nonatom   <- collect_hops("deep0", "deep4", list(IntTerm(99L)))
+d_order     <- collect_hops("ord0", "ord_root", character(0), sorted = FALSE)
 
 stopifnot(identical(d_multi_eq, c(2L, 2L)))
 stopifnot(identical(d_multi_une, c(1L, 3L)))
@@ -182,8 +184,9 @@ stopifnot(length(d_root_vis) == 0L)              # root already in Visited
 stopifnot(identical(d_depth, 3L))
 stopifnot(identical(d_num, 2L))
 stopifnot(length(d_num_miss) == 0L)
-# DFS order: a->b->d before a->c->d (edge order in TSV)
-stopifnot(identical(d_order, c(2L, 2L)))
+stopifnot(length(d_nonatom) == 0L)             # non-atoms still consume depth
+# Distinguishable DFS order: long branch is listed before short branch.
+stopifnot(identical(d_order, c(3L, 2L)))
 
 # Forced TermValue-capability fallback (lookup only, no lookup_ids)
 facts <- pred_cparent_facts; indexes <- pred_cparent_indexes
@@ -200,7 +203,8 @@ t_visited   <- collect_hops("a", "d", c("b"))
 t_root_vis  <- collect_hops("a", "d", c("d"))
 t_depth     <- collect_hops("deep0", "deep3", character(0))
 t_num       <- collect_hops("1827", "9001", character(0))
-t_order     <- collect_hops("a", "d", character(0), sorted = FALSE)
+t_nonatom   <- collect_hops("deep0", "deep4", list(IntTerm(99L)))
+t_order     <- collect_hops("ord0", "ord_root", character(0), sorted = FALSE)
 
 # Forced iterate_goal fallback (no capability)
 rm(list = "cparent/2", envir = shared_program$arg1_lookups)
@@ -212,7 +216,8 @@ f_visited   <- collect_hops("a", "d", c("b"))
 f_root_vis  <- collect_hops("a", "d", c("d"))
 f_depth     <- collect_hops("deep0", "deep3", character(0))
 f_num       <- collect_hops("1827", "9001", character(0))
-f_order     <- collect_hops("a", "d", character(0), sorted = FALSE)
+f_nonatom   <- collect_hops("deep0", "deep4", list(IntTerm(99L)))
+f_order     <- collect_hops("ord0", "ord_root", character(0), sorted = FALSE)
 
 # Three-way parity (sorted values)
 stopifnot(identical(d_multi_eq, t_multi_eq), identical(d_multi_eq, f_multi_eq))
@@ -222,6 +227,7 @@ stopifnot(identical(d_visited, t_visited), identical(d_visited, f_visited))
 stopifnot(identical(d_root_vis, t_root_vis), identical(d_root_vis, f_root_vis))
 stopifnot(identical(d_depth, t_depth), identical(d_depth, f_depth))
 stopifnot(identical(d_num, t_num), identical(d_num, f_num))
+stopifnot(identical(d_nonatom, t_nonatom), identical(d_nonatom, f_nonatom))
 # DFS emission order parity across all three paths
 stopifnot(identical(d_order, t_order), identical(d_order, f_order))
 cat("ok\n")
@@ -329,12 +335,16 @@ ca_direct_setup_program(TmpDir, RDir) :-
     unique_tmp('tmp_ca_direct_rt', TmpDir),
     % multipath equal: a->b->d, a->c->d
     % multipath unequal: a->z (1), a->p->q->z (3)
-    % cycle, depth boundary, numeric-looking atoms
+    % cycle, depth boundary, numeric-looking atoms, order-distinguishable paths
     write_edge_tsv(TmpDir, 'edges.tsv',
                    ['a\tb', 'a\tc', 'b\td', 'c\td',
                     'a\tz', 'a\tp', 'p\tq', 'q\tz',
                     'loop_a\tloop_b', 'loop_b\tloop_a',
                     'deep0\tdeep1', 'deep1\tdeep2', 'deep2\tdeep3',
+                    'deep3\tdeep4',
+                    'ord0\tord_long', 'ord_long\tord_mid',
+                    'ord_mid\tord_root', 'ord0\tord_short',
+                    'ord_short\tord_root',
                     '1827\tmid', 'mid\t9001']),
     directory_file_path(TmpDir, 'edges.tsv', TsvPath),
     atom_string(TsvPath, TsvPathStr),

--- a/tests/test_wam_r_ca_direct_lookup.pl
+++ b/tests/test_wam_r_ca_direct_lookup.pl
@@ -41,7 +41,13 @@ test(grouped_by_first_atoms_registers_indexed_lookup, [nondet]) :-
             assertion(once(sub_string(Code, _, _, _,
                 'arg1_lookups = new.env'))),
             assertion(once(sub_string(Code, _, _, _,
-                'pred_cat_anc_kernel_ca')))
+                'pred_cat_anc_kernel_ca'))),
+            directory_file_path(TmpDir, 'R/wam_runtime.R', RtPath),
+            read_file_to_string(RtPath, Rt, []),
+            assertion(once(sub_string(Rt, _, _, _,
+                'make_indexed_arg1_parent_lookup_ids'))),
+            assertion(once(sub_string(Rt, _, _, _,
+                'category_ancestor_hops_rec_ids')))
         ),
         (   cleanup_tmp(TmpDir),
             uninstall_ca_kernel
@@ -126,10 +132,14 @@ ca_direct_runtime_proof :-
 'source("generated_program.R")
 stopifnot(!is.null(shared_program$arg1_lookups))
 stopifnot(exists("cparent/2", envir = shared_program$arg1_lookups, inherits = FALSE))
+cap <- WamRuntime$get_arg1_capability(shared_program, "cparent/2")
+stopifnot(!is.null(cap$lookup), !is.null(cap$lookup_ids))
 lk <- WamRuntime$get_arg1_parent_lookup(shared_program, "cparent/2")
 stopifnot(!is.null(lk))
+lk_ids <- WamRuntime$get_arg1_parent_lookup_ids(shared_program, "cparent/2")
+stopifnot(!is.null(lk_ids))
 
-collect_hops <- function(cat, root, visited_chars) {
+collect_hops <- function(cat, root, visited_chars, sorted = TRUE) {
   state <- WamRuntime$new_state()
   WamRuntime$promote_regs(state)
   hops <- Unbound("H")
@@ -150,42 +160,70 @@ collect_hops <- function(cat, root, visited_chars) {
     out <- c(out, as.integer(v$val))
     ok <- isTRUE(WamRuntime$backtrack(state))
   }
-  sort(out)
+  if (isTRUE(sorted)) sort(out) else out
 }
 
-# Direct path (capability present)
+# ID-native path (lookup_ids present)
 d_multi_eq  <- collect_hops("a", "d", character(0))
 d_multi_une <- collect_hops("a", "z", character(0))
 d_cycle     <- collect_hops("loop_a", "loop_b", character(0))
 d_visited   <- collect_hops("a", "d", c("b"))
+d_root_vis  <- collect_hops("a", "d", c("d"))
 d_depth     <- collect_hops("deep0", "deep3", character(0))
 d_num       <- collect_hops("1827", "9001", character(0))
 d_num_miss  <- collect_hops("1827", "nope", character(0))
+d_order     <- collect_hops("a", "d", character(0), sorted = FALSE)
 
-stopifnot(identical(d_multi_eq, c(2L, 2L)))          # a->b->d and a->c->d
-stopifnot(identical(d_multi_une, c(1L, 3L)))         # a->z and a->p->q->z
-stopifnot(identical(d_cycle, 1L))                    # cycle edge ignored
-stopifnot(identical(d_visited, 2L))                  # b blocked; only a->c->d
-stopifnot(identical(d_depth, 3L))                    # edge at max_depth=3
-stopifnot(identical(d_num, 2L))                      # numeric-looking atoms
+stopifnot(identical(d_multi_eq, c(2L, 2L)))
+stopifnot(identical(d_multi_une, c(1L, 3L)))
+stopifnot(identical(d_cycle, 1L))
+stopifnot(identical(d_visited, 2L))
+stopifnot(length(d_root_vis) == 0L)              # root already in Visited
+stopifnot(identical(d_depth, 3L))
+stopifnot(identical(d_num, 2L))
 stopifnot(length(d_num_miss) == 0L)
+# DFS order: a->b->d before a->c->d (edge order in TSV)
+stopifnot(identical(d_order, c(2L, 2L)))
 
-# Fallback: clear capability -> iterate_goal collect_parents path
+# Forced TermValue-capability fallback (lookup only, no lookup_ids)
+facts <- pred_cparent_facts; indexes <- pred_cparent_indexes
+WamRuntime$register_arg1_capability(shared_program, "cparent/2", list(
+  lookup = WamRuntime$make_indexed_arg1_parent_lookup(facts, indexes),
+  lookup_ids = NULL
+))
+stopifnot(is.null(WamRuntime$get_arg1_parent_lookup_ids(shared_program, "cparent/2")))
+stopifnot(!is.null(WamRuntime$get_arg1_parent_lookup(shared_program, "cparent/2")))
+t_multi_eq  <- collect_hops("a", "d", character(0))
+t_multi_une <- collect_hops("a", "z", character(0))
+t_cycle     <- collect_hops("loop_a", "loop_b", character(0))
+t_visited   <- collect_hops("a", "d", c("b"))
+t_root_vis  <- collect_hops("a", "d", c("d"))
+t_depth     <- collect_hops("deep0", "deep3", character(0))
+t_num       <- collect_hops("1827", "9001", character(0))
+t_order     <- collect_hops("a", "d", character(0), sorted = FALSE)
+
+# Forced iterate_goal fallback (no capability)
 rm(list = "cparent/2", envir = shared_program$arg1_lookups)
 stopifnot(is.null(WamRuntime$get_arg1_parent_lookup(shared_program, "cparent/2")))
 f_multi_eq  <- collect_hops("a", "d", character(0))
 f_multi_une <- collect_hops("a", "z", character(0))
 f_cycle     <- collect_hops("loop_a", "loop_b", character(0))
 f_visited   <- collect_hops("a", "d", c("b"))
+f_root_vis  <- collect_hops("a", "d", c("d"))
 f_depth     <- collect_hops("deep0", "deep3", character(0))
 f_num       <- collect_hops("1827", "9001", character(0))
+f_order     <- collect_hops("a", "d", character(0), sorted = FALSE)
 
-stopifnot(identical(d_multi_eq, f_multi_eq))
-stopifnot(identical(d_multi_une, f_multi_une))
-stopifnot(identical(d_cycle, f_cycle))
-stopifnot(identical(d_visited, f_visited))
-stopifnot(identical(d_depth, f_depth))
-stopifnot(identical(d_num, f_num))
+# Three-way parity (sorted values)
+stopifnot(identical(d_multi_eq, t_multi_eq), identical(d_multi_eq, f_multi_eq))
+stopifnot(identical(d_multi_une, t_multi_une), identical(d_multi_une, f_multi_une))
+stopifnot(identical(d_cycle, t_cycle), identical(d_cycle, f_cycle))
+stopifnot(identical(d_visited, t_visited), identical(d_visited, f_visited))
+stopifnot(identical(d_root_vis, t_root_vis), identical(d_root_vis, f_root_vis))
+stopifnot(identical(d_depth, t_depth), identical(d_depth, f_depth))
+stopifnot(identical(d_num, t_num), identical(d_num, f_num))
+# DFS emission order parity across all three paths
+stopifnot(identical(d_order, t_order), identical(d_order, f_order))
 cat("ok\n")
 '),
                 close(S)),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds optional integer-ID traversal and downward hop accumulation to the R `category_ancestor/4` kernel, layered on the existing PERF-R-CA-DIRECT registry without adding another global registry.

## Existing-functionality audit

- Before this PR, R capabilities returned parent TermValues and CA used string-keyed visited state, upward hop rewrites, and repeated list growth.
- Rust already carries depth downward over integer IDs; F# accepts `int -> int list`.
- R kernels still receive explicit capabilities and never guess generated variable names.

## Capability and fallback design

Registry entries normalize to:

```r
list(
  lookup     = function(key_term) -> list(atom TermValues) | NULL,
  lookup_ids = function(atom_id)  -> integer parent IDs    | NULL
)
```

Selection remains:

1. `lookup_ids`: integer-ID DFS, integer visited vector, downward depth, buffered integer results.
2. `lookup`: existing TermValue DFS with upward rewrite.
3. No capability: existing `iterate_goal` fallback.

Lazy/cached LMDB converts on-demand lookup results to IDs without materializing the database. Indexed in-memory and eager sources reuse their existing indexes; no duplicate adjacency map is introduced. Legacy bare-function capabilities remain TermValue-only.

## Review finding and fix

The initial ID path compacted `Visited` to atom entries and used that compacted count as the depth budget. The existing TermValue and `iterate_goal` paths count every Prolog list element for depth while only atoms participate in cycle membership. A `Visited` list containing a non-atom could therefore traverse deeper only on the new fast path.

The fix preserves the full list length and stores non-atoms as a nonmatching zero sentinel in the integer visited vector.

The contract suite now also checks:

- non-atom `Visited` depth parity across all three paths
- distinguishable DFS order using unequal hop counts, rather than equal values that could not prove ordering

## Profiling

Post-#3943 profiling identified:

| Hot section | Evidence |
|---|---|
| TermValue parent capability | 516,522 calls; roughly 843k TermValues |
| string/index operations | `exists`, `as.character`, and `paste0` remained material |
| original R IDDFS profile | memory attribution fell from roughly 5.2 GB to 3.8 GB |

The ID path now traverses intern IDs, carries depth downward, grows an integer result buffer, and creates `IntTerm` values only at the WAM boundary.

## Comparable hosted benchmark

Scale 300, `kernels_on` + `functions`, Ubuntu 24.04 hosted runner, R 4.3.3:

| Metric | Post-#3943 | IDDFS |
|---|---:|---:|
| query samples | 11038, 10307, 10296 | 8260, 7509, 7521 |
| median query_ms | 10307 | 7521 |
| total_ms | 11103 | 8341 |
| incremental speedup | — | **1.37×** |
| initial BENCH-R cumulative speedup | — | **8.32×** |
| rows | 271 | 271 |
| reference | match | match |

The hosted result is recorded in the benchmark matrix. The temporary measurement step was removed; no permanent scale-300 run or performance threshold remains.

## Size

Current diff: **+273 / -72** across five files.

- Production runtime/templates: **+193 / -41**
- Extended existing contract suite: **+68 / -20**
- Benchmark documentation: **+12 / -11**

No second large test harness was added.

## Verification

- [x] ID-native, TermValue-capability, and `iterate_goal` three-way parity
- [x] distinguishable DFS emission-order parity
- [x] atom and non-atom initial `Visited`
- [x] multipath, cycles, root-in-Visited, boundary, unreachable, numeric atoms
- [x] functions and interpreter modes
- [x] indexed, eager, lazy, and cached source shapes
- [x] permanent hosted direct-lookup/IDDFS contract suite
- [x] full R classic conformance
- [x] hosted scale-300 271-row reference parity
- [x] `git diff --check`

The effective-distance runner remains unchanged and contains no graph traversal.
<!-- CURSOR_AGENT_PR_BODY_END -->