### PR TITLE
docs(mu_cosine): process-expression polish + future-work encoder/position-encoding designs

### DIFF
--- a/docs/design/ARCHITECTURE_filing_engine.md
+++ b/docs/design/ARCHITECTURE_filing_engine.md
@@ -174,6 +174,7 @@ resolution column is a compact evidence contract, not a protocol.
 | 9 | OPENQ-009 | `OPEN` | Which measured corpus properties predict when multipath teaching and gating help? | **Owner: rigor-lane.** Use structural multiplicity/path counts plus leakage-free conditional `R²`, not raw correlation. |
 | 10 | OPENQ-010 | `OPEN` | Do per-distance and dual-space bias states generalize, and what is the state-level `R_c`? | **Owner: rigor-lane.** Separate `R̂_row` from `R_c` with replicated/cross-fitted effects and require held global benefit. |
 | 11 | OPENQ-011 | `OPEN` | Can the operative historical e5 artifacts be given exact revision provenance? | **Owner: engineering-lane.** Regenerate or attest caches with exact Hugging Face commit, text/prefix contract, normalization, node order, and hashes. |
+| 12 | OPENQ-012 | `OPEN` | Does process-expression conditioning transfer across corpora (Pearltrees → SimpleMind → Wikipedia → unseen), not just across held-out compositions? | **Owner: rigor-lane; implementation: engineering-lane.** The P1 gate is single-corpus by design; the forest-level claim needs a preregistered cross-corpus LOCO arm (hold out a CORPUS under fixed expressions) on the three task-matched harnesses (`filing_assistant.py`, `sm_filing_hits.py`, `wiki_multiparent_hits.py`). Registered per the 2026-07-24 review discussion so a borderline P1 cannot silently drop the generalization question. |
 
 ## Evidence index
 

