### PR TITLE
mu_cosine: process-expression P0 — parser/canonicalizer/cards + r2 spec fixes

### DIFF
--- a/prototypes/mu_cosine/DESIGN_process_expression_implementation.md
+++ b/prototypes/mu_cosine/DESIGN_process_expression_implementation.md
@@ -53,10 +53,14 @@ cohort with a structurally frozen catalog, collected AFTER this design is fixed.
   (d) SHUFFLED cards — permutation defined as: within each split side, permute the card column
   across rows UNIFORMLY AT RANDOM among rows with distinct process ASTs (so a shuffled row's card
   is always wrong), 5 permutation draws, mean reported.
-- **Frozen primary decision (finding 7):** primary metric = held MRR of arm (a) vs arm (c),
-  paired two-endpoint node-block bootstrap, 3 training seeds pooled by mean-per-query; success =
-  CI excludes zero AND point gain ≥ +0.01 MRR. Everything else (R@1, arm (b), shuffled fraction
-  lost, per-process breakdowns) is secondary/descriptive — reported, no multiplicity claims.
+- **Frozen primary decision (finding 7; amended per review r2 item 2):** the claim is
+  "STRUCTURED EXPRESSIONS earn their keep over flat tokens", so the primary is arm (a) vs
+  arm (b) — held MRR, paired two-endpoint node-block bootstrap, 3 training seeds pooled by
+  mean-per-query; success = superiority (CI excludes zero, point gain ≥ +0.01 MRR) OR
+  noninferiority (CI lower bound ≥ −0.005) IF the P3 zero-shot LOCO pass succeeds — expressions
+  may tie flat tokens in-distribution and still win on generalization, which flat tokens cannot
+  attempt. Secondary: (a) vs (c) ("conditioning helps at all"), R@1, shuffled fraction lost,
+  per-process breakdowns — reported, no multiplicity claims.
 - Exit: primary success ⇒ proceed to P2; primary failure but rollback floor held ⇒ the language
   is not earning conditioning gain on this corpus — stop and hand the grammar to the theory lane
   before spending more.
@@ -72,8 +76,11 @@ cohort with a structurally frozen catalog, collected AFTER this design is fixed.
 
 ## P3 — compositional embedding + zero-shot
 
-- Tree encoder over the AST (superposition first — random_operator_embedding precedent — then a
-  small learned encoder if superposition plateaus).
+- Tree encoder over the AST — DETERMINISTIC composition (review r2 item 3): node embedding =
+  card-e5(operator) + Σ position-weighted child embeddings with fixed per-position weights; any
+  stochastic element (e.g. dropout-style card sampling) is seeded by SHA-256 of the canonical AST,
+  so identical expressions always embed identically. A small learned tree encoder follows only if
+  the deterministic superposition plateaus.
 - Zero-shot test (finding 9 — one held process proves nothing): PREREGISTERED
   leave-one-composition-out over SEVERAL held processes — at minimum {sonnet.lineage@N20,
   haiku@N10, kalman(luna.D, luna.S), one lineage-decay variant} — each evaluated against four

--- a/prototypes/mu_cosine/DESIGN_process_expression_language.md
+++ b/prototypes/mu_cosine/DESIGN_process_expression_language.md
@@ -7,16 +7,27 @@ the label it is fitting* — at a chosen level of specificity.
 ## Grammar (v0, amended per review #3974-r1)
 
 ```
-Expr     := Atom | Apply | Atom "." Ident            # dotted modifier: judge variant (sonnet.lineage)
-Apply    := Ident "(" [Args] ")"                     # an Ident may be BOTH atom and operator —
+Expr     := Atom | Apply | Expr "." Mod              # dotted modifier: variant/channel (sonnet.lineage, luna.D)
+Apply    := Name "(" [Args] ")"                      # a Name may be BOTH atom and operator —
 Args     := Arg ("," Arg)*                           #   e5 (embedding source) vs e5(...) (ranker over
 Arg      := Expr | Kwarg | Pin                       #   an inner process); resolved by the registry
 Kwarg    := Ident "=" Val                            # canonical: sorted by kw, defaults ELIDED
 Pin      := Expr "@" PinLit                          # provenance pin (V3 only): rev, date, hash
-Val      := Number | List | String | Ident
+Atom     := Name                                     # any registry-registered leaf source/judge
+Val      := Number | List | String | Name
 List     := "[" Val ("," Val)* "]"
-Number   := /-?[0-9]+(\.[0-9]+)?/ ;  Ident := /[a-z][a-z0-9_-]*/ ;  PinLit := /[A-Za-z0-9._\/-]+/
+String   := '"' /[^"]*/ '"'
+Number   := /-?[0-9]+(\.[0-9]+)?/ ;  Ident := /[a-z][a-z0-9_]*/ ;  Mod := /[A-Za-z][A-Za-z0-9_-]*/
+PinLit   := /[A-Za-z0-9._\/-]+/
+Name     := longest match against the registry's reserved name vocabulary
 ```
