### PR TITLE
mu_cosine: wiki multi-parent hit@k + strategic harvest prioritization

### DIFF
--- a/prototypes/mu_cosine/REPORT_wiki_multiparent.md
+++ b/prototypes/mu_cosine/REPORT_wiki_multiparent.md
@@ -1,0 +1,37 @@
+# Wikipedia multi-parent hit@k + strategic harvest prioritization
+
+## Multi-parent study (wiki_multiparent_hits.py)
+
+enwiki_named correct-ingest graph (9.9M title edges, admin cats excluded); 400 sampled categories
+with ≥4 parents (median 5, max 14); catalog = 5,000 (1,453 true-parent union + 3,547 random
+distractors); e5 query→passage ranking.
+
+| k | ≥1 parent | ≥2 | ≥3 | all 4 |
+|---|---|---|---|---|
+| 1 | 0.945 | 0 | 0 | 0 |
+| 5 | 0.973 | 0.920 | 0.752 | 0.347 |
+| 10 | 0.975 | 0.935 | 0.800 | 0.400 |
+| 50 | 0.985 | 0.958 | 0.868 | 0.448 |
+| 100 | 0.990 | 0.970 | 0.890 | 0.470 |
+| 500 | 0.998 | 0.988 | 0.922 | 0.580 |
+
+k to capture the 1st parent: median 1 (p90 1). k to capture all 4: **median 181, p75 1,806,
+p90 3,623** (of 5,000).
+
+Reading: corpus structure dominates. Wikipedia's multiple valid parents make ANY-parent trivial
+(0.945@1 vs Pearltrees single-folder R@1 0.203 — one right answer is the harder per-target task,
+as predicted). But parents are FACETS (decade × genre × country × …): e5 surfaces the semantically
+dominant facets within k≈5, and the last parent is typically an ORTHOGONAL facet with little
+lexical overlap — full multi-parent recovery is facet enumeration, not similarity ranking.
+Consequence for Pearltrees' 880 multi-parent filing folders: recovering non-principal parents
+needs facet-style candidate generation (graph/structural), not a better similarity ranker.
+Caveats: single seed; catalog-bounded (5k); distractors uniform-random (no hard negatives).
+
+## Strategic harvest prioritization (prioritize_harvest_queue.py)
+
+The augmented harvest queue (4,739 trees) drains over weeks at account-safe pacing, so ORDER is
+the lever: each queued tree is scored by max e5 similarity to the 741 filing-failure bookmarks
+(rank>5 on the standing manifest) and the queue is re-sorted. Top priorities came out as the
+politics/society gap topics (Authority, Deception, Injustice, Misinformation …) — matching
+REPORT_hybrid_candidates §B″ (the gap mass is news/politics, not STEM). Harvester relaunched on
+the prioritized queue at unchanged pacing; batch_state dedup makes reordering safe/resumable.

