### PR TITLE
design(mu_cosine): process-expression amendments per gpt-5.6-sol review

### DIFF
--- a/prototypes/mu_cosine/DESIGN_process_expression_implementation.md
+++ b/prototypes/mu_cosine/DESIGN_process_expression_implementation.md
@@ -6,8 +6,12 @@ architecture.
 
 ## P0 — expression module (`process_cards.py`)
 
-- AST for the v0 grammar (spec doc), canonicalizer, verbosity renderer V0–V3, e5 embedding via
-  the existing card path (cache keyed on canonical string).
+- AST for the v0 grammar (spec doc), the TYPED OPERATOR-SIGNATURE REGISTRY (versioned; arity,
+  param types + defaults, output type, atom/operator dual roles), canonicalizer, verbosity
+  renderer V0–V3, e5 embedding via table-expansion onboarding (cache keyed on canonical-AST hash
+  + verbosity + renderer version + embedding revision + prefix — never the rendered string alone).
+- Lossless process identity (canonical AST + factory/manifest fingerprint) split from lossy cards
+  per the amended spec; acceptance test: the registry parses every example in the spec doc.
 - Registry of CURRENT processes as expressions: e5-auto, haiku@N10 routing, sonnet.lineage@N10,
   sonnet.lineage@N20, kalman(luna.D, luna.S), lineage(graph, decay=0.85), the blend judges.
 - Unit tests: canonicalization idempotence, default elision, verbosity monotonicity (V1 ⊂ V2 ⊂ V3
@@ -20,19 +24,48 @@ Corpus (no new API spend): the four differently-generated label sets on manifest
 auto rows (margin ≥ 0.03, e5 top-1), haiku@N10 picks (695), sonnet.lineage@N10 picks (695),
 sonnet.lineage@N20 picks (227).
 
-- Model: e5-residual head — score = e5_cos + correction(μ | card), correction zero-init (starts
-  exactly at e5: the owner's "at least as good as e5" floor is mechanical, warm-start lesson).
-- Per-row card sampled per epoch: V1 60% / V2 25% / V3 5% / V0 10% (concise bias).
-- Split: node-disjoint over judged queries (#3845 rule); recorded placements are EVAL-ONLY.
-- Arms: (a) expression cards, (b) flat judge tokens, (c) merged unlabeled pile, (d) SHUFFLED cards
-  (specificity control — must hurt). Report held R@1/MRR vs the e5 floor + paired bootstrap.
-- Exit: (a) ≥ e5 on held (floor holds) AND (a) > (b),(c) with (d) degraded ⇒ the language earns
-  its keep on owned data.
+**Status: EXPLORATORY and TRANSDUCTIVE (review finding 5).** The 1,200-query manifest's outcomes
+already informed the routing ceilings and the selection of t, N, and Sonnet — no partition of it
+can serve as an untouched confirmatory test. Confirmation is reserved for a future bookmark
+cohort with a structurally frozen catalog, collected AFTER this design is fixed.
 
-## P2 — MDL verbosity sweep
+- **Frozen row ledger (finding 4), built and hashed before any training:** 1,200 unique queries;
+  922 unique judged queries; 1,617 judge pick-records (695 haiku@N10 + 695 sonnet.lineage@N10 +
+  227 sonnet.lineage@N20; 695 queries appear under BOTH haiku and sonnet processes); + 278
+  auto-rows (margin ≥ 0.03, process = e5-auto) → 1,895 process-target records. The ledger file
+  records (query, folder-menu, process AST hash, pick|null, card renderings) per row.
+- **Estimand + targets:** the trained object scores (query, folder) pairs conditioned on a card;
+  the training target of a judge row is its picked folder (one positive vs the other menu
+  folders as in-menu negatives); NULL picks contribute no positive — they train only the
+  abstention-consistent negatives (all menu folders down-weighted ×0.5, recorded knob).
+  Per-process row weights normalize so no process dominates by count (recorded in the ledger).
+- **Split grouping:** node-disjoint over (bookmark, true-folder) identities AND process-complete —
+  every process rendering of a query travels with it to the same side. Uncertainty: resample
+  typed query-blocks and folder-blocks (two-endpoint node-block bootstrap, the #3845 machinery),
+  never individual process rows.
+- Model: e5-residual head — score = e5_cos + correction(μ | card), correction zero-init. **Zero
+  init is an equality START, not a floor (finding 6):** training can degrade held metrics. The
+  guarantee is procedural — e5 is an explicit ROLLBACK CANDIDATE selected on inner validation
+  (if no checkpoint beats e5 there, ship e5), then ONE evaluation on the outer held set with a
+  prespecified noninferiority margin (held MRR ≥ MRR_e5 − 0.01).
+- Per-row card sampled per epoch: V1 60% / V2 25% / V3 5% / V0 10% (concise bias; P2 tunes this).
+- Arms: (a) expression cards, (b) flat process tokens, (c) merged pile (no conditioning),
+  (d) SHUFFLED cards — permutation defined as: within each split side, permute the card column
+  across rows UNIFORMLY AT RANDOM among rows with distinct process ASTs (so a shuffled row's card
+  is always wrong), 5 permutation draws, mean reported.
+- **Frozen primary decision (finding 7):** primary metric = held MRR of arm (a) vs arm (c),
+  paired two-endpoint node-block bootstrap, 3 training seeds pooled by mean-per-query; success =
+  CI excludes zero AND point gain ≥ +0.01 MRR. Everything else (R@1, arm (b), shuffled fraction
+  lost, per-process breakdowns) is secondary/descriptive — reported, no multiplicity claims.
+- Exit: primary success ⇒ proceed to P2; primary failure but rollback floor held ⇒ the language
+  is not earning conditioning gain on this corpus — stop and hand the grammar to the theory lane
+  before spending more.
 
-- Retrain P1-arm-(a) at fixed single verbosities V1/V2/V3 and at 3 mixture profiles; measure
-  held ΔNLL (and ΔMRR) per mean expression token.
+## P2 — gain-per-token verbosity sweep (naming per finding 8: efficiency curve, not MDL)
+
+- Retrain P1-arm-(a) at fixed single verbosities V1/V2/V3 and at 3 mixture profiles; SELECT on an
+  inner validation split, report once on held (never select on the reported set). Token counts
+  under the pinned e5 tokenizer revision.
 - Deliverable: the gain-per-token curve — the empirical answer to "how specific should the
   language be", and the tuned training mixture (replacing the indicative 60/25/5/10).
 - Exit: a chosen default profile with the curve as justification, recorded in the report.
@@ -41,10 +74,13 @@ sonnet.lineage@N20 picks (227).
 
 - Tree encoder over the AST (superposition first — random_operator_embedding precedent — then a
   small learned encoder if superposition plateaus).
-- Zero-shot test: hold out ONE process entirely (e.g. sonnet.lineage@N20), condition on its
-  expression at inference, measure whether structure transfers from the seen siblings vs a cold
-  flat token. This is the test flat tokens cannot pass by construction.
-- Exit: zero-shot conditioned > unconditioned on the held process.
+- Zero-shot test (finding 9 — one held process proves nothing): PREREGISTERED
+  leave-one-composition-out over SEVERAL held processes — at minimum {sonnet.lineage@N20,
+  haiku@N10, kalman(luna.D, luna.S), one lineage-decay variant} — each evaluated against four
+  controls: frozen-string e5 card, additive bag-of-nodes embedding, cold flat token, and
+  unconditional. Report per-held-process and pooled.
+- Exit: pooled zero-shot conditioned > unconditional AND > cold flat token across the LOCO set
+  (not just one favorable sibling).
 
 ## P4 — program integration
 

--- a/prototypes/mu_cosine/DESIGN_process_expression_language.md
+++ b/prototypes/mu_cosine/DESIGN_process_expression_language.md
@@ -4,17 +4,25 @@ Declarative functional expressions that name the DATA-GENERATING PROCESS of a tr
 map deterministically to a conditioning embedding. The model is always told *what function produced
 the label it is fitting* — at a chosen level of specificity.
 
-## Grammar (v0)
+## Grammar (v0, amended per review #3974-r1)
 
 ```
-Expr    := Source | Apply
-Apply   := Fn "(" Posargs [ "," Kwargs ] ")"
-Posargs := Expr ("," Expr)*
-Kwargs  := kw "=" val ("," kw "=" val)*        # canonical: sorted by kw, defaults ELIDED
-Source  := e5 | graph | human
-         | luna | sonnet | haiku | gpt-5.5-low | gemini | opus | ...   # judge roster
-Fn      := routing | pick | kalman | blend | lineage | distill | menu | margin | ...
+Expr     := Atom | Apply | Atom "." Ident            # dotted modifier: judge variant (sonnet.lineage)
+Apply    := Ident "(" [Args] ")"                     # an Ident may be BOTH atom and operator —
+Args     := Arg ("," Arg)*                           #   e5 (embedding source) vs e5(...) (ranker over
+Arg      := Expr | Kwarg | Pin                       #   an inner process); resolved by the registry
+Kwarg    := Ident "=" Val                            # canonical: sorted by kw, defaults ELIDED
+Pin      := Expr "@" PinLit                          # provenance pin (V3 only): rev, date, hash
+Val      := Number | List | String | Ident
+List     := "[" Val ("," Val)* "]"
+Number   := /-?[0-9]+(\.[0-9]+)?/ ;  Ident := /[a-z][a-z0-9_-]*/ ;  PinLit := /[A-Za-z0-9._\/-]+/
 ```
+
+**Typed operator-signature registry (versioned):** every Ident used as an operator has a registry
+entry — arity, positional/kw parameter types + defaults, output type (score | pick | target-set),
+and whether the same Ident is also a valid atom. The registry version is part of process identity.
+The P0 round-trip requirement (parse ∘ render = id) is against THIS grammar + registry, and the
+registry must parse every example in this document (the v0 acceptance test).
 
 Examples (the deployed three-tier filing policy, at three verbosities):
 
@@ -29,12 +37,26 @@ Other current processes, expressed: `kalman(luna.D, luna.S)` (the "kalman-fused"
 `blend(graph.discrim, llm.element, llm.subcat)` ("dir-blend"), `lineage(graph, decay=0.85)`
 (the LINEAGE target factory), `distill(e5(routing(...)))` (the label-factory corpus).
 
+## Process identity vs training cards (review finding 2 — the load-bearing split)
+
+- **Identity is LOSSLESS:** a process is identified by its canonical AST (all args, all pins,
+  registry version) plus a factory/manifest fingerprint (hashes of the code + data manifests that
+  realize it). This is what P4 provenance headers carry, and what "distinct factories must remain
+  distinguishable" means. Two processes are the same iff their canonical ASTs + fingerprints match.
+- **Cards are LOSSY, derived views:** V0–V3 renderings are projections of the canonical AST for
+  CONDITIONING only. A V1 card deliberately merges distinct processes into an equivalence class —
+  that is its job — and is therefore never a process identifier.
+- **Cache keys:** embedding caches are keyed on (canonical-AST hash, verbosity level, renderer
+  version, embedding model revision, e5 prefix mode) — never on the rendered string alone.
+
 ## Canonicalization rules
 
-1. Kwargs sorted; values in canonical numeric form; DEFAULTS ELIDED (conciseness is the norm).
+1. Kwargs sorted; values in canonical numeric form; DEFAULTS ELIDED in renderings (the canonical
+   AST keeps explicit resolved values for identity).
 2. `judge.modifier` dot-syntax for judge variants (`sonnet.lineage` = sonnet with lineage-context
-   menus); `@` suffixes reserved for pins (model revision, date, prompt hash) — V3 only.
-3. One canonical string per (expression, verbosity level); the string IS the cache key.
+   menus); `@` pins (model revision, date, prompt hash) rendered at V3 only, always present in
+   the canonical AST.
+3. One canonical string per (AST, verbosity level, renderer version).
 
 ## Verbosity levels
 
@@ -47,9 +69,13 @@ Other current processes, expressed: `kalman(luna.D, luna.S)` (the "kalman-fused"
 
 ## Expression → embedding
 
-Phase 1 (zero new architecture): canonical string → e5 passage embedding → NameFunctionCond
-conditioning residual — exactly the existing judge-card onboarding path (`judge_cards.py`, r=0
-name-prior). A new expression needs no new token, no retraining of the pathway.
+Phase 1 (honest about the code — review finding 3): NameFunctionCond is an integer-indexed frozen
+card table + per-index learned residual (`forward(idx) = W(name_e5[idx]) + resid(idx)`,
+mu_attention.py:399). So phase 1 = **table expansion**: each registered expression appends a card
+row (its rendered string, e5-embedded) and receives a learned residual — the existing judge
+onboarding, not a token-free path. For UNSEEN expressions the shared projection gives the dynamic
+path `W(e_expr)` with residual = 0 (pure name prior) — a one-line forward generalization, used at
+inference/zero-shot only until P3 makes it a trained pathway.
 
 Phase 3 (compositional): tree encoding over the AST — node embedding = card-e5(fn) combined with
 position-weighted child embeddings (the `random_operator_embedding` superposition precedent) or a

--- a/prototypes/mu_cosine/DESIGN_process_expression_philosophy.md
+++ b/prototypes/mu_cosine/DESIGN_process_expression_philosophy.md
@@ -23,14 +23,20 @@ card is its documentation") from atoms to programs.
 The language must balance CONCISENESS against SPECIFICITY. Operationalized: an expression
 distinction earns its tokens iff it buys held-out predictive gain —
 
-    maximize   Δ(held-out NLL of the conditioned model)  per  expression token
+    the GAIN-PER-TOKEN EFFICIENCY CURVE:  Δ(held-out NLL)  per  expression token
 
-an MDL criterion. Too coarse (all judges = "llm") discards distinctions that change the label
-distribution; too fine (temperature, prompt hash, date on every row) adds description length
-without gain and fragments the data into unlearnable slivers. The optimal grammar level is an
-EMPIRICAL quantity, found by sweeping card verbosity and measuring gain-per-token — not decided
-by taste. Control: shuffled/mismatched cards must HURT (if the model ignores its conditioning,
-the language is decoration and the result is void).
+(Naming amended per review #3974-r1 finding 8: this is NOT MDL — a true MDL objective would also
+charge for the grammar/registry/model code length and require a pinned tokenizer so "token" is
+well-defined. We adopt the efficiency-curve framing, pin the tokenizer (the e5 tokenizer at a
+recorded revision) so lengths are comparable, and leave a genuine two-part code-length objective
+to the Codex/theory lane if the curve proves insufficient.) Too coarse (all judges = "llm")
+discards distinctions that change the label distribution; too fine (temperature, prompt hash,
+date on every row) adds description length without gain and fragments the data into unlearnable
+slivers. The optimal grammar level is an EMPIRICAL quantity — swept on an INNER validation split,
+never on the set later used for reported inference. Control: shuffled/mismatched cards must
+DEGRADE the conditioned arm toward (not necessarily below) the unconditional arm — when judges
+often agree, a wrong card still carries mostly-right information, so the prespecified check is
+"shuffling loses a significant fraction of the conditioning gain", not "shuffling goes negative".
 
 ## Multi-verbosity training (owner's design point)
 


### PR DESCRIPTION
Follow-up to #3974 addressing all nine review findings: grammar fixed to parse its own examples (lexical rules + typed versioned signature registry); lossless AST+fingerprint identity split from lossy cards with fully-qualified cache keys; honest NameFunctionCond path (table expansion + residual-free W(e_expr) for unseen); P1 frozen row ledger/estimand/null-handling/process-complete splits/typed-block bootstrap; P1-P2 relabeled exploratory-transductive with confirmation reserved for a future frozen-catalog cohort; zero-init reframed as rollback+noninferiority (not a floor); frozen primary decision + precise shuffled-card permutation; MDL renamed to gain-per-token efficiency curve (pinned tokenizer, inner-validation selection); P3 zero-shot upgraded to preregistered multi-process LOCO with four controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fB4ZfA4bW4XNEnboUncgc