+
+**Registry-driven lexing (review r2 item 1):** names like `gpt-5.5-low` contain `.` and `-`, which
+would collide with the modifier and minus syntax under naive lexing. Resolution: the lexer
+longest-matches `Name` tokens against the versioned registry vocabulary FIRST, so any registered
+name — dots, hyphens and all — is one token; `.Mod` parsing applies only to text following a
+complete parsed Expr. `Mod` permits uppercase (channel modifiers `luna.D`, `luna.S`). Unregistered
+bare words are a parse error (no guessing).
 
 **Typed operator-signature registry (versioned):** every Ident used as an operator has a registry
 entry — arity, positional/kw parameter types + defaults, output type (score | pick | target-set),

--- a/prototypes/mu_cosine/process_cards.py
+++ b/prototypes/mu_cosine/process_cards.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""P0 of DESIGN_process_expression_*: AST, registry-driven parser, canonicalizer, verbosity cards.
+
+Lossless process identity = canonical AST string + registry version (+ factory fingerprint,
+supplied by callers). Cards (V0-V3) are lossy renderings for conditioning only. Embedding cache
+keys bind (ast_sha, verbosity, RENDERER_VERSION, embedding revision, prefix) — never the string.
+"""
+from dataclasses import dataclass, field
+import hashlib
+import re
+
+RENDERER_VERSION = "r1"
+REGISTRY_VERSION = "v0.2"
+
+# name -> (is_atom, is_operator, {kw: default}) ; longest-match lexing over these names
+REGISTRY = {
+    "e5": (True, True, {}),
+    "graph": (True, True, {}),
+    "human": (True, False, {}),
+    "luna": (True, False, {}), "sonnet": (True, False, {}), "haiku": (True, False, {}),
+    "gpt-5.5-low": (True, False, {}), "gemini": (True, False, {}), "opus": (True, False, {}),
+    "routing": (False, True, {"t": None, "menus": None}),
+    "pick": (False, True, {}),
+    "kalman": (False, True, {}),
+    "blend": (False, True, {"w": None}),
+    "lineage": (False, True, {"decay": 0.85, "depth": None}),
+    "distill": (False, True, {}),
+    "menu": (False, True, {"n": None}),
+    "margin": (False, True, {"t": None}),
+    "llm": (True, False, {}),
+}
+_NAMES = sorted(REGISTRY, key=len, reverse=True)
+_MOD = re.compile(r"[A-Za-z][A-Za-z0-9_-]*")
+_NUM = re.compile(r"-?[0-9]+(\.[0-9]+)?")
+_PIN = re.compile(r"[A-Za-z0-9._/-]+")
+_KW = re.compile(r"[a-z][a-z0-9_]*=")
+
+
+class ParseError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Node:
+    name: str
+    args: tuple = ()                 # positional child Nodes
+    kwargs: tuple = ()               # sorted (kw, value) pairs; values canonical
+    mods: tuple = ()                 # dotted modifiers, in order
+    pins: tuple = ()                 # provenance pins, in order
+
+
+def _lex_name(s, i):
+    for n in _NAMES:
+        if s.startswith(n, i):
+            return n, i + len(n)
+    raise ParseError(f"unregistered name at {i}: {s[i:i+24]!r}")
+
+
+def _parse_val(s, i):
+    if s[i] == "[":
+        out, i = [], i + 1
+        while s[i] != "]":
+            v, i = _parse_val(s, i)
+            out.append(v)
+            if s[i] == ",":
+                i += 1
+        return tuple(out), i + 1
+    if s[i] == '"':
+        j = s.index('"', i + 1)
+        return s[i + 1:j], j + 1
+    m = _NUM.match(s, i)
+    if m:
+        t = m.group(0)
+        return (float(t) if "." in t else int(t)), m.end()
+    n, i = _lex_name(s, i)
+    return n, i
+
+
+def _parse_expr(s, i):
+    name, i = _lex_name(s, i)
+    args, kwargs = [], []
+    if i < len(s) and s[i] == "(":
+        if not REGISTRY[name][1]:
+            raise ParseError(f"{name} is not an operator")
+        i += 1
+        while s[i] != ")":
+            if _KW.match(s, i):
+                kw = s[i:s.index("=", i)]
+                v, i = _parse_val(s, s.index("=", i) + 1)
+                kwargs.append((kw, v))
+            else:
+                child, i = _parse_expr(s, i)
+                args.append(child)
+            if s[i] == ",":
+                i += 1
+        i += 1
+    elif not REGISTRY[name][0]:
+        raise ParseError(f"{name} is not an atom")
+    # normalize: an explicitly-written default kwarg is the same process as the elided form
+    defaults = REGISTRY[name][2]
+    kwargs = [(k, v) for k, v in kwargs if defaults.get(k) != v]
+    mods, pins = [], []
+    while i < len(s) and s[i] in ".@":
+        c, i2 = s[i], i + 1
+        m = (_MOD if c == "." else _PIN).match(s, i2)
+        if not m:
+            raise ParseError(f"bad {'modifier' if c=='.' else 'pin'} at {i2}")
+        (mods if c == "." else pins).append(m.group(0))
+        i = m.end()
+    return Node(name, tuple(args), tuple(sorted(kwargs)), tuple(mods), tuple(pins)), i
+
+
+def parse(text):
+    node, i = _parse_expr(text.replace(" ", ""), 0)
+    if i != len(text.replace(" ", "")):
+        raise ParseError(f"trailing input at {i}")
+    return node
+
+
+def _render_val(v):
+    if isinstance(v, tuple):
+        return "[" + ",".join(_render_val(x) for x in v) + "]"
+    if isinstance(v, float):
+        return f"{v:g}"
+    return str(v)
+
+
+def render(node, verbosity=3):
+    """V1: names+structure, kwargs elided. V2: + non-default kwargs. V3: + pins. V0: ''. Lossless
+    canonical = V3 plus default kwargs made explicit (identity string)."""
+    if verbosity == 0:
+        return ""
+    kw = ""
+    if verbosity >= 2:
+        defaults = REGISTRY[node.name][2]
+        kept = [(k, v) for k, v in node.kwargs if defaults.get(k) != v]
+        if kept:
+            kw = ("," if node.args else "") + ",".join(f"{k}={_render_val(v)}" for k, v in kept)
+    inner = ",".join(render(a, verbosity) for a in node.args)
+    s = node.name + (f"({inner}{kw})" if (node.args or kw) else "")
+    s += "".join("." + m for m in node.mods)
+    if verbosity >= 3:
+        s += "".join("@" + p for p in node.pins)
+    return s
+
+
+def canonical(node):
+    """Lossless identity string: V3 rendering with ALL kwargs explicit (defaults resolved)."""
+    defaults = dict(REGISTRY[node.name][2])
+    kws = dict(defaults)
+    kws.update(dict(node.kwargs))
+    kw = ",".join(f"{k}={_render_val(v)}" for k, v in sorted(kws.items()) if v is not None)
+    inner = ",".join(canonical(a) for a in node.args)
+    body = ",".join(x for x in (inner, kw) if x)
+    s = node.name + (f"({body})" if body else "")
+    return s + "".join("." + m for m in node.mods) + "".join("@" + p for p in node.pins)
+
+
+def ast_sha(node):
+    return hashlib.sha256(
+        (REGISTRY_VERSION + "|" + canonical(node)).encode()).hexdigest()[:16]
+
+
+def embedding_cache_key(node, verbosity, e5_revision, prefix="passage"):
+    return hashlib.sha256("|".join(
+        [ast_sha(node), str(verbosity), RENDERER_VERSION, e5_revision, prefix]
+    ).encode()).hexdigest()[:16]
+
+
+# Registry of CURRENT processes (P0 exit requirement)
+PROCESSES = {
+    "e5-auto": "e5(margin(t=0.03))",
+    "haiku-n10": "e5(routing(e5,haiku,t=[0.02],menus=[10]))",
+    "sonnet-lin-n10": "e5(routing(e5,sonnet.lineage,t=[0.02],menus=[10]))",
+    "sonnet-lin-n20": "e5(routing(e5,sonnet.lineage,t=[0.02,0.03],menus=[10,20]))",
+    "kalman-fused": "kalman(luna.D,luna.S)",
+    "blend": "blend(luna.D,luna.S)",
+    "dir-blend": "blend(graph.discrim,llm.element,llm.subcat)",
+    "lineage-graph": "lineage(graph,decay=0.85)",
+    "distill-3tier": "distill(e5(routing(e5,sonnet.lineage,t=[0.02,0.03],menus=[10,20])))",
+}

--- a/prototypes/mu_cosine/test_process_cards.py
+++ b/prototypes/mu_cosine/test_process_cards.py
@@ -1,0 +1,49 @@
+"""P0 acceptance tests: parse-the-spec, round-trip, identity/card split, determinism."""
+import pytest
+
+from process_cards import (PROCESSES, ParseError, ast_sha, canonical,
+                           embedding_cache_key, parse, render)
+
+
+def test_registry_parses_every_registered_process():
+    for name, expr in PROCESSES.items():
+        node = parse(expr)
+        assert parse(render(node, 3)) == node, name          # round-trip at V3
+
+
+def test_dotted_and_hyphen_dot_names():
+    n = parse("kalman(luna.D,luna.S)")
+    assert n.args[0].mods == ("D",)                          # uppercase channel modifier
+    assert parse("gpt-5.5-low").name == "gpt-5.5-low"        # dots inside registered name
+
+
+def test_canonical_resolves_defaults_and_is_lossless():
+    a = parse("lineage(graph)")
+    b = parse("lineage(graph,decay=0.85)")
+    assert canonical(a) == canonical(b) and ast_sha(a) == ast_sha(b)
+    assert render(a, 1) == "lineage(graph)"                  # V1 elides kwargs entirely
+    assert "decay=0.85" in canonical(a)                      # identity keeps resolved defaults
+
+
+def test_verbosity_ladder_monotone():
+    n = parse("e5(routing(e5,sonnet.lineage,t=[0.02,0.03],menus=[10,20]))@fcf5e1d6")
+    v = [render(n, k) for k in (0, 1, 2, 3)]
+    assert v[0] == "" and "t=" not in v[1] and "t=[0.02,0.03]" in v[2] and "@fcf5e1d6" in v[3]
+    assert "@" not in v[2]                                   # pins are V3-only
+
+
+def test_cache_key_binds_revision_and_verbosity():
+    n = parse("kalman(luna.D,luna.S)")
+    k = embedding_cache_key(n, 1, "rev-a")
+    assert k != embedding_cache_key(n, 2, "rev-a")
+    assert k != embedding_cache_key(n, 1, "rev-b")
+    assert k == embedding_cache_key(parse("kalman(luna.D,luna.S)"), 1, "rev-a")  # deterministic
+
+
+def test_fail_closed():
+    with pytest.raises(ParseError):
+        parse("mystery(e5)")                                 # unregistered operator
+    with pytest.raises(ParseError):
+        parse("routing")                                     # operator used as atom
+    with pytest.raises(ParseError):
+        parse("human(e5)")                                   # atom used as operator


### PR DESCRIPTION
P0 of the process-expression plan plus sol's three r2 items: self-parsing grammar (Atom/String productions, uppercase Mod, registry-driven longest-match lexing for names like gpt-5.5-low), P1 primary re-aimed at expressions-vs-flat-tokens with a decision-bearing gate, deterministic P3 composition (AST-SHA seeding). process_cards.py: typed registry, parser→frozen AST (defaults normalized; canonical() lossless), V0–V3 renderer, ast_sha + fully-bound embedding cache keys, all nine current processes registered. 6/6 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fB4ZfA4bW4XNEnboUncgc