### PR TITLE
design(mu_cosine): process-expression language — spec, philosophy, implementation plan

### DIFF
--- a/prototypes/mu_cosine/DESIGN_process_expression_implementation.md
+++ b/prototypes/mu_cosine/DESIGN_process_expression_implementation.md
@@ -1,0 +1,68 @@
+# Process-Expression Language — Implementation Plan
+
+Phased, each phase independently shippable with a measurable exit criterion. Reuse-first: the
+card→e5→NameFunctionCond pathway already exists (judge onboarding at r=0); phase 1 adds no
+architecture.
+
+## P0 — expression module (`process_cards.py`)
+
+- AST for the v0 grammar (spec doc), canonicalizer, verbosity renderer V0–V3, e5 embedding via
+  the existing card path (cache keyed on canonical string).
+- Registry of CURRENT processes as expressions: e5-auto, haiku@N10 routing, sonnet.lineage@N10,
+  sonnet.lineage@N20, kalman(luna.D, luna.S), lineage(graph, decay=0.85), the blend judges.
+- Unit tests: canonicalization idempotence, default elision, verbosity monotonicity (V1 ⊂ V2 ⊂ V3
+  informationally), embedding cache determinism.
+- Exit: every existing judge/op token has an expression rendering; round-trip stable.
+
+## P1 — minimal experiment: expression-conditioned distillation (the data already exists)
+
+Corpus (no new API spend): the four differently-generated label sets on manifest fcf5e1d6 —
+auto rows (margin ≥ 0.03, e5 top-1), haiku@N10 picks (695), sonnet.lineage@N10 picks (695),
+sonnet.lineage@N20 picks (227).
+
+- Model: e5-residual head — score = e5_cos + correction(μ | card), correction zero-init (starts
+  exactly at e5: the owner's "at least as good as e5" floor is mechanical, warm-start lesson).
+- Per-row card sampled per epoch: V1 60% / V2 25% / V3 5% / V0 10% (concise bias).
+- Split: node-disjoint over judged queries (#3845 rule); recorded placements are EVAL-ONLY.
+- Arms: (a) expression cards, (b) flat judge tokens, (c) merged unlabeled pile, (d) SHUFFLED cards
+  (specificity control — must hurt). Report held R@1/MRR vs the e5 floor + paired bootstrap.
+- Exit: (a) ≥ e5 on held (floor holds) AND (a) > (b),(c) with (d) degraded ⇒ the language earns
+  its keep on owned data.
+
+## P2 — MDL verbosity sweep
+
+- Retrain P1-arm-(a) at fixed single verbosities V1/V2/V3 and at 3 mixture profiles; measure
+  held ΔNLL (and ΔMRR) per mean expression token.
+- Deliverable: the gain-per-token curve — the empirical answer to "how specific should the
+  language be", and the tuned training mixture (replacing the indicative 60/25/5/10).
+- Exit: a chosen default profile with the curve as justification, recorded in the report.
+
+## P3 — compositional embedding + zero-shot
+
+- Tree encoder over the AST (superposition first — random_operator_embedding precedent — then a
+  small learned encoder if superposition plateaus).
+- Zero-shot test: hold out ONE process entirely (e.g. sonnet.lineage@N20), condition on its
+  expression at inference, measure whether structure transfers from the seen siblings vs a cold
+  flat token. This is the test flat tokens cannot pass by construction.
+- Exit: zero-shot conditioned > unconditioned on the held process.
+
+## P4 — program integration
+
+- Expressions as target-factory descriptors everywhere targets are minted (fine_tune_*,
+  meta-judge, campaign emitters): every scored TSV/pick file carries its canonical expression in
+  the header; loaders fail closed on missing/unknown expressions (provenance contract).
+- Judge-card registry entries for composite judges become expression cards (kalman-fused, blend,
+  dir-blend) — delete the flattening.
+- Hand the grammar's formal semantics + the information objective to the Codex lane (their kind
+  of object); keep the empirical ladder here.
+
+## Risks / open questions
+
+- 922 judged rows is small for 4 conditions — P1 leans on the e5-residual floor and the shared-
+  strength effect of concise cards; if underpowered, the label factory has a costed refill path
+  (the routing loop, now with measured judge value).
+- Card embedding via e5 of a formal string is a leap of faith at V2/V3 (bracketed kwargs are not
+  natural language); if e5 collapses them, fall back to template rendering ("sonnet judge with
+  lineage context, menus of 10") — canonicalization keeps the mapping deterministic either way.
+- Verbosity mixture is per-row augmentation: verify no train/held row shares (query, folder) under
+  different cards across the split (the node-disjoint rule already covers this; test it anyway).

--- a/prototypes/mu_cosine/DESIGN_process_expression_language.md
+++ b/prototypes/mu_cosine/DESIGN_process_expression_language.md
@@ -1,0 +1,64 @@
+# Process-Expression Language — Specification
+
+Declarative functional expressions that name the DATA-GENERATING PROCESS of a training target, and
+map deterministically to a conditioning embedding. The model is always told *what function produced
+the label it is fitting* — at a chosen level of specificity.
+
+## Grammar (v0)
+
+```
+Expr    := Source | Apply
+Apply   := Fn "(" Posargs [ "," Kwargs ] ")"
+Posargs := Expr ("," Expr)*
+Kwargs  := kw "=" val ("," kw "=" val)*        # canonical: sorted by kw, defaults ELIDED
+Source  := e5 | graph | human
+         | luna | sonnet | haiku | gpt-5.5-low | gemini | opus | ...   # judge roster
+Fn      := routing | pick | kalman | blend | lineage | distill | menu | margin | ...
+```
+
+Examples (the deployed three-tier filing policy, at three verbosities):
+
+```
+V1  e5(routing(e5, sonnet))
+V2  e5(routing(e5, sonnet.lineage, t=[0.02,0.03], menus=[10,20]))
+V3  e5(routing(e5@e5-small-v2, sonnet.lineage@2026-07-23/menu-order-blind,
+       t=[0.02,0.03], menus=[10,20], manifest=fcf5e1d6))
+```
+
+Other current processes, expressed: `kalman(luna.D, luna.S)` (the "kalman-fused" judge token),
+`blend(graph.discrim, llm.element, llm.subcat)` ("dir-blend"), `lineage(graph, decay=0.85)`
+(the LINEAGE target factory), `distill(e5(routing(...)))` (the label-factory corpus).
+
+## Canonicalization rules
+
+1. Kwargs sorted; values in canonical numeric form; DEFAULTS ELIDED (conciseness is the norm).
+2. `judge.modifier` dot-syntax for judge variants (`sonnet.lineage` = sonnet with lineage-context
+   menus); `@` suffixes reserved for pins (model revision, date, prompt hash) — V3 only.
+3. One canonical string per (expression, verbosity level); the string IS the cache key.
+
+## Verbosity levels
+
+| level | content | role |
+|---|---|---|
+| V0 | empty card | agnostic/unconditional row (the agnostic-anchor precedent) |
+| V1 | fn names + sources, defaults elided | the WORKHORSE — most training rows |
+| V2 | + decision-relevant hyperparams (t, N, decay) | distinctions that change the label distribution |
+| V3 | + pins (versions, dates, manifest hashes) | provenance/audit; rare in training |
+
+## Expression → embedding
+
+Phase 1 (zero new architecture): canonical string → e5 passage embedding → NameFunctionCond
+conditioning residual — exactly the existing judge-card onboarding path (`judge_cards.py`, r=0
+name-prior). A new expression needs no new token, no retraining of the pathway.
+
+Phase 3 (compositional): tree encoding over the AST — node embedding = card-e5(fn) combined with
+position-weighted child embeddings (the `random_operator_embedding` superposition precedent) or a
+small learned tree encoder — so UNSEEN compositions (swap a judge, move a threshold) land near
+their relatives and can be conditioned on zero-shot.
+
+## Scope
+
+The language names processes; it does not execute them. An expression is valid iff we can map it
+to a concrete training-set construction (the target factory that realizes it). Exactness is not
+required — the criterion is: two expressions differ iff the label distributions they induce differ
+enough to matter (see the philosophy doc's information objective).

--- a/prototypes/mu_cosine/DESIGN_process_expression_philosophy.md
+++ b/prototypes/mu_cosine/DESIGN_process_expression_philosophy.md
@@ -1,0 +1,62 @@
+# Process-Expression Language — Philosophy
+
+## Why declare the data-generating process
+
+Every training target is the output of some function: a judge, a fusion, a routing policy, a decay
+schedule. The model currently learns per-process calibrations through FLAT tokens (judge_emb,
+corpus_emb, op_emb) — and the roster already smuggles in compositions as opaque names:
+"kalman-fused" IS kalman(D,S); "blend" IS blend(j₁,j₂); "dir-blend" IS a 3-estimator
+superposition. Flattening throws away structure the model could use:
+
+- **Transfer:** `routing(e5, sonnet, t=0.02)` and `routing(e5, sonnet, t=0.03)` are near-identical
+  processes; flat tokens make them strangers, expressions make them neighbors.
+- **Zero-shot conditioning:** an unseen composition (swap haiku→sonnet, add lineage context) gets
+  a meaningful embedding by construction instead of a cold token.
+- **Honest provenance:** mixing corpora produced by different pipelines without declaring the
+  pipeline invites silent distribution confusion — the expression is the antidote, machine-readable.
+
+This extends the name-function principle (NameFunctionCond: "the name is a function pointer, the
+card is its documentation") from atoms to programs.
+
+## The information objective
+
+The language must balance CONCISENESS against SPECIFICITY. Operationalized: an expression
+distinction earns its tokens iff it buys held-out predictive gain —
+
+    maximize   Δ(held-out NLL of the conditioned model)  per  expression token
+
+an MDL criterion. Too coarse (all judges = "llm") discards distinctions that change the label
+distribution; too fine (temperature, prompt hash, date on every row) adds description length
+without gain and fragments the data into unlearnable slivers. The optimal grammar level is an
+EMPIRICAL quantity, found by sweeping card verbosity and measuring gain-per-token — not decided
+by taste. Control: shuffled/mismatched cards must HURT (if the model ignores its conditioning,
+the language is decoration and the result is void).
+
+## Multi-verbosity training (owner's design point)
+
+Train on SEVERAL verbosity renderings of the same expression, biased toward concise:
+
+- Each row's card is sampled per epoch from {V0, V1, V2, V3} with a concise-heavy distribution
+  (indicative: V1 60%, V2 25%, V3 5%, V0 10%).
+- WHY BOTH DIRECTIONS: concise cards teach the equivalence classes (all sonnet-routing variants
+  share a V1 rendering → shared statistical strength); verbose cards teach the distinctions that
+  matter within a class (t, N, judge modifier). The model learns the abstraction HIERARCHY, so at
+  inference you can condition at whichever specificity you actually know.
+- WHY BIAS CONCISE: (1) most distinctions don't survive the MDL test — spending most gradient on
+  V1 matches where the information is; (2) concise cards are what inference will usually supply;
+  (3) V3-heavy training would fragment 922 judged rows into near-singleton conditions.
+- V0 (empty card) rows keep an unconditional readout alive — the agnostic-anchor precedent — and
+  double as the conditioning-dropout that makes the verbosity ladder robust.
+
+## Relation to the program
+
+- **Label factory economics:** judge routing is an inference-time COST but a training-time ASSET.
+  The end-state filer is μ (self-contained, free at inference); judges generate labels and
+  occasionally re-rank. The expression `distill(e5(routing(...)))` names precisely this asset.
+- **Target-factory policy:** the sqrt-KF-in-training decision (Kalman as target factory, not
+  in-loop layer) generalizes: EVERY target factory gets an expression; the expression is the
+  factory's name. Codex's theory lane owns the grammar's formal semantics; the application lane
+  owns the empirical MDL ladder.
+- **Certainty re-entry:** once expression-conditioned μ exceeds e5 in some region, the bias-state
+  info_ratio gate becomes meaningful again — certainty-weighting returns exactly when the
+  precondition (μ ≥ e5 somewhere) is met, per the owner's framing.


### PR DESCRIPTION
Three design docs for the declarative process-expression language: expressions name the data-generating process of every training target and map to conditioning embeddings via the existing NameFunctionCond card path (no new architecture in phase 1). Information objective: held-out gain per expression token (MDL); grammar granularity found empirically. Multi-verbosity training (owner's design): V0–V3 renderings sampled per row, biased concise (~60/25/5/10) — model learns both equivalence classes and distinctions. P1 runs on the 922 judged rows we already own (e5-residual floor, shuffled-card control), zero new API spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fB4ZfA4bW4XNEnboUncgc