### PR TITLE
mu_cosine: freeze process-expression P1 rigor contract

### DIFF
--- a/prototypes/mu_cosine/DESIGN_process_expression_implementation.md
+++ b/prototypes/mu_cosine/DESIGN_process_expression_implementation.md
@@ -16,28 +16,35 @@ architecture.
   sonnet.lineage@N20, kalman(luna.D, luna.S), lineage(graph, decay=0.85), the blend judges.
 - Unit tests: canonicalization idempotence, default elision, verbosity monotonicity (V1 ⊂ V2 ⊂ V3
   informationally), embedding cache determinism.
-- Exit: every existing judge/op token has an expression rendering; round-trip stable.
+- Exit: every existing judge/op token has an expression rendering; V3 and canonical identities
+  round-trip stably. Lower-verbosity cards are intentionally lossy and are never identifiers.
 
-## P1 — minimal experiment: expression-conditioned distillation (the data already exists)
+## P1 — minimal experiment: expression-conditioned distillation
 
-Corpus (no new API spend): the four differently-generated label sets on manifest fcf5e1d6 —
-auto rows (margin ≥ 0.03, e5 top-1), haiku@N10 picks (695), sonnet.lineage@N10 picks (695),
-sonnet.lineage@N20 picks (227).
+The prospective, machine-checked contract is
+`PROTOCOL_process_expression_p1.md` + `PROCESS_EXPRESSION_P1_PREREG.json`; it is authoritative
+where this implementation sketch is less specific.
+
+The old manifest `fcf5e1d6` contains the four useful process families, but its judge tasks/picks
+are `legacy_unbound` and included nonpublic candidates. They cannot be upgraded retroactively to
+the v2 execution/privacy contract and therefore cannot enter the primary ledger. They remain a
+local-only descriptive sensitivity. Primary P1 either uses newly verified public-only v2 bundles
+or records `blocked_no_eligible_v2_labels`; producing new labels is a separate spending decision.
 
 **Status: EXPLORATORY and TRANSDUCTIVE (review finding 5).** The 1,200-query manifest's outcomes
 already informed the routing ceilings and the selection of t, N, and Sonnet — no partition of it
 can serve as an untouched confirmatory test. Confirmation is reserved for a future bookmark
 cohort with a structurally frozen catalog, collected AFTER this design is fixed.
 
-- **Frozen row ledger (finding 4), built and hashed before any training:** 1,200 unique queries;
-  922 unique judged queries; 1,617 judge pick-records (695 haiku@N10 + 695 sonnet.lineage@N10 +
-  227 sonnet.lineage@N20; 695 queries appear under BOTH haiku and sonnet processes); + 278
-  auto-rows (margin ≥ 0.03, process = e5-auto) → 1,895 process-target records. The ledger file
-  records (query, folder-menu, process AST hash, pick|null, card renderings) per row.
+- **Frozen row ledger (finding 4), built and hashed before any training:** the historical
+  1,200-query population had 922 unique judged queries, 1,617 judge pick-records, 278 auto rows,
+  and 1,895 process-target records. Those are descriptive counts, not a required P1 sample size.
+  The primary ledger records whatever survives prospective v2 re-derivation, privacy,
+  execution-bundle, population, and join gates.
 - **Estimand + targets:** the trained object scores (query, folder) pairs conditioned on a card;
   the training target of a judge row is its picked folder (one positive vs the other menu
-  folders as in-menu negatives); NULL picks contribute no positive — they train only the
-  abstention-consistent negatives (all menu folders down-weighted ×0.5, recorded knob).
+  folders as in-menu alternatives); NULL picks contribute no primary ranking loss because they
+  identify no positive. A fractional-negative treatment is inner-training sensitivity only.
   Per-process row weights normalize so no process dominates by count (recorded in the ledger).
 - **Split grouping:** node-disjoint over (bookmark, true-folder) identities AND process-complete —
   every process rendering of a query travels with it to the same side. Uncertainty: resample
@@ -56,14 +63,13 @@ cohort with a structurally frozen catalog, collected AFTER this design is fixed.
 - **Frozen primary decision (finding 7; amended per review r2 item 2):** the claim is
   "STRUCTURED EXPRESSIONS earn their keep over flat tokens", so the primary is arm (a) vs
   arm (b) — held MRR, paired two-endpoint node-block bootstrap, 3 training seeds pooled by
-  mean-per-query; success = superiority (CI excludes zero, point gain ≥ +0.01 MRR) OR
-  noninferiority (CI lower bound ≥ −0.005) IF the P3 zero-shot LOCO pass succeeds — expressions
-  may tie flat tokens in-distribution and still win on generalization, which flat tokens cannot
-  attempt. Secondary: (a) vs (c) ("conditioning helps at all"), R@1, shuffled fraction lost,
-  per-process breakdowns — reported, no multiplicity claims.
-- Exit: primary success ⇒ proceed to P2; primary failure but rollback floor held ⇒ the language
-  is not earning conditioning gain on this corpus — stop and hand the grammar to the theory lane
-  before spending more.
+  mean-per-query; success = superiority (CI lower endpoint > 0 and point gain ≥ +0.01 MRR).
+  A CI lower bound ≥ −0.005 is classified as in-distribution noninferiority only, never P1
+  success. A later P3 zero-shot LOCO result cannot retroactively change that classification.
+  Secondary: (a) vs (c) ("conditioning helps at all"), R@1, shuffled fraction lost, per-process
+  breakdowns — reported, no multiplicity claims.
+- Exit: superiority authorizes P2. Noninferiority may authorize a separately preregistered P3
+  mechanism study, but not P2; inferiority or failure of the e5 safety margin stops the ladder.
 
 ## P2 — gain-per-token verbosity sweep (naming per finding 8: efficiency curve, not MDL)
 
@@ -101,9 +107,10 @@ cohort with a structurally frozen catalog, collected AFTER this design is fixed.
 
 ## Risks / open questions
 