--- a/prototypes/mu_cosine/prioritize_harvest_queue.py
+++ b/prototypes/mu_cosine/prioritize_harvest_queue.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Strategically reorder the Pearltrees harvest queue toward filing-failure topics.
+
+The augmented harvest queue (build_pearltrees_dag.py) lists missing trees in arbitrary order. At
+the harvester's account-safe pacing the full drain takes weeks, so ORDER IS THE LEVER: this script
+scores every queued tree by max e5 similarity to the bookmarks the filing eval currently FAILS
+(rank > --fail-rank on the standing manifest) and writes a priority-sorted queue. Harvesting
+completes the DAG first exactly where the eval says our graph has gaps (the `missing` stratum).
+
+Output queue keeps the input schema (+ per-row `priority`), so batch_repair.py consumes it
+directly via --queue-file. PRIVATE paths only; nothing committed.
+
+  python3 prioritize_harvest_queue.py            # writes harvest_queue_prioritized.json
+"""
+import argparse
+import json
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+PT_API = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                      "..", "..", ".local", "data", "pearltrees_api")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--queue", default=os.path.join(PT_API, "harvest_queue_augmented.json"))
+    ap.add_argument("--out", default=os.path.join(PT_API, "harvest_queue_prioritized.json"))
+    ap.add_argument("--fail-rank", type=int, default=5,
+                    help="a bookmark counts as a failure topic if its true folder ranks below this")
+    ap.add_argument("--min-bm", type=int, default=3)
+    ap.add_argument("--max-queries", type=int, default=1200)
+    ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--top-k", type=int, default=100)
+    ap.add_argument("--e5-cache", default="/tmp/mu_data/queue_prior_e5.pt")
+    a = ap.parse_args(argv)
+
+    import routed_queries as rq
+    from mu_attention import build_e5_tables
+    q_titles, f_titles, truepos, cos, ranks, margin, order, qman = rq.build(a)
+    fail = [q_titles[b] for b in range(len(q_titles)) if ranks[b] > a.fail_rank]
+    print(f"failure bookmarks (rank>{a.fail_rank}): {len(fail)} (manifest {qman[:16]})")
+
+    q = json.load(open(a.queue))
+    rows = q["maps"]
+    titles = [r.get("title") or r["tree_id"] for r in rows]
+    names = sorted(set(titles) | set(fail))
+    qtbl, ptbl, idx = build_e5_tables(names, cache_path=a.e5_cache, batch_size=128)
+    tv = np.stack([ptbl.numpy()[idx[t]] for t in titles])
+    fv = np.stack([qtbl.numpy()[idx[t]] for t in fail])
+    prio = (fv @ tv.T).max(axis=0)
+    oq = np.argsort(-prio)
+    out = dict(q)
+    out["maps"] = [dict(rows[i], priority=float(prio[i])) for i in oq]
+    out["prioritized"] = f"max e5 cos to rank>{a.fail_rank} filing-failure bookmarks"
+    json.dump(out, open(a.out, "w"), ensure_ascii=False, indent=0)
+    print(f"prioritized queue -> {a.out}")
+    for i in oq[:5]:
+        print(f"  {prio[i]:.3f}  {titles[i][:60]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/wiki_multiparent_hits.py
+++ b/prototypes/mu_cosine/wiki_multiparent_hits.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Wikipedia multi-parent hit@k: at what k does e5 capture ALL true parent categories?
+
+Pearltrees/SimpleMind filing is single-principal-folder ranking (one right answer). Wikipedia
+categories differ structurally: a category has SEVERAL valid parents (mean ~3.8 on the correct
+enwiki ingest), so the natural metrics split:
+
+  any-parent hit@k   — ≥1 true parent in the e5 top-k (the easy direction: more targets)
+  all-parents hit@k  — ALL j true parents in the top-k (the owner's question: "at what k do we
+                       capture four of the parent categories")
+
+Setup mirrors the Pearltrees harness scale: queries = categories with ≥ --min-parents parents
+(sampled), catalog = the union of all sampled queries' parents plus random distractor categories
+(--catalog-size total), ranking = e5 query→passage cosine over the catalog, title-equivalence not
+needed (titles are unique keys in the named graph). Graph: data/benchmark/enwiki_named (3-dump
+Correct-mode ingest, admin categories excluded).
+
+  python3 wiki_multiparent_hits.py                # defaults: 400 queries x >=4 parents, 5k catalog
+"""
+import argparse
+import os
+import random
+import sys
+from collections import defaultdict
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mu_attention import build_e5_tables
+
+EDGES = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     "..", "..", "data", "benchmark", "enwiki_named", "category_parent.tsv")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--min-parents", type=int, default=4)
+    ap.add_argument("--n-queries", type=int, default=400)
+    ap.add_argument("--catalog-size", type=int, default=5000)
+    ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--ks", type=int, nargs="*", default=(1, 5, 10, 20, 50, 100, 200, 500))
+    ap.add_argument("--e5-cache", default="/tmp/mu_data/wiki_multiparent_e5.pt")
+    a = ap.parse_args(argv)
+    rng = random.Random(a.seed)
+
+    parents = defaultdict(set)
+    all_nodes = set()
+    with open(EDGES, encoding="utf-8") as f:
+        next(f)
+        for ln in f:
+            c, p = ln.rstrip("\n").split("\t")
+            parents[c].add(p)
+            all_nodes.add(c)
+            all_nodes.add(p)
+    print(f"graph: {len(all_nodes):,} nodes; children with >= {a.min_parents} parents: "
+          f"{sum(1 for v in parents.values() if len(v) >= a.min_parents):,}")
+
+    eligible = sorted(c for c, v in parents.items() if len(v) >= a.min_parents)
+    queries = rng.sample(eligible, a.n_queries)
+    true_parents = {q: sorted(parents[q]) for q in queries}
+
+    cat = set()
+    for q in queries:
+        cat |= parents[q]
+    pool = sorted(all_nodes - cat - set(queries))
+    n_fill = max(0, a.catalog_size - len(cat))
+    cat = sorted(cat) + rng.sample(pool, n_fill)
+    ci = {t: i for i, t in enumerate(cat)}
+    print(f"queries: {len(queries)} (parents per query: median "
+          f"{int(np.median([len(true_parents[q]) for q in queries]))}, "
+          f"max {max(len(true_parents[q]) for q in queries)}); catalog: {len(cat)} "
+          f"({len(ci) - n_fill} true-parent union + {n_fill} random distractors)")
+
+    names = sorted(set(cat) | set(queries))
+    qtbl, ptbl, idx = build_e5_tables(names, cache_path=a.e5_cache, batch_size=128)
+    Q, P = qtbl.numpy(), ptbl.numpy()
+    qv = np.stack([Q[idx[t]] for t in queries])
+    cv = np.stack([P[idx[t]] for t in cat])
+    cos = qv @ cv.T
+    order = np.argsort(-cos, axis=1)
+
+    # per-query sorted ranks of the true parents
+    j_max = 4
+    ranks_of_true = []
+    for i, q in enumerate(queries):
+        pos = {int(c): r + 1 for r, c in enumerate(order[i])}
+        rs = sorted(pos[ci[p]] for p in true_parents[q])
+        ranks_of_true.append(rs)
+
+    print(f"\nhit-j@k = fraction of queries with >= j true parents inside the e5 top-k "
+          f"(catalog {len(cat)}):")
+    hdr = "  k      " + "".join(f"  >= {j}   " for j in range(1, j_max + 1))
+    print(hdr)
+    for k in a.ks:
+        cells = []
+        for j in range(1, j_max + 1):
+            cells.append(np.mean([len(rs) >= j and rs[j - 1] <= k for rs in ranks_of_true]))
+        print(f"  {k:<6d}" + "".join(f"  {c:.3f} " for c in cells))
+
+    # the owner's number: k needed to capture the 4th parent
+    k4 = [rs[3] for rs in ranks_of_true if len(rs) >= 4]
+    k1 = [rs[0] for rs in ranks_of_true]
+    print(f"\nk to capture the 1st parent: median {int(np.median(k1))}, "
+          f"p75 {int(np.percentile(k1, 75))}, p90 {int(np.percentile(k1, 90))}")
+    print(f"k to capture 4 parents:      median {int(np.median(k4))}, "
+          f"p75 {int(np.percentile(k4, 75))}, p90 {int(np.percentile(k4, 90))}")
+    print("\n(Contrast: Pearltrees/SimpleMind are single-principal-folder tasks — one target, "
+          "harder per-target; Wikipedia's multiple valid parents make ANY-parent easy and "
+          "ALL-parents the structurally interesting curve.)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Multi-parent study on enwiki_named (400 queries ≥4 parents, 5k catalog): any-parent@1 0.945 vs PT single-folder 0.203; all-4 parents median k=181 / p90 3,623 — parents are facets, the last one orthogonal; multi-parent recovery = facet enumeration, not similarity ranking. Plus prioritize_harvest_queue.py: harvest queue reordered by proximity to the 741 filing-failure bookmarks (top hits = the §B″ politics/society gap topics); harvester relaunched at unchanged pacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fB4ZfA4bW4XNEnboUncgc