### PR TITLE
mu_cosine: pin routed filing e5 revision and cache identity

### DIFF
--- a/prototypes/mu_cosine/PROTOCOL_filing_ranker_eval.md
+++ b/prototypes/mu_cosine/PROTOCOL_filing_ranker_eval.md
@@ -196,10 +196,12 @@ run, add a parent-task manifest that binds every chunk, provider run, and draw t
 plus a frozen aggregation rule. Manually concatenating partial responses is not an acceptable
 substitute.
 
-The current ranker receipt binds the e5 model name and exact candidate/query embedding arrays, so
-upstream model drift fails reproduction rather than silently changing a result. Before a future
-decision-bearing task is emitted, replace the `unresolved` Hub revision with an immutable e5
-revision so those bound arrays can also be regenerated long-term.
+The ranker is frozen to `intfloat/e5-small-v2` at immutable Hugging Face commit
+`ffb93f3bd4047442299a41ebb6fa998a38507c52`. Candidate and query encoders both pass that revision
+explicitly. Regenerable embedding caches bind the model ID and revision and reject legacy or
+mismatched entries. Ranker receipts bind the same commit plus the exact candidate/query embedding
+arrays, so both long-term regeneration and fail-closed output comparison are available before a
+future decision-bearing task is emitted.
 
 ## 8. Reproducibility and fail-closed audit
 

--- a/prototypes/mu_cosine/filing_assistant.py
+++ b/prototypes/mu_cosine/filing_assistant.py
@@ -37,7 +37,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from eval_filing import load_filing, metrics
 from filing_privacy import public_catalog_title_eligible
-from mu_attention import E5_MODEL, build_e5_tables
+from mu_attention import E5_MODEL, E5_REVISION, build_e5_tables
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 TREES = os.path.join(ROOT, "..", "..", ".local", "data", "pearltrees_api", "trees")
@@ -73,9 +73,15 @@ def catalog_tables(min_bm, cache_tag, *, return_privacy=False):
     os.makedirs(cache_root, exist_ok=True)
     cache = os.path.join(
         cache_root,
-        f"filing_assistant_e5_{cache_tag}_{privacy.manifest_sha256[:12]}.pt",
+        f"filing_assistant_e5_{cache_tag}_{privacy.manifest_sha256[:12]}_"
+        f"{E5_REVISION[:12]}.pt",
     )
-    _, ptbl, idx = build_e5_tables(names, cache_path=cache, batch_size=128)
+    _, ptbl, idx = build_e5_tables(
+        names,
+        cache_path=cache,
+        batch_size=128,
+        model_revision=E5_REVISION,
+    )
     P = ptbl.numpy()
     cand_vec = np.stack([P[idx[t]] for t in f_titles])
     result = (queries, f_ids, f_titles, cand_vec)
@@ -84,7 +90,7 @@ def catalog_tables(min_bm, cache_tag, *, return_privacy=False):
 
 def encode_queries(titles):
     from sentence_transformers import SentenceTransformer
-    model = SentenceTransformer(E5_MODEL)
+    model = SentenceTransformer(E5_MODEL, revision=E5_REVISION)
     q = model.encode(["query: " + t.replace("_", " ") for t in titles], batch_size=64,
                      convert_to_numpy=True, normalize_embeddings=True, show_progress_bar=False)
     return q

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -36,6 +36,7 @@ ROOT = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.abspath(os.path.join(ROOT, "..", ".."))
 GRAPH = os.environ.get("UW_MU_GRAPH", os.path.join(REPO, "data", "benchmark", "10k", "category_parent.tsv"))
 E5_MODEL = "intfloat/e5-small-v2"
+E5_REVISION = "ffb93f3bd4047442299a41ebb6fa998a38507c52"
 
 # operator codebook (the relation axis). OPERATORS = pure RELATIONS (what the edge is). SOURCE lives on other axes:
 # corpus_emb (enwiki/simplewiki/pearltrees/mindmap) = which knowledge base; judge_emb (graph/haiku/…) = how labeled.