-- 922 judged rows is small for 4 conditions — P1 leans on the e5-residual floor and the shared-
-  strength effect of concise cards; if underpowered, the label factory has a costed refill path
-  (the routing loop, now with measured judge value).
+- The historical 922 judged-query count was small for four conditions, and the eligible
+  public-only v2 population may be smaller. P1 uses e5 as an explicit rollback candidate rather
+  than pretending zero initialization guarantees a floor; if underpowered, the label factory has
+  a costed refill path that requires a separate spending decision.
 - Card embedding via e5 of a formal string is a leap of faith at V2/V3 (bracketed kwargs are not
   natural language); if e5 collapses them, fall back to template rendering ("sonnet judge with
   lineage context, menus of 10") — canonicalization keeps the mapping deterministic either way.

--- a/prototypes/mu_cosine/DESIGN_process_expression_language.md
+++ b/prototypes/mu_cosine/DESIGN_process_expression_language.md
@@ -7,17 +7,18 @@ the label it is fitting* — at a chosen level of specificity.
 ## Grammar (v0, amended per review #3974-r1)
 
 ```
-Expr     := Atom | Apply | Expr "." Mod              # dotted modifier: variant/channel (sonnet.lineage, luna.D)
+Expr     := Primary ("." Mod)* ("@" PinLit)*          # modifiers precede provenance pins
+Primary  := Atom | Apply
 Apply    := Name "(" [Args] ")"                      # a Name may be BOTH atom and operator —
 Args     := Arg ("," Arg)*                           #   e5 (embedding source) vs e5(...) (ranker over
-Arg      := Expr | Kwarg | Pin                       #   an inner process); resolved by the registry
+Arg      := Expr | Kwarg                             #   an inner process); resolved by the registry
 Kwarg    := Ident "=" Val                            # canonical: sorted by kw, defaults ELIDED
-Pin      := Expr "@" PinLit                          # provenance pin (V3 only): rev, date, hash
 Atom     := Name                                     # any registry-registered leaf source/judge
-Val      := Number | List | String | Name
+Val      := Number | List | String
 List     := "[" Val ("," Val)* "]"
-String   := '"' /[^"]*/ '"'
-Number   := /-?[0-9]+(\.[0-9]+)?/ ;  Ident := /[a-z][a-z0-9_]*/ ;  Mod := /[A-Za-z][A-Za-z0-9_-]*/
+String   := a JSON string literal                    # whitespace and escapes are content
+Number   := /-?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?/ ; Ident := /[a-z][a-z0-9_]*/
+Mod      := /[A-Za-z][A-Za-z0-9_-]*/
 PinLit   := /[A-Za-z0-9._\/-]+/
 Name     := longest match against the registry's reserved name vocabulary
 ```
@@ -29,11 +30,16 @@ name — dots, hyphens and all — is one token; `.Mod` parsing applies only to 
 complete parsed Expr. `Mod` permits uppercase (channel modifiers `luna.D`, `luna.S`). Unregistered
 bare words are a parse error (no guessing).
 
-**Typed operator-signature registry (versioned):** every Ident used as an operator has a registry
-entry — arity, positional/kw parameter types + defaults, output type (score | pick | target-set),
-and whether the same Ident is also a valid atom. The registry version is part of process identity.
-The P0 round-trip requirement (parse ∘ render = id) is against THIS grammar + registry, and the
-registry must parse every example in this document (the v0 acceptance test).
+**Typed operator-signature registry (versioned):** every Name used as an operator has a registry
+entry — arity, positional/kw parameter types + defaults, output type
+(`source | score | pick | target-set`), allowed modifiers, and whether the same Name is also a
+valid atom. Composition validates each child's output type against the parent's positional type.
+The registry version is part of process identity.
+The P0 lossless round-trip requirement (`parse(render(ast, V3)) = ast`, and likewise for the
+canonical identity string) is against THIS grammar + registry, and the registry must parse every
+example in this document (the v0 acceptance test). V0–V2 are deliberately lossy conditioning
+views; an elided required parameter can make such a card non-executable, so they are never parsed
+back as process identities.
 
 Examples (the deployed three-tier filing policy, at three verbosities):
 
@@ -41,7 +47,7 @@ Examples (the deployed three-tier filing policy, at three verbosities):
 V1  e5(routing(e5, sonnet))
 V2  e5(routing(e5, sonnet.lineage, t=[0.02,0.03], menus=[10,20]))
 V3  e5(routing(e5@e5-small-v2, sonnet.lineage@2026-07-23/menu-order-blind,
-       t=[0.02,0.03], menus=[10,20], manifest=fcf5e1d6))
+       t=[0.02,0.03], menus=[10,20], manifest="fcf5e1d6"))
 ```
 
 Other current processes, expressed: `kalman(luna.D, luna.S)` (the "kalman-fused" judge token),
@@ -62,8 +68,9 @@ Other current processes, expressed: `kalman(luna.D, luna.S)` (the "kalman-fused"
 
 ## Canonicalization rules
 
-1. Kwargs sorted; values in canonical numeric form; DEFAULTS ELIDED in renderings (the canonical
-   AST keeps explicit resolved values for identity).
+1. Kwargs sorted; finite floats use Python's shortest lossless round-trip form (including exponent
+   notation when needed); DEFAULTS ELIDED in renderings (the canonical AST keeps explicit resolved
+   values for identity).
 2. `judge.modifier` dot-syntax for judge variants (`sonnet.lineage` = sonnet with lineage-context
    menus); `@` pins (model revision, date, prompt hash) rendered at V3 only, always present in
    the canonical AST.

--- a/prototypes/mu_cosine/PROCESS_EXPRESSION_P1_PREREG.json
+++ b/prototypes/mu_cosine/PROCESS_EXPRESSION_P1_PREREG.json
@@ -1,0 +1,133 @@
+{
+  "schema": "unifyweaver.process-expression-p1-prereg.v1",
+  "protocol_path": "PROTOCOL_process_expression_p1.md",
+  "protocol_sha256": "21adc652d33ce374002ffad447118f8a2a288280c267a559874307a989242b39",
+  "evidence_status": "prospective-exploratory-transductive",
+  "legacy_sources": {
+    "historical_manifest_prefix": "fcf5e1d6",
+    "historical_counts_are_descriptive_only": true,
+    "legacy_unbound_picks_authorized": false,
+    "private_inclusive_sources_authorized": false
+  },
+  "required_source_contract": {
+    "task_schema": "unifyweaver.routed-task.v2",
+    "picks_schema": "unifyweaver.routed-picks.v2",
+    "execution_bundle_schema": "unifyweaver.routed-execution-bundle.v1",
+    "privacy_policy_id": "pearltrees-public-only-v1",
+    "catalog_policy_id": "pearltrees-public-alphanumeric-title-v1",
+    "missing_bundle_outcome": "blocked_no_eligible_v2_labels"
+  },
+  "process_identity": {
+    "digest": "sha256(REGISTRY_VERSION+'|'+canonical_expression)",
+    "digest_hex_length": 64,
+    "compact_ast_sha_is_identity": false,
+    "registry_version": "v0.3",
+    "renderer_version": "r2",
+    "processes": {
+      "e5_auto": {
+        "expression": "e5(margin(t=0.03))",
+        "canonical": "e5(margin(t=0.03))",
+        "sha256": "d2a12a2cfb43740a3ffddbd37a8ba777627714a0ffcd27b5c38016e6472914b1"
+      },
+      "haiku_n10": {
+        "expression": "e5(routing(e5,haiku,t=[0.02],menus=[10]))",
+        "canonical": "e5(routing(e5,haiku,menus=[10],t=[0.02]))",
+        "sha256": "ab4d7afc2ec5915c429d5e00b7270d0b2cd84309a1bfa46dfc52b901224dd4e2"
+      },
+      "sonnet_lineage_n10": {
+        "expression": "e5(routing(e5,sonnet.lineage,t=[0.02],menus=[10]))",
+        "canonical": "e5(routing(e5,sonnet.lineage,menus=[10],t=[0.02]))",
+        "sha256": "22949ce22cb3c224bfb2f1059a553f6d455d79f3ecfc382e30b4e89cd5ced7c0"
+      },
+      "sonnet_lineage_n20": {
+        "expression": "e5(routing(e5,sonnet.lineage,t=[0.02,0.03],menus=[10,20]))",
+        "canonical": "e5(routing(e5,sonnet.lineage,menus=[10,20],t=[0.02,0.03]))",
+        "sha256": "8fd632d50e639ce670fa0e81b064c5d7b5135b4b4221b04cd561089f81ea2b02"
+      }
+    }
+  },
+  "ledger": {
+    "record_unit": "query-process-target",
+    "recorded_destination_in_training_ledger": false,
+    "all_process_rows_for_query_share_split": true,
+    "null_primary_ranking_loss": "excluded",
+    "nonnull_loss": "one-normalized-listwise-cross-entropy-per-record",
+    "process_total_training_mass": "equal",
+    "historical_expected_counts": {
+      "unique_queries": 1200,
+      "unique_judged_queries": 922,
+      "judge_records": 1617,
+      "auto_records": 278,
+      "all_process_target_records": 1895,
+      "required_for_primary": false
+    }
+  },
+  "split": {
+    "function": "node_disjoint_pair_split",
+    "typed_pair": [
+      "bookmark_id",
+      "destination_folder_id"
+    ],
+    "outer_seed": 3980001,
+    "held_node_fraction": 0.4,
+    "candidate_assignments": 64,
+    "cross_rows": "excluded",
+    "selection_scope": "outer-train-only"
+  },
+  "training": {
+    "seeds": [
+      3980101,
+      3980102,
+      3980103
+    ],
+    "matched_budget_across_arms": true,
+    "training_plan_required_before_fit": true,
+    "verbosity_probabilities": {
+      "V0": 0.1,
+      "V1": 0.6,
+      "V2": 0.25,
+      "V3": 0.05
+    },
+    "arms": [
+      "expression",
+      "flat",
+      "merged",
+      "shuffled"
+    ],
+    "shuffled_train_permutations": 5
+  },
+  "primary": {
+    "population": "verified-public-only-held-queries",
+    "metric": "exact-destination-mrr",
+    "contrast": "expression-minus-flat",
+    "seed_aggregation": "mean-per-query-before-contrast",
+    "superiority": {
+      "minimum_point_gain": 0.01,
+      "interval_lower_strictly_greater_than": 0.0
+    },
+    "noninferiority_classification_only": {
+      "interval_lower_at_least": -0.005,
+      "counts_as_superiority": false
+    },
+    "e5_deployment_safety_margin": -0.01,
+    "bootstrap": {
+      "function": "paired_node_bootstrap_ci",
+      "resamples": 9999,
+      "seed": 3980999,
+      "confidence": 0.95,
+      "minimum_endpoint_components_for_decision": 20
+    }
+  },
+  "primary_policy_process": {
+    "margin_lt_0.02": "sonnet_lineage_n10",
+    "margin_ge_0.02_lt_0.03": "sonnet_lineage_n20",
+    "margin_ge_0.03": "e5_auto",
+    "haiku_role": "auxiliary-supervision-and-descriptive-only"
+  },
+  "multiplicity": {
+    "expression_vs_flat_is_only_decision_bearing_contrast": true,
+    "secondary_results_are_descriptive": true,
+    "p3_cannot_retroactively_change_p1": true
+  },
+  "prereg_id": "8817947193635a720957964b47501034aeed177a23bbe826bbd79aa85cc61b7a"
+}

--- a/prototypes/mu_cosine/PROTOCOL_process_expression_p1.md
+++ b/prototypes/mu_cosine/PROTOCOL_process_expression_p1.md
@@ -1,0 +1,236 @@
+# Prospective protocol: process-expression P1 distillation
+
+**Status:** frozen before construction of the P1 ledger, fitting, checkpoint selection, or held
+scoring. This protocol governs the first process-expression experiment described in
+`DESIGN_process_expression_implementation.md`. A material change requires a new protocol version
+and preregistration ID before any affected held metric is computed.
+
+P1 is an **exploratory, transductive representation study**. It cannot become confirmatory by
+freezing a split now: the historical 1,200-query benchmark informed the routing thresholds, menu
+sizes, judge/context choice, and process roster. A later bookmark cohort, drawn from a catalog
+frozen before its placement labels exist, is required for a generalization or deployment claim.
+
+## 1. Decision and estimand
+
+The decision question is whether structured process-expression cards improve the same residual
+ranker over flat learned process tokens. Merely beating an unconditioned pile does not answer that
+question.
+
+For each retained held query \(q\) and training seed \(s\), let
+\(RR_{\mathrm{expr},s}(q)\) and \(RR_{\mathrm{flat},s}(q)\) be reciprocal rank under the identical
+frozen candidate list, production-policy process selection, and exact-destination grade. The
+primary paired value is
+
+\[
+d(q)=\frac{1}{3}\sum_s
+\left[RR_{\mathrm{expr},s}(q)-RR_{\mathrm{flat},s}(q)\right],
+\qquad
+\Delta_{\mathrm{MRR}}=\operatorname{mean}_{q\in T}d(q).
+\]
+
+The expression arm is **superior** only when both:
+
+1. \(\Delta_{\mathrm{MRR}}\ge 0.010\); and
+2. the lower endpoint of the frozen 95% paired two-endpoint node-block interval is greater than
+   zero.
+
+If the interval lower endpoint is at least \(-0.005\), the result may be called
+**in-distribution noninferior**, but not successful or superior. A later P3 zero-shot result may
+justify retaining a noninferior representation; it must not retroactively change the P1
+classification. Every other outcome is reported as practically positive but inconclusive,
+statistically positive but below the floor, inconclusive, or inferior.
+
+The expression arm also has a deployment-safety comparison against frozen e5. Failure to keep the
+held MRR interval above the \(-0.010\) noninferiority margin bars deployment and selects the e5
+rollback. This safety comparison is not evidence that expressions beat flat tokens.
+
+## 2. Population and source-artifact gate
+
+The historical counts—1,200 unique queries, 922 judged queries, 1,617 judge records, and 1,895
+records after 278 automatic rows—describe the old development population. They are **not required
+counts for P1**.
+
+The historical judge tasks and picks are `legacy_unbound`, included nonpublic candidates, and
+cannot be upgraded retroactively. They may not enter the primary ledger. They may be examined only
+as a separately labeled, local-only sensitivity analysis that cannot tune P1 or satisfy an exit
+criterion.
+
+Primary P1 construction fails closed unless every judge-derived source has:
+
+- a reproducible `unifyweaver.routed-task.v2` parent task from the certified-public population;
+- `pearltrees-public-only-v1` and
+  `pearltrees-public-alphanumeric-title-v1` receipts;
+- a verified `unifyweaver.routed-execution-bundle.v1`;
+- the byte-identical aggregate `unifyweaver.routed-picks.v2`; and
+- the frozen policy, prompt, judge/model/revision/settings, e5 revision, task, plan, attempt-set,
+  bundle, and pick identifiers.
+
+The verifier must call the repository's task and execution-bundle re-derivation paths; copying
+stored IDs into the ledger is insufficient. If no such bundles exist, the honest result is
+`blocked_no_eligible_v2_labels`. Producing new labels is a separate, explicit spending decision.
+
+Automatic rows are regenerated from the same verified public-only population and frozen policy.
+They may not be appended from the historical population. Therefore the final primary-ledger count
+is whatever survives the prospective privacy, population, execution, and join gates—not 1,895 by
+fiat.
+
+## 3. Process identity and ledger contract
+
+The ledger is built and hashed before training. Process identity uses:
+
+```
+sha256(REGISTRY_VERSION + "|" + canonical_process_expression)
+```
+
+as the full 64-hex-character digest, plus the canonical expression, registry version, factory
+fingerprint, and applicable task/policy/bundle identifiers. The current 16-hex `ast_sha()` is a
+compact cache/display key and must never be the sole ledger or provenance identity.
+`PROCESS_EXPRESSION_P1_PREREG.json` pins the registry version, renderer version, canonical string,
+and full digest for every P1 process. Registry or canonicalization drift requires a new
+preregistration rather than silently changing a process identity.
+
+Each process-target record contains at least:
+
+- stable typed bookmark ID and frozen query text hash;
+- ordered candidate folder IDs, menu positions, and candidate-score content record;
+- canonical process expression, full process digest, factory fingerprint, and card-cache keys;
+- source kind (`judge_pick` or `auto_top1`);
+- task ID, pick ID, bundle ID, execution-policy ID, policy ID, privacy-manifest digest, and full
+  file content records where applicable;
+- selected folder ID or explicit null reason (`null_majority` or `no_consensus`);
+- process-normalized training weight; and
+- split assignment.
+
+The training ledger must not contain the recorded destination. Destination labels live in a
+separately sealed evaluation artifact. The splitter may use typed bookmark/destination identities
+to construct the split manifest, but training and checkpoint selection receive only the
+outer-train labels. Outer-held destinations remain unreadable until all arms, checkpoints, and
+inference code are frozen.
+
+Every rendering and process record for one query stays on the same split side. Joins are one-to-one
+on stable IDs and fail on missing, extra, duplicate, cross-task, cross-population, or ambiguous
+title-only matches.
+
+### Nulls and loss normalization
+
+A null pick does not identify a positive folder and therefore contributes no primary listwise
+ranking loss. Null-majority and no-consensus rows remain in the ledger and reports. Treating all
+menu items as fractional negatives is an inner-training sensitivity only; it cannot be selected
+after held metrics are visible.
+
+Non-null rows use one normalized listwise cross-entropy per process record: the chosen folder is
+positive and the other frozen menu folders are alternatives. The per-record loss is normalized
+over its menu, then process weights are scaled so each process has equal total training mass.
+This prevents N=20 or a duplicated process cohort from dominating by pair count.
+
+## 4. Frozen split and training boundary
+
+Use `node_disjoint_pair_split` over typed `(bookmark_id, destination_folder_id)` pairs with:
+
+- outer seed `3980001`;
+- held-node fraction `0.40`;
+- `64` outcome-blind candidate assignments; and
+- process/band labels as coverage strata.
+
+Cross pairs are excluded from both fitting and evaluation. Persist the exact train, held, cross,
+typed-node, and per-process manifests with full SHA-256 digests. All rows sharing a query follow
+the query's pair assignment.
+
+Hyperparameters, early stopping, checkpoint choice, loss details, trainable parameter sets, and
+the candidate text/scoring pipeline are selected only through repeated node-disjoint inner splits
+inside outer-train. Before the first fit, install a content-bound training-plan manifest containing
+the complete grid, tie rule, maximum steps, optimizer, precision, determinism settings, and package
+versions. No arm gets an additional search or training budget.
+
+The three frozen training seeds are `3980101`, `3980102`, and `3980103`. Every arm starts from the
+same base checkpoint and uses matched data order, batches, optimization budget, candidate lists,
+and early-stopping rule for each seed.
+
+## 5. Arms and conditioning
+
+The frozen arms are:
+
+1. **expression:** frozen card embedding and shared name projection plus one trainable residual row
+   per registered process;
+2. **flat:** one trainable process row per process with the same residual dimension and condition
+   dropout, but no card-derived prior;
+3. **merged:** no process identity; and
+4. **shuffled:** expression architecture with training cards permuted across distinct process
+   identities under five frozen train-only permutations.
+
+V0/V1/V2/V3 sampling probabilities are `0.10/0.60/0.25/0.05`. The draw for a row and epoch is a
+deterministic function of training seed, epoch, and stable ledger-row ID. The flat arm receives the
+same 10% condition dropout; its other three outcomes map to the same flat process row.
+
+Expression and flat arms must expose matched trainable-parameter and initialization reports.
+Parameters common to both arms are initialized byte-identically per seed. Any unavoidable
+parameter-count difference is reported and prevents a claim that representation alone caused the
+gain.
+
+The shuffled arm is a diagnostic, not part of the primary decision. Its permutation is derived
+only from outer-train rows and never changes labels, split membership, process frequencies, or
+verbosity frequencies.
+
+## 6. Primary evaluation
+
+Each held query produces exactly one ranking under the frozen production policy:
+
+- margin below 0.02: `sonnet-lin-n10`;
+- margin from 0.02 inclusive to 0.03 exclusive: `sonnet-lin-n20`; and
+- margin at least 0.03: `e5-auto`.
+
+Haiku rows are auxiliary supervision and a per-process diagnostic, not a second primary observation
+for low-band queries. Both primary arms rank the same frozen public-only e5 top-100 catalog.
+Missing true destinations receive reciprocal rank zero. Exact destination ID is primary;
+best-title-equivalent grading is sensitivity-only.
+
+P1 neither retunes the e5 margin thresholds nor calls them calibrated probabilities. They are a
+frozen routing input inherited from the exploratory filing work. Any later confidence-policy
+development must fit a joint calibrated combiner on inner node-disjoint data and evaluate
+margin-gated risk/coverage separately; it is not an implicit part of this representation test.
+
+Average each query's reciprocal rank across the three trained seeds before forming the paired arm
+difference. Report each seed separately. The primary percentile interval uses
+`paired_node_bootstrap_ci` with 9,999 resamples, seed `3980999`, confidence 0.95, and the same
+bookmark/folder weights for both arms. Report the number of held queries, unique typed endpoints,
+connected components, bootstrap attempts, bootstrap mean, and a deterministic rerun check.
+
+This interval is conditional on the frozen label corpus and three fitted seeds. It does not include
+judge-draw, provider-session, prompt-call, label-factory-selection, or future-cohort variation.
+If the held graph has fewer than 20 endpoint-connected components, the interval is descriptive and
+cannot satisfy the superiority gate.
+
+## 7. Secondary analyses and multiplicity
+
+Secondary, explicitly descriptive outputs are:
+
+- expression versus merged;
+- expression and flat versus e5;
+- R@1 and NLL;
+- per-process and per-band results;
+- all individual training seeds;
+- shuffled-card loss of conditioning gain;
+- null-majority, no-consensus, abstention, and candidate-miss rates; and
+- historical legacy-population sensitivity, if run entirely in the private workspace.
+
+No secondary result rescues a failed primary contrast. P2 is authorized only by P1 superiority.
+P3 may proceed as a separately preregistered mechanism study after P1 noninferiority, but not after
+P1 inferiority or deployment-safety failure.
+
+## 8. Privacy, artifacts, and reporting
+
+Task, execution, ledger, split, label, feature, prediction, checkpoint, optimizer, and report-row
+artifacts remain local-only. Nothing containing titles, browsing interests, private/nonpublic
+membership, raw provider output, or model derivatives is committed.
+
+Before any checkpoint is exported or published, conduct a separate release review. Public-only
+training provenance does not by itself authorize publishing a user-specific filing model.
+Historical private-inclusive sensitivity taints all transitive outputs as private.
+
+The final report includes every tested configuration, including failures; exact source and
+protocol IDs; ledger counts before and after each gate; process weights; split retention; candidate
+recall; null reasons; all seeds; interval diagnostics; peak memory; and wall time. Allowed evidence
+language is restricted to this finite, exploratory, transductive study. “Confirmed,” “production
+gain,” “generalizes,” and “calibrated confidence” are not authorized.
+
+An honest blocked, null, noninferior, or negative result completes P1.

--- a/prototypes/mu_cosine/process_cards.py
+++ b/prototypes/mu_cosine/process_cards.py
@@ -5,35 +5,137 @@ Lossless process identity = canonical AST string + registry version (+ factory f
 supplied by callers). Cards (V0-V3) are lossy renderings for conditioning only. Embedding cache
 keys bind (ast_sha, verbosity, RENDERER_VERSION, embedding revision, prefix) — never the string.
 """
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 import hashlib
+import json
+import math
 import re
 
-RENDERER_VERSION = "r1"
-REGISTRY_VERSION = "v0.2"
+RENDERER_VERSION = "r2"
+REGISTRY_VERSION = "v0.3"
 
-# name -> (is_atom, is_operator, {kw: default}) ; longest-match lexing over these names
+
+@dataclass(frozen=True)
+class KwSpec:
+    kind: str
+    default: object = None
+    required: bool = False
+
+
+@dataclass(frozen=True)
+class Signature:
+    atom: bool
+    min_args: int | None
+    max_args: int | None
+    arg_types: tuple[str, ...] = ()
+    variadic_arg_type: str | None = None
+    kwargs: dict[str, KwSpec] = field(default_factory=dict)
+    output: str = "source"
+    modifiers: frozenset[str] = frozenset()
+
+    @property
+    def operator(self):
+        return self.min_args is not None
+
+
+def _sig(
+    *,
+    atom=False,
+    args=None,
+    arg_types=(),
+    variadic_arg_type=None,
+    kwargs=None,
+    output="source",
+    modifiers=(),
+):
+    minimum, maximum = (None, None) if args is None else args
+    if args is None and (arg_types or variadic_arg_type is not None):
+        raise ValueError("non-operator signature cannot declare positional types")
+    if args is not None:
+        if len(arg_types) < minimum:
+            raise ValueError("signature lacks a type for a required positional argument")
+        if maximum is not None and len(arg_types) > maximum:
+            raise ValueError("signature has more positional types than arguments")
+        if maximum is None and variadic_arg_type is None:
+            raise ValueError("unbounded signature requires a variadic positional type")
+    return Signature(
+        atom=atom,
+        min_args=minimum,
+        max_args=maximum,
+        arg_types=tuple(arg_types),
+        variadic_arg_type=variadic_arg_type,
+        kwargs=dict(kwargs or {}),
+        output=output,
+        modifiers=frozenset(modifiers),
+    )
+
+
+# Longest-match lexing over registered names keeps dotted model names distinct
+# from modifiers. Signatures are intentionally strict: P0 process identity must
+# fail before hashing if a factory expression has unknown or mistyped inputs.
 REGISTRY = {
-    "e5": (True, True, {}),
-    "graph": (True, True, {}),
-    "human": (True, False, {}),
-    "luna": (True, False, {}), "sonnet": (True, False, {}), "haiku": (True, False, {}),
-    "gpt-5.5-low": (True, False, {}), "gemini": (True, False, {}), "opus": (True, False, {}),
-    "routing": (False, True, {"t": None, "menus": None}),
-    "pick": (False, True, {}),
-    "kalman": (False, True, {}),
-    "blend": (False, True, {"w": None}),
-    "lineage": (False, True, {"decay": 0.85, "depth": None}),
-    "distill": (False, True, {}),
-    "menu": (False, True, {"n": None}),
-    "margin": (False, True, {"t": None}),
-    "llm": (True, False, {}),
+    "e5": _sig(atom=True, args=(1, 1), arg_types=("process",), output="score"),
+    "graph": _sig(atom=True, output="source", modifiers=("discrim",)),
+    "human": _sig(atom=True),
+    "luna": _sig(atom=True, modifiers=("D", "S")),
+    "sonnet": _sig(atom=True, modifiers=("lineage",)),
+    "haiku": _sig(atom=True),
+    "gpt-5.5-low": _sig(atom=True),
+    "gemini": _sig(atom=True),
+    "opus": _sig(atom=True),
+    "routing": _sig(
+        args=(2, 2),
+        arg_types=("score", "source"),
+        kwargs={
+            "t": KwSpec("number_list"),
+            "menus": KwSpec("int_list"),
+            "manifest": KwSpec("string"),
+        },
+        output="pick",
+    ),
+    "pick": _sig(args=(1, 1), arg_types=("target-set",), output="pick"),
+    "kalman": _sig(
+        args=(2, 2),
+        arg_types=("source", "source"),
+        output="target-set",
+    ),
+    "blend": _sig(
+        args=(2, None),
+        arg_types=("source", "source"),
+        variadic_arg_type="source",
+        kwargs={"w": KwSpec("number_list")},
+        output="target-set",
+    ),
+    "lineage": _sig(
+        args=(1, 1),
+        arg_types=("source",),
+        kwargs={
+            "decay": KwSpec("number", 0.85),
+            "depth": KwSpec("int"),
+        },
+        output="target-set",
+    ),
+    "distill": _sig(args=(1, 1), arg_types=("score",), output="target-set"),
+    "menu": _sig(
+        args=(1, 1),
+        arg_types=("source",),
+        kwargs={"n": KwSpec("int", required=True)},
+        output="target-set",
+    ),
+    "margin": _sig(
+        args=(0, 0),
+        kwargs={"t": KwSpec("number", required=True)},
+        output="score",
+    ),
+    "llm": _sig(atom=True, modifiers=("element", "subcat")),
 }
 _NAMES = sorted(REGISTRY, key=len, reverse=True)
 _MOD = re.compile(r"[A-Za-z][A-Za-z0-9_-]*")
-_NUM = re.compile(r"-?[0-9]+(\.[0-9]+)?")
+_NUM = re.compile(r"-?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?")
 _PIN = re.compile(r"[A-Za-z0-9._/-]+")
-_KW = re.compile(r"[a-z][a-z0-9_]*=")
+_KW = re.compile(r"(?P<name>[a-z][a-z0-9_]*)\s*=")
 
 
 class ParseError(ValueError):
@@ -49,71 +151,249 @@ class Node:
     pins: tuple = ()                 # provenance pins, in order
 
 
+def _skip_ws(s, i):
+    while i < len(s) and s[i].isspace():
+        i += 1
+    return i
+
+
 def _lex_name(s, i):
+    i = _skip_ws(s, i)
     for n in _NAMES:
         if s.startswith(n, i):
-            return n, i + len(n)
+            end = i + len(n)
+            if end == len(s) or s[end] in " \t\r\n(),.@=[]":
+                return n, end
     raise ParseError(f"unregistered name at {i}: {s[i:i+24]!r}")
 
 
 def _parse_val(s, i):
+    i = _skip_ws(s, i)
+    if i >= len(s):
+        raise ParseError("missing value at end of input")
     if s[i] == "[":
         out, i = [], i + 1
-        while s[i] != "]":
+        i = _skip_ws(s, i)
+        if i < len(s) and s[i] == "]":
+            return tuple(out), i + 1
+        while True:
             v, i = _parse_val(s, i)
             out.append(v)
+            i = _skip_ws(s, i)
+            if i >= len(s):
+                raise ParseError("unterminated list")
+            if s[i] == "]":
+                return tuple(out), i + 1
             if s[i] == ",":
                 i += 1
-        return tuple(out), i + 1
+                i = _skip_ws(s, i)
+                if i < len(s) and s[i] == "]":
+                    raise ParseError("trailing comma in list")
+                continue
+            raise ParseError(f"expected ',' or ']' at {i}")
     if s[i] == '"':
-        j = s.index('"', i + 1)
-        return s[i + 1:j], j + 1
+        try:
+            value, consumed = json.JSONDecoder().raw_decode(s[i:])
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise ParseError(f"invalid string at {i}: {exc}") from exc
+        if not isinstance(value, str):
+            raise ParseError(f"expected string at {i}")
+        if any(0xD800 <= ord(character) <= 0xDFFF for character in value):
+            raise ParseError(f"string contains an invalid Unicode surrogate at {i}")
+        return value, i + consumed
     m = _NUM.match(s, i)
     if m:
         t = m.group(0)
-        return (float(t) if "." in t else int(t)), m.end()
-    n, i = _lex_name(s, i)
-    return n, i
+        value = float(t) if ("." in t or "e" in t.lower()) else int(t)
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ParseError(f"non-finite number at {i}")
+        return value, m.end()
+    raise ParseError(f"expected number, list, or quoted string at {i}")
+
+
+def _value_matches(kind, value):
+    number = (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and (not isinstance(value, float) or math.isfinite(value))
+    )
+    if kind == "number":
+        return number
+    if kind == "int":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if kind == "string":
+        return (
+            isinstance(value, str)
+            and not any(0xD800 <= ord(character) <= 0xDFFF for character in value)
+        )
+    if kind == "number_list":
+        return (
+            isinstance(value, tuple)
+            and bool(value)
+            and all(_value_matches("number", item) for item in value)
+        )
+    if kind == "int_list":
+        return isinstance(value, tuple) and bool(value) and all(
+            isinstance(item, int) and not isinstance(item, bool) for item in value
+        )
+    raise AssertionError(f"unknown registry value kind: {kind}")
+
+
+def _output_matches(expected, actual):
+    return expected == "process" or expected == actual
+
+
+def _validate_signature(name, called, args, kwargs, mods):
+    signature = REGISTRY[name]
+    if called:
+        if not signature.operator:
+            raise ParseError(f"{name} is not an operator")
+        if len(args) < signature.min_args or (
+            signature.max_args is not None and len(args) > signature.max_args
+        ):
+            maximum = "unbounded" if signature.max_args is None else signature.max_args
+            raise ParseError(
+                f"{name} expects {signature.min_args}..{maximum} positional args, got {len(args)}"
+            )
+        for index, child in enumerate(args):
+            if index < len(signature.arg_types):
+                expected = signature.arg_types[index]
+            else:
+                expected = signature.variadic_arg_type
+            if expected is None:
+                raise AssertionError(f"{name} signature lacks positional type {index}")
+            actual = REGISTRY[child.name].output
+            if not _output_matches(expected, actual):
+                raise ParseError(
+                    f"{name} argument {index + 1} must be {expected}, got {actual}"
+                )
+    elif not signature.atom:
+        raise ParseError(f"{name} is not an atom")
+    seen = set()
+    for key, value in kwargs:
+        if key in seen:
+            raise ParseError(f"duplicate kwarg for {name}: {key}")
+        seen.add(key)
+        spec = signature.kwargs.get(key)
+        if spec is None:
+            raise ParseError(f"unknown kwarg for {name}: {key}")
+        if not _value_matches(spec.kind, value):
+            raise ParseError(f"{name}.{key} must be {spec.kind}")
+    missing = [
+        key for key, spec in signature.kwargs.items()
+        if spec.required and key not in seen
+    ]
+    if missing:
+        raise ParseError(f"missing required kwargs for {name}: {','.join(sorted(missing))}")
+    unknown_mods = set(mods) - signature.modifiers
+    if unknown_mods:
+        raise ParseError(f"unknown modifiers for {name}: {','.join(sorted(unknown_mods))}")
+    if len(mods) != len(set(mods)):
+        raise ParseError(f"duplicate modifier for {name}")
+    if len(mods) > 1:
+        raise ParseError(f"{name} accepts at most one modifier")
+    values = dict(kwargs)
+    if name == "routing":
+        has_thresholds = "t" in values
+        has_menus = "menus" in values
+        if has_thresholds != has_menus:
+            raise ParseError("routing.t and routing.menus must be supplied together")
+        if has_thresholds and len(values["t"]) != len(values["menus"]):
+            raise ParseError("routing.t and routing.menus must have equal lengths")
+    if name == "blend" and "w" in values and len(values["w"]) != len(args):
+        raise ParseError("blend.w must contain one weight per positional source")
 
 
 def _parse_expr(s, i):
+    i = _skip_ws(s, i)
     name, i = _lex_name(s, i)
     args, kwargs = [], []
-    if i < len(s) and s[i] == "(":
-        if not REGISTRY[name][1]:
-            raise ParseError(f"{name} is not an operator")
+    i = _skip_ws(s, i)
+    called = i < len(s) and s[i] == "("
+    if called:
         i += 1
-        while s[i] != ")":
-            if _KW.match(s, i):
-                kw = s[i:s.index("=", i)]
-                v, i = _parse_val(s, s.index("=", i) + 1)
+        i = _skip_ws(s, i)
+        while i < len(s) and s[i] != ")":
+            kw_match = _KW.match(s, i)
+            if kw_match:
+                kw = kw_match.group("name")
+                v, i = _parse_val(s, kw_match.end())
                 kwargs.append((kw, v))
             else:
                 child, i = _parse_expr(s, i)
                 args.append(child)
+            i = _skip_ws(s, i)
+            if i >= len(s):
+                raise ParseError(f"unterminated call to {name}")
             if s[i] == ",":
                 i += 1
+                i = _skip_ws(s, i)
+                if i < len(s) and s[i] == ")":
+                    raise ParseError(f"trailing comma in call to {name}")
+            elif s[i] != ")":
+                raise ParseError(f"expected ',' or ')' at {i}")
+        if i >= len(s):
+            raise ParseError(f"unterminated call to {name}")
         i += 1
-    elif not REGISTRY[name][0]:
-        raise ParseError(f"{name} is not an atom")
-    # normalize: an explicitly-written default kwarg is the same process as the elided form
-    defaults = REGISTRY[name][2]
-    kwargs = [(k, v) for k, v in kwargs if defaults.get(k) != v]
+    i = _skip_ws(s, i)
     mods, pins = [], []
-    while i < len(s) and s[i] in ".@":
-        c, i2 = s[i], i + 1
-        m = (_MOD if c == "." else _PIN).match(s, i2)
+    while i < len(s) and s[i] == ".":
+        m = _MOD.match(s, i + 1)
         if not m:
-            raise ParseError(f"bad {'modifier' if c=='.' else 'pin'} at {i2}")
-        (mods if c == "." else pins).append(m.group(0))
+            raise ParseError(f"bad modifier at {i + 1}")
+        mods.append(m.group(0))
         i = m.end()
+    while i < len(s) and s[i] == "@":
+        m = _PIN.match(s, i + 1)
+        if not m:
+            raise ParseError(f"bad pin at {i + 1}")
+        pins.append(m.group(0))
+        i = m.end()
+    _validate_signature(name, called, args, kwargs, mods)
+    # An explicitly written default is the same process as its elided form.
+    defaults = {key: spec.default for key, spec in REGISTRY[name].kwargs.items()}
+    kwargs = [(key, value) for key, value in kwargs if defaults.get(key) != value]
     return Node(name, tuple(args), tuple(sorted(kwargs)), tuple(mods), tuple(pins)), i
 
 
 def parse(text):
-    node, i = _parse_expr(text.replace(" ", ""), 0)
-    if i != len(text.replace(" ", "")):
+    if not isinstance(text, str) or not text.strip():
+        raise ParseError("expression must be a nonempty string")
+    node, i = _parse_expr(text, 0)
+    i = _skip_ws(text, i)
+    if i != len(text):
         raise ParseError(f"trailing input at {i}")
+    return node
+
+
+def validate(node):
+    """Fail closed on a parsed or programmatically constructed process AST."""
+    if not isinstance(node, Node):
+        raise ParseError("process AST must contain Node instances")
+    if not isinstance(node.name, str) or node.name not in REGISTRY:
+        raise ParseError(f"unregistered node name: {node.name!r}")
+    if not isinstance(node.args, tuple) or not isinstance(node.kwargs, tuple):
+        raise ParseError(f"{node.name} args and kwargs must be tuples")
+    if not isinstance(node.mods, tuple) or not isinstance(node.pins, tuple):
+        raise ParseError(f"{node.name} modifiers and pins must be tuples")
+    for child in node.args:
+        validate(child)
+    for item in node.kwargs:
+        if not (
+            isinstance(item, tuple)
+            and len(item) == 2
+            and isinstance(item[0], str)
+        ):
+            raise ParseError(f"{node.name} has a malformed kwarg")
+    for modifier in node.mods:
+        if not isinstance(modifier, str) or _MOD.fullmatch(modifier) is None:
+            raise ParseError(f"{node.name} has a malformed modifier")
+    for pin in node.pins:
+        if not isinstance(pin, str) or _PIN.fullmatch(pin) is None:
+            raise ParseError(f"{node.name} has a malformed provenance pin")
+    signature = REGISTRY[node.name]
+    called = bool(node.args or node.kwargs) or (signature.operator and not signature.atom)
+    _validate_signature(node.name, called, node.args, node.kwargs, node.mods)
     return node
 
 
@@ -121,23 +401,39 @@ def _render_val(v):
     if isinstance(v, tuple):
         return "[" + ",".join(_render_val(x) for x in v) + "]"
     if isinstance(v, float):
-        return f"{v:g}"
+        if not math.isfinite(v):
+            raise ValueError("cannot render non-finite process value")
+        return repr(v)
+    if isinstance(v, str):
+        return json.dumps(v, ensure_ascii=False, separators=(",", ":"))
     return str(v)
+
+
+def _validate_verbosity(verbosity):
+    if isinstance(verbosity, bool) or not isinstance(verbosity, int) or not 0 <= verbosity <= 3:
+        raise ValueError("verbosity must be one of 0, 1, 2, or 3")
 
 
 def render(node, verbosity=3):
     """V1: names+structure, kwargs elided. V2: + non-default kwargs. V3: + pins. V0: ''. Lossless
     canonical = V3 plus default kwargs made explicit (identity string)."""
+    validate(node)
+    _validate_verbosity(verbosity)
     if verbosity == 0:
         return ""
     kw = ""
     if verbosity >= 2:
-        defaults = REGISTRY[node.name][2]
+        defaults = {
+            key: spec.default for key, spec in REGISTRY[node.name].kwargs.items()
+        }
         kept = [(k, v) for k, v in node.kwargs if defaults.get(k) != v]
         if kept:
             kw = ("," if node.args else "") + ",".join(f"{k}={_render_val(v)}" for k, v in kept)
     inner = ",".join(render(a, verbosity) for a in node.args)
-    s = node.name + (f"({inner}{kw})" if (node.args or kw) else "")
+    called = bool(node.args or kw) or (
+        REGISTRY[node.name].operator and not REGISTRY[node.name].atom
+    )
+    s = node.name + (f"({inner}{kw})" if called else "")
     s += "".join("." + m for m in node.mods)
     if verbosity >= 3:
         s += "".join("@" + p for p in node.pins)
@@ -146,7 +442,10 @@ def render(node, verbosity=3):
 
 def canonical(node):
     """Lossless identity string: V3 rendering with ALL kwargs explicit (defaults resolved)."""
-    defaults = dict(REGISTRY[node.name][2])
+    validate(node)
+    defaults = {
+        key: spec.default for key, spec in REGISTRY[node.name].kwargs.items()
+    }
     kws = dict(defaults)
     kws.update(dict(node.kwargs))
     kw = ",".join(f"{k}={_render_val(v)}" for k, v in sorted(kws.items()) if v is not None)
@@ -162,6 +461,7 @@ def ast_sha(node):
 
 
 def embedding_cache_key(node, verbosity, e5_revision, prefix="passage"):
+    _validate_verbosity(verbosity)
     return hashlib.sha256("|".join(
         [ast_sha(node), str(verbosity), RENDERER_VERSION, e5_revision, prefix]
     ).encode()).hexdigest()[:16]

--- a/prototypes/mu_cosine/process_expression_p1_protocol.py
+++ b/prototypes/mu_cosine/process_expression_p1_protocol.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Validate the frozen process-expression P1 preregistration contract."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, Mapping
+
+from process_cards import REGISTRY_VERSION, RENDERER_VERSION, canonical, parse
+from routed_policy import canonical_json_bytes, strict_json_loads
+
+
+ROOT = Path(__file__).resolve().parent
+PREREG_PATH = ROOT / "PROCESS_EXPRESSION_P1_PREREG.json"
+SCHEMA = "unifyweaver.process-expression-p1-prereg.v1"
+
+
+class ProtocolError(ValueError):
+    """The process-expression P1 contract is malformed or has drifted."""
+
+
+def _require(condition: bool, message: str):
+    if not condition:
+        raise ProtocolError(message)
+
+
+def _full_process_digest(expression: str) -> str:
+    node = parse(expression)
+    return hashlib.sha256(
+        f"{REGISTRY_VERSION}|{canonical(node)}".encode("utf-8")
+    ).hexdigest()
+
+
+def _prereg_id(document: Mapping[str, Any]) -> str:
+    core = dict(document)
+    core.pop("prereg_id", None)
+    return hashlib.sha256(canonical_json_bytes(core)).hexdigest()
+
+
+def load_and_verify(path: str | Path = PREREG_PATH) -> dict[str, Any]:
+    path = Path(path)
+    try:
+        document = strict_json_loads(path.read_bytes(), source=str(path))
+    except (OSError, ValueError) as exc:
+        if isinstance(exc, ProtocolError):
+            raise
+        raise ProtocolError(f"cannot load P1 preregistration: {exc}") from exc
+    _require(isinstance(document, dict), "preregistration must be a JSON object")
+    _require(document.get("schema") == SCHEMA, "unsupported preregistration schema")
+
+    protocol_path = path.parent / document.get("protocol_path", "")
+    _require(protocol_path.is_file(), "protocol document is missing")
+    protocol_sha = hashlib.sha256(protocol_path.read_bytes()).hexdigest()
+    _require(
+        document.get("protocol_sha256") == protocol_sha,
+        "protocol document hash differs from preregistration",
+    )
+
+    source = document.get("required_source_contract", {})
+    _require(source.get("task_schema") == "unifyweaver.routed-task.v2", "task v2 required")
+    _require(source.get("picks_schema") == "unifyweaver.routed-picks.v2", "picks v2 required")
+    _require(
+        source.get("execution_bundle_schema")
+        == "unifyweaver.routed-execution-bundle.v1",
+        "execution bundle v1 required",
+    )
+    _require(
+        source.get("privacy_policy_id") == "pearltrees-public-only-v1",
+        "public-only privacy policy required",
+    )
+    _require(
+        source.get("catalog_policy_id")
+        == "pearltrees-public-alphanumeric-title-v1",
+        "public catalog policy required",
+    )
+    _require(
+        source.get("missing_bundle_outcome")
+        == "blocked_no_eligible_v2_labels",
+        "missing eligible labels must block",
+    )
+    _require(
+        document.get("legacy_sources", {}).get("legacy_unbound_picks_authorized") is False,
+        "legacy picks must remain unauthorized",
+    )
+    _require(
+        document.get("legacy_sources", {}).get("private_inclusive_sources_authorized") is False,
+        "private-inclusive sources must remain unauthorized",
+    )
+
+    identity = document.get("process_identity", {})
+    _require(identity.get("digest_hex_length") == 64, "full process SHA-256 required")
+    _require(identity.get("compact_ast_sha_is_identity") is False, "compact AST hash is not identity")
+    _require(
+        identity.get("registry_version") == REGISTRY_VERSION,
+        "process registry version drifted",
+    )
+    _require(
+        identity.get("renderer_version") == RENDERER_VERSION,
+        "process renderer version drifted",
+    )
+    processes = identity.get("processes")
+    _require(isinstance(processes, dict) and len(processes) == 4, "four P1 processes required")
+    process_digests = {}
+    process_canonicals = {}
+    for name, record in sorted(processes.items()):
+        _require(isinstance(name, str) and isinstance(record, dict), "invalid process entry")
+        expression = record.get("expression")
+        _require(isinstance(expression, str), "process expression is missing")
+        process_canonicals[name] = canonical(parse(expression))
+        _require(
+            record.get("canonical") == process_canonicals[name],
+            f"canonical process drifted for {name}",
+        )
+        process_digests[name] = _full_process_digest(expression)
+        _require(len(process_digests[name]) == 64, "process digest is truncated")
+        _require(
+            record.get("sha256") == process_digests[name],
+            f"full process digest drifted for {name}",
+        )
+    _require(len(set(process_digests.values())) == len(process_digests), "process identities collide")
+
+    ledger = document.get("ledger", {})
+    _require(
+        ledger.get("recorded_destination_in_training_ledger") is False,
+        "training ledger must exclude recorded destinations",
+    )
+    _require(
+        ledger.get("all_process_rows_for_query_share_split") is True,
+        "process-complete query grouping required",
+    )
+    _require(ledger.get("null_primary_ranking_loss") == "excluded", "null loss rule drifted")
+    _require(ledger.get("process_total_training_mass") == "equal", "process weighting drifted")
+
+    split = document.get("split", {})
+    _require(split.get("function") == "node_disjoint_pair_split", "wrong split function")
+    _require(split.get("outer_seed") == 3980001, "outer seed drifted")
+    _require(split.get("held_node_fraction") == 0.4, "held fraction drifted")
+    _require(split.get("candidate_assignments") == 64, "split search drifted")
+    _require(split.get("cross_rows") == "excluded", "cross rows must be excluded")
+
+    training = document.get("training", {})
+    _require(training.get("seeds") == [3980101, 3980102, 3980103], "training seeds drifted")
+    _require(
+        training.get("arms") == ["expression", "flat", "merged", "shuffled"],
+        "training arms drifted",
+    )
+    _require(training.get("matched_budget_across_arms") is True, "arm budgets must match")
+    _require(
+        training.get("training_plan_required_before_fit") is True,
+        "training plan must precede fitting",
+    )
+    _require(training.get("shuffled_train_permutations") == 5, "shuffle count drifted")
+    probs = training.get("verbosity_probabilities", {})
+    _require(set(probs) == {"V0", "V1", "V2", "V3"}, "verbosity levels drifted")
+    _require(abs(sum(float(value) for value in probs.values()) - 1.0) < 1e-12, "verbosity mass != 1")
+    _require(
+        probs == {"V0": 0.1, "V1": 0.6, "V2": 0.25, "V3": 0.05},
+        "verbosity probabilities drifted",
+    )
+
+    primary = document.get("primary", {})
+    _require(primary.get("metric") == "exact-destination-mrr", "primary metric drifted")
+    _require(primary.get("contrast") == "expression-minus-flat", "primary contrast drifted")
+    _require(
+        primary.get("superiority", {}).get("minimum_point_gain") == 0.01,
+        "practical floor drifted",
+    )
+    _require(
+        primary.get("superiority", {}).get("interval_lower_strictly_greater_than")
+        == 0.0,
+        "superiority interval gate drifted",
+    )
+    _require(
+        primary.get("noninferiority_classification_only", {}).get("interval_lower_at_least")
+        == -0.005,
+        "noninferiority margin drifted",
+    )
+    _require(
+        primary.get("noninferiority_classification_only", {}).get("counts_as_superiority")
+        is False,
+        "noninferiority must not count as superiority",
+    )
+    _require(primary.get("e5_deployment_safety_margin") == -0.01, "e5 safety margin drifted")
+    bootstrap = primary.get("bootstrap", {})
+    _require(bootstrap.get("function") == "paired_node_bootstrap_ci", "bootstrap drifted")
+    _require(bootstrap.get("resamples") == 9999, "bootstrap count drifted")
+    _require(bootstrap.get("seed") == 3980999, "bootstrap seed drifted")
+    _require(bootstrap.get("confidence") == 0.95, "bootstrap confidence drifted")
+    _require(
+        bootstrap.get("minimum_endpoint_components_for_decision") == 20,
+        "bootstrap component floor drifted",
+    )
+
+    policy = document.get("primary_policy_process", {})
+    _require(policy.get("margin_lt_0.02") == "sonnet_lineage_n10", "low-band policy drifted")
+    _require(
+        policy.get("margin_ge_0.02_lt_0.03") == "sonnet_lineage_n20",
+        "middle-band policy drifted",
+    )
+    _require(policy.get("margin_ge_0.03") == "e5_auto", "high-band policy drifted")
+
+    multiplicity = document.get("multiplicity", {})
+    _require(
+        multiplicity.get("expression_vs_flat_is_only_decision_bearing_contrast") is True,
+        "primary multiplicity rule drifted",
+    )
+    _require(
+        multiplicity.get("secondary_results_are_descriptive") is True,
+        "secondary analyses must remain descriptive",
+    )
+    _require(
+        multiplicity.get("p3_cannot_retroactively_change_p1") is True,
+        "P3 must not retroactively change P1",
+    )
+
+    _require(document.get("prereg_id") == _prereg_id(document), "preregistration ID mismatch")
+    document["_derived_process_sha256"] = process_digests
+    document["_derived_process_canonical"] = process_canonicals
+    return document
+
+
+def main():
+    document = load_and_verify()
+    print(document["prereg_id"])
+    for name, digest in document["_derived_process_sha256"].items():
+        print(f"{name}\t{digest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/test_process_cards.py
+++ b/prototypes/mu_cosine/test_process_cards.py
@@ -1,14 +1,41 @@
 """P0 acceptance tests: parse-the-spec, round-trip, identity/card split, determinism."""
 import pytest
 
-from process_cards import (PROCESSES, ParseError, ast_sha, canonical,
-                           embedding_cache_key, parse, render)
+from process_cards import (
+    PROCESSES,
+    REGISTRY,
+    REGISTRY_VERSION,
+    RENDERER_VERSION,
+    Node,
+    ParseError,
+    ast_sha,
+    canonical,
+    embedding_cache_key,
+    parse,
+    render,
+    validate,
+)
 
 
 def test_registry_parses_every_registered_process():
     for name, expr in PROCESSES.items():
         node = parse(expr)
         assert parse(render(node, 3)) == node, name          # round-trip at V3
+
+
+def test_registry_parses_all_three_spec_cards():
+    examples = [
+        "e5(routing(e5, sonnet))",
+        "e5(routing(e5, sonnet.lineage, t=[0.02,0.03], menus=[10,20]))",
+        (
+            'e5(routing(e5@e5-small-v2, '
+            'sonnet.lineage@2026-07-23/menu-order-blind, '
+            't=[0.02,0.03], menus=[10,20], manifest="fcf5e1d6"))'
+        ),
+    ]
+    for expression in examples:
+        node = parse(expression)
+        assert parse(render(node, 3)) == node
 
 
 def test_dotted_and_hyphen_dot_names():
@@ -47,3 +74,104 @@ def test_fail_closed():
         parse("routing")                                     # operator used as atom
     with pytest.raises(ParseError):
         parse("human(e5)")                                   # atom used as operator
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "e5()",                                              # arity
+        "kalman()",                                          # arity
+        "kalman(margin(t=0.1),luna.S)",                      # positional type
+        "lineage(graph,bogus=1)",                            # unknown kwarg
+        "lineage(graph,depth=1,depth=2)",                    # duplicate kwarg
+        "lineage(graph,depth=1.5)",                          # wrong kwarg type
+        "routing(e5,sonnet,t=[0.02],menus=[10.5])",          # wrong list type
+        "routing(e5,sonnet,t=[],menus=[10])",                # empty typed list
+        "routing(e5,sonnet,t=[0.02])",                       # paired kwargs
+        "routing(e5,sonnet,t=[0.02],menus=[10,20])",         # paired lengths
+        "blend(luna.D,luna.S,w=[1])",                        # one weight per source
+        "sonnet.unknown",                                    # unknown modifier
+        "luna.D.S",                                          # mutually exclusive modifiers
+        "luna.D.D",                                          # duplicate modifier
+        "routing(e5,sonnet,t=[0.02,],menus=[10])",           # trailing list comma
+        "routing(e5,sonnet,t=[0.02],menus=[10],)",           # trailing call comma
+    ],
+)
+def test_typed_registry_rejects_malformed_expressions(expression):
+    with pytest.raises(ParseError):
+        parse(expression)
+
+
+def test_strings_and_whitespace_round_trip_without_content_loss():
+    expression = (
+        'e5(routing(e5, sonnet.lineage, t = [0.02, 0.03], '
+        'menus = [10, 20], manifest = "hash with \\"quoted\\" space"))'
+    )
+    node = parse(expression)
+    rendered = render(node, 3)
+    assert '"hash with \\"quoted\\" space"' in rendered
+    assert parse(rendered) == node
+
+
+def test_float_canonicalization_is_lossless_and_collision_resistant():
+    first = parse("lineage(graph,decay=0.12345671)")
+    second = parse("lineage(graph,decay=0.12345672)")
+    assert canonical(first) != canonical(second)
+    assert ast_sha(first) != ast_sha(second)
+    for expression in (
+        "lineage(graph,decay=1.0000001)",
+        "lineage(graph,decay=1234567.1)",
+        "lineage(graph,decay=1e-12)",
+    ):
+        node = parse(expression)
+        assert parse(render(node, 3)) == node
+        assert parse(canonical(node)) == node
+
+
+def test_nonfinite_numeric_input_fails_closed():
+    with pytest.raises(ParseError, match="non-finite"):
+        parse("lineage(graph,decay=1e9999)")
+
+
+def test_invalid_unicode_string_fails_before_identity_hashing():
+    with pytest.raises(ParseError, match="Unicode surrogate"):
+        parse('routing(e5,sonnet,manifest="\\ud800")')
+
+
+@pytest.mark.parametrize("verbosity", [-1, 4, True, 1.5])
+def test_invalid_verbosity_fails_closed(verbosity):
+    node = parse("kalman(luna.D,luna.S)")
+    with pytest.raises(ValueError, match="verbosity"):
+        render(node, verbosity)
+    with pytest.raises(ValueError, match="verbosity"):
+        embedding_cache_key(node, verbosity, "rev-a")
+
+
+def test_programmatic_nodes_are_validated_before_render_or_hash():
+    malformed = Node("kalman", (Node("human"),))
+    with pytest.raises(ParseError, match="expects"):
+        validate(malformed)
+    with pytest.raises(ParseError, match="expects"):
+        canonical(malformed)
+    with pytest.raises(ParseError, match="expects"):
+        ast_sha(malformed)
+    with pytest.raises(ParseError, match="unregistered"):
+        validate(Node([], ()))
+    with pytest.raises(ParseError, match="malformed modifier"):
+        validate(Node("luna", mods=([],)))
+    with pytest.raises(ParseError, match="must be string"):
+        ast_sha(
+            Node(
+                "routing",
+                (Node("e5"), Node("sonnet")),
+                (("manifest", "\ud800"),),
+            )
+        )
+
+
+def test_registry_is_versioned_and_has_typed_signatures():
+    assert REGISTRY_VERSION == "v0.3"
+    assert RENDERER_VERSION == "r2"
+    assert REGISTRY["routing"].arg_types == ("score", "source")
+    assert REGISTRY["routing"].kwargs["manifest"].kind == "string"
+    assert REGISTRY["routing"].output == "pick"

--- a/prototypes/mu_cosine/test_process_expression_p1_protocol.py
+++ b/prototypes/mu_cosine/test_process_expression_p1_protocol.py
@@ -1,0 +1,120 @@
+"""Enforcement tests for the prospective process-expression P1 contract."""
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from process_cards import ast_sha, parse
+from process_expression_p1_protocol import (
+    PREREG_PATH,
+    ProtocolError,
+    _full_process_digest,
+    _prereg_id,
+    load_and_verify,
+)
+
+
+def _document():
+    return json.loads(PREREG_PATH.read_text(encoding="utf-8"))
+
+
+def _write_fixture(tmp_path, document, protocol_bytes=None):
+    source_protocol = PREREG_PATH.with_name(document["protocol_path"])
+    protocol_bytes = protocol_bytes if protocol_bytes is not None else source_protocol.read_bytes()
+    protocol = tmp_path / document["protocol_path"]
+    protocol.write_bytes(protocol_bytes)
+    document["protocol_sha256"] = hashlib.sha256(protocol_bytes).hexdigest()
+    document["prereg_id"] = _prereg_id(document)
+    path = tmp_path / PREREG_PATH.name
+    path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def test_committed_preregistration_verifies():
+    document = load_and_verify()
+    assert document["primary"]["contrast"] == "expression-minus-flat"
+    assert len(document["_derived_process_sha256"]) == 4
+
+
+def test_process_identity_is_full_registry_bound_sha():
+    document = load_and_verify()
+    for name, record in document["process_identity"]["processes"].items():
+        expression = record["expression"]
+        full = _full_process_digest(expression)
+        assert len(full) == 64
+        assert full.startswith(ast_sha(parse(expression)))
+        assert record["sha256"] == full
+        assert record["canonical"] == document["_derived_process_canonical"][name]
+        assert document["_derived_process_sha256"][name] == full
+
+
+@pytest.mark.parametrize(
+    "mutation, message",
+    [
+        (
+            lambda d: d["legacy_sources"].update(legacy_unbound_picks_authorized=True),
+            "legacy picks",
+        ),
+        (
+            lambda d: d["primary"].update(contrast="expression-minus-merged"),
+            "primary contrast",
+        ),
+        (
+            lambda d: d["split"].update(outer_seed=1),
+            "outer seed",
+        ),
+        (
+            lambda d: d["training"].update(seeds=[1, 2, 3]),
+            "training seeds",
+        ),
+        (
+            lambda d: d["process_identity"].update(registry_version="v0.0"),
+            "registry version",
+        ),
+        (
+            lambda d: d["process_identity"]["processes"]["e5_auto"].update(
+                sha256="0" * 64
+            ),
+            "full process digest",
+        ),
+        (
+            lambda d: d["required_source_contract"].update(
+                catalog_policy_id="private-inclusive"
+            ),
+            "public catalog policy",
+        ),
+        (
+            lambda d: d["primary"]["noninferiority_classification_only"].update(
+                counts_as_superiority=True
+            ),
+            "must not count as superiority",
+        ),
+    ],
+)
+def test_resealed_material_mutations_still_fail(tmp_path, mutation, message):
+    document = _document()
+    mutation(document)
+    path = _write_fixture(tmp_path, document)
+    with pytest.raises(ProtocolError, match=message):
+        load_and_verify(path)
+
+
+def test_protocol_text_tamper_fails_without_resealing(tmp_path):
+    document = _document()
+    path = _write_fixture(tmp_path, document)
+    protocol = path.with_name(document["protocol_path"])
+    protocol.write_bytes(protocol.read_bytes() + b"\nchanged\n")
+    with pytest.raises(ProtocolError, match="protocol document hash"):
+        load_and_verify(path)
+
+
+def test_preregistration_id_tamper_fails(tmp_path):
+    document = _document()
+    path = _write_fixture(tmp_path, document)
+    changed = json.loads(path.read_text(encoding="utf-8"))
+    changed["prereg_id"] = "0" * 64
+    path.write_text(json.dumps(changed, indent=2) + "\n", encoding="utf-8")
+    with pytest.raises(ProtocolError, match="ID mismatch"):
+        load_and_verify(path)


### PR DESCRIPTION
## Summary

- Freeze the prospective P1 process-expression distillation protocol and machine-readable preregistration.
- Require verified public-only v2 task, pick, and execution bundles before constructing the primary ledger.
- Define the primary expression-versus-flat-token MRR contrast, practical gain floor, node-block interval, three training seeds, matched budgets, and e5 rollback rule.
- Harden the P0 parser from #3980 with genuinely typed positional signatures, strict arity/keyword/modifier validation, lossless numeric and string canonicalization, full AST validation, and version-bound process identities.
- Reconcile the process-expression design documents with the prospective protocol.

## Scientific boundary

The historical 1,895 process-target records are `legacy_unbound` and included nonpublic candidates. They cannot be retroactively upgraded into v2/public-only evidence.

They may be used only for a separately labeled, local-only descriptive sensitivity analysis. Primary P1 must either construct a new ledger from verified public-only bundles or stop with `blocked_no_eligible_v2_labels`.

P1 remains exploratory and transductive. Superiority requires:

- expression-minus-flat held MRR ≥ +0.01; and
- a paired typed-node-block 95% interval with lower endpoint greater than zero.

Noninferiority does not count as P1 success and cannot be retroactively promoted by P3.

The existing margin bands are frozen routing inputs, not calibrated probabilities; this PR does not retune them or authorize a calibrated-confidence claim.

## P0 hardening

- Pin registry version, renderer version, canonical expressions, and full SHA-256 identities.
- Validate positional output types and cross-field constraints.
- Reject malformed calls, unknown or duplicate keywords, invalid modifiers, nonfinite numbers, Unicode surrogates, and invalid programmatic ASTs before hashing.
- Preserve spaces and escapes in quoted strings.
- Use lossless float rendering, including exponent notation.
- Clarify that only V3/canonical identities round-trip; V0–V2 cards are intentionally lossy conditioning views.

## Verification

- 67 focused process-card, preregistration, routed-policy, and routed-execution tests pass.
- Python 3.8 compilation passes.
- Preregistration hash and all four full process identities reproduce deterministically.

## Coordination

The engineering lane may implement the ledger builder next, but should not queue the 12 training runs until the eligibility verifier finds usable public-only v2 bundles and the resulting ledger is frozen.