### PR TITLE
PERF-R-CA-IDCACHE: memoized numeric-key parent buckets for R CA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,15 +246,6 @@ jobs:
         run: |
           swipl -q -f init.pl -s tests/test_wam_r_ca_direct_lookup.pl -g "run_tests, halt" -t "halt(1)"
 
-      # Review-only measurement on the same hosted runner class as the
-      # documented post-PERF-R-CA-IDDFS baseline. Remove after recording.
-      - name: Measure PERF-R-CA-IDCACHE scale-300 timing
-        run: |
-          OUT="$RUNNER_TEMP/wam-r-ed-300"
-          swipl -q -s examples/benchmark/generate_wam_r_effective_distance_benchmark.pl -- data/benchmark/300/facts.pl "$OUT" kernels_on functions
-          ( cd "$OUT/R" && Rscript run_effective_distance.R "$GITHUB_WORKSPACE/data/benchmark/300" 3 ) > "$RUNNER_TEMP/wam-r-ed-300.tsv" 2> "$RUNNER_TEMP/wam-r-ed-300.metrics"
-          cat "$RUNNER_TEMP/wam-r-ed-300.metrics"
-
       - name: Run full R classic conformance
         run: |
           swipl -q -f init.pl -s tests/test_wam_cross_target_conformance.pl -g "run_tests" -t halt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,6 +246,15 @@ jobs:
         run: |
           swipl -q -f init.pl -s tests/test_wam_r_ca_direct_lookup.pl -g "run_tests, halt" -t "halt(1)"
 
+      # Review-only measurement on the same hosted runner class as the
+      # documented post-PERF-R-CA-IDDFS baseline. Remove after recording.
+      - name: Measure PERF-R-CA-IDCACHE scale-300 timing
+        run: |
+          OUT="$RUNNER_TEMP/wam-r-ed-300"
+          swipl -q -s examples/benchmark/generate_wam_r_effective_distance_benchmark.pl -- data/benchmark/300/facts.pl "$OUT" kernels_on functions
+          ( cd "$OUT/R" && Rscript run_effective_distance.R "$GITHUB_WORKSPACE/data/benchmark/300" 3 ) > "$RUNNER_TEMP/wam-r-ed-300.tsv" 2> "$RUNNER_TEMP/wam-r-ed-300.metrics"
+          cat "$RUNNER_TEMP/wam-r-ed-300.metrics"
+
       - name: Run full R classic conformance
         run: |
           swipl -q -f init.pl -s tests/test_wam_cross_target_conformance.pl -g "run_tests" -t halt

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -833,7 +833,7 @@ Add each target to the scale-300 effective-distance matrix in
 
 ### BENCH-R: Add R row to effective-distance scale-300 matrix ✅
 - **Lever:** Effective-distance benchmark rows  **Target:** R  **Size:** L  **Depends on:** —
-- **Status:** Done — `examples/benchmark/generate_wam_r_effective_distance_benchmark.pl`, guarded Rscript harness block, scale-300 matrix row + subsection in `WAM_CROSS_TARGET_BENCHMARK_RESULTS.md` (hosted-CI query_ms=7521 median / total_ms=8341 from process start after direct arg1 lookup plus integer-ID DFS/downward hops; reference parity match). Initial BENCH-R branch `cursor/bench-r-effective-distance-f421`; optimized by PERF-R-CA-DIRECT and PERF-R-CA-IDDFS.
+- **Status:** Done — `examples/benchmark/generate_wam_r_effective_distance_benchmark.pl`, guarded Rscript harness block, scale-300 matrix row + subsection in `WAM_CROSS_TARGET_BENCHMARK_RESULTS.md` (cloud-agent query_ms=2940 median / total_ms=3455 after IDCACHE; same-host post-IDDFS was 4612/5126; prior GHA IDDFS median was 7521/8341; reference parity match). Initial BENCH-R branch `cursor/bench-r-effective-distance-f421`; optimized by PERF-R-CA-DIRECT, PERF-R-CA-IDDFS, and PERF-R-CA-IDCACHE.
 
 ---
 

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -833,7 +833,7 @@ Add each target to the scale-300 effective-distance matrix in
 
 ### BENCH-R: Add R row to effective-distance scale-300 matrix ✅
 - **Lever:** Effective-distance benchmark rows  **Target:** R  **Size:** L  **Depends on:** —