@@ -151,29 +152,60 @@ def sample_ancestors(node, parents, deg, k=1, beta=1.0, stop=0.33, depth_cap=5, 
 # --------------------------------------------------------------------------------------------------
 # e5 embedding cache (frozen) — query: for the root/anchor, passage: for candidate + ancestors
 # --------------------------------------------------------------------------------------------------
-def build_e5_tables(names, cache_path=None, model_name=E5_MODEL, batch_size=512, device=None, texts=None):
+def build_e5_tables(
+    names,
+    cache_path=None,
+    model_name=E5_MODEL,
+    batch_size=512,
+    device=None,
+    texts=None,
+    model_revision=None,
+):
     """Return (query_tbl, passage_tbl, idx) — two [N,384] unit-normed frozen e5 tables. Cached to disk
     (regenerable, git-ignored). `query:`/`passage:` are e5's asymmetric prefixes — the directional
     motivation for choosing e5 (the root is the query, the candidate/ancestors are passages).
 
     `texts` (optional {name: text}) overrides the embedded string for a name — used for fused nodes whose
-    KEY (e.g. `mm:cybernetics`) is not its text; they embed their title/embed_text instead of the key."""
+    KEY (e.g. `mm:cybernetics`) is not its text; they embed their title/embed_text instead of the key.
+
+    ``model_revision`` is an immutable Hub commit when reproducibility is decision-bearing. Cache reuse
+    requires the same model ID and revision; legacy or mismatched caches are regenerated rather than
+    silently crossing model versions.
+    """
     idx = {n: i for i, n in enumerate(names)}
     texts = texts or {}
     human = [texts.get(n, n.replace("_", " ")) for n in names]
     if cache_path and os.path.exists(cache_path):
         d = torch.load(cache_path, weights_only=False)
-        if d["names"] == list(names) and d.get("human") == human:
+        if (
+            d.get("names") == list(names)
+            and d.get("human") == human
+            and d.get("model_name") == model_name
+            and d.get("model_revision") == model_revision
+        ):
             return d["query"], d["passage"], idx
     from sentence_transformers import SentenceTransformer
-    model = SentenceTransformer(model_name, device=device)
+    model_kwargs = {"device": device}
+    if model_revision is not None:
+        model_kwargs["revision"] = model_revision
+    model = SentenceTransformer(model_name, **model_kwargs)
     q = model.encode(["query: " + h for h in human], batch_size=batch_size,
                      convert_to_numpy=True, normalize_embeddings=True, show_progress_bar=False)
     p = model.encode(["passage: " + h for h in human], batch_size=batch_size,
                      convert_to_numpy=True, normalize_embeddings=True, show_progress_bar=False)
     qt, pt = torch.tensor(q, dtype=torch.float32), torch.tensor(p, dtype=torch.float32)
     if cache_path:
-        torch.save({"names": list(names), "human": human, "query": qt, "passage": pt}, cache_path)
+        torch.save(
+            {
+                "names": list(names),
+                "human": human,
+                "model_name": model_name,
+                "model_revision": model_revision,
+                "query": qt,
+                "passage": pt,
+            },
+            cache_path,
+        )
     return qt, pt, idx
 
 

--- a/prototypes/mu_cosine/requirements.txt
+++ b/prototypes/mu_cosine/requirements.txt
@@ -4,7 +4,7 @@
 # separate project: training the real encoder with MiniLM-initialised embeddings.
 torch>=2.0
 numpy>=1.24
-sentence-transformers>=2.2    # provides the embedders below (needs HF egress)
+sentence-transformers>=2.3    # revision= pin support; provides the embedders below (needs HF egress)
 einops>=0.7                   # only for the nomic-ai/nomic-embed-text-v1.5 preset in dense_mu_direct.py
 # Embedder choice (see prior project eval: skill_embedding_models.md, reports/answer_level_*.json):
 #   intfloat/e5-small-v2          384-d, lightweight, query:/passage: prefixes  (best cosine-to-target)

--- a/prototypes/mu_cosine/routed_queries.py
+++ b/prototypes/mu_cosine/routed_queries.py
@@ -59,7 +59,7 @@ from filing_assistant import (
     ranks_np,
     stable_score_order,
 )
-from mu_attention import E5_MODEL
+from mu_attention import E5_MODEL, E5_REVISION
 from routed_policy import (
     RoutedPolicyError,
     band_qids,
@@ -288,8 +288,8 @@ def build(a):
         "ranker": {
             "name": "e5-cos",
             "model_id": E5_MODEL,
-            "model_revision": "unresolved",
-            "model_revision_status": "name-plus-output-bound",
+            "model_revision": E5_REVISION,
+            "model_revision_status": "immutable-huggingface-commit",
             "top_k": a.top_k,
             "tie_break": "candidate_catalog_column_ascending",
             "candidate_embeddings": _array_record(cand_vec),

--- a/prototypes/mu_cosine/test_e5_revision_pin.py
+++ b/prototypes/mu_cosine/test_e5_revision_pin.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Offline enforcement tests for the routed filing e5 revision pin."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+import filing_assistant
+from mu_attention import E5_MODEL, E5_REVISION, build_e5_tables
+import routed_queries
+
+
+def _fake_sentence_transformers():
+    class FakeSentenceTransformer:
+        calls = []
+
+        def __init__(self, model_name, **kwargs):
+            self.calls.append((model_name, dict(kwargs)))
+
+        def encode(self, texts, **_kwargs):
+            vectors = np.zeros((len(texts), 4), dtype=np.float32)
+            for row, text in enumerate(texts):
+                vectors[row, row % 4] = 1.0
+                vectors[row, (len(text) + 1) % 4] += 0.25
+            vectors /= np.linalg.norm(vectors, axis=1, keepdims=True)
+            return vectors
+
+    return SimpleNamespace(SentenceTransformer=FakeSentenceTransformer), FakeSentenceTransformer
+
+
+def test_e5_revision_is_the_frozen_immutable_commit():
+    assert E5_REVISION == "ffb93f3bd4047442299a41ebb6fa998a38507c52"
+    assert len(E5_REVISION) == 40
+    assert all(character in "0123456789abcdef" for character in E5_REVISION)
+
+
+def test_build_e5_tables_forwards_revision_and_reuses_matching_cache(
+    tmp_path, monkeypatch
+):
+    module, fake_model = _fake_sentence_transformers()
+    monkeypatch.setitem(sys.modules, "sentence_transformers", module)
+    cache = tmp_path / "e5.pt"
+
+    first_q, first_p, first_idx = build_e5_tables(
+        ["alpha", "beta"],
+        cache_path=cache,
+        model_revision=E5_REVISION,
+    )
+    assert len(fake_model.calls) == 1
+    model_name, model_kwargs = fake_model.calls[0]
+    assert model_name == E5_MODEL
+    assert model_kwargs["revision"] == E5_REVISION
+    payload = torch.load(cache, weights_only=False)
+    assert payload["model_name"] == E5_MODEL
+    assert payload["model_revision"] == E5_REVISION
+
+    class MustNotConstruct:
+        def __init__(self, *_args, **_kwargs):
+            raise AssertionError("matching cache should avoid model construction")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        SimpleNamespace(SentenceTransformer=MustNotConstruct),
+    )
+    second_q, second_p, second_idx = build_e5_tables(
+        ["alpha", "beta"],
+        cache_path=cache,
+        model_revision=E5_REVISION,
+    )
+    assert torch.equal(second_q, first_q)
+    assert torch.equal(second_p, first_p)
+    assert second_idx == first_idx
+
+
+def test_build_e5_tables_keeps_generic_unpinned_callers_compatible(monkeypatch):
+    module, fake_model = _fake_sentence_transformers()
+    monkeypatch.setitem(sys.modules, "sentence_transformers", module)
+
+    build_e5_tables(["alpha"], model_name="fixture/model")
+
+    assert fake_model.calls == [("fixture/model", {"device": None})]
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {},
+        {"model_name": E5_MODEL},
+        {"model_name": E5_MODEL, "model_revision": "wrong-revision"},
+        {"model_name": "other/model", "model_revision": E5_REVISION},
+    ],
+)
+def test_build_e5_tables_invalidates_legacy_or_mismatched_cache(
+    tmp_path, monkeypatch, metadata
+):
+    cache = tmp_path / "e5.pt"
+    torch.save(
+        {
+            "names": ["alpha"],
+            "human": ["alpha"],
+            "query": torch.full((1, 4), -1.0),
+            "passage": torch.full((1, 4), -1.0),
+            **metadata,
+        },
+        cache,
+    )
+    module, fake_model = _fake_sentence_transformers()
+    monkeypatch.setitem(sys.modules, "sentence_transformers", module)
+
+    query, passage, _ = build_e5_tables(
+        ["alpha"],
+        cache_path=cache,
+        model_revision=E5_REVISION,
+    )
+    assert len(fake_model.calls) == 1
+    assert not torch.equal(query, torch.full((1, 4), -1.0))
+    assert not torch.equal(passage, torch.full((1, 4), -1.0))
+    payload = torch.load(cache, weights_only=False)
+    assert payload["model_name"] == E5_MODEL
+    assert payload["model_revision"] == E5_REVISION
+
+
+def test_filing_candidate_and_query_encoders_use_one_pinned_revision(
+    tmp_path, monkeypatch
+):
+    module, fake_model = _fake_sentence_transformers()
+    monkeypatch.setitem(sys.modules, "sentence_transformers", module)
+    monkeypatch.setenv("MU_COSINE_CACHE_DIR", str(tmp_path))
+    privacy = SimpleNamespace(manifest_sha256="a" * 64)
+    monkeypatch.setattr(
+        filing_assistant,
+        "load_filing",
+        lambda *_args, **_kwargs: (
+            [("bookmark one", 1), ("bookmark two", 2)],
+            {1: "Folder One", 2: "Folder Two"},
+            privacy,
+        ),
+    )
+
+    filing_assistant.catalog_tables(1, "test")
+    filing_assistant.encode_queries(["bookmark one"])
+
+    assert len(fake_model.calls) == 2
+    assert all(
+        model_name == E5_MODEL and kwargs["revision"] == E5_REVISION
+        for model_name, kwargs in fake_model.calls
+    )
+    assert [
+        path.name
+        for path in tmp_path.iterdir()
+        if E5_REVISION[:12] in path.name
+    ] == [
+        f"filing_assistant_e5_test_{privacy.manifest_sha256[:12]}_"
+        f"{E5_REVISION[:12]}.pt"
+    ]
+
+
+def test_routed_receipt_reports_immutable_ranker_revision(monkeypatch):
+    class FakePrivacy:
+        manifest_sha256 = "a" * 64
+        source_snapshot = {
+            "schema": "unifyweaver.pearltrees-source-snapshot.v1",
+            "file_count": 1,
+            "members_sha256": "b" * 64,
+            "total_size_bytes": 1,
+        }
+
+        @staticmethod
+        def receipt():
+            return {
+                "schema": "unifyweaver.pearltrees-privacy-index.v1",
+                "policy_id": "pearltrees-public-only-v1",
+                "counts": {"public": 2, "private": 0, "quarantined": 0},
+            }
+
+    monkeypatch.setattr(
+        routed_queries,
+        "catalog_tables",
+        lambda *_args, **_kwargs: (
+            [("bookmark", 10)],
+            [10, 11],
+            ["Folder A", "Folder B"],
+            np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32),
+            FakePrivacy(),
+        ),
+    )
+    monkeypatch.setattr(
+        routed_queries,
+        "encode_queries",
+        lambda _titles: np.array([[1.0, 0.0]], dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        routed_queries,
+        "_implementation_record",
+        lambda: {"git_commit": "test", "files_sha256": "c" * 64},
+    )
+
+    state = routed_queries.build(
+        SimpleNamespace(min_bm=1, max_queries=10, seed=7, top_k=2)
+    )
+    ranker = state.receipt["ranker"]
+    assert ranker["model_id"] == E5_MODEL
+    assert ranker["model_revision"] == E5_REVISION
+    assert ranker["model_revision_status"] == "immutable-huggingface-commit"


### PR DESCRIPTION
## Summary

Freeze intfloat/e5-small-v2 at Hugging Face commit ffb93f3bd4047442299a41ebb6fa998a38507c52.

Pass the immutable revision to both candidate-folder and bookmark-query encoders.

Bind embedding caches to the complete model ID and revision.

Reject and regenerate legacy, wrong-model, or wrong-revision caches.

Record the immutable revision in routed-task ranker receipts.

Raise the minimum sentence-transformers version to 2.3 for revision= support.

Update the filing evaluation protocol and add offline enforcement tests.


## Why

Future decision-bearing routed tasks need to reproduce the exact embedding model rather than rely on whatever the Hugging Face main reference resolves to later. The previous receipts bound the generated arrays but recorded the model revision as unresolved.

This PR closes that provenance gap before the repeated-draw and chunked-provider execution work begins.

Validation

41 targeted tests passed.

Python compilation and git diff --check passed.

An offline before/after comparison reproduced the merged baseline exactly:

candidate embedding SHA-256: fc6393c63e42689b54d8d991a8c74b2a03e535ea8cff48c9bba18a2ffd9232e2

query embedding SHA-256: 04dd81d77aa319e2b949d26492259d6fd8e4f43ccf4cfde7dcbbec8f793e676a

ranking SHA-256: a8b77bb34d4828b70d8f9bde3fb53cabd84c775aed7c595ff3d6bbea40ea6deb



There is no ranking or routing-policy change. Future task IDs change intentionally because their receipts now contain the immutable model revision. Existing legacy embedding caches regenerate once.