--- a/prototypes/mu_cosine/DESIGN_expression_encoder_future.md
+++ b/prototypes/mu_cosine/DESIGN_expression_encoder_future.md
@@ -1,0 +1,75 @@
+# Expression Encoder–Decoder (FUTURE WORK — do not schedule before the P1 gate)
+
+**Status: future-work design capture, 2026-07-24.** Not part of the current P0–P4 ladder and not
+to interrupt the frozen P1 protocol (#3982's rigor contract). Sits at "P3.5": pursue only if
+P1 passes (expression conditioning earns its keep) AND P3's deterministic composition plateaus.
+Self-contained enough to hand to a separate agent with spare inference; the handoff needs only
+this doc, the companion `DESIGN_tree_position_encoding_theory.md`, and the current-art references
+below.
+
+## Current art (what exists today, and its limits)
+
+- `DESIGN_process_expression_{language,philosophy,implementation}.md` + `process_cards.py` (P0,
+  PR #3980): the process-expression grammar with registry-driven lexing. **Today the grammar is
+  used ONLY for canonicalization and token identification** — lossless identity (canonical AST +
+  ast_sha) and deterministic card rendering (V0–V3). "Self-parsing" in #3980 means only that the
+  parser must parse the spec's own examples (acceptance test), not a formal novelty.
+- Embedding today: rendered card string → frozen e5 → NameFunctionCond residual. The
+  implementation doc flags e5-on-formal-strings as a leap of faith at V2/V3; P2 adds an
+  NL-template arm to test it.
+- P3 (planned): DETERMINISTIC composition — node embedding = card-e5(operator) + Σ fixed
+  position-weighted child embeddings; stochastic elements seeded by SHA-256 of the canonical AST.
+  No learning anywhere in the composition.
+- `ARCHITECTURE_filing_engine.md` rows this feeds: FUSE-003 (name-conditioned identity — the
+  motivation), OPENQ-012 (cross-corpus transfer of process conditioning — the forest question).
+
+## The proposal (owner's design, from the 2026-07-24 Perplexity/Sonnet-5 discussion)
+
+A small transformer over the PARSED, TOKENIZED, CANONICALIZED expression, trained with a dual
+objective:
+
+```
+canonical AST ──tokenize──▶ transformer encoder ──▶ latent z
+                                        ├─▶ MLP alignment head  → ê5(card)   (match frozen e5 of the rendered card)
+                                        └─▶ cotrained decoder   → canonical string (reconstruction)
+```
+
+1. **Alignment head:** keeps z anchored to e5's semantic space — the μ-stack's conditioning
+   pathway (NameFunctionCond's W) continues to work unchanged, consuming ê5 instead of e5.
+2. **Reconstruction decoder:** forces z to preserve the compositional structure e5 may collapse
+   (the V2/V3 leap-of-faith risk). Structural echo worth preserving in any implementation: the
+   decoder enforces exactly the language spec's LOSSLESS-IDENTITY vs LOSSY-CARD split — z is the
+   identity, the alignment head's output is the card.
+3. **Variant:** CLIP-style contrastive training between (formal-expression encoding, NL-template
+   rendering fed to e5) instead of a fixed MLP map — learns WHICH structural distinctions are
+   semantically meaningful to e5 rather than assuming a mapping.
+
+## Why training cost is smaller than it looks
+
+The encoder/decoder pretrain ENTIRELY SYNTHETICALLY: the grammar + registry generate unlimited
+valid expressions (combinatorial composition of operators, judges, kwargs); e5-small alignment
+targets cost one cheap inference pass per sample. Judge labels are needed only for the downstream
+μ-head fine-tune, which is the small real ledger P1 already uses. The expensive open question is
+coverage: how many synthetic samples before the compositional space is dense enough that unseen
+real expressions interpolate.
+
+## Why this could matter (the generalization argument)
+
+e5 generalizes over strings by surface similarity; a trained expression encoder generalizes over
+PROGRAMS by structure. If OPENQ-012's cross-corpus arm shows expression conditioning transfers,
+this encoder is the natural next step — compositional generalization to unseen process
+combinations (`kalman(sonnet.D, luna.S)` never seen, both parents seen) is precisely what the
+reconstruction objective buys and what surface-string e5 cannot.
+
+## Gates and sequencing (explicit, to protect the current lanes)
+
+1. P1 frozen primary must pass (expressions vs flat tokens). If it fails, this direction is moot.
+2. P3 deterministic superposition must be tried first; this design activates on plateau.
+3. The position-encoding component is specified separately in
+   `DESIGN_tree_position_encoding_theory.md` (depth⊗breadth factorization; Kronecker vs
+   convolution; learned bilinear recommendation) — the encoder should adopt whichever variant
+   that doc's ablation ladder selects.
+4. Evaluation inherits the amended P3 protocol: multi-process LOCO + cross-corpus LOCO
+   (OPENQ-012), against the four controls (frozen-string e5, additive bag-of-nodes, flat token,
+   unconditional) — plus one new control: NL-template e5 (P2's arm), which is the strongest
+   no-new-architecture baseline this design must beat to justify its cost.

--- a/prototypes/mu_cosine/DESIGN_process_expression_implementation.md
+++ b/prototypes/mu_cosine/DESIGN_process_expression_implementation.md
@@ -4,6 +4,20 @@ Phased, each phase independently shippable with a measurable exit criterion. Reu
 card→e5→NameFunctionCond pathway already exists (judge onboarding at r=0); phase 1 adds no
 architecture.
 
+## Reader's key (external-review shorthand + glossary)
+
+"Finding N" = gpt-5.6-sol's review of #3974 (amended in #3978): 1 grammar self-parse, 2 identity
+vs cards, 3 NameFunctionCond honesty, 4 row ledger/estimand, 5 exploratory-only manifest,
+6 zero-init ≠ floor, 7 frozen primary, 8 not-MDL naming, 9 multi-process LOCO. "r2 item N" =
+sol's follow-up: 1 lexical gaps, 2 flat-token primary, 3 deterministic composition.
+
+Glossary — **legacy_unbound**: pre-v2 task/pick artifacts without content-bound hashes;
+descriptive evidence only, never upgradeable. **v2 bundle**: content-bound task+pick envelope
+(routed_policy.py) binding catalog, privacy index, policy tier, judge contract, and byte hashes.
+**node-block bootstrap**: resampling typed (bookmark, folder) identity blocks — never individual
+process rows — so dependence between rows sharing a node is respected (#3845 machinery).
+**process-complete split**: every process rendering of a query lives on the same split side.
+
 ## P0 — expression module (`process_cards.py`)
 
 - AST for the v0 grammar (spec doc), the TYPED OPERATOR-SIGNATURE REGISTRY (versioned; arity,
@@ -70,6 +84,11 @@ cohort with a structurally frozen catalog, collected AFTER this design is fixed.
 - Retrain P1-arm-(a) at fixed single verbosities V1/V2/V3 and at 3 mixture profiles; SELECT on an
   inner validation split, report once on held (never select on the reported set). Token counts
   under the pinned e5 tokenizer revision.
+- **NL-template arm (2026-07-24 review):** e5 embedding a formal bracketed string is a leap of
+  faith — e5 was trained on natural language. Add one arm rendering the SAME canonical AST as a
+  natural-language template ("sonnet judge with lineage context, menus of 10 and 20, thresholds
+  0.02/0.03") and compare against the formal V2 card at matched information content. This
+  promotes the risk-section fallback to a tested primary design choice.
 - Deliverable: the gain-per-token curve — the empirical answer to "how specific should the
   language be", and the tuned training mixture (replacing the indicative 60/25/5/10).
 - Exit: a chosen default profile with the curve as justification, recorded in the report.
@@ -86,6 +105,11 @@ cohort with a structurally frozen catalog, collected AFTER this design is fixed.
   haiku@N10, kalman(luna.D, luna.S), one lineage-decay variant} — each evaluated against four
   controls: frozen-string e5 card, additive bag-of-nodes embedding, cold flat token, and
   unconditional. Report per-held-process and pooled.
+- **Cross-corpus LOCO arm (OPENQ-012, preregistered here):** composition-level LOCO answers
+  generalization across PROCESSES; the program's forest-level question is generalization across
+  CORPORA. Hold out a corpus (Pearltrees / SimpleMind / wiki — the three task-matched harnesses)
+  under fixed expressions and measure whether expression conditioning transfers better than flat
+  tokens. Additive arm; does not modify the frozen P1 primary.
 - Exit: pooled zero-shot conditioned > unconditional AND > cold flat token across the LOCO set
   (not just one favorable sibling).
 

--- a/prototypes/mu_cosine/DESIGN_process_expression_language.md
+++ b/prototypes/mu_cosine/DESIGN_process_expression_language.md
@@ -93,6 +93,29 @@ position-weighted child embeddings (the `random_operator_embedding` superpositio
 small learned tree encoder — so UNSEEN compositions (swap a judge, move a threshold) land near
 their relatives and can be conditioned on zero-shot.
 
+## Worked example (round trip)
+
+Input (any whitespace/default spelling): `e5( routing(e5, sonnet.lineage, t=[0.02,0.03], menus=[10,20]) )@fcf5e1d6`
+
+1. **Parse** (registry-driven lexing: `sonnet` is a Name token; `.lineage` a Mod; `@fcf5e1d6` a Pin)
+   → frozen AST; explicit-default kwargs are normalized away at parse.
+2. **Canonical identity string** (lossless — resolved defaults explicit, pins always present):
+   `e5(routing(e5,sonnet.lineage,menus=[10,20],t=[0.02,0.03]))@fcf5e1d6` → `ast_sha` (bound to
+   REGISTRY_VERSION) is the process identity, alongside the factory/manifest fingerprint.
+3. **Cards** (lossy conditioning views):
+   - V0: `` (empty — agnostic row)
+   - V1: `e5(routing(e5,sonnet.lineage))` — kwargs elided, the equivalence-class card
+   - V2: `e5(routing(e5,sonnet.lineage,menus=[10,20],t=[0.02,0.03]))` — decision-relevant knobs
+   - V3: V2 + `@fcf5e1d6` — pins
+4. **Embedding cache key** = sha256(ast_sha | verbosity | RENDERER_VERSION | e5 revision | prefix)
+   — so a renderer or embedding-model change can never silently reuse a stale vector.
+
+Note on the term "self-parsing" (used in PR #3980): it means only that the P0 acceptance test
+requires the parser + registry to parse every example in this spec document — not a formal
+novelty claim. The notation is ordinary parenthesized functional syntax; the one non-standard
+element is registry-driven longest-match lexing so registered names containing `.`/`-`
+(`gpt-5.5-low`) lex as single tokens.
+
 ## Scope
 
 The language names processes; it does not execute them. An expression is valid iff we can map it

--- a/prototypes/mu_cosine/DESIGN_tree_position_encoding_theory.md
+++ b/prototypes/mu_cosine/DESIGN_tree_position_encoding_theory.md
@@ -1,0 +1,73 @@
+# Tree Position Encodings for Expression ASTs — Theory Note (FUTURE WORK)
+
+**Status: theory capture, 2026-07-24 (owner + Perplexity/Sonnet-5 discussion).** Companion to
+`DESIGN_expression_encoder_future.md`; same gating (post-P1, post-P3-plateau). This note records
+the mathematical structure so a future implementer (possibly a separate agent) does not
+re-derive it.
+
+## The problem
+
+A node in an expression AST (`e5(routing(e5, sonnet.lineage, ...))`) is doubly positioned:
+**depth** k (operator vs argument vs sub-argument — abstraction level) and **breadth** j
+(which argument at that depth — role/order). P3's current plan collapses this to fixed scalar
+per-position weights. The question: how should a positional embedding represent (k, j) jointly?
+
+## The factorization and the combination operator
+
+Give depth and breadth their own embedding vocabularies, d_k and b_j, and combine. The candidate
+combinations form a strict information hierarchy:
+
+| operation | output dim | information preserved | Gaussian analogy |
+|---|---|---|---|
+| Kronecker d ⊗ b | D_d · D_b | exact, fully separable joint | full joint covariance Σ |
+| circular convolution d ∗ b | D | Fourier-basis projection of the Kronecker | low-rank/diagonal Σ approximation |
+| learned bilinear W(d ⊗ b) | D | learned projection of the Kronecker | fitted low-rank Σ |
+| quadratic form dᵀA b | 1 | one interaction scalar | log-likelihood of the joint |
+| additive d + b | D | marginals only, no interactions | independence, Σ = diag |
+
+**Key identity (the owner's question, answered affirmatively): circular convolution IS a
+dimensionality reduction of the Kronecker product** — a fixed linear projection. In the Fourier
+domain, F(d ∗ b)_n = F(d)_n · F(b)_n: the D²-dimensional outer product is contracted to D
+dimensions using the DFT matrix as the projection basis. Fixed (no training, approximately
+invertible — the holographic reduced representation / HRR construction), but the Fourier basis
+is not necessarily optimal for a given vocabulary.
+
+**The quadratic-form / joint-Gaussian analogy, made precise:** for zero-mean joint Gaussian x,
+−½ xᵀΣ⁻¹x = −½ vec(xxᵀ)ᵀ vec(Σ⁻¹) — the outer product xxᵀ is the rank-1 Kronecker self-product,
+and contracting against the precision matrix is a linear projection of the Kronecker product to a
+SCALAR: maximal compression, keeping exactly the information a score needs and nothing
+recoverable. Attention's qᵀk is this same object; multi-head attention learns D_head such
+projections in parallel — i.e., a learned partial recovery of the Kronecker structure. This
+places the whole design space on one axis: how much of the joint (depth × breadth) interaction
+structure do you keep, and is the projection fixed (Fourier) or learned (W)?
+
+## Separability requirement
+
+Depth and breadth vocabularies must be DISTINCT (independent initializations; distinguishable
+subspaces). With a shared vocabulary the combination degenerates: the network cannot tell
+(depth=k, breadth=j) from other pairs producing the same product. This was the owner's own
+caveat and it is load-bearing — it is what makes the joint representation identifiable.
+
+## Recommendation for THIS grammar
+
+Expression trees here are shallow and narrow (depth ≤ ~4: operator → argument → sub-argument /
+kwarg; breadth ≤ ~8). Therefore:
+
+- Full Kronecker is FEASIBLE (small vocabularies ⇒ manageable D_d·D_b) but likely wasteful.
+- **Learned bilinear W(d ⊗ b) is the recommended sweet spot**: a few hundred parameters,
+  exactly separable, discovers which depth×breadth interactions matter for this grammar instead
+  of assuming the Fourier basis. P3's fixed scalar position weights are its rank-degenerate
+  special case, so it slots into the existing ablation ladder rather than replacing it.
+- Preregistered ablation ladder when implemented: fixed-weight sum (P3 baseline) → additive
+  d + b → circular convolution (HRR) → learned bilinear → full Kronecker. Determinism contract
+  carries over: any stochastic element seeded by SHA-256 of the canonical AST.
+
+## Cautions
+
+- With ~922 labeled rows, NO learned position scheme is trainable from task labels alone — this
+  only becomes feasible on the synthetic-pretraining path of the encoder–decoder design
+  (grammar-generated expressions, reconstruction + e5-alignment objectives).
+- Current art references: `process_cards.py` (P0 — canonicalization/token identification only,
+  no embeddings composed today), `DESIGN_process_expression_implementation.md` P3 (deterministic
+  superposition), `ARCHITECTURE_filing_engine.md` OPENQ-012 (cross-corpus transfer — the
+  evaluation any position scheme ultimately serves).


### PR DESCRIPTION
Two things, docs-only, frozen P1 primary untouched:

**Polish** (from the 2026-07-24 review discussion): worked round-trip example + 'self-parsing' clarification in the language spec; reader's key + glossary in the implementation plan; P2 NL-template arm (leap-of-faith promoted to tested arm); preregistered P3 cross-corpus LOCO arm; ARCHITECTURE OPENQ-012 (cross-corpus transfer of process conditioning).

**Future-work captures** (owner + Perplexity/Sonnet-5; gated post-P1/P3, handoff-ready): dual-objective expression encoder–decoder (e5-alignment + reconstruction, synthetic pretraining, CLIP-style variant) and the tree-position-encoding theory note (depth⊗breadth; circular convolution = fixed Fourier dimensionality reduction of the Kronecker product; quadratic-form/joint-Gaussian analogy; learned-bilinear recommendation + ablation ladder). Both cite current art and note the grammar today does canonicalization + token identification only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fB4ZfA4bW4XNEnboUncgc