-- **Status:** Done — `examples/benchmark/generate_wam_r_effective_distance_benchmark.pl`, guarded Rscript harness block, scale-300 matrix row + subsection in `WAM_CROSS_TARGET_BENCHMARK_RESULTS.md` (cloud-agent query_ms=2940 median / total_ms=3455 after IDCACHE; same-host post-IDDFS was 4612/5126; prior GHA IDDFS median was 7521/8341; reference parity match). Initial BENCH-R branch `cursor/bench-r-effective-distance-f421`; optimized by PERF-R-CA-DIRECT, PERF-R-CA-IDDFS, and PERF-R-CA-IDCACHE.
+- **Status:** Done — `examples/benchmark/generate_wam_r_effective_distance_benchmark.pl`, guarded Rscript harness block, scale-300 matrix row + subsection in `WAM_CROSS_TARGET_BENCHMARK_RESULTS.md` (hosted-CI query_ms=4812 median / total_ms=5610 after IDCACHE; post-IDDFS hosted median was 7521/8341; reference parity match). Initial BENCH-R branch `cursor/bench-r-effective-distance-f421`; optimized by PERF-R-CA-DIRECT, PERF-R-CA-IDDFS, and PERF-R-CA-IDCACHE.
 
 ---
 

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -62,8 +62,8 @@ default 4096), and explicit `auto` (codegen resolves via shared
 - Effective-distance cross-target matrix row populated (BENCH-R): scale-300
   `emit_mode(functions)` + auto `category_ancestor/4` kernel, reference
   parity match — see `docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md`.
-  Further optimized by PERF-R-CA-DIRECT / IDDFS / IDCACHE (cloud-agent
-  median query_ms=2940 after numeric-key parent-id memoization).
+  Further optimized by PERF-R-CA-DIRECT / IDDFS / IDCACHE (hosted-CI
+  median query_ms=4812 after numeric-key parent-id memoization).
 
 ## Path forward
 

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -62,6 +62,8 @@ default 4096), and explicit `auto` (codegen resolves via shared
 - Effective-distance cross-target matrix row populated (BENCH-R): scale-300
   `emit_mode(functions)` + auto `category_ancestor/4` kernel, reference
   parity match — see `docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md`.
+  Further optimized by PERF-R-CA-DIRECT / IDDFS / IDCACHE (cloud-agent
+  median query_ms=2940 after numeric-key parent-id memoization).
 
 ## Path forward
 
@@ -70,5 +72,6 @@ default 4096), and explicit `auto` (codegen resolves via shared
 
 ## Document status
 
-Fleet-aligned snapshot updated for BENCH-R closeout (2026-07-22): scale-300
-effective-distance matrix row measured and documented after ISO-R-2B.
+Fleet-aligned snapshot updated for PERF-R-CA-IDCACHE (2026-07-23): scale-300
+effective-distance matrix row remeasured after closure-private parent-id
+memoization.

--- a/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
+++ b/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
@@ -22,7 +22,7 @@ All primary measurements at **scale 300** (6004 `category_parent` facts,
 | **F# WAM + FFI (functions mode)** | **11** | **159** | **1** | **Yes** | Lowered predicates; .NET 8 Release build |
 | **F# LMDB cached (two-level L1/L2)** | **2** | -- | **1** | **Yes** | Fact-access only (no WAM overhead); see below |
 | Python WAM | 215 | 689 | 1 | Yes | CPython 3.12; WAM interpreter, FFI for `category_parent/2` |
-| R WAM (functions, kernels_on) | 2940 | 3455 | 1 | Yes | Cursor cloud agent, R 4.3.3; + memoized numeric-key parent-id buckets (IDCACHE); 3-rep median query |
+| R WAM (functions, kernels_on) | 4812 | 5610 | 1 | Yes | Hosted Ubuntu 24.04 CI, R 4.3.3; + memoized numeric-key parent-id buckets (IDCACHE); 3-rep median query |
 | Go WAM | -- | -- | -- | Yes | Build OK; benchmark driver in progress |
 
 **Key takeaway:** Atom interning (replacing `HashMap<String, Vec<String>>` with
@@ -344,28 +344,29 @@ python3 /tmp/wam-bench/python-300/main.py data/benchmark/300 3
 
 ### R WAM (functions mode)
 
-Measured 2026-07-23 on a Cursor cloud agent using
+Measured 2026-07-23 in hosted GitHub Actions using
 `generate_wam_r_effective_distance_benchmark.pl`
 with `emit_mode(functions)`, auto-detected `category_ancestor/4` kernel
 (fleet hops layout), and `category_parent/2` FactSource via
 `grouped_by_first_atoms` (preserves Prolog atom identity for numeric-looking
-Wikipedia IDs). Host: Linux cloud agent, SWI-Prolog, R 4.3.3, single-core.
+Wikipedia IDs). Host: Ubuntu 24.04 hosted runner, SWI-Prolog 10.0.2,
+R 4.3.3, single-core.
 
 | Scale | query_ms | total_ms | rows | Cores | vs reference |
 |-------|----------|----------|------|-------|--------------|
-| 300 | 2940 | 3455 | 271 | 1 | match (`normalize_three_column_float_rows`, 6 dp) |
+| 300 | 4812 | 5610 | 271 | 1 | match (`normalize_three_column_float_rows`, 6 dp) |
 
 `query_ms` is the 3-run median of article×root enumeration only
-(samples: 3445, 2929, 2940). `total_ms` is setup (Rscript startup +
+(samples: 5573, 4812, 4795). `total_ms` is setup (Rscript startup +
 generated-program / FactSource load + article/root TSV load) plus that
 median query. Output validated against
 `data/benchmark/300/reference_output.tsv` with canonical sort and 6-decimal
 float tolerance (not row-count-only).
 
-Same-host post-PERF-R-CA-IDDFS baseline on this agent was query_ms=4612 /
-total_ms=5126 (samples: 5183, 4499, 4612). PERF-R-CA-IDCACHE reduces that to
-2940 / 3455 (1.57x query). For cross-host context, the prior published GitHub
-Actions Ubuntu 24.04 IDDFS median was 7521 / 8341.
+The prior hosted GitHub Actions post-PERF-R-CA-IDDFS median was query_ms=7521 /
+total_ms=8341 (samples: 8260, 7509, 7521). PERF-R-CA-IDCACHE reduces that to
+4812 / 5610 (1.56x query). An independent same-host cloud-agent comparison
+(4612 to 2940 ms) also measured a 1.57x query improvement.
 
 PERF-R-CA-DIRECT reduced the hosted-runner query baseline from 62595 ms to
 10307 ms (6.07x) by giving the native CA kernel a capability-gated bound-arg1
@@ -374,9 +375,10 @@ GHA median to 7521 ms (a further 1.37x; 8.32x cumulative vs original) by
 traversing intern IDs, carrying depth downward, and constructing `IntTerm`
 results only at the WAM boundary. PERF-R-CA-IDCACHE then memoizes ordered
 parent-id vectors by numeric atom id inside the in-memory indexed
-`lookup_ids` closure (lazy list slots; ~151 KiB for a full scale-300
-adjacency image), avoiding repeated `paste0` key construction, index-env
-bucket walks, and parent extraction. Profiled scale-300 path: 516522
+`lookup_ids` closure (bounded lazy list slots with sparse-id overflow;
+~151 KiB for the scale-300 adjacency image), avoiding repeated `paste0` key
+construction, index-env bucket walks, and parent extraction. Profiled
+scale-300 path: 516522
 `lookup_ids` calls over only 2273 distinct ids (99.56% hit opportunity);
 instrumented lookup time fell from ~4.3 s to ~1.0 s. Lazy/cached LMDB
 capabilities are unchanged (on-demand / existing bounded cache). Sources

--- a/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
+++ b/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
@@ -22,7 +22,7 @@ All primary measurements at **scale 300** (6004 `category_parent` facts,
 | **F# WAM + FFI (functions mode)** | **11** | **159** | **1** | **Yes** | Lowered predicates; .NET 8 Release build |
 | **F# LMDB cached (two-level L1/L2)** | **2** | -- | **1** | **Yes** | Fact-access only (no WAM overhead); see below |
 | Python WAM | 215 | 689 | 1 | Yes | CPython 3.12; WAM interpreter, FFI for `category_parent/2` |
-| R WAM (functions, kernels_on) | 7521 | 8341 | 1 | Yes | Hosted Ubuntu 24.04 CI, R 4.3.3; direct indexed lookup + integer-ID CA DFS/downward hops; 3-rep median query |
+| R WAM (functions, kernels_on) | 2940 | 3455 | 1 | Yes | Cursor cloud agent, R 4.3.3; + memoized numeric-key parent-id buckets (IDCACHE); 3-rep median query |
 | Go WAM | -- | -- | -- | Yes | Build OK; benchmark driver in progress |
 
 **Key takeaway:** Atom interning (replacing `HashMap<String, Vec<String>>` with
@@ -344,33 +344,45 @@ python3 /tmp/wam-bench/python-300/main.py data/benchmark/300 3
 
 ### R WAM (functions mode)
 
-Measured 2026-07-22 in hosted GitHub Actions using
+Measured 2026-07-23 on a Cursor cloud agent using
 `generate_wam_r_effective_distance_benchmark.pl`
 with `emit_mode(functions)`, auto-detected `category_ancestor/4` kernel
 (fleet hops layout), and `category_parent/2` FactSource via
 `grouped_by_first_atoms` (preserves Prolog atom identity for numeric-looking
-Wikipedia IDs). Host: Ubuntu 24.04 hosted runner, SWI-Prolog 10.0.2,
-R 4.3.3, single-core.
+Wikipedia IDs). Host: Linux cloud agent, SWI-Prolog, R 4.3.3, single-core.
 
 | Scale | query_ms | total_ms | rows | Cores | vs reference |
 |-------|----------|----------|------|-------|--------------|
-| 300 | 7521 | 8341 | 271 | 1 | match (`normalize_three_column_float_rows`, 6 dp) |
+| 300 | 2940 | 3455 | 271 | 1 | match (`normalize_three_column_float_rows`, 6 dp) |
 
 `query_ms` is the 3-run median of article×root enumeration only
-(samples: 8260, 7509, 7521). `total_ms` is setup (Rscript startup +
+(samples: 3445, 2929, 2940). `total_ms` is setup (Rscript startup +
 generated-program / FactSource load + article/root TSV load) plus that
 median query. Output validated against
 `data/benchmark/300/reference_output.tsv` with canonical sort and 6-decimal
 float tolerance (not row-count-only).
 
+Same-host post-PERF-R-CA-IDDFS baseline on this agent was query_ms=4612 /
+total_ms=5126 (samples: 5183, 4499, 4612). PERF-R-CA-IDCACHE reduces that to
+2940 / 3455 (1.57x query). For cross-host context, the prior published GitHub
+Actions Ubuntu 24.04 IDDFS median was 7521 / 8341.
+
 PERF-R-CA-DIRECT reduced the hosted-runner query baseline from 62595 ms to
 10307 ms (6.07x) by giving the native CA kernel a capability-gated bound-arg1
-lookup over the existing FactSource index. PERF-R-CA-IDDFS then reduced it to
-7521 ms (a further 1.37x; 8.32x cumulative) by traversing intern IDs, carrying
-depth downward, and constructing `IntTerm` results only at the WAM boundary.
-Sources without these capabilities retain the TermValue and generic
-`iterate_goal` fallbacks. The remaining cost is interpreted R lookup/DFS and
-lowered power-sum orchestration rather than generic WAM fact dispatch.
+lookup over the existing FactSource index. PERF-R-CA-IDDFS then reduced the
+GHA median to 7521 ms (a further 1.37x; 8.32x cumulative vs original) by
+traversing intern IDs, carrying depth downward, and constructing `IntTerm`
+results only at the WAM boundary. PERF-R-CA-IDCACHE then memoizes ordered
+parent-id vectors by numeric atom id inside the in-memory indexed
+`lookup_ids` closure (lazy list slots; ~151 KiB for a full scale-300
+adjacency image), avoiding repeated `paste0` key construction, index-env
+bucket walks, and parent extraction. Profiled scale-300 path: 516522
+`lookup_ids` calls over only 2273 distinct ids (99.56% hit opportunity);
+instrumented lookup time fell from ~4.3 s to ~1.0 s. Lazy/cached LMDB
+capabilities are unchanged (on-demand / existing bounded cache). Sources
+without these capabilities retain the TermValue and generic `iterate_goal`
+fallbacks. Residual cost is interpreted R DFS and lowered power-sum
+orchestration.
 
 #### Reproduction
 

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -4408,11 +4408,26 @@ WamRuntime$make_indexed_arg1_parent_lookup_ids <- function(facts, indexes) {
   # on the CA ID-DFS hot path. Does not duplicate the full edge table up
   # front — entries are filled lazily on first query of each id.
   cache <- list()
+  # Keep the numeric-list fast path bounded. Intern ids are normally dense,
+  # but a capability caller can supply an arbitrary positive integer; growing
+  # a list to that id would turn a cache miss into an unbounded allocation.
+  # Rare ids beyond the dense bound use a closure-private hashed overflow.
+  dense_limit <- max(4096L, length(facts))
+  overflow <- new.env(hash = TRUE, parent = emptyenv())
   function(atom_id) {
     aid <- as.integer(atom_id)
-    if (!is.na(aid) && aid >= 1L && aid <= length(cache)) {
-      hit <- cache[[aid]]
-      if (!is.null(hit)) return(hit)
+    if (!is.na(aid) && aid >= 1L) {
+      if (aid <= dense_limit) {
+        if (aid <= length(cache)) {
+          hit <- cache[[aid]]
+          if (!is.null(hit)) return(hit)
+        }
+      } else {
+        overflow_key <- as.character(aid)
+        if (exists(overflow_key, envir = overflow, inherits = FALSE)) {
+          return(get(overflow_key, envir = overflow, inherits = FALSE))
+        }
+      }
     }
     out <- integer(0)
     if (!is.na(aid)) {
@@ -4436,8 +4451,12 @@ WamRuntime$make_indexed_arg1_parent_lookup_ids <- function(facts, indexes) {
         }
       }
       if (aid >= 1L) {
-        if (aid > length(cache)) length(cache) <<- aid
-        cache[[aid]] <<- out
+        if (aid <= dense_limit) {
+          if (aid > length(cache)) length(cache) <<- aid
+          cache[[aid]] <<- out
+        } else {
+          assign(as.character(aid), out, envir = overflow)
+        }
       }
     }
     out

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -4327,7 +4327,8 @@ WamRuntime$build_fact_indexes <- function(facts, arity) {
 }
 
 # ----------------------------------------------------------
-# Bound-arg1 parent-lookup capability (PERF-R-CA-DIRECT / IDDFS)
+# Bound-arg1 parent-lookup capability
+# (PERF-R-CA-DIRECT / IDDFS / IDCACHE)
 # ----------------------------------------------------------
 # Registry: program$arg1_lookups["pred/arity"] -> capability list:
 #   list(lookup = function(key_term) -> list(atom TermValues) | NULL,
@@ -4336,6 +4337,9 @@ WamRuntime$build_fact_indexes <- function(facts, arity) {
 # by guessing pred_*_indexes names from a kernel. lookup_ids enables the
 # integer-ID DFS; lookup alone keeps the TermValue path; neither falls
 # back to iterate_goal. Atom-only parents match collect_parents filtering.
+# In-memory indexed lookup_ids memoizes parent-id vectors by numeric atom
+# id inside the capability closure (PERF-R-CA-IDCACHE). Lazy/cached LMDB
+# capabilities stay on-demand and retain their existing cache policy.
 WamRuntime$arg1_parent_terms_from_tuples <- function(tuples) {
   n <- length(tuples)
   if (n == 0L) return(list())
@@ -4398,24 +4402,45 @@ WamRuntime$make_indexed_arg1_parent_lookup <- function(facts, indexes) {
 WamRuntime$make_indexed_arg1_parent_lookup_ids <- function(facts, indexes) {
   if (is.null(indexes) || length(indexes) < 1L) return(NULL)
   idx0 <- indexes[[1L]]
+  # Closure-private memo: list indexed by intern atom id.
+  # NULL slot = not yet computed; integer vector (possibly empty) = cached.
+  # Avoids repeated paste0("a", id) / env bucket walks / parent extraction
+  # on the CA ID-DFS hot path. Does not duplicate the full edge table up
+  # front — entries are filled lazily on first query of each id.
+  cache <- list()
   function(atom_id) {
-    bk <- paste0("a", as.integer(atom_id))
-    if (!exists(bk, envir = idx0, inherits = FALSE)) return(integer(0))
-    tidxs <- get(bk, envir = idx0, inherits = FALSE)
-    n <- length(tidxs)
-    if (n == 0L) return(integer(0))
-    ids <- integer(n)
-    k <- 0L
-    for (ti in tidxs) {
-      tup <- facts[[ti]]
-      if (length(tup) < 2L) next
-      p <- tup[[2L]]
-      if (!is.null(p) && !is.null(p$tag) && identical(p$tag, "atom")) {
-        k <- k + 1L
-        ids[[k]] <- as.integer(p$id)
+    aid <- as.integer(atom_id)
+    if (!is.na(aid) && aid >= 1L && aid <= length(cache)) {
+      hit <- cache[[aid]]
+      if (!is.null(hit)) return(hit)
+    }
+    out <- integer(0)
+    if (!is.na(aid)) {
+      bk <- paste0("a", aid)
+      if (exists(bk, envir = idx0, inherits = FALSE)) {
+        tidxs <- get(bk, envir = idx0, inherits = FALSE)
+        n <- length(tidxs)
+        if (n > 0L) {
+          ids <- integer(n)
+          k <- 0L
+          for (ti in tidxs) {
+            tup <- facts[[ti]]
+            if (length(tup) < 2L) next
+            p <- tup[[2L]]
+            if (!is.null(p) && !is.null(p$tag) && identical(p$tag, "atom")) {
+              k <- k + 1L
+              ids[[k]] <- as.integer(p$id)
+            }
+          }
+          out <- if (k == 0L) integer(0) else if (k == n) ids else ids[seq_len(k)]
+        }
+      }
+      if (aid >= 1L) {
+        if (aid > length(cache)) length(cache) <<- aid
+        cache[[aid]] <<- out
       }
     }
-    if (k == 0L) integer(0) else if (k == n) ids else ids[seq_len(k)]
+    out
   }
 }
 

--- a/tests/test_wam_r_ca_direct_lookup.pl
+++ b/tests/test_wam_r_ca_direct_lookup.pl
@@ -2,8 +2,9 @@
 % SPDX-License-Identifier: MIT OR Apache-2.0
 % Copyright (c) 2026 John William Creighton (@s243a)
 %
-% PERF-R-CA-DIRECT: capability-gated bound-arg1 parent lookup for the
-% R category_ancestor/4 recursive kernel.
+% PERF-R-CA-DIRECT / IDDFS / IDCACHE: capability-gated bound-arg1 parent
+% lookup for the R category_ancestor/4 recursive kernel, including
+% integer-ID DFS and closure-private numeric-key parent-id memoization.
 %
 % Usage: swipl -g run_tests -t halt tests/test_wam_r_ca_direct_lookup.pl
 
@@ -47,7 +48,12 @@ test(grouped_by_first_atoms_registers_indexed_lookup, [nondet]) :-
             assertion(once(sub_string(Rt, _, _, _,
                 'make_indexed_arg1_parent_lookup_ids'))),
             assertion(once(sub_string(Rt, _, _, _,
-                'category_ancestor_hops_rec_ids')))
+                'category_ancestor_hops_rec_ids'))),
+            % IDCACHE: in-memory lookup_ids keeps a closure-private memo
+            assertion(once(sub_string(Rt, _, _, _,
+                'Closure-private memo'))),
+            assertion(once(sub_string(Rt, _, _, _,
+                'cache[[aid]] <<- out')))
         ),
         (   cleanup_tmp(TmpDir),
             uninstall_ca_kernel
@@ -138,6 +144,47 @@ lk <- WamRuntime$get_arg1_parent_lookup(shared_program, "cparent/2")
 stopifnot(!is.null(lk))
 lk_ids <- WamRuntime$get_arg1_parent_lookup_ids(shared_program, "cparent/2")
 stopifnot(!is.null(lk_ids))
+
+# ------------------------------------------------------------------
+# IDCACHE: memoized numeric-key parent buckets (in-memory indexed)
+# ------------------------------------------------------------------
+aid <- function(nm) as.integer(WamRuntime$intern(intern_table, nm))
+# miss then hit: identical ordered parent ids
+p_a1 <- lk_ids(aid("a"))
+p_a2 <- lk_ids(aid("a"))
+stopifnot(identical(p_a1, p_a2))
+stopifnot(identical(p_a1, c(aid("b"), aid("c"), aid("z"), aid("p"))))
+# shared parents across source ids
+p_b <- lk_ids(aid("b"))
+p_c <- lk_ids(aid("c"))
+stopifnot(identical(p_b, aid("d")), identical(p_c, aid("d")))
+# missing key and empty-after-filter both yield integer(0)
+stopifnot(identical(lk_ids(aid("no_such_node")), integer(0)))
+# numeric-looking atom names remain atoms (not ints)
+stopifnot(identical(lk_ids(aid("1827")), aid("mid")))
+stopifnot(identical(lk_ids(aid("mid")), aid("9001")))
+# Synthetic facts: mixed atom/non-atom parents + empty bucket + cache sticky
+syn_facts <- list(
+  list(Atom(aid("sx")), Atom(aid("pa"))),
+  list(Atom(aid("sx")), IntTerm(99L)),
+  list(Atom(aid("sx")), Atom(aid("pb"))),
+  list(Atom(aid("sy")), Atom(aid("pa"))),
+  list(Atom(aid("sz")), IntTerm(1L))
+)
+syn_idx <- WamRuntime$build_fact_indexes(syn_facts, 2L)
+syn_ids <- WamRuntime$make_indexed_arg1_parent_lookup_ids(syn_facts, syn_idx)
+stopifnot(identical(syn_ids(aid("sx")), c(aid("pa"), aid("pb"))))
+stopifnot(identical(syn_ids(aid("sy")), aid("pa")))
+stopifnot(identical(syn_ids(aid("sz")), integer(0)))  # non-atom-only bucket
+stopifnot(identical(syn_ids(aid("missing_syn")), integer(0)))
+# cache hit retains first result even if underlying facts are mutated
+first_sx <- syn_ids(aid("sx"))
+syn_facts[[1L]][[2L]] <- Atom(aid("mutated"))
+stopifnot(identical(syn_ids(aid("sx")), first_sx))
+stopifnot(identical(first_sx, c(aid("pa"), aid("pb"))))
+# fresh uncached builder sees the mutation
+syn_ids2 <- WamRuntime$make_indexed_arg1_parent_lookup_ids(syn_facts, syn_idx)
+stopifnot(identical(syn_ids2(aid("sx")), c(aid("mutated"), aid("pb"))))
 
 collect_hops <- function(cat, root, visited_chars, sorted = TRUE) {
   state <- WamRuntime$new_state()

--- a/tests/test_wam_r_ca_direct_lookup.pl
+++ b/tests/test_wam_r_ca_direct_lookup.pl
@@ -185,6 +185,16 @@ stopifnot(identical(first_sx, c(aid("pa"), aid("pb"))))
 # fresh uncached builder sees the mutation
 syn_ids2 <- WamRuntime$make_indexed_arg1_parent_lookup_ids(syn_facts, syn_idx)
 stopifnot(identical(syn_ids2(aid("sx")), c(aid("mutated"), aid("pb"))))
+# Arbitrary sparse ids must not grow the dense list to the id value.
+high_id <- 1000000000L
+high_facts <- list(list(Atom(high_id), Atom(aid("pa"))))
+high_idx <- WamRuntime$build_fact_indexes(high_facts, 2L)
+high_ids <- WamRuntime$make_indexed_arg1_parent_lookup_ids(high_facts, high_idx)
+stopifnot(identical(high_ids(high_id), aid("pa")))
+high_facts[[1L]][[2L]] <- Atom(aid("mutated"))
+stopifnot(identical(high_ids(high_id), aid("pa")))  # sparse cache hit
+stopifnot(identical(high_ids(.Machine$integer.max), integer(0)))
+stopifnot(identical(high_ids(.Machine$integer.max), integer(0)))  # cached miss
 
 collect_hops <- function(cat, root, visited_chars, sorted = TRUE) {
   state <- WamRuntime$new_state()


### PR DESCRIPTION
## Summary

Memoize ordered parent-ID vectors by numeric atom id inside the in-memory indexed `lookup_ids` capability used by the R common-ancestor ID-DFS kernel.

Based on `main` after PR #3961.

## Profiling

The post-#3961 scale-300 path made 516,522 `lookup_ids` calls for only 2,273 distinct atom IDs (99.56% cache-hit opportunity).

Instrumented uncached lookup time was about 4.31 s:

| Component | Time |
|---|---:|
| `paste0` key construction | 1.373 s |
| index environment lookup | 1.179 s |
| parent-ID extraction | 1.503 s |

A numeric-list adjacency image for the scale-300 workload is about 151 KiB (2,165 keys, 6,008 parent integers, maximum ID 2,548), versus about 283 KiB for a named list.

## Implementation

- Closure-private lazy numeric-list memo for the common dense-ID path.
- Dense growth bounded to `max(4096, length(facts))`.
- Rare large/sparse IDs use a closure-private hashed overflow, so an arbitrary high-ID miss cannot force an enormous list allocation.
- No separate global adjacency registry.
- Lazy LMDB remains on-demand and uncached here.
- Cached LMDB retains its existing bounded cache with no second cache.
- Eager LMDB materializes indexed facts and uses this in-memory capability.
- TermValue and `iterate_goal` fallbacks are unchanged.

## Contract coverage

The existing focused suite covers:

- cache miss then hit, including cached empty results
- ordered parents, shared parents, duplicate/mixed values
- missing and non-atom-only buckets
- numeric-looking atoms
- large sparse valid and missing IDs without dense-list growth
- sticky memo semantics over immutable indexed facts
- `Visited` depth/cycle behavior and distinguishable DFS order
- parity among ID, TermValue, and generic fallback paths
- unchanged lazy/cached/eager LMDB registration

## Hosted benchmark

GitHub Actions `ubuntu-24.04`, SWI-Prolog 10.0.2, R 4.3.3, scale 300, three query repetitions:

| Stage | query_ms median | total_ms | samples |
|---|---:|---:|---|
| Post-#3961 IDDFS | 7521 | 8341 | 8260, 7509, 7521 |
| **IDCACHE** | **4812** | **5610** | **5573, 4812, 4795** |

That is a **1.56× query improvement** on the same hosted runner class. An independent same-host cloud-agent comparison (4612 → 2940 ms) measured the same 1.57× relative improvement.

Output retained exact reference parity for 271 rows. The temporary hosted measurement step was removed after the benchmark and the fleet documents now use the hosted result.

## Size

The final production change is approximately +44 net lines in `runtime.R.mustache`, with focused additions to the existing test suite.