### PR TITLE
mu_cosine: bind SimpleMind privacy views and local-review benchmark

### DIFF
--- a/prototypes/mu_cosine/REPORT_sm_fs_filing.md
+++ b/prototypes/mu_cosine/REPORT_sm_fs_filing.md
@@ -1,16 +1,123 @@
-# SimpleMind filesystem filing corpus — a fresh, frozen-holdout filing dataset
+# SimpleMind filesystem filing corpus — fresh exploratory filing data
 
 **The owner's insight, validated:** the .smmx maps live inside a real Dropbox folder hierarchy,
 so each map's path is a RECORDED FILING DECISION — map root ↔ parent directory, the same
 single-principal-folder task as Pearltrees, on a corpus the eval program has never touched.
 
-## Corpus + discipline (sm_fs_filing.py)
+## Historical v1 corpus + discipline (sm_fs_filing.py)
 
-4,385 maps scanned; privacy-filtered (any path component containing 'private' dropped) → 4,367
+4,385 maps scanned; the original coarse filter (any path component containing `private`) → 4,367
 with a filing folder; catalog = 270 distinct directory names (313 dirs ≥3 maps, the PT min_bm
-analog) → 1,272 eligible queries. **Frozen holdout at first touch (finding-5 lesson): 508
-queries (40%, seed 0) RESERVED before any scoring** — hashes digested in ~/mu_data/sm_fs_ledger
-.json (`eb02e3694be3b71d`); this script never scores them. Exploration split n=764.
+analog) → 1,272 eligible queries. A deterministic 508-query reserve (40%, seed 0) was selected
+before scoring and digested in `~/mu_data/sm_fs_ledger.json` (`eb02e3694be3b71d`); this script
+never scores it. Exploration split n=764.
+
+The reserve is **unscored but transductive**, not confirmatory: the catalog was derived from all
+placements and the query split is not destination-folder-node-disjoint. A future prospective
+cohort is required for a clean confirmatory claim.
+
+The original substring filter was also not privacy certification. `sm_fs_privacy.py` now builds
+a local contextual index: ordinary `/ACCOUNT/SLUG/id…` root links are public evidence;
+`/private/id…` is unknown rather than automatically private; and exact `private` topic containers
+mark their specifically linked child maps. Corpus model review is operationally disabled until a
+versioned, verified passing benchmark lock exists, so model output cannot enter an index or change
+a classification in this version.
+The local filing default excludes private while retaining unknown; `public-only` excludes both
+private and unknown and fails closed while an explicit-private target reference is unresolved.
+New privacy-bound runs use the separate `~/mu_data/sm_fs_ledger_v2.json` ledger by default.
+Historical metrics below are not silently recomputed under that new population. Here `public`
+means allowed by the owner's conservative metadata policy, not independently certified public
+availability. Privacy propagation follows only references beneath an explicit `private` topic; it
+does not recursively taint every ordinary link inside the referenced map. Unreadable maps and
+unresolved references remain visible as unknown/review-perimeter counts.
+
+The v2 freezer requires a content-integrity-bound, source-verified index and has no substring
+fallback. Its `public-only` and `private-only` runs produce separate mode-0600, no-replace
+ledgers, transductive training catalogs, and lineage targets; unknown rows are review-only. Each
+catalog contains admitted destinations and their ancestors, not an outcome-independent evaluation
+catalog. Exact map and ancestor paths remain the identities, duplicate titles do not collapse, and
+private/unknown names are not carried in a public training bundle.
+
+### Rule-only inventory on the current local snapshot
+
+The final source-rederived v2 rule-only pass bound 4,385 map files
+(`members_sha256=bec85e7439a56815f65272a4f4732ab4c242482d96b6c73076c95281d68be46f`)
+and classified **3,612 public-policy / 7 private / 766 unknown**
+(`index_sha256=475ccacc6087e7c21ee31309654b4636b87ba5249e71870039db42245ea8f537`).
+No model or API was called, and an independent full rescan reproduced every row. The review
+perimeter is explicit: 691 unreadable/structurally invalid maps (593 are zero-byte conflict-copy
+placeholders and 98 fail topic-graph validation), 74 ambiguous `/private/id…` roots, and two
+unresolved map references below explicit private markers.
+
+### Local-model development evidence and candidate slate
+
+Windows Ollama can run small local models on the GTX 1660 SUPER without consuming WSL's
+constrained RAM. The synthetic benchmark contains 12 hand-designed policy cases, uses a strict
+JSON schema and deterministic decoding, and never reads corpus data. Its repeated runs test
+transport and label stability; they are not independent observations, and this post-rubric case
+set does not estimate population accuracy or establish statistical significance.
+
+Two model families remain worth further testing:
+
+| role | local model | development result | disposition |
+|---|---|---:|---|
+| accuracy-first | Gemma 4 E2B IT QAT (`07ea59a47401`) | stable **10/12**, **6/7** model-review-eligible, explicit 2,048-token cap | retain |
+| lighter second family | Qwen3 4B (`359d7dd4bcda`) | stable **9/12**, **5/7** model-review-eligible in the earlier complete-response run | retain; rerun under the normalized cap |
+
+Neither passes the deliberately strict 12/12 development gate, so neither authorizes a corpus
+pilot. Qwen2.5 7B's earlier 11-row outputs are not comparable because completion truncation was not
+yet distinguished from schema failure. Qwen3 8B, Gemma 4 E4B QAT, Llama 3.1 8B, and DeepSeek-R1
+8B were slower and/or less accurate on this smoke set, so they are not current hardware-constrained
+front-runners. Phi-3's earlier three-card check was anecdotal and supplies no acceptance evidence.
+Benchmark v2 now fixes the output budget, rejects length-truncated completions, captures timing and
+token metadata, and binds the exact model/source identities before and after every run.
+
+Both retained results comprise three deterministic stability repetitions over the same synthetic
+case set (`case_set_sha256=1e883c3beda4500caf84edef4942ccf82d111f675372cefc7d9d7aeb0dbe6955`)
+and prompt (`prompt_sha256=6a744904779617448e48c86b4783f91aa9beb8b6bd66f75f30ff065dc8edc6bf`).
+The sealed local-only artifact digests are
+`6a702c0769cb52def78e5d84ac3da6fde2cbab6feb4fc2c40dc36e8e9e74ecf7`
+(Gemma) and
+`8066607ee3e8ae6f818ec4f0f3ba9b1e8a33540df96f7ac48bb7d5e5540a15c0`
+(Qwen). The Qwen artifact predates benchmark v2's explicit normalized output cap, so it remains
+development evidence and must be rerun under v2 before a family comparison.
+
+### Proposed two-family advisory ranker (not implemented)
+
+Gemma and Qwen can be retained as distinct advisory sources for ranking the rule-`unknown` review
+queue. Each would emit an ordinal access-control score under the same frozen rubric; those
+self-reported scores are not probabilities. Freeze the owner-label estimand as binary private
+handling versus public-policy handling; unresolved reviews remain unresolved and do not silently
+become negatives. Select the untouched outer lineage sample independently of either model's score.
+If score-guided sampling is ever used to save review effort, seal its inclusion probabilities and
+use the corresponding weighted estimand so verification bias is visible.
+
+Use lineage-blocked cross-fitting: fit each calibrator on inner-training lineages, produce
+out-of-fold categorical predictions for the joint head, then refit the calibrators on all
+outer-training lineages and evaluate the frozen stack exactly once on untouched outer lineages.
+Freeze precision at a stated review budget as the primary queue-ranking metric; report recall at
+that budget, average precision, per-source separability and correlation, log loss, stated-bin ECE,
+and margin-gated AURC as secondary measures with a paired lineage-block bootstrap.
+
+Compare Gemma-only, Qwen-only, a prior-corrected PoE, and the learned joint combiner on identical
+Gemma/Qwen inputs; add rule evidence to the joint head only as a separate ablation. The
+prior-corrected PoE combines calibrated posteriors as
+`p_G(y) p_Q(y) / pi(y)` and then renormalizes (equivalently, combine two likelihood factors with
+one class prior). Estimate `pi(y)` from only the corresponding inner-training lineages, then refit
+it on all outer-training lineages; preregister smoothing and fail closed when any fold lacks class
+support. A raw posterior-product can be reported only as a clearly named naive control;
+neither control multiplies raw ordinal scores. PoE is not the primary method: the models share a
+prompt and likely correlated training evidence, so treating them as independent can double-count
+confidence. Regardless of ranking quality, model output remains advisory and cannot change privacy
+state or authorize publication.
+
+Internal synthetic benchmarking is loopback-Ollama-only: the bridge rejects remote,
+credential-bearing, proxied, or disguised endpoints and does not pull absent models. The corpus
+index CLI is rule-only and rejects all model providers because no verified passing benchmark lock
+has been implemented. Hosted review would require a separate owner-approved redacted export and
+is not implemented here. Loopback transport alone does not prove local execution: before any
+future private-data pilot, the Ollama server must also run with cloud features disabled
+(`disable_ollama_cloud: true` or `OLLAMA_NO_CLOUD=1`) and the pilot must verify that setting.
 
 ## Result (exploration split, e5 ranking)
 
@@ -31,14 +138,14 @@ PT ≈ SM-in-map (wild/deep queries), SM-FS much easier (topic-identity queries)
 
 ## Uses
 
-1. **Training corpus:** 4,367 real filing decisions with materialized directory paths — the
+1. **Training corpus:** thousands of real filing decisions with materialized directory paths — the
    LINEAGE target-factory shape (`lineage(fs, decay=…)` as a process expression), 5.5× the 799
-   campaign rows, available NOW while the harvester drains and P1 awaits v2 bundles.
+   campaign rows under the historical count, available while the harvester drains and P1 awaits
+   v2 bundles. Training must bind the selected privacy-index view.
 2. **OPENQ-012 cross-corpus arm:** a fourth task-matched corpus (PT / SM-in-map / wiki / SM-FS).
-3. **Confirmatory reserve:** the 508 frozen queries are this program's first
-   designed-before-touched holdout — usable for confirmatory tests under a preregistered
-   protocol only.
+3. **Unscored transductive reserve:** retain the 508 rows for one frozen evaluation, while making
+   no node-disjoint or confirmatory claim.
 
 Caveats: exploration-split numbers are descriptive (single seed, no CIs); catalog uses directory
 NAMES (duplicates title-equivalent); depth-0 maps (no filing folder) excluded; per-item data
-stays in ~/mu_data (paths/names may be personal), repo carries aggregates only.
+stays in `~/mu_data` (paths/names may be personal), repo carries aggregates only.

--- a/prototypes/mu_cosine/benchmark_sm_fs_privacy_local.py
+++ b/prototypes/mu_cosine/benchmark_sm_fs_privacy_local.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Synthetic-only contract check for a local SimpleMind privacy reviewer.
+
+This benchmark never reads the SimpleMind corpus.  Passing it is necessary but
+not sufficient for an advisory pilot: a separate, versioned benchmark lock and
+owner-authorized pilot protocol would still be required.  Model recommendations
+remain ``unknown`` in the privacy index implemented here.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import copy
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(HERE))
+
+from llm_cli import (  # noqa: E402
+    call_ollama_json,
+    local_ollama_endpoint,
+    resolve_ollama_cli,
+)
+from sm_fs_privacy import (  # noqa: E402
+    INTERPRETATIONS,
+    MODEL_RESPONSE_SCHEMA,
+    POLICY_ID,
+    SmFsPrivacyError,
+    _parse_model_response,
+    build_review_prompt,
+    canonical_json_bytes,
+    sha256_file,
+)
+
+
+SCHEMA = "unifyweaver.sm-fs-privacy-synthetic-benchmark.v2"
+REVIEW_ELIGIBLE = frozenset(
+    ("AC-04", "TP-02", "TP-03", "UN-01", "UN-02", "UN-03", "UN-04")
+)
+
+
+def _case(
+    case_id: str,
+    relative_path: str,
+    root_title: str,
+    root_urls: Sequence[str],
+    rule_reasons: Sequence[str],
+    expected: str,
+) -> Dict[str, Any]:
+    qid = hashlib.sha256(relative_path.encode("utf-8")).hexdigest()[:20]
+    return {
+        "case_id": case_id,
+        "expected": expected,
+        "review_eligible": case_id in REVIEW_ELIGIBLE,
+        "task": {
+            "qid": qid,
+            "relative_path": relative_path,
+            "root_title": root_title,
+            "root_urls": list(root_urls),
+            "rule_reasons": list(rule_reasons),
+            "allowed_interpretations": sorted(INTERPRETATIONS),
+        },
+    }
+
+
+def synthetic_cases() -> List[Dict[str, Any]]:
+    return [
+        _case(
+            "AC-01",
+            "Synthetic/Private/Field Notes.smmx",
+            "Field Notes",
+            (),
+            ("private_dir_or_access_prefix",),
+            "access_control",
+        ),
+        _case(
+            "AC-02",
+            "Synthetic/Private_Project Atlas.smmx",
+            "Private: Project Atlas",
+            (),
+            ("private_dir_or_access_prefix",),
+            "access_control",
+        ),
+        _case(
+            "AC-03",
+            "Synthetic/Archive/Private - Team Copy.smmx",
+            "Team Copy",
+            ("https://www.pearltrees.com/private/id1001",),
+            ("private_dir_or_access_prefix", "pearltrees_private_link_unknown"),
+            "access_control",
+        ),
+        _case(
+            "AC-04",
+            "Synthetic/Archive/Private copy of Team Notes.smmx",
+            "Copy of Team Notes",
+            ("https://www.pearltrees.com/private/id1002",),
+            ("private_word_marker_vs_topic", "pearltrees_private_link_unknown"),
+            "access_control",
+        ),
+        _case(
+            "TP-01",
+            "Synthetic/STEM/Private-key cryptography.smmx",
+            "Private-key cryptography",
+            ("https://www.pearltrees.com/example/private-key/id2001",),
+            ("public_root_link",),
+            "topical",
+        ),
+        _case(
+            "TP-02",
+            "Synthetic/Law/Privacy law.smmx",
+            "Privacy law",
+            ("https://en.wikipedia.org/wiki/Privacy_law",),
+            ("private_word_marker_vs_topic",),
+            "topical",
+        ),
+        _case(
+            "TP-03",
+            "Synthetic/Statistics/MMSE.smmx",
+            "Minimum mean square error",
+            ("https://www.pearltrees.com/private/id2003",),
+            ("pearltrees_private_link_unknown",),
+            "topical",
+        ),
+        _case(
+            "TP-04",
+            "Synthetic/Programming/C++ private methods.smmx",
+            "C++ private methods",
+            ("https://www.pearltrees.com/example/cpp-private/id2004",),
+            ("public_root_link",),
+            "topical",
+        ),
+        _case(
+            "UN-01",
+            "Synthetic/Private/Private-key cryptography.smmx",
+            "Private-key cryptography",
+            (),
+            ("private_marker_with_topical_root",),
+            "uncertain",
+        ),
+        _case(
+            "UN-02",
+            "Synthetic/Topics/Private research.smmx",
+            "Private research",
+            ("https://www.pearltrees.com/private/id3002",),
+            ("private_word_marker_vs_topic", "pearltrees_private_link_unknown"),
+            "uncertain",
+        ),
+        _case(
+            "UN-03",
+            "Synthetic/Topics/Private networks.smmx",
+            "Private networks",
+            (),
+            ("private_word_marker_vs_topic",),
+            "uncertain",
+        ),
+        _case(
+            "UN-04",
+            "Synthetic/Topics/Private.smmx",
+            "Private",
+            (),
+            ("private_word_marker_vs_topic",),
+            "uncertain",
+        ),
+    ]
+
+
+def score_response(
+    response: Optional[str], cases: Sequence[Mapping[str, Any]]
+) -> Dict[str, Any]:
+    tasks = [case["task"] for case in cases]
+    expected_qids = {task["qid"] for task in tasks}
+    result = {
+        "transport_ok": response is not None,
+        "raw_unfenced_json": False,
+        "schema_ok": False,
+        "labels": {},
+        "correct": 0,
+        "review_eligible_correct": 0,
+        "raw_response": response,
+        "raw_response_sha256": (
+            hashlib.sha256(response.encode("utf-8")).hexdigest()
+            if response is not None
+            else None
+        ),
+        "error": None,
+    }
+    if response is None:
+        result["error"] = "model call failed"
+        return result
+    stripped = response.strip()
+    result["raw_unfenced_json"] = stripped.startswith("[") and stripped.endswith(
+        "]"
+    ) and "```" not in stripped
+    try:
+        decisions = _parse_model_response(response, expected_qids)
+    except SmFsPrivacyError as exc:
+        result["error"] = str(exc)
+        return result
+    result["schema_ok"] = True
+    expected_by_case = {case["case_id"]: case["expected"] for case in cases}
+    for case in cases:
+        predicted = decisions[case["task"]["qid"]]["interpretation"]
+        result["labels"][case["case_id"]] = predicted
+        if predicted == expected_by_case[case["case_id"]]:
+            result["correct"] += 1
+            if case["review_eligible"]:
+                result["review_eligible_correct"] += 1
+    return result
+
+
+def _command_text(command: Sequence[str], timeout: int = 30) -> str:
+    completed = subprocess.run(
+        list(command),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return completed.stdout.strip() if completed.returncode == 0 else ""
+
+
+def _model_identity(model: str) -> Dict[str, str]:
+    cli = resolve_ollama_cli()
+    listing = _command_text((cli, "list"))
+    digest = ""
+    for line in listing.splitlines()[1:]:
+        columns = line.split()
+        if len(columns) >= 2 and columns[0] == model:
+            digest = columns[1]
+            break
+    return {
+        "tag": model,
+        "digest": digest,
+        "ollama_version": _command_text((cli, "--version")),
+        "ollama_cli": cli,
+    }
+
+
+def _provenance_snapshot(model: str) -> Dict[str, Any]:
+    """Capture the code, repository, endpoint, and resolved model before a run."""
+
+    model_identity = _model_identity(model)
+    if (
+        not re.fullmatch(r"[0-9a-fA-F]{12,64}", model_identity["digest"])
+        or not model_identity["ollama_version"]
+        or not model_identity["ollama_cli"]
+    ):
+        raise RuntimeError("cannot bind the installed Ollama model identity")
+    repo_commit = _command_text(("git", "-C", str(ROOT), "rev-parse", "HEAD"))
+    if not re.fullmatch(r"[0-9a-f]{40}", repo_commit):
+        raise RuntimeError("cannot bind the repository commit")
+    return {
+        "model": model_identity,
+        "repo_commit": repo_commit,
+        "endpoint": local_ollama_endpoint(),
+        "sources": {
+            "classifier_sha256": sha256_file(HERE / "sm_fs_privacy.py"),
+            "evaluator_sha256": sha256_file(Path(__file__)),
+            "llm_bridge_sha256": sha256_file(ROOT / "scripts" / "llm_cli.py"),
+        },
+    }
+
+
+def _install_private_json(path: Path, value: Mapping[str, Any]) -> None:
+    parent_existed = path.parent.exists()
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if not parent_existed:
+        os.chmod(path.parent, 0o700)
+    payload = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, indent=1, allow_nan=False
+    ).encode("utf-8") + b"\n"
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        directory_fd = os.open(str(path.parent), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except BaseException:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="qwen3:4b")
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument(
+        "--max-output-tokens",
+        type=int,
+        default=2048,
+        help="explicit shared output budget; never rely on a model-specific default",
+    )
+    parser.add_argument(
+        "--reasoning",
+        action="store_true",
+        help="enable the model's reasoning channel while scoring only its final JSON",
+    )
+    parser.add_argument(
+        "--out",
+        default=os.path.expanduser(
+            "~/mu_data/sm_fs_privacy_qwen3_4b_synthetic.json"
+        ),
+    )
+    args = parser.parse_args(argv)
+    if args.repetitions <= 0:
+        raise ValueError("--repetitions must be positive")
+    if args.max_output_tokens <= 0:
+        raise ValueError("--max-output-tokens must be positive")
+
+    provenance = _provenance_snapshot(args.model)
+    cases = synthetic_cases()
+    tasks = [case["task"] for case in cases]
+    prompt = build_review_prompt(tasks)
+    response_schema = copy.deepcopy(MODEL_RESPONSE_SCHEMA)
+    response_schema["minItems"] = len(tasks)
+    response_schema["maxItems"] = len(tasks)
+    started = datetime.now(timezone.utc)
+    runs = []
+    for repetition in range(args.repetitions):
+        run_started = datetime.now(timezone.utc)
+        clock = time.monotonic()
+        ollama_eval: Dict[str, Any] = {}
+        response = call_ollama_json(
+            prompt,
+            args.model,
+            args.timeout,
+            response_schema=response_schema,
+            max_output_tokens=args.max_output_tokens,
+            think=args.reasoning,
+            metadata_out=ollama_eval,
+        )
+        scored = score_response(response, cases)
+        scored.update(
+            {
+                "repetition": repetition,
+                "started_at": run_started.isoformat(),
+                "elapsed_seconds": round(time.monotonic() - clock, 6),
+                "ollama_eval": ollama_eval,
+            }
+        )
+        runs.append(scored)
+
+    if _provenance_snapshot(args.model) != provenance:
+        raise RuntimeError("benchmark provenance changed while the model was evaluated")
+
+    label_vectors = [
+        tuple(run["labels"].get(case["case_id"]) for case in cases)
+        for run in runs
+    ]
+    strict_pass = bool(runs) and all(
+        run["transport_ok"]
+        and run["raw_unfenced_json"]
+        and run["schema_ok"]
+        and run["correct"] == len(cases)
+        for run in runs
+    ) and len(set(label_vectors)) == 1
+    confusion = Counter()
+    for run in runs:
+        for case in cases:
+            prediction = run["labels"].get(case["case_id"], "missing")
+            confusion[(case["expected"], prediction)] += 1
+    report = {
+        "schema": SCHEMA,
+        "policy_id": POLICY_ID,
+        "private_data_used": False,
+        "decision": (
+            "benchmark_gate_passed_lock_not_implemented"
+            if strict_pass
+            else "advisory_pilot_not_allowed"
+        ),
+        "strict_pass": strict_pass,
+        "started_at": started.isoformat(),
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+        "provider": "ollama-json",
+        "endpoint": provenance["endpoint"],
+        "decoding": {
+            "stream": False,
+            "format": "json_schema",
+            "schema_sha256": hashlib.sha256(
+                canonical_json_bytes(response_schema)
+            ).hexdigest(),
+            "think": args.reasoning,
+            "temperature": 0,
+            "seed": 0,
+            "num_predict": args.max_output_tokens,
+        },
+        "model": provenance["model"],
+        "repo_commit": provenance["repo_commit"],
+        "case_set_sha256": hashlib.sha256(
+            b"".join(canonical_json_bytes(case) for case in cases)
+        ).hexdigest(),
+        "prompt_sha256": hashlib.sha256(prompt.encode("utf-8")).hexdigest(),
+        **provenance["sources"],
+        "cases": cases,
+        "runs": runs,
+        "confusion": {
+            f"{expected}->{predicted}": count
+            for (expected, predicted), count in sorted(confusion.items())
+        },
+        "review_eligible_total_per_run": sum(
+            case["review_eligible"] for case in cases
+        ),
+        "note": (
+            "Synthetic contract evidence only. Passing never authorizes model "
+            "recommendations to replace owner classifications."
+        ),
+    }
+    _install_private_json(Path(args.out), report)
+    print(
+        f"synthetic privacy benchmark: {'PASS' if strict_pass else 'FAIL'}; "
+        f"runs={len(runs)}; output={args.out}"
+    )
+    return 0 if strict_pass else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/mu_attention.py
+++ b/prototypes/mu_cosine/mu_attention.py
@@ -176,7 +176,7 @@ def build_e5_tables(
     texts = texts or {}
     human = [texts.get(n, n.replace("_", " ")) for n in names]
     if cache_path and os.path.exists(cache_path):
-        d = torch.load(cache_path, weights_only=False)
+        d = torch.load(cache_path, weights_only=True)
         if (
             d.get("names") == list(names)
             and d.get("human") == human

--- a/prototypes/mu_cosine/sm_fs_filing.py
+++ b/prototypes/mu_cosine/sm_fs_filing.py
@@ -5,14 +5,16 @@ The .smmx maps live inside a real folder hierarchy, so each map's path is ground
 the same single-principal-folder task as Pearltrees (map root ≈ bookmark, parent directory ≈
 folder), on a corpus the eval program has NEVER touched. Two disciplines applied at first touch:
 
-  FROZEN HOLDOUT — a deterministic 40% of queries is RESERVED at first scan (never scored by this
-  script; the file records only their hashes). The Pearltrees manifest lost its confirmatory
-  value through adaptive reuse (P1 rigor contract, finding 5); this corpus keeps its own from
-  day one. Exploration uses only the 60% split.
+  UNSCORED RESERVE — a deterministic 40% of queries is reserved and never scored by this script.
+  Because the catalog is placement-derived and the split is not folder-node-disjoint, this is a
+  transductive reserve, not a confirmatory holdout. Exploration uses only the 60% split.
 
-  PRIVACY — any path with a component containing 'private' (case-insensitive) is dropped before
-  anything is derived from it; per-item outputs stay in ~/mu_data (never committed); the repo
-  sees only aggregate metrics.
+  PRIVACY — ``sm_fs_privacy.py`` classifies the frozen filesystem snapshot with contextual rules.
+  Corpus model review remains disabled until a verified passing benchmark lock exists. The local
+  default excludes records classified private while retaining unknown records;
+  ``--privacy-policy public-only`` is the stricter candidate view for owner-approved external use,
+  not independent public-availability certification. Per-item outputs stay in ~/mu_data and are
+  never committed.
 
 Task: query = map filename stem; true folder = immediate parent directory (title-equivalence
 across duplicate directory names); catalog = directories holding >= --min-maps maps. e5 ranking.
@@ -22,16 +24,609 @@ Comparators: PT single-folder R@1 0.203 / MRR 0.291; SM parent-level (in-map) 0.
 """
 import argparse
 import hashlib
+import importlib.metadata
+import io
 import json
 import os
+import platform
+import stat
 import sys
+import tempfile
+from pathlib import Path, PurePosixPath
 
 import numpy as np
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from mu_attention import build_e5_tables
+import mu_attention
+from mu_attention import E5_MODEL, E5_REVISION, build_e5_tables
+from sm_fs_privacy import (
+    SmFsPrivacyError,
+    build_index,
+    load_index,
+    sha256_file,
+    verify_index_source,
+    write_index,
+)
 
 DEFAULT_ROOT = "/mnt/c/Users/johnc/Dropbox/root"
+DEFAULT_PRIVACY_INDEX = os.path.expanduser("~/mu_data/sm_fs_privacy_index.jsonl")
+
+
+class UnsafePrivatePathError(OSError):
+    """A supposedly private artifact path has an unsafe filesystem perimeter."""
+
+
+def _absolute_without_resolving(path):
+    """Make *path* absolute without following any symlink component."""
+    return Path(os.path.abspath(os.path.expanduser(os.fspath(path))))
+
+
+def _lstat_or_none(path):
+    try:
+        return os.lstat(path)
+    except FileNotFoundError:
+        return None
+
+
+def _prepare_private_parent(parent):
+    """Create/validate a private leaf directory without traversing symlinks.
+
+    The leaf must be owned by this process and inaccessible to group/other
+    users. Existing ancestors may be public, but may not be symlinks or
+    non-sticky group/world-writable directories.
+    """
+    parent = _absolute_without_resolving(parent)
+    chain = list(reversed(parent.parents)) + [parent]
+    for component in chain:
+        info = _lstat_or_none(component)
+        if info is None:
+            try:
+                os.mkdir(component, 0o700)
+            except FileExistsError:
+                pass
+            info = _lstat_or_none(component)
+        if info is None:
+            raise UnsafePrivatePathError(
+                f"private artifact parent disappeared: {component}"
+            )
+        if stat.S_ISLNK(info.st_mode):
+            raise UnsafePrivatePathError(
+                f"refusing symlink parent for private artifact: {component}"
+            )
+        if not stat.S_ISDIR(info.st_mode):
+            raise UnsafePrivatePathError(
+                f"private artifact parent is not a directory: {component}"
+            )
+        mode = stat.S_IMODE(info.st_mode)
+        if (
+            component != parent
+            and mode & 0o022
+            and not mode & stat.S_ISVTX
+        ):
+            raise UnsafePrivatePathError(
+                f"refusing writable ancestor for private artifact: {component}"
+            )
+
+    leaf_info = os.lstat(parent)
+    leaf_mode = stat.S_IMODE(leaf_info.st_mode)
+    if leaf_info.st_uid != os.geteuid():
+        raise UnsafePrivatePathError(
+            f"private artifact parent is not owned by this user: {parent}"
+        )
+    if leaf_mode & 0o077 or leaf_mode & 0o700 != 0o700:
+        raise UnsafePrivatePathError(
+            f"private artifact parent must have mode 0700: {parent}"
+        )
+    return parent
+
+
+def _validate_private_target(target, *, must_not_exist=False):
+    target = _absolute_without_resolving(target)
+    _prepare_private_parent(target.parent)
+    info = _lstat_or_none(target)
+    if info is None:
+        return target
+    if stat.S_ISLNK(info.st_mode):
+        raise UnsafePrivatePathError(
+            f"refusing symlink private artifact target: {target}"
+        )
+    if must_not_exist:
+        raise FileExistsError(
+            f"refusing to replace frozen ledger: {target}; "
+            "choose a new --ledger path"
+        )
+    if not stat.S_ISREG(info.st_mode):
+        raise UnsafePrivatePathError(
+            f"private artifact target is not a regular file: {target}"
+        )
+    if info.st_uid != os.geteuid():
+        raise UnsafePrivatePathError(
+            f"private artifact target is not owned by this user: {target}"
+        )
+    if info.st_nlink != 1:
+        raise UnsafePrivatePathError(
+            f"private artifact target has multiple hard links: {target}"
+        )
+    return target
+
+
+def _open_private_parent(target):
+    flags = os.O_RDONLY | os.O_DIRECTORY
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(target.parent, flags)
+    info = os.fstat(descriptor)
+    mode = stat.S_IMODE(info.st_mode)
+    if (
+        not stat.S_ISDIR(info.st_mode)
+        or info.st_uid != os.geteuid()
+        or mode & 0o077
+    ):
+        os.close(descriptor)
+        raise UnsafePrivatePathError(
+            f"private artifact parent changed while opening: {target.parent}"
+        )
+    return descriptor
+
+
+def _open_private_regular(target, flags=os.O_RDONLY):
+    descriptor = os.open(
+        target,
+        flags
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+    )
+    info = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or info.st_uid != os.geteuid()
+        or info.st_nlink != 1
+    ):
+        os.close(descriptor)
+        raise UnsafePrivatePathError(
+            f"private artifact target changed while opening: {target}"
+        )
+    return descriptor
+
+
+def _atomic_json(path, value):
+    target = _validate_private_target(path, must_not_exist=True)
+    directory_fd = _open_private_parent(target)
+    fd = None
+    temporary_name = None
+    linked = False
+    durable = False
+    try:
+        fd, temporary = tempfile.mkstemp(
+            prefix=f".{target.name}.", dir=str(target.parent)
+        )
+        temporary_name = Path(temporary).name
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = None
+            json.dump(value, handle, ensure_ascii=False, indent=1, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.link(
+            temporary_name,
+            target.name,
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+            follow_symlinks=False,
+        )
+        linked = True
+        os.fsync(directory_fd)
+        durable = True
+    except BaseException:
+        if linked and not durable:
+            try:
+                os.unlink(target.name, dir_fd=directory_fd)
+            except FileNotFoundError:
+                pass
+            try:
+                os.fsync(directory_fd)
+            except OSError:
+                pass
+        raise
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            if temporary_name is not None:
+                os.unlink(temporary_name, dir_fd=directory_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(directory_fd)
+
+
+def privacy_allows(classification, policy):
+    if policy == "all-local":
+        return True
+    if policy == "exclude-private":
+        return classification != "private"
+    if policy == "public-only":
+        return classification == "public"
+    raise ValueError(f"unknown privacy policy: {policy}")
+
+
+def load_or_build_privacy_index(root, index_path):
+    path = Path(index_path)
+    if not path.exists():
+        header, records = build_index(Path(root))
+        write_index(path, header, records)
+    header, by_path = load_index(path)
+    verify_index_source(Path(root), header, by_path)
+    return header, by_path
+
+
+def require_public_privacy_perimeter(header, policy):
+    unresolved = header.get("counts", {}).get(
+        "unresolved_private_target_refs", 0
+    )
+    if policy == "public-only" and unresolved:
+        raise SmFsPrivacyError(
+            f"privacy index has {unresolved} unresolved private target "
+            "reference(s); public-only filing is not authorized"
+        )
+
+
+def prepare_private_cache(path):
+    cache = _validate_private_target(path)
+    if cache.exists():
+        descriptor = _open_private_regular(cache)
+        try:
+            os.fchmod(descriptor, 0o600)
+        finally:
+            os.close(descriptor)
+    return cache
+
+
+def harden_private_cache(path):
+    cache = _validate_private_target(path)
+    if _lstat_or_none(cache) is not None:
+        descriptor = _open_private_regular(cache)
+        try:
+            os.fchmod(descriptor, 0o600)
+        finally:
+            os.close(descriptor)
+
+
+def _distribution_version(name):
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def filing_provenance(cache_sha256=None):
+    provenance = {
+        "sm_fs_filing_sha256": sha256_file(Path(__file__)),
+        "mu_attention_sha256": sha256_file(Path(mu_attention.__file__)),
+        "e5_model_id": E5_MODEL,
+        "e5_revision": E5_REVISION,
+        "runtime_versions": {
+            "python": platform.python_version(),
+            "numpy": np.__version__,
+            "torch": mu_attention.torch.__version__,
+            "sentence_transformers": _distribution_version(
+                "sentence-transformers"
+            ),
+            "transformers": _distribution_version("transformers"),
+        },
+    }
+    if cache_sha256 is not None:
+        provenance["e5_cache_sha256"] = cache_sha256
+    return provenance
+
+
+def _cache_payload_is_usable(payload, names, human):
+    if not isinstance(payload, dict):
+        return False
+    if (
+        payload.get("names") != list(names)
+        or payload.get("human") != human
+        or payload.get("model_name") != E5_MODEL
+        or payload.get("model_revision") != E5_REVISION
+    ):
+        return False
+    query = payload.get("query")
+    passage = payload.get("passage")
+    if not isinstance(query, mu_attention.torch.Tensor):
+        return False
+    if not isinstance(passage, mu_attention.torch.Tensor):
+        return False
+    if (
+        query.ndim != 2
+        or passage.shape != query.shape
+        or query.shape[0] != len(names)
+        or query.shape[1] == 0
+        or query.dtype != mu_attention.torch.float32
+        or passage.dtype != mu_attention.torch.float32
+        or not query.is_floating_point()
+        or not passage.is_floating_point()
+    ):
+        return False
+    return bool(
+        mu_attention.torch.isfinite(query).all()
+        and mu_attention.torch.isfinite(passage).all()
+    )
+
+
+def _cache_stat_signature(info):
+    return (
+        info.st_dev,
+        info.st_ino,
+        info.st_uid,
+        info.st_nlink,
+        stat.S_IMODE(info.st_mode),
+        info.st_size,
+        info.st_mtime_ns,
+        info.st_ctime_ns,
+    )
+
+
+def _validate_cache_descriptor(descriptor):
+    info = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or info.st_uid != os.geteuid()
+        or info.st_nlink != 1
+        or stat.S_IMODE(info.st_mode) != 0o600
+    ):
+        raise UnsafePrivatePathError(
+            "e5 cache descriptor is not a private, singly-linked regular file"
+        )
+    return info
+
+
+def _assert_cache_path_still_names(cache, expected):
+    actual = _lstat_or_none(cache)
+    if actual is None:
+        raise UnsafePrivatePathError(
+            f"e5 cache disappeared during provenance binding: {cache}"
+        )
+    if stat.S_ISLNK(actual.st_mode):
+        raise UnsafePrivatePathError(
+            f"e5 cache became a symlink during provenance binding: {cache}"
+        )
+    if (
+        not stat.S_ISREG(actual.st_mode)
+        or actual.st_uid != os.geteuid()
+        or actual.st_nlink != 1
+        or stat.S_IMODE(actual.st_mode) != 0o600
+    ):
+        raise UnsafePrivatePathError(
+            f"e5 cache became unsafe during provenance binding: {cache}"
+        )
+    if (actual.st_dev, actual.st_ino) != (expected.st_dev, expected.st_ino):
+        raise UnsafePrivatePathError(
+            f"e5 cache was replaced during provenance binding: {cache}"
+        )
+    if _cache_stat_signature(actual) != _cache_stat_signature(expected):
+        raise UnsafePrivatePathError(
+            f"e5 cache changed during provenance binding: {cache}"
+        )
+
+
+def _read_cache_bytes(descriptor, names):
+    before = _validate_cache_descriptor(descriptor)
+    raw_tensor_bytes = max(1, len(names)) * 2 * 384 * 4
+    if before.st_size > raw_tensor_bytes * 2 + 16 * 1024 * 1024:
+        return None
+
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    remaining = before.st_size
+    chunks = []
+    while remaining:
+        chunk = os.read(descriptor, min(remaining, 1024 * 1024))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    extra = os.read(descriptor, 1)
+    after = _validate_cache_descriptor(descriptor)
+    if (
+        remaining
+        or extra
+        or _cache_stat_signature(before) != _cache_stat_signature(after)
+    ):
+        raise UnsafePrivatePathError(
+            "e5 cache changed while its provenance bytes were read"
+        )
+    return b"".join(chunks), after
+
+
+def _load_private_e5_cache_descriptor(descriptor, cache, names):
+    exact = _read_cache_bytes(descriptor, names)
+    if exact is None:
+        _assert_cache_path_still_names(
+            cache, _validate_cache_descriptor(descriptor)
+        )
+        return None
+    cache_bytes, cache_info = exact
+    try:
+        payload = mu_attention.torch.load(
+            io.BytesIO(cache_bytes),
+            map_location="cpu",
+            weights_only=True,
+        )
+    except Exception:
+        # The cache is regenerable; every safe-load failure is a miss.
+        payload = None
+
+    # Hash the immutable byte string that torch.load just consumed, then prove
+    # the pathname still names that same singly-linked inode. A concurrent
+    # rename, symlink, hard-link, or in-place mutation is an error, not a miss.
+    cache_sha256 = hashlib.sha256(cache_bytes).hexdigest()
+    current = os.fstat(descriptor)
+    if _cache_stat_signature(current) != _cache_stat_signature(cache_info):
+        _assert_cache_path_still_names(cache, cache_info)
+        raise UnsafePrivatePathError(
+            "e5 cache changed during deserialization/provenance binding"
+        )
+    _assert_cache_path_still_names(cache, cache_info)
+
+    if payload is None:
+        return None
+    human = [name.replace("_", " ") for name in names]
+    if not _cache_payload_is_usable(payload, names, human):
+        return None
+    idx = {name: index for index, name in enumerate(names)}
+    return payload["query"], payload["passage"], idx, cache_sha256
+
+
+def _load_private_e5_cache(cache, names):
+    if _lstat_or_none(cache) is None:
+        return None
+    descriptor = _open_private_regular(cache)
+    try:
+        return _load_private_e5_cache_descriptor(descriptor, cache, names)
+    finally:
+        os.close(descriptor)
+
+
+def _as_cpu_float_tensor(table):
+    if isinstance(table, mu_attention.torch.Tensor):
+        tensor = table.detach().to(device="cpu", dtype=mu_attention.torch.float32)
+    else:
+        tensor = mu_attention.torch.as_tensor(
+            table.numpy(), dtype=mu_attention.torch.float32
+        )
+    return tensor.contiguous()
+
+
+def build_private_e5_tables(names, cache_path, batch_size=128):
+    """Load/build an e5 cache through a no-follow, atomic private-file path."""
+    cache = prepare_private_cache(cache_path)
+    cached = _load_private_e5_cache(cache, names)
+    if cached is not None:
+        return cached
+
+    stage_dir = Path(
+        tempfile.mkdtemp(prefix=f".{cache.name}.build.", dir=str(cache.parent))
+    )
+    os.chmod(stage_dir, 0o700)
+    generated = stage_dir / "generated.pt"
+    sanitized = stage_dir / "install.pt"
+    try:
+        query, passage, _ = build_e5_tables(
+            names,
+            cache_path=str(generated),
+            batch_size=batch_size,
+            model_name=E5_MODEL,
+            model_revision=E5_REVISION,
+        )
+        safe_query = _as_cpu_float_tensor(query)
+        safe_passage = _as_cpu_float_tensor(passage)
+        human = [name.replace("_", " ") for name in names]
+        payload = {
+            "names": list(names),
+            "human": human,
+            "model_name": E5_MODEL,
+            "model_revision": E5_REVISION,
+            "query": safe_query,
+            "passage": safe_passage,
+        }
+        if not _cache_payload_is_usable(payload, names, human):
+            raise ValueError("e5 builder returned malformed embedding tables")
+        descriptor = os.open(
+            sanitized,
+            os.O_RDWR
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_CLOEXEC", 0),
+            0o600,
+        )
+        try:
+            with os.fdopen(descriptor, "wb", closefd=False) as handle:
+                mu_attention.torch.save(payload, handle)
+                handle.flush()
+                os.fsync(handle.fileno())
+
+            source_directory_fd = _open_private_parent(sanitized)
+            try:
+                destination_directory_fd = _open_private_parent(cache)
+                try:
+                    os.replace(
+                        sanitized.name,
+                        cache.name,
+                        src_dir_fd=source_directory_fd,
+                        dst_dir_fd=destination_directory_fd,
+                    )
+                    os.fsync(source_directory_fd)
+                    os.fsync(destination_directory_fd)
+                finally:
+                    os.close(destination_directory_fd)
+            finally:
+                os.close(source_directory_fd)
+
+            installed = _load_private_e5_cache_descriptor(
+                descriptor, cache, names
+            )
+            if installed is None:
+                raise RuntimeError(
+                    "newly installed e5 cache failed safe validation"
+                )
+            return installed
+        finally:
+            os.close(descriptor)
+    finally:
+        for artifact in (generated, sanitized):
+            try:
+                artifact.unlink()
+            except FileNotFoundError:
+                pass
+        stage_dir.rmdir()
+
+
+def discover_filing_rows(root, privacy_by_path, policy):
+    """Derive filing rows from a source-verified privacy index.
+
+    ``load_or_build_privacy_index`` has already re-read every source member
+    through a retained no-follow root descriptor. Rewalking the path-named
+    corpus here would add a second, unbound race surface, so this view is
+    derived solely from those verified relative identities.
+    """
+
+    rows, counts = [], {"public": 0, "private": 0, "unknown": 0}
+    del root  # identities are bound by the verified index, not a second walk
+    for relative in sorted(
+        privacy_by_path,
+        key=lambda value: (value.casefold(), value),
+    ):
+        privacy = privacy_by_path[relative]
+        path = PurePosixPath(relative)
+        if (
+            path.is_absolute()
+            or path.as_posix() != relative
+            or any(part in ("", ".", "..") for part in path.parts)
+            or path.suffix.casefold() != ".smmx"
+        ):
+            raise SmFsPrivacyError(
+                f"privacy index contains invalid map identity: {relative!r}"
+            )
+        classification = privacy["classification"]
+        counts[classification] += 1
+        if not privacy_allows(classification, policy):
+            continue
+        parts = list(path.parent.parts)
+        stem = path.name[:-5].strip()
+        if stem and parts and parts != ["."]:  # root maps have no filing folder
+            rows.append(
+                {
+                    "title": stem,
+                    "dir": parts[-1],
+                    "path": "/".join(parts),
+                    "privacy": classification,
+                }
+            )
+    rows.sort(key=lambda row: (row["path"], row["title"]))
+    return rows, counts
 
 
 def main(argv=None):
@@ -40,22 +635,28 @@ def main(argv=None):
     ap.add_argument("--min-maps", type=int, default=3, help="catalog floor (= PT min_bm analog)")
     ap.add_argument("--holdout-frac", type=float, default=0.40)
     ap.add_argument("--split-seed", type=int, default=0)
-    ap.add_argument("--ledger", default=os.path.expanduser("~/mu_data/sm_fs_ledger.json"))
-    ap.add_argument("--e5-cache", default="/tmp/mu_data/sm_fs_e5.pt")
+    ap.add_argument("--ledger", default=os.path.expanduser("~/mu_data/sm_fs_ledger_v2.json"))
+    ap.add_argument("--e5-cache", default=os.path.expanduser("~/mu_data/sm_fs_e5.pt"))
+    ap.add_argument("--privacy-index", default=DEFAULT_PRIVACY_INDEX)
+    ap.add_argument(
+        "--privacy-policy",
+        choices=("exclude-private", "public-only", "all-local"),
+        default="exclude-private",
+        help="local default excludes only private; public-only is required before external/public use",
+    )
     a = ap.parse_args(argv)
 
-    rows = []
-    for dirpath, _, files in os.walk(a.root):
-        rel = os.path.relpath(dirpath, a.root)
-        parts = [] if rel == "." else rel.split(os.sep)
-        if any("private" in p.lower() for p in parts):
-            continue
-        for f in files:
-            if f.endswith(".smmx") and "private" not in f.lower():
-                stem = f[:-5].strip()
-                if stem and parts:                      # depth-0 maps have no filing folder
-                    rows.append({"title": stem, "dir": parts[-1], "path": "/".join(parts)})
-    print(f"maps with a filing folder (privacy-filtered): {len(rows)}")
+    privacy_header, privacy_by_path = load_or_build_privacy_index(
+        a.root, a.privacy_index
+    )
+    require_public_privacy_perimeter(privacy_header, a.privacy_policy)
+    rows, privacy_counts = discover_filing_rows(
+        a.root, privacy_by_path, a.privacy_policy
+    )
+    print(
+        f"maps with a filing folder ({a.privacy_policy}): {len(rows)} "
+        f"[privacy index: {privacy_counts}]"
+    )
 
     # catalog: directories holding >= min_maps maps
     from collections import Counter
@@ -77,24 +678,38 @@ def main(argv=None):
     hold_idx = set(perm[:n_hold].tolist())
     explore = [r for i, r in enumerate(rows) if i not in hold_idx]
     held_hashes = sorted(qkey(rows[i]) for i in hold_idx)
-    os.makedirs(os.path.dirname(a.ledger), exist_ok=True)
+
+    # Prepare and bind the exact embedding artifact before sealing the ledger.
+    # Ranking/scoring still happens only after the ledger is durable.
+    _validate_private_target(a.ledger, must_not_exist=True)
+    q_titles = [r["title"] for r in explore]
+    names = sorted(set(q_titles) | set(cat_titles))
+    qtbl, ptbl, idx, cache_sha256 = build_private_e5_tables(
+        names, a.e5_cache, batch_size=128
+    )
+
     ledger = {
-        "corpus": "simplemind-fs-filing-v1", "root": a.root, "min_maps": a.min_maps,
+        "corpus": "simplemind-fs-filing-v2", "root": a.root, "min_maps": a.min_maps,
         "split_seed": a.split_seed, "holdout_frac": a.holdout_frac,
         "n_total": len(rows), "n_explore": len(explore), "n_reserved": n_hold,
         "reserved_query_hashes_sha256": hashlib.sha256(
             "".join(held_hashes).encode()).hexdigest(),
         "catalog_sha256": hashlib.sha256("\n".join(cat_titles).encode()).hexdigest(),
-        "status": "reserved split NEVER scored by sm_fs_filing.py; confirmatory use only",
+        "privacy": {
+            "policy": a.privacy_policy,
+            "index_schema": privacy_header["schema"],
+            "index_policy_id": privacy_header["policy_id"],
+            "index_sha256": privacy_header["index_sha256"],
+            "counts": privacy_counts,
+        },
+        "provenance": filing_provenance(cache_sha256),
+        "status": "unscored transductive reserve; not a node-disjoint confirmatory holdout",
     }
-    json.dump(ledger, open(a.ledger, "w"), indent=1)
+    _atomic_json(a.ledger, ledger)
     print(f"ledger -> {a.ledger} (reserved {n_hold} queries, digest "
           f"{ledger['reserved_query_hashes_sha256'][:16]})")
 
     # e5 ranking on the EXPLORATION split only
-    q_titles = [r["title"] for r in explore]
-    names = sorted(set(q_titles) | set(cat_titles))
-    qtbl, ptbl, idx = build_e5_tables(names, cache_path=a.e5_cache, batch_size=128)
     Q, P = qtbl.numpy(), ptbl.numpy()
     cv = np.stack([P[idx[t]] for t in cat_titles])
     ranks = []

--- a/prototypes/mu_cosine/sm_fs_freeze.py
+++ b/prototypes/mu_cosine/sm_fs_freeze.py
@@ -2,9 +2,10 @@
 """SM-FS corpus freezer v2 — repairs sm_fs_filing.py per gpt-5.6-sol's review before any training.
 
 Fixes, point by point (sol 2026-07-24):
-  1. CATALOG WITHOUT PLACEMENT COUNTS: candidates = every directory in the frozen tree snapshot
-     (structure-derived), not dirs-with-≥N-maps. Exact PATH identity is primary; duplicate leaf
-     titles stay distinct rows (title-equivalence available downstream as sensitivity only).
+  1. CATALOG WITHOUT PLACEMENT COUNTS: each privacy-specific training view retains every admitted
+     exact destination plus its ancestors, with no dirs-with-≥N-maps threshold. This catalog is
+     still placement-derived/transductive and is not an evaluation catalog. Exact PATH identity
+     is primary; duplicate leaf titles stay distinct rows (title-equivalence is a sensitivity).
   2. DESTINATION-DISJOINT SPLIT: split by destination directory (all maps filed in a directory
      travel together); training additionally EXCLUDES any row whose destination is an ancestor
      or descendant of a reserved destination (lineage-family isolation). Ancestor components
@@ -12,10 +13,12 @@ Fixes, point by point (sol 2026-07-24):
   3. REPRODUCIBLE MEMBERSHIP: the ledger stores every row individually (path id, file sha256,
      split, classification) plus tree-snapshot and code/E5-revision fingerprints — membership is
      independently reproducible, not an aggregate digest.
-  4. PRIVACY: consumes sol's privacy index (~/mu_data/sm_fs_privacy_index.json, classification ∈
-     {public, private, unknown, excluded}) when present; falls back to the conservative
-     path-substring rule, RECORDED as fallback — not certification. 'excluded' rows never enter
-     the ledger; private/unknown rows are ledgered local-only (never published/hosted).
+  4. PRIVACY: consumes and source-verifies the content-addressed JSONL index from
+     sm_fs_privacy.py
+     (~/mu_data/sm_fs_privacy_index.jsonl). Public and private training views are emitted as
+     separate policy-filtered bundles; unknown rows remain review-only. No unaudited fallback is
+     accepted. Content addressing provides integrity and reproducibility, not external
+     authentication.
   5. DURABLE CACHE + PINNED REVISION: everything under ~/mu_data; E5_REVISION recorded.
 
 Also emits the lineage(fs) TRAINING TARGETS from the exploration partition only: rows
@@ -25,19 +28,38 @@ Also emits the lineage(fs) TRAINING TARGETS from the exploration partition only:
   python3 sm_fs_freeze.py            # freeze + emit ledger and training targets (no scoring)
 """
 import argparse
+from collections import Counter
+import ctypes
+import errno
 import hashlib
+import io
 import json
+import math
 import os
+from pathlib import Path, PurePosixPath
+import shutil
+import stat
 import sys
+import tempfile
 
 import numpy as np
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import mu_attention
+import sm_fs_privacy
 from mu_attention import E5_REVISION
+from sm_fs_privacy import (
+    load_index,
+    verify_index_source,
+)
 
 DEFAULT_ROOT = "/mnt/c/Users/johnc/Dropbox/root"
 DECAY = 0.85
 EXPR = f"lineage(fs,decay={DECAY})"
+BUNDLE_SCHEMA = "unifyweaver.sm-fs-training-bundle.v1"
+BUNDLE_FILES = frozenset(
+    {"ledger.json", "lineage_fs_targets.tsv", "manifest.json"}
+)
 
 
 def sha_file(p, cap=1 << 20):
@@ -45,138 +67,1264 @@ def sha_file(p, cap=1 << 20):
     with open(p, "rb") as f:
         for chunk in iter(lambda: f.read(cap), b""):
             h.update(chunk)
-    return h.hexdigest()[:16]
+    return h.hexdigest()
+
+
+def canonical_json_bytes(value):
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _artifact_record(data):
+    return {
+        "bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+    }
+
+
+def _valid_artifact_record(value):
+    if not isinstance(value, dict) or set(value) != {"bytes", "sha256"}:
+        return False
+    byte_count = value["bytes"]
+    digest = value["sha256"]
+    return (
+        isinstance(byte_count, int)
+        and not isinstance(byte_count, bool)
+        and byte_count >= 0
+        and isinstance(digest, str)
+        and len(digest) == 64
+        and all(character in "0123456789abcdef" for character in digest)
+    )
+
+
+def _absolute_path(path):
+    return Path(os.path.abspath(os.path.expanduser(str(path))))
+
+
+def _descriptor_snapshot(metadata):
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_uid,
+        metadata.st_gid,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _validate_private_regular(metadata, description):
+    if not stat.S_ISREG(metadata.st_mode):
+        raise ValueError(f"{description} is not a regular file")
+    if stat.S_IMODE(metadata.st_mode) != 0o600:
+        raise ValueError(f"{description} is not mode 0600")
+    if metadata.st_uid != os.geteuid():
+        raise ValueError(f"{description} is not owned by the current user")
+    if metadata.st_nlink != 1:
+        raise ValueError(f"{description} must have exactly one hard link")
+
+
+def _read_validated_descriptor(descriptor, description, path_stat):
+    """Read bytes from one inode and prove the named path stayed on that inode."""
+
+    descriptor_before = os.fstat(descriptor)
+    _validate_private_regular(descriptor_before, description)
+    try:
+        path_before = path_stat()
+    except OSError as exc:
+        raise ValueError(f"{description} path is unavailable") from exc
+    if _descriptor_snapshot(path_before) != _descriptor_snapshot(
+        descriptor_before
+    ):
+        raise ValueError(f"{description} path/descriptor identity mismatch")
+
+    chunks = []
+    while True:
+        chunk = os.read(descriptor, 1 << 20)
+        if not chunk:
+            break
+        chunks.append(chunk)
+
+    descriptor_after = os.fstat(descriptor)
+    try:
+        path_after = path_stat()
+    except OSError as exc:
+        raise ValueError(f"{description} path changed while being read") from exc
+    before = _descriptor_snapshot(descriptor_before)
+    if (
+        _descriptor_snapshot(descriptor_after) != before
+        or _descriptor_snapshot(path_after) != before
+    ):
+        raise ValueError(f"{description} changed while being read")
+    return b"".join(chunks)
+
+
+def _read_bound_bytes(path, description):
+    """Read one regular file once and bind all later parsing to those bytes."""
+
+    resolved = _absolute_path(path)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    try:
+        descriptor = os.open(str(resolved), flags)
+    except OSError as exc:
+        raise ValueError(f"{description} is unavailable: {resolved}") from exc
+    try:
+        data = _read_validated_descriptor(
+            descriptor,
+            description,
+            lambda: resolved.lstat(),
+        )
+    finally:
+        os.close(descriptor)
+    return resolved, data, _artifact_record(data)
+
+
+def _parse_privacy_index_bytes(data):
+    """Parse exactly ``data`` through sm_fs_privacy's validating API."""
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=".sm-fs-privacy-bound.", suffix=".jsonl"
+    )
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as stream:
+            descriptor = -1
+            stream.write(data)
+        return load_index(Path(temporary_name))
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            os.unlink(temporary_name)
+        except OSError:
+            pass
+
+
+def _load_bound_privacy_index(path):
+    resolved, data, artifact = _read_bound_bytes(path, "privacy index")
+    header, index = _parse_privacy_index_bytes(data)
+    return resolved, artifact, header, index
+
+
+def _code_records():
+    return {
+        "mu_attention.py": {
+            "path": "prototypes/mu_cosine/mu_attention.py",
+            "sha256": sha_file(Path(mu_attention.__file__)),
+        },
+        "sm_fs_freeze.py": {
+            "path": "prototypes/mu_cosine/sm_fs_freeze.py",
+            "sha256": sha_file(Path(__file__)),
+        },
+        "sm_fs_privacy.py": {
+            "path": "prototypes/mu_cosine/sm_fs_privacy.py",
+            "sha256": sha_file(Path(sm_fs_privacy.__file__)),
+        },
+    }
+
+
+def catalog_for_rows(rows):
+    """Return the exact policy view: included destinations and all ancestors."""
+
+    return sorted(
+        {
+            "/".join(parts[:depth])
+            for row in rows
+            for parts in (row["dest"].split("/"),)
+            for depth in range(1, len(parts) + 1)
+        }
+    )
+
+
+def assert_catalog_complete(rows, catalog):
+    catalog_set = set(catalog)
+    for row in rows:
+        if row["dest"] not in catalog_set:
+            raise ValueError(
+                f"policy catalog omitted included destination: {row['dest']}"
+            )
+        parts = row["dest"].split("/")
+        missing = [
+            "/".join(parts[:depth])
+            for depth in range(1, len(parts) + 1)
+            if "/".join(parts[:depth]) not in catalog_set
+        ]
+        if missing:
+            raise ValueError(
+                "policy catalog omitted included destination ancestor(s): "
+                + ", ".join(missing)
+            )
 
 
 def classify(rel_parts, fname, index):
     key = "/".join(rel_parts + [fname])
-    if index:
-        for scope_len in range(len(rel_parts) + 1, 0, -1):   # most specific record wins
-            k = "/".join((rel_parts + [fname])[:scope_len])
-            if k in index:
-                return index[k], "index"
-    if any("private" in p.lower() for p in rel_parts) or "private" in fname.lower():
-        return "private", "fallback_substring"
-    return "unknown", "fallback_default"
+    record = index.get(key)
+    if record is None:
+        raise ValueError(f"privacy index omitted current map: {key}")
+    return (
+        record["classification"],
+        list(record.get("reasons", ())),
+        "parse_error_type" not in record,
+    )
+
+
+def training_privacy_allows(classification, policy):
+    if policy == "public-only":
+        return classification == "public"
+    if policy == "private-only":
+        return classification == "private"
+    raise ValueError(f"unknown training privacy policy: {policy}")
+
+
+def _smmx_paths(corpus_root):
+    corpus_root = _absolute_path(corpus_root)
+    try:
+        with sm_fs_privacy.open_corpus_root(corpus_root) as (root, root_fd):
+            return [
+                root / PurePosixPath(binding.relative)
+                for binding in sm_fs_privacy.smmx_member_bindings(root_fd)
+            ]
+    except sm_fs_privacy.SmFsPrivacyError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+def _iter_verified_source_maps(corpus_root, index):
+    """Yield current maps only after their exact bytes match their index row."""
+
+    corpus_root = _absolute_path(corpus_root)
+    seen = set()
+    try:
+        root_context = sm_fs_privacy.open_corpus_root(corpus_root)
+        with root_context as (root, root_fd):
+            bindings = sm_fs_privacy.smmx_member_bindings(root_fd)
+            for binding in bindings:
+                relative = binding.relative
+                if relative in seen:
+                    raise ValueError(
+                        f"duplicate current map identity: {relative}"
+                    )
+                indexed = index.get(relative)
+                if indexed is None:
+                    raise ValueError(
+                        "privacy index is stale: current map is not indexed: "
+                        f"{relative}"
+                    )
+                try:
+                    data = sm_fs_privacy.read_corpus_member(
+                        root_fd,
+                        relative,
+                        binding=binding,
+                    )
+                except sm_fs_privacy.SmFsPrivacyError as exc:
+                    raise ValueError(
+                        "privacy index is stale: map changed while being read: "
+                        f"{relative}"
+                    ) from exc
+                digest = hashlib.sha256(data).hexdigest()
+                if indexed.get("file_sha256") != digest:
+                    raise ValueError(
+                        "privacy index is stale: map contents changed: "
+                        f"{relative}"
+                    )
+                seen.add(relative)
+                # The caller consumes this digest directly into the ledger; it
+                # must not reopen the source map between comparison/inclusion.
+                yield relative, root / PurePosixPath(relative), digest, indexed
+    except sm_fs_privacy.SmFsPrivacyError as exc:
+        raise ValueError(str(exc)) from exc
+    missing = set(index) - seen
+    extra = seen - set(index)
+    if missing or extra:
+        detail = sorted(missing or extra, key=str.casefold)[0]
+        raise ValueError(
+            "privacy index is stale: map set changed "
+            f"(first mismatched member: {detail})"
+        )
+
+
+def _expected_ledger_privacy_fields(relative, digest, indexed):
+    parts = relative.split("/")
+    return {
+        "map_path": relative,
+        "dest": "/".join(parts[:-1]),
+        "title": parts[-1][:-5].strip(),
+        "sha256": digest,
+        "classification": indexed["classification"],
+        "evidence": "content_addressed_index",
+        "privacy_reasons": list(indexed.get("reasons", ())),
+        "training_usable": "parse_error_type" not in indexed,
+    }
+
+
+def _verify_ledger_against_privacy_source(
+    ledger, corpus_root, privacy_header, index
+):
+    """Rederive policy membership and privacy-bound row fields from live inputs."""
+
+    verify_index_source(corpus_root, privacy_header, index)
+    policy = ledger.get("training_privacy_policy")
+    expected = {}
+    observed_privacy = Counter()
+    for relative, _path, digest, indexed in _iter_verified_source_maps(
+        corpus_root, index
+    ):
+        classification = indexed["classification"]
+        observed_privacy[classification] += 1
+        if not training_privacy_allows(classification, policy):
+            continue
+        fields = _expected_ledger_privacy_fields(relative, digest, indexed)
+        if not fields["dest"]:
+            raise ValueError(
+                "policy-eligible privacy-index map has no destination: "
+                f"{relative}"
+            )
+        expected[relative] = fields
+
+    rows = ledger.get("rows")
+    if not isinstance(rows, list):
+        raise ValueError("training bundle ledger rows are malformed")
+    observed = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ValueError("training bundle ledger row is malformed")
+        relative = row.get("map_path")
+        if not isinstance(relative, str) or relative in observed:
+            raise ValueError("training bundle ledger map identity is invalid")
+        observed[relative] = row
+    if set(observed) != set(expected):
+        raise ValueError(
+            "training bundle policy-eligible privacy membership mismatch"
+        )
+    for relative, fields in expected.items():
+        row = observed[relative]
+        if any(row.get(key) != value for key, value in fields.items()):
+            raise ValueError(
+                "training bundle ledger privacy/source derivation mismatch: "
+                f"{relative}"
+            )
+    expected_counts = dict(sorted(observed_privacy.items()))
+    if (
+        ledger.get("privacy_index", {}).get("observed_counts")
+        != expected_counts
+    ):
+        raise ValueError("training bundle observed privacy counts mismatch")
+
+
+def _validate_holdout_fraction(holdout_frac, *, allow_degenerate=False):
+    if not isinstance(allow_degenerate, bool):
+        raise ValueError("degenerate-holdout authorization must be boolean")
+    if (
+        isinstance(holdout_frac, bool)
+        or not isinstance(holdout_frac, (int, float))
+        or not math.isfinite(holdout_frac)
+        or holdout_frac < 0
+        or holdout_frac > 1
+    ):
+        raise ValueError("--holdout-frac must be a finite number in [0, 1]")
+    if holdout_frac in (0, 1) and not allow_degenerate:
+        raise ValueError(
+            "holdout fractions 0 and 1 are diagnostic-only; pass "
+            "--allow-degenerate-holdout to record that waiver"
+        )
+    if allow_degenerate and holdout_frac not in (0, 1):
+        raise ValueError(
+            "--allow-degenerate-holdout is valid only with a 0 or 1 "
+            "diagnostic holdout fraction"
+        )
+    return float(holdout_frac)
+
+
+def derive_split(
+    rows,
+    holdout_frac,
+    split_seed,
+    *,
+    allow_degenerate=False,
+):
+    """Purely derive each row's split plus counts from immutable row fields."""
+
+    holdout_frac = _validate_holdout_fraction(
+        holdout_frac,
+        allow_degenerate=allow_degenerate,
+    )
+    block_depth = 3
+    cap = max(1, int(0.08 * len(rows)))
+
+    def assign_blocks(deepen):
+        assigned = []
+        for row in rows:
+            parts = row["dest"].split("/")
+            depth = block_depth
+            while True:
+                block = "/".join(parts[:depth])
+                if block not in deepen or depth >= len(parts):
+                    break
+                depth += 1
+            assigned.append(block)
+        return assigned
+
+    deepen = set()
+    while True:
+        block_by_row = assign_blocks(deepen)
+        weight = Counter(block_by_row)
+        newly_oversized = {
+            block for block, count in weight.items() if count > cap
+        } - deepen
+        if not newly_oversized:
+            break
+        deepen |= newly_oversized
+
+    blocks = sorted(set(block_by_row))
+    rng = np.random.default_rng(split_seed)
+    order = rng.permutation(len(blocks))
+    held_blocks = set()
+    held_rows = 0
+    target = holdout_frac * len(rows)
+    for index in order:
+        if held_rows >= target:
+            break
+        block = blocks[index]
+        held_blocks.add(block)
+        held_rows += weight[block]
+
+    preliminary = [
+        "reserved" if block in held_blocks else "explore"
+        for block in block_by_row
+    ]
+    reserved = {
+        row["dest"]
+        for row, split in zip(rows, preliminary)
+        if split == "reserved"
+    }
+    reserved_ancestors = {
+        "/".join(parts[:depth])
+        for destination in reserved
+        for parts in (destination.split("/"),)
+        for depth in range(1, len(parts) + 1)
+    }
+    splits = []
+    for row, split in zip(rows, preliminary):
+        if split != "explore":
+            splits.append(split)
+            continue
+        parts = row["dest"].split("/")
+        explore_ancestors = {
+            "/".join(parts[:depth]) for depth in range(1, len(parts) + 1)
+        }
+        if row["dest"] in reserved_ancestors or reserved.intersection(
+            explore_ancestors
+        ):
+            splits.append("cross_lineage_excluded")
+        else:
+            splits.append("explore")
+
+    counts = {
+        split: splits.count(split)
+        for split in ("explore", "reserved", "cross_lineage_excluded")
+    }
+    if not allow_degenerate and (
+        counts["explore"] == 0 or counts["reserved"] == 0
+    ):
+        raise ValueError(
+            "realized split has no explore or reserved rows; use more data "
+            "(diagnostic bundles must explicitly request a 0 or 1 holdout)"
+        )
+    metadata = {
+        "base_depth": block_depth,
+        "cap": cap,
+        "blocks": len(blocks),
+        "held_blocks": len(held_blocks),
+    }
+    return splits, counts, metadata
+
+
+def _validate_training_target_count(target_rows, *, allow_degenerate):
+    if (
+        isinstance(target_rows, bool)
+        or not isinstance(target_rows, int)
+        or target_rows < 0
+    ):
+        raise ValueError("training target-row count is invalid")
+    if target_rows == 0 and not allow_degenerate:
+        raise ValueError(
+            "realized explore split has no usable training targets; use more "
+            "data (diagnostic bundles must request a 0 or 1 holdout)"
+        )
+
+
+def _verify_split_derivation(ledger, parameters, manifest):
+    rows = ledger.get("rows")
+    if not isinstance(rows, list) or any(
+        not isinstance(row, dict) for row in rows
+    ):
+        raise ValueError("training bundle ledger rows are malformed")
+    expected_splits, expected_counts, _metadata = derive_split(
+        rows,
+        parameters.get("holdout_frac"),
+        parameters.get("split_seed"),
+        allow_degenerate=parameters.get("allow_degenerate_holdout", False),
+    )
+    observed_splits = [row.get("split") for row in rows]
+    if canonical_json_bytes(observed_splits) != canonical_json_bytes(
+        expected_splits
+    ):
+        raise ValueError("training bundle deterministic split mismatch")
+    expected_count_bytes = canonical_json_bytes(expected_counts)
+    if (
+        canonical_json_bytes(ledger.get("counts")) != expected_count_bytes
+        or canonical_json_bytes(manifest.get("counts"))
+        != expected_count_bytes
+    ):
+        raise ValueError("training bundle deterministic split counts mismatch")
+
+
+def exclude_cross_lineage(rows):
+    """Move explore rows related to a reserved destination out of training."""
+
+    reserved = {row["dest"] for row in rows if row["split"] == "reserved"}
+    reserved_ancestors = {
+        "/".join(parts[:depth])
+        for destination in reserved
+        for parts in (destination.split("/"),)
+        for depth in range(1, len(parts) + 1)
+    }
+    excluded = 0
+    for row in rows:
+        if row["split"] != "explore":
+            continue
+        parts = row["dest"].split("/")
+        explore_ancestors = {
+            "/".join(parts[:depth]) for depth in range(1, len(parts) + 1)
+        }
+        if row["dest"] in reserved_ancestors or reserved.intersection(
+            explore_ancestors
+        ):
+            row["split"] = "cross_lineage_excluded"
+            excluded += 1
+    return excluded
+
+
+def _write_private(path, data):
+    fd = os.open(
+        str(path),
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+        0o600,
+    )
+    with os.fdopen(fd, "wb") as handle:
+        os.fchmod(handle.fileno(), 0o600)
+        handle.write(data)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _fsync_directory(path):
+    directory_fd = os.open(str(path), os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _rename_directory_noreplace(source, target):
+    libc = ctypes.CDLL(None, use_errno=True)
+    renameat2 = getattr(libc, "renameat2", None)
+    if renameat2 is None:
+        raise RuntimeError("atomic no-replace directory rename is unavailable")
+    renameat2.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    renameat2.restype = ctypes.c_int
+    result = renameat2(
+        -100,
+        os.fsencode(source),
+        -100,
+        os.fsencode(target),
+        1,  # RENAME_NOREPLACE
+    )
+    if result == 0:
+        return
+    error_number = ctypes.get_errno()
+    if error_number in {errno.EEXIST, errno.ENOTEMPTY}:
+        raise FileExistsError(f"refusing to replace frozen output: {target}")
+    raise RuntimeError("atomic no-replace bundle installation failed") from OSError(
+        error_number, os.strerror(error_number)
+    )
+
+
+def _privacy_provenance(header):
+    keys = (
+        "schema",
+        "policy_id",
+        "index_sha256",
+        "source_snapshot",
+        "classifier_sha256",
+        "parser_sha256",
+        "counts",
+    )
+    return {key: header[key] for key in keys if key in header}
+
+
+def build_bundle_manifest(
+    *,
+    ledger,
+    ledger_bytes,
+    targets_bytes,
+    target_rows,
+    fs_root,
+    privacy_index,
+    privacy_index_artifact,
+    privacy_header,
+    holdout_frac,
+    split_seed,
+    training_privacy_policy,
+    allow_unresolved_private_targets,
+    allow_degenerate_holdout,
+):
+    privacy_index = _absolute_path(privacy_index)
+    if not _valid_artifact_record(privacy_index_artifact):
+        raise ValueError("privacy-index artifact record is invalid")
+    core = {
+        "schema": BUNDLE_SCHEMA,
+        "parameters": {
+            "allow_unresolved_private_targets": bool(
+                allow_unresolved_private_targets
+            ),
+            "allow_degenerate_holdout": bool(allow_degenerate_holdout),
+            "decay": DECAY,
+            "fs_root": str(_absolute_path(fs_root)),
+            "holdout_frac": holdout_frac,
+            "process_expression": EXPR,
+            "split_seed": split_seed,
+            "training_privacy_policy": training_privacy_policy,
+        },
+        "inputs": {
+            "privacy_index": {
+                "artifact": dict(privacy_index_artifact),
+                "path": str(privacy_index),
+                "provenance": _privacy_provenance(privacy_header),
+            }
+        },
+        "code": _code_records(),
+        "e5_revision": E5_REVISION,
+        "tree_snapshot": ledger["tree_snapshot"],
+        "counts": ledger["counts"],
+        "target_rows": target_rows,
+        "outputs": {
+            "ledger.json": _artifact_record(ledger_bytes),
+            "lineage_fs_targets.tsv": _artifact_record(targets_bytes),
+        },
+    }
+    manifest = dict(core)
+    manifest["manifest_sha256"] = hashlib.sha256(
+        canonical_json_bytes(core)
+    ).hexdigest()
+    return manifest
+
+
+def _validate_private_directory(metadata):
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError("training bundle is not a directory")
+    if stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise ValueError("training bundle directory is not mode 0700")
+    if metadata.st_uid != os.geteuid():
+        raise ValueError("training bundle directory is not owned by the current user")
+
+
+def _read_bundle_files(bundle_dir):
+    bundle = _absolute_path(bundle_dir)
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    try:
+        directory_fd = os.open(str(bundle), directory_flags)
+    except OSError as exc:
+        raise ValueError("training bundle directory is unavailable") from exc
+    try:
+        directory_before = os.fstat(directory_fd)
+        _validate_private_directory(directory_before)
+        try:
+            path_before = bundle.lstat()
+        except OSError as exc:
+            raise ValueError(
+                "training bundle directory path is unavailable"
+            ) from exc
+        if _descriptor_snapshot(path_before) != _descriptor_snapshot(
+            directory_before
+        ):
+            raise ValueError(
+                "training bundle directory path/descriptor identity mismatch"
+            )
+
+        names = os.listdir(directory_fd)
+        if set(names) != BUNDLE_FILES or len(names) != len(BUNDLE_FILES):
+            raise ValueError("training bundle file set mismatch")
+        values = {}
+        artifact_flags = (
+            os.O_RDONLY
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+        )
+        for name in sorted(names):
+            try:
+                descriptor = os.open(
+                    name,
+                    artifact_flags,
+                    dir_fd=directory_fd,
+                )
+            except OSError as exc:
+                raise ValueError(
+                    f"training bundle artifact is unavailable: {name}"
+                ) from exc
+            try:
+                values[name] = _read_validated_descriptor(
+                    descriptor,
+                    f"training bundle artifact {name}",
+                    lambda name=name: os.stat(
+                        name,
+                        dir_fd=directory_fd,
+                        follow_symlinks=False,
+                    ),
+                )
+            finally:
+                os.close(descriptor)
+
+        if set(os.listdir(directory_fd)) != BUNDLE_FILES:
+            raise ValueError("training bundle file set changed while being read")
+        directory_after = os.fstat(directory_fd)
+        try:
+            path_after = bundle.lstat()
+        except OSError as exc:
+            raise ValueError(
+                "training bundle directory path changed while being read"
+            ) from exc
+        before = _descriptor_snapshot(directory_before)
+        if (
+            _descriptor_snapshot(directory_after) != before
+            or _descriptor_snapshot(path_after) != before
+        ):
+            raise ValueError("training bundle directory changed while being read")
+        return values
+    finally:
+        os.close(directory_fd)
+
+
+def verify_private_bundle(out_dir, privacy_index=None):
+    """Verify bundle integrity and, when supplied, rederive it from live inputs."""
+
+    values = _read_bundle_files(out_dir)
+    try:
+        manifest = json.loads(values["manifest.json"])
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("training bundle manifest is invalid JSON") from exc
+    if manifest.get("schema") != BUNDLE_SCHEMA:
+        raise ValueError("training bundle manifest schema mismatch")
+    supplied_digest = manifest.get("manifest_sha256")
+    core = dict(manifest)
+    core.pop("manifest_sha256", None)
+    expected_digest = hashlib.sha256(canonical_json_bytes(core)).hexdigest()
+    if supplied_digest != expected_digest:
+        raise ValueError("training bundle manifest digest mismatch")
+    if set(manifest.get("outputs", {})) != {
+        "ledger.json",
+        "lineage_fs_targets.tsv",
+    }:
+        raise ValueError("training bundle output inventory mismatch")
+    for name, expected in manifest["outputs"].items():
+        if expected != _artifact_record(values[name]):
+            raise ValueError(f"training bundle artifact digest mismatch: {name}")
+    if manifest.get("code") != _code_records():
+        raise ValueError("training bundle code/dependency fingerprint mismatch")
+    if manifest.get("e5_revision") != E5_REVISION:
+        raise ValueError("training bundle E5 revision mismatch")
+
+    try:
+        ledger = json.loads(values["ledger.json"])
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("training bundle ledger is invalid JSON") from exc
+    parameters = manifest.get("parameters", {})
+    if not isinstance(parameters, dict) or set(parameters) != {
+        "allow_degenerate_holdout",
+        "allow_unresolved_private_targets",
+        "decay",
+        "fs_root",
+        "holdout_frac",
+        "process_expression",
+        "split_seed",
+        "training_privacy_policy",
+    }:
+        raise ValueError("training bundle parameter inventory mismatch")
+    inputs = manifest.get("inputs")
+    if not isinstance(inputs, dict) or set(inputs) != {"privacy_index"}:
+        raise ValueError("training bundle input inventory mismatch")
+    privacy_input = inputs["privacy_index"]
+    if (
+        not isinstance(privacy_input, dict)
+        or set(privacy_input) != {"artifact", "path", "provenance"}
+        or not _valid_artifact_record(privacy_input.get("artifact"))
+        or not isinstance(privacy_input.get("path"), str)
+        or not isinstance(privacy_input.get("provenance"), dict)
+    ):
+        raise ValueError("training bundle privacy input record is malformed")
+    provenance = privacy_input.get("provenance", {})
+    ledger_privacy = ledger.get("privacy_index", {})
+    cross_checks = (
+        (ledger.get("bundle_manifest_schema"), manifest.get("schema")),
+        (ledger.get("code"), manifest.get("code")),
+        (ledger.get("fs_root"), parameters.get("fs_root")),
+        (ledger.get("tree_snapshot"), manifest.get("tree_snapshot")),
+        (ledger.get("e5_revision"), manifest.get("e5_revision")),
+        (ledger.get("counts"), manifest.get("counts")),
+        (ledger.get("split_seed"), parameters.get("split_seed")),
+        (ledger.get("holdout_frac"), parameters.get("holdout_frac")),
+        (
+            ledger.get("allow_degenerate_holdout"),
+            parameters.get("allow_degenerate_holdout"),
+        ),
+        (
+            ledger.get("training_privacy_policy"),
+            parameters.get("training_privacy_policy"),
+        ),
+        (
+            ledger.get("unresolved_private_targets_waived"),
+            parameters.get("allow_unresolved_private_targets"),
+        ),
+        (
+            ledger_privacy.get("index_sha256"),
+            provenance.get("index_sha256"),
+        ),
+        (ledger.get("privacy_source"), "content_addressed_index"),
+        (ledger_privacy.get("artifact"), privacy_input.get("artifact")),
+        (ledger_privacy.get("path"), privacy_input.get("path")),
+    )
+    if any(left != right for left, right in cross_checks):
+        raise ValueError("training bundle manifest/ledger binding mismatch")
+    if any(
+        ledger_privacy.get(key) != value
+        for key, value in provenance.items()
+    ):
+        raise ValueError("training bundle privacy provenance mismatch")
+    _verify_split_derivation(ledger, parameters, manifest)
+    catalog = ledger.get("catalog", [])
+    if (
+        catalog != sorted(set(catalog))
+        or ledger.get("catalog_size") != len(catalog)
+        or hashlib.sha256("\n".join(catalog).encode()).hexdigest()
+        != ledger.get("tree_snapshot")
+    ):
+        raise ValueError("training bundle catalog snapshot mismatch")
+    assert_catalog_complete(ledger.get("rows", []), ledger.get("catalog", []))
+
+    if privacy_index is not None:
+        _privacy_path, data, observed_artifact = _read_bound_bytes(
+            privacy_index, "privacy index"
+        )
+        if observed_artifact != privacy_input["artifact"]:
+            raise ValueError("training bundle privacy-index binding mismatch")
+        privacy_header, index = _parse_privacy_index_bytes(data)
+        if _privacy_provenance(privacy_header) != provenance:
+            raise ValueError("training bundle privacy-index provenance mismatch")
+        _verify_ledger_against_privacy_source(
+            ledger,
+            parameters.get("fs_root"),
+            privacy_header,
+            index,
+        )
+
+    try:
+        target_lines = (
+            values["lineage_fs_targets.tsv"].decode("utf-8").splitlines()
+        )
+    except UnicodeDecodeError as exc:
+        raise ValueError("training bundle targets are not UTF-8") from exc
+    data_lines = [line for line in target_lines if not line.startswith("#")]
+    if len(data_lines) != manifest.get("target_rows"):
+        raise ValueError("training bundle target-row count mismatch")
+    _validate_training_target_count(
+        manifest.get("target_rows"),
+        allow_degenerate=parameters["allow_degenerate_holdout"],
+    )
+    header_values = {}
+    for line in target_lines:
+        if not line.startswith("# "):
+            continue
+        columns = line[2:].split("\t")
+        if len(columns) == 2:
+            header_values[columns[0]] = columns[1]
+    expected_headers = {
+        "e5_revision": E5_REVISION,
+        "privacy_index_artifact_bytes": str(
+            privacy_input["artifact"]["bytes"]
+        ),
+        "privacy_index_artifact_sha256": privacy_input["artifact"]["sha256"],
+        "privacy_index_sha256": provenance.get("index_sha256"),
+        "process_expression": parameters.get("process_expression"),
+        "training_privacy_policy": parameters.get(
+            "training_privacy_policy"
+        ),
+        "tree_snapshot": manifest.get("tree_snapshot"),
+    }
+    if any(
+        header_values.get(key) != value
+        for key, value in expected_headers.items()
+    ):
+        raise ValueError("training bundle target header binding mismatch")
+
+    catalog_set = set(catalog)
+    expected_rows = set()
+    policy = parameters.get("training_privacy_policy")
+    for row in ledger.get("rows", []):
+        if (
+            row.get("split") != "explore"
+            or not row.get("training_usable")
+            or not training_privacy_allows(row.get("classification"), policy)
+        ):
+            continue
+        parts = row["dest"].split("/")
+        for hop, ancestor_title in enumerate(reversed(parts), start=1):
+            expected_rows.add(
+                (
+                    row["map_path"],
+                    row["title"],
+                    "/".join(parts[: len(parts) - hop + 1]),
+                    ancestor_title,
+                    str(hop),
+                    f"{DECAY ** (hop - 1):.6f}",
+                    row["classification"],
+                )
+            )
+    observed_rows = set()
+    for line in data_lines:
+        columns = line.split("\t")
+        if len(columns) != 7 or columns[2] not in catalog_set:
+            raise ValueError("training target references a non-catalog ancestor")
+        observed_rows.add(tuple(columns))
+    if (
+        len(observed_rows) != len(data_lines)
+        or observed_rows != expected_rows
+        or len(expected_rows) != manifest.get("target_rows")
+    ):
+        raise ValueError("training bundle target/ledger derivation mismatch")
+    return manifest
+
+
+def install_private_outputs(out_dir, payloads, *, privacy_index):
+    """Crash-atomically install a complete local-only bundle without replacement."""
+
+    if set(payloads) != BUNDLE_FILES:
+        raise ValueError("private bundle payload set mismatch")
+    out = Path(os.path.abspath(os.path.expanduser(str(out_dir))))
+    parent = out.parent
+    parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if out.exists() or out.is_symlink():
+        raise FileExistsError(f"refusing to replace frozen output: {out}")
+    temporary = Path(
+        tempfile.mkdtemp(prefix=f".{out.name}.staging.", dir=str(parent))
+    )
+    os.chmod(temporary, 0o700)
+    installed = False
+    try:
+        for name in sorted(payloads, key=lambda item: item == "manifest.json"):
+            _write_private(temporary / name, payloads[name])
+        _fsync_directory(temporary)
+        # The complete external-input check belongs on the staging directory:
+        # after the no-replace rename succeeds, no verification failure may
+        # strand an installed bundle that this invocation already rejected.
+        verify_private_bundle(temporary, privacy_index=privacy_index)
+        _rename_directory_noreplace(temporary, out)
+        installed = True
+        _fsync_directory(parent)
+    finally:
+        if not installed and temporary.exists():
+            shutil.rmtree(temporary)
+    return {name: out / name for name in payloads}
 
 
 def main(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument("--fs-root", default=DEFAULT_ROOT)
     ap.add_argument("--privacy-index", default=os.path.expanduser(
-        "~/mu_data/sm_fs_privacy_index.json"))
+        "~/mu_data/sm_fs_privacy_index.jsonl"))
     ap.add_argument("--out-dir", default=os.path.expanduser("~/mu_data/sm_fs_v2"))
     ap.add_argument("--holdout-frac", type=float, default=0.40)
+    ap.add_argument(
+        "--allow-degenerate-holdout",
+        action="store_true",
+        help=(
+            "permit a 0 or 1 holdout fraction for diagnostic fixtures only; "
+            "the waiver is sealed into the bundle"
+        ),
+    )
     ap.add_argument("--split-seed", type=int, default=0)
+    ap.add_argument(
+        "--training-privacy-policy",
+        choices=("public-only", "private-only"),
+        default="public-only",
+        help=(
+            "rows allowed into training targets; public-only is the safe default, "
+            "while private-only creates a separate local expert target"
+        ),
+    )
+    ap.add_argument(
+        "--allow-unresolved-private-targets",
+        action="store_true",
+        help=(
+            "owner waiver for unresolved references below explicit private markers; "
+            "recorded in the ledger and normally forbidden for public-only output"
+        ),
+    )
     a = ap.parse_args(argv)
+    a.holdout_frac = _validate_holdout_fraction(
+        a.holdout_frac,
+        allow_degenerate=a.allow_degenerate_holdout,
+    )
 
-    index = None
-    if os.path.exists(a.privacy_index):
-        raw = json.load(open(a.privacy_index))
-        index = {r["relative_path"]: r["classification"] for r in raw.get("records", [])}
-        print(f"privacy index: {len(index)} records (sol classifier)")
-    else:
-        print("privacy index absent -> conservative substring FALLBACK (not certification)")
+    fs_root = _absolute_path(a.fs_root)
+    privacy_path = _absolute_path(a.privacy_index)
+    if not privacy_path.exists():
+        raise ValueError(
+            "training requires a content-addressed privacy index; "
+            "build sm_fs_privacy.py first"
+        )
+    (
+        privacy_path,
+        privacy_index_artifact,
+        privacy_header,
+        index,
+    ) = _load_bound_privacy_index(privacy_path)
+    verify_index_source(fs_root, privacy_header, index)
+    print(
+        f"privacy index: {len(index)} source-verified records "
+        f"(policy {privacy_header['policy_id']}, "
+        f"digest {privacy_header['index_sha256'][:16]})"
+    )
+    unresolved = privacy_header.get("counts", {}).get(
+        "unresolved_private_target_refs", 0
+    )
+    if (
+        a.training_privacy_policy == "public-only"
+        and unresolved
+        and not a.allow_unresolved_private_targets
+    ):
+        raise ValueError(
+            f"privacy index has {unresolved} unresolved private target "
+            "reference(s); resolve them or record an explicit owner waiver"
+        )
 
-    all_dirs, rows = set(), []
-    for dirpath, dirnames, files in os.walk(a.fs_root):
-        rel = os.path.relpath(dirpath, a.fs_root)
-        parts = [] if rel == "." else rel.split(os.sep)
-        if parts:
-            all_dirs.add("/".join(parts))
-        for f in sorted(files):
-            if not f.endswith(".smmx"):
-                continue
-            cls, ev = classify(parts, f, index)
-            # 'excluded' never enters; under the UNCERTIFIED fallback, substring-private is
-            # treated as excluded too (conservative). A certified index's 'private' rows are
-            # ledgered local-only per the privacy spec.
-            if cls == "excluded" or (cls == "private" and ev == "fallback_substring") or not parts:
-                continue
-            rows.append({"map_path": "/".join(parts + [f]), "dest": "/".join(parts),
-                         "title": f[:-5].strip(), "sha256": sha_file(os.path.join(dirpath, f)),
-                         "classification": cls, "evidence": ev})
-    catalog = sorted(all_dirs)                                   # structure-derived, no counts
-    tree_snapshot = hashlib.sha256("\n".join(catalog).encode()).hexdigest()[:16]
-    print(f"rows: {len(rows)}; catalog (ALL directories, exact-path identity): {len(catalog)}; "
-          f"tree snapshot {tree_snapshot}")
+    rows = []
+    observed_privacy = Counter()
+    for relative, _path, digest, indexed in _iter_verified_source_maps(
+        fs_root, index
+    ):
+        classification = indexed["classification"]
+        observed_privacy[classification] += 1
+        if not training_privacy_allows(
+            classification, a.training_privacy_policy
+        ):
+            continue
+        row = _expected_ledger_privacy_fields(relative, digest, indexed)
+        if not row["dest"]:
+            raise ValueError(
+                "policy-eligible privacy-index map has no destination: "
+                f"{relative}"
+            )
+        # This is deliberately adjacent to the source/index digest comparison
+        # in the iterator: the ledger stores that same digest, never a reread.
+        rows.append(row)
+    expected_policy_members = {
+        relative
+        for relative, record in index.items()
+        if training_privacy_allows(
+            record["classification"], a.training_privacy_policy
+        )
+    }
+    included_members = {row["map_path"] for row in rows}
+    if included_members != expected_policy_members:
+        raise ValueError(
+            "policy-eligible privacy-index map omitted from training bundle"
+        )
+    # A policy view is a lineage closure, not "all nonsensitive directories".
+    # Include every accepted destination and all of its ancestors. This keeps
+    # target identities representable while excluding unrelated/unknown branches.
+    catalog = catalog_for_rows(rows)
+    assert_catalog_complete(rows, catalog)
+    tree_snapshot = hashlib.sha256("\n".join(catalog).encode()).hexdigest()
+    print(f"rows ({a.training_privacy_policy}): {len(rows)}; "
+          f"policy-filtered catalog (exact-path identity): {len(catalog)}; "
+          f"tree snapshot {tree_snapshot[:16]}")
 
-    # SUBTREE-BLOCK split: reserve whole depth-K subtrees, so no explore destination is inside
-    # any reserved subtree (and vice versa). Ancestors ABOVE block roots are necessarily shared —
-    # the documented transductive-at-ancestor limitation, not a leak within blocks.
-    K = 3
-    cap = max(1, int(0.08 * len(rows)))          # split any block holding >8% of rows deeper
-    from collections import Counter
-    def assign(depth_map=None):
-        blocks = {}
-        for r in rows:
-            parts = r["dest"].split("/")
-            k = K
-            while True:
-                b = "/".join(parts[:k])
-                if depth_map is None or b not in depth_map or k >= len(parts):
-                    break
-                k += 1
-            blocks[r["map_path"]] = b
-        return blocks
-    oversized, depth_map = True, set()
-    while oversized:
-        bmap = assign(depth_map)
-        w = Counter(bmap.values())
-        big = {b for b, c in w.items() if c > cap}
-        new = big - depth_map
-        oversized = bool(new)
-        depth_map |= new
-    for r in rows:
-        r["_block"] = bmap[r["map_path"]]
-    blocks = sorted(set(bmap.values()))
-    rng = np.random.default_rng(a.split_seed)
-    order = rng.permutation(len(blocks))
-    weight = Counter(bmap.values())
-    held_blocks, acc = set(), 0
-    target = a.holdout_frac * len(rows)
-    for i in order:
-        if acc >= target:
-            break
-        held_blocks.add(blocks[i])
-        acc += weight[blocks[i]]
-    for r in rows:
-        r["split"] = "reserved" if r.pop("_block") in held_blocks else "explore"
-    n = {s: sum(1 for r in rows if r["split"] == s) for s in ("explore", "reserved")}
-    print(f"split (adaptive subtree blocks, base depth {K}, cap {cap} rows, seed {a.split_seed}): "
+    # SUBTREE-BLOCK split: reserve whole depth-K subtrees, so no explore
+    # destination is inside any reserved subtree (and vice versa). Ancestors
+    # ABOVE block roots are necessarily shared — the documented
+    # transductive-at-ancestor limitation, not a leak within blocks.
+    splits, n, split_metadata = derive_split(
+        rows,
+        a.holdout_frac,
+        a.split_seed,
+        allow_degenerate=a.allow_degenerate_holdout,
+    )
+    for row, split in zip(rows, splits):
+        row["split"] = split
+    excluded = n["cross_lineage_excluded"]
+    print(f"split (adaptive subtree blocks, base depth "
+          f"{split_metadata['base_depth']}, cap {split_metadata['cap']} rows, "
+          f"seed {a.split_seed}): "
           f"explore {n['explore']}, "
-          f"reserved {n['reserved']} across {len(held_blocks)}/{len(blocks)} blocks (never score; "
-          f"whole subtrees — no explore dest inside a reserved subtree)")
+          f"reserved {n['reserved']} across "
+          f"{split_metadata['held_blocks']}/{split_metadata['blocks']} blocks "
+          f"(never score; "
+          f"whole subtrees); {excluded} lineage-related explore rows excluded")
 
-    os.makedirs(a.out_dir, exist_ok=True)
     ledger = {
-        "schema": "sm_fs_corpus.v2", "fs_root": a.fs_root, "tree_snapshot": tree_snapshot,
+        "schema": "sm_fs_corpus.v2",
+        "bundle_manifest_schema": BUNDLE_SCHEMA,
+        "fs_root": str(fs_root),
+        "tree_snapshot": tree_snapshot,
         "e5_revision": E5_REVISION, "split_seed": a.split_seed,
         "holdout_frac": a.holdout_frac, "counts": n, "catalog_size": len(catalog),
-        "privacy_source": "index" if index else "fallback_substring",
+        "allow_degenerate_holdout": bool(a.allow_degenerate_holdout),
+        "code": _code_records(),
+        "privacy_source": "content_addressed_index",
+        "privacy_index": {
+            **_privacy_provenance(privacy_header),
+            "artifact": dict(privacy_index_artifact),
+            "observed_counts": dict(sorted(observed_privacy.items())),
+            "path": str(privacy_path),
+        },
+        "training_privacy_policy": a.training_privacy_policy,
+        "unresolved_private_targets_waived": bool(
+            a.allow_unresolved_private_targets
+        ),
         "limitations": ["ancestor components above destination level shared across splits "
                         "(transductive at ancestor level)",
-                        "fallback privacy rule is conservative filtering, not certification"],
+                        "public classification is an owner risk-policy decision, not independent "
+                        "public-availability certification",
+                        "privacy-index hashes provide content integrity and reproducibility, "
+                        "not external authentication"]
+        + (
+            [
+                "degenerate holdout explicitly authorized for diagnostics; "
+                "this bundle is not an evaluation reserve"
+            ]
+            if a.allow_degenerate_holdout
+            else []
+        ),
         "rows": rows, "catalog": catalog,
     }
-    lp = os.path.join(a.out_dir, "ledger.json")
-    json.dump(ledger, open(lp, "w"), ensure_ascii=False, indent=0)
-    print(f"ledger -> {lp} (sha {sha_file(lp)}) — per-row membership, independently reproducible")
 
     # lineage(fs) training targets — EXPLORE partition only
-    tp = os.path.join(a.out_dir, "lineage_fs_targets.tsv")
-    with open(tp, "w", encoding="utf-8") as f:
-        f.write(f"# process_expression\t{EXPR}\n# tree_snapshot\t{tree_snapshot}"
-                f"\t# e5_revision\t{E5_REVISION}\n# node\tancestor\thop\ttarget\n")
-        kept = 0
-        for r in rows:
-            if r["split"] != "explore":
-                continue
-            parts = r["dest"].split("/")
-            for hop, anc in enumerate(reversed(parts), start=1):
-                f.write(f"{r['title']}\t{anc}\t{hop}\t{DECAY ** (hop - 1):.6f}\n")
-                kept += 1
-    print(f"training targets -> {tp} ({kept} rows, expr `{EXPR}`, explore partition only)")
+    target_buffer = io.StringIO()
+    target_buffer.write(
+        f"# process_expression\t{EXPR}\n"
+        f"# tree_snapshot\t{tree_snapshot}\n"
+        f"# e5_revision\t{E5_REVISION}\n"
+        f"# training_privacy_policy\t{a.training_privacy_policy}\n"
+        f"# privacy_index_artifact_bytes\t"
+        f"{privacy_index_artifact['bytes']}\n"
+        f"# privacy_index_artifact_sha256\t"
+        f"{privacy_index_artifact['sha256']}\n"
+        f"# privacy_index_sha256\t"
+        f"{privacy_header['index_sha256']}\n"
+        "# map_path\tmap_title\tancestor_path\tancestor_title\t"
+        "hop\ttarget\tclassification\n"
+    )
+    kept = 0
+    catalog_set = set(catalog)
+    for r in rows:
+        if (
+            r["split"] != "explore"
+            or not r["training_usable"]
+            or not training_privacy_allows(
+                r["classification"], a.training_privacy_policy
+            )
+        ):
+            continue
+        parts = r["dest"].split("/")
+        for hop, ancestor_title in enumerate(reversed(parts), start=1):
+            ancestor_path = "/".join(parts[: len(parts) - hop + 1])
+            if ancestor_path not in catalog_set:
+                raise ValueError(
+                    "training target references a non-catalog ancestor: "
+                    f"{ancestor_path}"
+                )
+            target_buffer.write(
+                f"{r['map_path']}\t{r['title']}\t{ancestor_path}\t"
+                f"{ancestor_title}\t{hop}\t{DECAY ** (hop - 1):.6f}\t"
+                f"{r['classification']}\n"
+            )
+            kept += 1
+    _validate_training_target_count(
+        kept,
+        allow_degenerate=a.allow_degenerate_holdout,
+    )
+    ledger_bytes = (
+        json.dumps(ledger, ensure_ascii=False, indent=0, sort_keys=True)
+        + "\n"
+    ).encode("utf-8")
+    targets_bytes = target_buffer.getvalue().encode("utf-8")
+    manifest = build_bundle_manifest(
+        ledger=ledger,
+        ledger_bytes=ledger_bytes,
+        targets_bytes=targets_bytes,
+        target_rows=kept,
+        fs_root=fs_root,
+        privacy_index=privacy_path,
+        privacy_index_artifact=privacy_index_artifact,
+        privacy_header=privacy_header,
+        holdout_frac=a.holdout_frac,
+        split_seed=a.split_seed,
+        training_privacy_policy=a.training_privacy_policy,
+        allow_unresolved_private_targets=a.allow_unresolved_private_targets,
+        allow_degenerate_holdout=a.allow_degenerate_holdout,
+    )
+    payloads = {
+        "ledger.json": ledger_bytes,
+        "lineage_fs_targets.tsv": targets_bytes,
+        "manifest.json": canonical_json_bytes(manifest),
+    }
+    installed = install_private_outputs(
+        a.out_dir,
+        payloads,
+        privacy_index=privacy_path,
+    )
+    lp = installed["ledger.json"]
+    tp = installed["lineage_fs_targets.tsv"]
+    mp = installed["manifest.json"]
+    print(
+        f"ledger -> {lp} (sha {sha_file(lp)[:16]}) — per-row membership, "
+        "independently reproducible; mode 0600, no-replace"
+    )
+    print(
+        f"training targets -> {tp} ({kept} rows, expr `{EXPR}`, "
+        f"explore + {a.training_privacy_policy} + readable only)"
+    )
+    print(
+        f"binding manifest -> {mp} "
+        f"(sha {manifest['manifest_sha256'][:16]}); "
+        "bundle installed crash-atomically, mode 0700/0600, no-replace"
+    )
 
 
 if __name__ == "__main__":

--- a/prototypes/mu_cosine/sm_fs_privacy.py
+++ b/prototypes/mu_cosine/sm_fs_privacy.py
@@ -1,0 +1,1580 @@
+#!/usr/bin/env python3
+"""Lightweight privacy triage for the SimpleMind filesystem filing corpus.
+
+This is deliberately separate from ``privacy.py``'s conservative public-dataset
+scrubber.  The corpus owner permits local use of all three states here; this
+index exists so downstream tools can distinguish:
+
+``public``
+    No private signal under the owner's stated risk policy, or a topical
+    ``Private`` name backed by a normal Pearltrees root link. This is not an
+    independent public-availability certification.
+``private``
+    A contextual filesystem marker, or a map targeted from an exact in-map
+    ``private`` container.
+``unknown``
+    Evidence is ambiguous or the map could not be inspected.
+
+Rules resolve the easy cases.  The production index builder is rule-only until
+a versioned, verified passing benchmark lock exists.  Internal benchmark helpers
+can exercise a cheap model on synthetic ``marker_vs_topic`` cases, but no model
+result can currently enter a corpus index or change a classification.
+
+Map-level propagation is deliberately narrow: only cloud-map references below
+an explicit ``private`` topic mark their target maps. It does not recursively
+follow every ordinary link inside a newly private target map.
+
+Example:
+
+    python3 sm_fs_privacy.py \
+      --root /mnt/c/Users/johnc/Dropbox/root \
+      --out ~/mu_data/sm_fs_privacy_index.jsonl
+
+The detailed index is local data.  It records paths and titles and must not be
+committed.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass
+from functools import partial
+import hashlib
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import posixpath
+import re
+import stat
+import tempfile
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Set, Tuple
+from urllib.parse import unquote, urlparse
+import xml.etree.ElementTree as ET
+import zipfile
+
+from parse_smmx import label
+
+
+SCHEMA = "unifyweaver.sm-fs-privacy-index.v1"
+POLICY_ID = "sm-fs-owner-triage-v1"
+PARSER_PATH = Path(__file__).with_name("parse_smmx.py")
+MODEL_REVIEW_DISABLED_REASON = (
+    "corpus model review is disabled until a versioned, verified passing "
+    "benchmark lock is implemented"
+)
+CLASSIFICATIONS = frozenset(("public", "private", "unknown"))
+INTERPRETATIONS = frozenset(("access_control", "topical", "uncertain"))
+MODEL_RESPONSE_SCHEMA = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "qid": {"type": "string"},
+            "interpretation": {
+                "type": "string",
+                "enum": sorted(INTERPRETATIONS),
+            },
+            "reason": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 300,
+            },
+        },
+        "required": ["qid", "interpretation", "reason"],
+        "additionalProperties": False,
+    },
+}
+PRIVATE_WORD = re.compile(r"(?i)\bprivate\b")
+PRIVATE_OR_PRIVACY_WORD = re.compile(r"(?i)\b(?:private|privacy)\b")
+# Access-copy conventions observed in this corpus: ``Private: ...``,
+# ``Private_...``, and ``Private - ...``. A lexical subject such as
+# ``private-key`` must remain marker-vs-topic evidence, not an automatic seed.
+ACCESS_PREFIX = re.compile(r"(?i)^\s*\*?private\*?\s*(?::|_|-\s+)")
+PEARLTREES_ID = re.compile(r"(?i)^id\d+$")
+PEARLTREES_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._~-]*$")
+SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
+HEADER_FIELDS = frozenset(
+    (
+        "record_type",
+        "schema",
+        "policy_id",
+        "corpus_root",
+        "source_snapshot",
+        "classifier_sha256",
+        "parser_sha256",
+        "model",
+        "model_review_authorization",
+        "counts",
+        "index_sha256",
+    )
+)
+MAP_FIELDS = frozenset(
+    (
+        "record_type",
+        "relative_path",
+        "file_sha256",
+        "root_title",
+        "root_urls",
+        "classification",
+        "reasons",
+        "model_review",
+        "unresolved_private_targets",
+    )
+)
+MAP_OPTIONAL_FIELDS = frozenset(("parse_error_type",))
+COUNT_FIELDS = frozenset(
+    (
+        "public",
+        "private",
+        "unknown",
+        "observed",
+        "model_access_control",
+        "model_topical",
+        "model_uncertain",
+        "map_parse_errors",
+        "unresolved_private_target_refs",
+    )
+)
+
+
+class SmFsPrivacyError(ValueError):
+    """The filesystem privacy index is malformed or cannot be built safely."""
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        + b"\n"
+    )
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _read_all_from_fd(fd: int) -> bytes:
+    blocks = []
+    while True:
+        try:
+            block = os.read(fd, 1024 * 1024)
+        except InterruptedError:
+            continue
+        if not block:
+            return b"".join(blocks)
+        blocks.append(block)
+
+
+_DIRECTORY_OPEN_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+
+
+@contextmanager
+def open_corpus_root(corpus_root: Path):
+    """Retain a no-follow descriptor for an absolute corpus root.
+
+    Opening every path component relative to its already-open parent prevents
+    a concurrent root or ancestor swap from redirecting a private-data scan.
+    Callers must keep this context open for enumeration and all member reads.
+    """
+
+    corpus_root = Path(os.path.abspath(os.path.normpath(str(corpus_root))))
+    try:
+        descriptor = os.open(os.path.sep, _DIRECTORY_OPEN_FLAGS)
+    except OSError as exc:
+        raise SmFsPrivacyError("cannot open filesystem root safely") from exc
+    try:
+        for component in corpus_root.parts[1:]:
+            try:
+                child = os.open(
+                    component,
+                    _DIRECTORY_OPEN_FLAGS,
+                    dir_fd=descriptor,
+                )
+            except OSError as exc:
+                raise SmFsPrivacyError(
+                    f"cannot open corpus root without following links: "
+                    f"{corpus_root}"
+                ) from exc
+            os.close(descriptor)
+            descriptor = child
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise SmFsPrivacyError(
+                f"corpus root is not a directory: {corpus_root}"
+            )
+        yield corpus_root, descriptor
+    finally:
+        os.close(descriptor)
+
+
+def _open_directory_component(parent_fd: int, name: str, relative: str) -> int:
+    try:
+        before = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+        if stat.S_ISLNK(before.st_mode):
+            raise SmFsPrivacyError(
+                f"refusing symlink corpus directory: {relative}"
+            )
+        if not stat.S_ISDIR(before.st_mode):
+            raise SmFsPrivacyError(
+                f"corpus member changed type: {relative}"
+            )
+        descriptor = os.open(
+            name,
+            _DIRECTORY_OPEN_FLAGS,
+            dir_fd=parent_fd,
+        )
+    except SmFsPrivacyError:
+        raise
+    except OSError as exc:
+        raise SmFsPrivacyError(
+            f"cannot safely open corpus directory: {relative}"
+        ) from exc
+    opened = os.fstat(descriptor)
+    if (
+        not stat.S_ISDIR(opened.st_mode)
+        or (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino)
+    ):
+        os.close(descriptor)
+        raise SmFsPrivacyError(
+            f"corpus directory changed while opening: {relative}"
+        )
+    return descriptor
+
+
+@dataclass(frozen=True)
+class CorpusMemberBinding:
+    """One member identity plus every directory identity used to reach it."""
+
+    relative: str
+    directory_identities: Tuple[Tuple[int, int], ...]
+    file_identity: Tuple[int, int]
+
+
+def _identity(metadata) -> Tuple[int, int]:
+    return metadata.st_dev, metadata.st_ino
+
+
+def smmx_member_bindings(root_fd: int) -> List[CorpusMemberBinding]:
+    """Enumerate and identity-bind SMMX members below a retained root."""
+
+    bindings: List[CorpusMemberBinding] = []
+    root_metadata = os.fstat(root_fd)
+    if not stat.S_ISDIR(root_metadata.st_mode):
+        raise SmFsPrivacyError("retained corpus root changed type")
+
+    def walk(
+        directory_fd: int,
+        prefix: Tuple[str, ...],
+        directory_identities: Tuple[Tuple[int, int], ...],
+    ) -> None:
+        try:
+            names = os.listdir(directory_fd)
+        except OSError as exc:
+            relative = "/".join(prefix) or "."
+            raise SmFsPrivacyError(
+                f"cannot enumerate corpus directory: {relative}"
+            ) from exc
+        for name in sorted(names, key=lambda value: (value.casefold(), value)):
+            relative_parts = prefix + (name,)
+            relative = "/".join(relative_parts)
+            try:
+                metadata = os.stat(
+                    name,
+                    dir_fd=directory_fd,
+                    follow_symlinks=False,
+                )
+            except OSError as exc:
+                raise SmFsPrivacyError(
+                    f"cannot inspect corpus member: {relative}"
+                ) from exc
+            if stat.S_ISLNK(metadata.st_mode):
+                # A linked directory can hide unindexed maps, and a linked map
+                # can escape the retained corpus root. Reject both.
+                raise SmFsPrivacyError(
+                    f"refusing symlink corpus member: {relative}"
+                )
+            if name.casefold().endswith(".smmx"):
+                if not stat.S_ISREG(metadata.st_mode):
+                    raise SmFsPrivacyError(
+                        f"refusing non-regular corpus member: {relative}"
+                    )
+                bindings.append(
+                    CorpusMemberBinding(
+                        relative=relative,
+                        directory_identities=directory_identities,
+                        file_identity=_identity(metadata),
+                    )
+                )
+                continue
+            if stat.S_ISDIR(metadata.st_mode):
+                child = _open_directory_component(
+                    directory_fd,
+                    name,
+                    relative,
+                )
+                try:
+                    walk(
+                        child,
+                        relative_parts,
+                        directory_identities + (_identity(os.fstat(child)),),
+                    )
+                finally:
+                    os.close(child)
+                continue
+
+    walk(root_fd, (), (_identity(root_metadata),))
+    return bindings
+
+
+def smmx_member_paths(root_fd: int) -> List[str]:
+    """Compatibility view over identity-bound corpus members."""
+
+    return [
+        binding.relative for binding in smmx_member_bindings(root_fd)
+    ]
+
+
+def _open_member_parent(
+    root_fd: int,
+    relative: str,
+    expected_directories: Optional[Tuple[Tuple[int, int], ...]] = None,
+) -> Tuple[int, str]:
+    relative_path = PurePosixPath(relative)
+    if (
+        relative_path.is_absolute()
+        or relative_path.as_posix() != relative
+        or any(part in ("", ".", "..") for part in relative_path.parts)
+    ):
+        raise SmFsPrivacyError(f"invalid corpus member path: {relative!r}")
+    descriptor = os.dup(root_fd)
+    try:
+        if (
+            expected_directories is not None
+            and (
+                len(expected_directories) != len(relative_path.parts)
+                or _identity(os.fstat(descriptor))
+                != expected_directories[0]
+            )
+        ):
+            raise SmFsPrivacyError(
+                f"corpus directory identity changed: {relative}"
+            )
+        for depth, component in enumerate(relative_path.parts[:-1], start=1):
+            prefix = "/".join(relative_path.parts[:depth])
+            child = _open_directory_component(descriptor, component, prefix)
+            if (
+                expected_directories is not None
+                and _identity(os.fstat(child)) != expected_directories[depth]
+            ):
+                os.close(child)
+                raise SmFsPrivacyError(
+                    f"corpus directory identity changed: {prefix}"
+                )
+            os.close(descriptor)
+            descriptor = child
+        return descriptor, relative_path.name
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def read_corpus_member(
+    root_fd: int,
+    relative: str,
+    *,
+    binding: Optional[CorpusMemberBinding] = None,
+) -> bytes:
+    """Read stable exact bytes through a retained root descriptor."""
+
+    if binding is not None and binding.relative != relative:
+        raise SmFsPrivacyError("corpus member binding path mismatch")
+    parent_fd, name = _open_member_parent(
+        root_fd,
+        relative,
+        None if binding is None else binding.directory_identities,
+    )
+    descriptor = -1
+    try:
+        try:
+            before = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+            if stat.S_ISLNK(before.st_mode):
+                raise SmFsPrivacyError(
+                    f"refusing symlink corpus member: {relative}"
+                )
+            if not stat.S_ISREG(before.st_mode):
+                raise SmFsPrivacyError(
+                    f"refusing non-regular corpus member: {relative}"
+                )
+            if (
+                binding is not None
+                and _identity(before) != binding.file_identity
+            ):
+                raise SmFsPrivacyError(
+                    f"corpus member identity changed: {relative}"
+                )
+            descriptor = os.open(
+                name,
+                os.O_RDONLY
+                | getattr(os, "O_CLOEXEC", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=parent_fd,
+            )
+        except SmFsPrivacyError:
+            raise
+        except OSError as exc:
+            raise SmFsPrivacyError(
+                f"cannot safely open corpus member: {relative}"
+            ) from exc
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or (before.st_dev, before.st_ino)
+            != (opened.st_dev, opened.st_ino)
+        ):
+            raise SmFsPrivacyError(
+                f"corpus member changed while opening: {relative}"
+            )
+        data = _read_all_from_fd(descriptor)
+        after_read = os.fstat(descriptor)
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        confirmed = _read_all_from_fd(descriptor)
+        after_confirmation = os.fstat(descriptor)
+        try:
+            after_name = os.stat(
+                name,
+                dir_fd=parent_fd,
+                follow_symlinks=False,
+            )
+        except OSError as exc:
+            raise SmFsPrivacyError(
+                f"corpus member changed while reading: {relative}"
+            ) from exc
+        if data != confirmed:
+            raise SmFsPrivacyError(
+                f"corpus member bytes changed while reading: {relative}"
+            )
+        identity = (opened.st_dev, opened.st_ino)
+        if any(
+            (value.st_dev, value.st_ino) != identity
+            for value in (after_read, after_confirmation, after_name)
+        ):
+            raise SmFsPrivacyError(
+                f"corpus member changed while reading: {relative}"
+            )
+        stable = (opened.st_size, opened.st_mtime_ns)
+        if any(
+            (value.st_size, value.st_mtime_ns) != stable
+            for value in (after_read, after_confirmation, after_name)
+        ):
+            raise SmFsPrivacyError(
+                f"corpus member changed while reading: {relative}"
+            )
+        if len(data) != opened.st_size:
+            raise SmFsPrivacyError(
+                f"corpus member size changed while reading: {relative}"
+            )
+        return data
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        os.close(parent_fd)
+
+
+def _read_regular_file_no_follow(path: Path) -> bytes:
+    """Read stable exact bytes without ever following the final symlink.
+
+    DrvFs/Dropbox hydration updates ``ctime`` and ``atime`` on the first read
+    even when the file identity, size, ``mtime``, and bytes do not change.
+    Therefore content stability is established by two identical reads from the
+    same descriptor rather than by treating ``ctime`` as a content version.
+    """
+
+    path = Path(path)
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    no_follow = getattr(os, "O_NOFOLLOW", 0)
+    try:
+        before = path.lstat()
+        if stat.S_ISLNK(before.st_mode):
+            raise SmFsPrivacyError(f"refusing symlink file: {path}")
+        if not stat.S_ISREG(before.st_mode):
+            raise SmFsPrivacyError(f"refusing non-regular file: {path}")
+        fd = os.open(path, flags | no_follow)
+    except SmFsPrivacyError:
+        raise
+    except OSError as exc:
+        raise SmFsPrivacyError(f"cannot safely open regular file: {path}") from exc
+
+    try:
+        opened = os.fstat(fd)
+        if not stat.S_ISREG(opened.st_mode):
+            raise SmFsPrivacyError(f"refusing non-regular file: {path}")
+        if (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino):
+            raise SmFsPrivacyError(f"file changed while opening: {path}")
+        data = _read_all_from_fd(fd)
+        after_read = os.fstat(fd)
+        os.lseek(fd, 0, os.SEEK_SET)
+        confirmed = _read_all_from_fd(fd)
+        after_confirmation = os.fstat(fd)
+        try:
+            after_path = path.lstat()
+        except OSError as exc:
+            raise SmFsPrivacyError(f"file changed while reading: {path}") from exc
+        if data != confirmed:
+            raise SmFsPrivacyError(f"file bytes changed while reading: {path}")
+        identity_fields = ("st_dev", "st_ino")
+        if any(
+            getattr(opened, field) != getattr(value, field)
+            for field in identity_fields
+            for value in (after_read, after_confirmation, after_path)
+        ):
+            raise SmFsPrivacyError(f"file changed while reading: {path}")
+        stable_fields = ("st_size", "st_mtime_ns")
+        if any(
+            getattr(opened, field) != getattr(value, field)
+            for field in stable_fields
+            for value in (after_read, after_confirmation, after_path)
+        ):
+            raise SmFsPrivacyError(f"file changed while reading: {path}")
+        if len(data) != opened.st_size:
+            raise SmFsPrivacyError(f"file size changed while reading: {path}")
+        if any(
+            not stat.S_ISREG(value.st_mode)
+            for value in (after_read, after_confirmation, after_path)
+        ):
+            raise SmFsPrivacyError(f"file changed type while reading: {path}")
+        return data
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
+def sha256_file(path: Path) -> str:
+    return sha256_bytes(_read_regular_file_no_follow(path))
+
+
+def _strict_object(pairs):
+    out = {}
+    for key, value in pairs:
+        if key in out:
+            raise SmFsPrivacyError(f"duplicate JSON key: {key!r}")
+        out[key] = value
+    return out
+
+
+def _normal_text(value: Any) -> str:
+    return " ".join(str(value or "").replace("\\N", " ").split())
+
+
+def _exact_private_marker(value: Any) -> bool:
+    text = _normal_text(value).casefold()
+    text = text.strip(" \t\r\n*[](){}.!?")
+    return text == "private"
+
+
+def _access_prefix(value: Any) -> bool:
+    return bool(ACCESS_PREFIX.search(_normal_text(value)))
+
+
+def _contains_private_word(value: Any) -> bool:
+    return bool(PRIVATE_WORD.search(_normal_text(value)))
+
+
+def _looks_like_privacy_topic_url(url: str) -> bool:
+    parsed = urlparse(url)
+    searchable = unquote(f"{parsed.path} {parsed.query} {parsed.fragment}")
+    return bool(PRIVATE_OR_PRIVACY_WORD.search(searchable.replace("-", " ").replace("_", " ")))
+
+
+def pearltrees_url_kind(url: str) -> Optional[str]:
+    """Return ``public``, ``private_unknown``, or ``None`` for one URL.
+
+    ``/private/id...`` is deliberately ambiguous: in this corpus it is often
+    an authentication/export artifact on otherwise ordinary STEM maps.
+    """
+
+    if not isinstance(url, str):
+        return None
+    try:
+        parsed = urlparse(url)
+        host = (parsed.hostname or "").casefold()
+    except ValueError:
+        return None
+    if parsed.scheme.casefold() not in ("http", "https"):
+        return None
+    if host not in ("pearltrees.com", "www.pearltrees.com"):
+        return None
+    # A public root link has exactly /ACCOUNT/SLUG/idNNN. Comparing netloc as
+    # well as hostname rejects credentials and ports that merely parse to the
+    # trusted hostname.
+    if parsed.netloc.casefold() != host:
+        return None
+    decoded_path = unquote(parsed.path)
+    match = re.fullmatch(r"/([^/]+)/([^/]+)/(id\d+)/?", decoded_path, re.I)
+    parts = [part for part in decoded_path.split("/") if part]
+    if (
+        parts
+        and any(part.casefold() == "private" for part in parts)
+        and PEARLTREES_ID.fullmatch(parts[-1])
+    ):
+        return "private_unknown"
+    if match is None:
+        # The unreliable export form is the sole accepted two-component
+        # exception, and it remains unknown rather than public.
+        private_match = re.fullmatch(r"/private/(id\d+)/?", decoded_path, re.I)
+        return "private_unknown" if private_match else None
+    account, slug, pearltrees_id = match.groups()
+    if (
+        account.casefold() != "private"
+        and slug.casefold() != "private"
+        and PEARLTREES_SEGMENT.fullmatch(account)
+        and PEARLTREES_SEGMENT.fullmatch(slug)
+        and PEARLTREES_ID.fullmatch(pearltrees_id)
+    ):
+        return "public"
+    return None
+
+
+def _topic_links(topic, attribute: str) -> List[str]:
+    return [
+        value
+        for value in (link.get(attribute) for link in topic.findall("link"))
+        if isinstance(value, str) and value
+    ]
+
+
+def _topic_has_public_topical_link(topic) -> bool:
+    for url in _topic_links(topic, "urllink"):
+        parsed = urlparse(url)
+        host = (parsed.hostname or "").casefold()
+        if (
+            pearltrees_url_kind(url) != "private_unknown"
+            and parsed.scheme in ("http", "https")
+            and (host == "wikipedia.org" or host.endswith(".wikipedia.org"))
+            and _looks_like_privacy_topic_url(url)
+        ):
+            return True
+    return False
+
+
+def _inside(root: Path, path: Path) -> bool:
+    try:
+        return os.path.commonpath((str(root), str(path))) == str(root)
+    except ValueError:
+        return False
+
+
+def _relative_member_path(corpus_root: Path, path: Path) -> Optional[str]:
+    path = Path(os.path.abspath(os.path.normpath(str(path))))
+    if not _inside(corpus_root, path):
+        return None
+    return path.relative_to(corpus_root).as_posix()
+
+
+def _member_catalog(
+    corpus_root: Path, paths: Sequence[Path]
+) -> Tuple[Dict[str, Path], Dict[str, Optional[Path]]]:
+    exact: Dict[str, Path] = {}
+    folded: Dict[str, Optional[Path]] = {}
+    for path in paths:
+        relative = path.relative_to(corpus_root).as_posix()
+        exact[relative] = path
+        key = relative.casefold()
+        if key in folded and folded[key] != path:
+            folded[key] = None
+        else:
+            folded[key] = path
+    return exact, folded
+
+
+def _catalog_member(
+    corpus_root: Path,
+    candidate: Path,
+    members: Tuple[Mapping[str, Path], Mapping[str, Optional[Path]]],
+) -> Optional[Path]:
+    relative = _relative_member_path(corpus_root, candidate)
+    if relative is None:
+        return None
+    exact, folded = members
+    if relative in exact:
+        return exact[relative]
+    return folded.get(relative.casefold())
+
+
+def resolve_cloudmapref(
+    corpus_root: Path,
+    source: Path,
+    ref: str,
+    *,
+    members: Optional[
+        Tuple[Mapping[str, Path], Mapping[str, Optional[Path]]]
+    ] = None,
+) -> Optional[Path]:
+    """Resolve SimpleMind relative and virtual ``/root/...`` map references."""
+
+    corpus_root = Path(os.path.abspath(str(corpus_root)))
+    source = Path(os.path.abspath(str(source)))
+    normalized = ref.replace("\\", "/").strip()
+    if not normalized or normalized == ".":
+        return None
+    if normalized.casefold().startswith("/root/"):
+        candidates = [corpus_root / normalized[len("/root/") :]]
+    elif normalized.casefold().startswith("root/"):
+        candidates = [corpus_root / normalized[len("root/") :]]
+    elif normalized.startswith("/"):
+        return None
+    else:
+        candidates = [
+            source.parent / normalized,
+            corpus_root / normalized,
+        ]
+    candidates = [
+        Path(os.path.abspath(os.path.normpath(str(candidate))))
+        for candidate in candidates
+        if _inside(
+            corpus_root,
+            Path(os.path.abspath(os.path.normpath(str(candidate)))),
+        )
+    ]
+    if not candidates:
+        return None
+    if members is not None:
+        resolved_members = {
+            target
+            for target in (
+                _catalog_member(corpus_root, candidate, members)
+                for candidate in candidates
+            )
+            if target is not None
+        }
+        return next(iter(resolved_members)) if len(resolved_members) == 1 else None
+
+    regular_candidates = []
+    for candidate in candidates:
+        try:
+            mode = candidate.lstat().st_mode
+        except OSError:
+            continue
+        if stat.S_ISREG(mode):
+            regular_candidates.append(candidate)
+    distinct = set(regular_candidates)
+    if len(distinct) > 1:
+        return None
+    if len(distinct) == 1:
+        return next(iter(distinct))
+    # Preserve the resolver's lexical behavior for callers that are checking a
+    # virtual /root target before it has been created.
+    return candidates[0]
+
+
+def _private_word_components(
+    relative_path: Path,
+) -> Tuple[List[str], List[str], List[str]]:
+    exact, access, broad = [], [], []
+    for component in relative_path.parent.parts:
+        if _exact_private_marker(component):
+            exact.append(component)
+        elif _access_prefix(component):
+            access.append(component)
+        elif _contains_private_word(component):
+            broad.append(component)
+    return exact, access, broad
+
+
+def _load_smmx_bytes(raw: bytes):
+    stream = io.BytesIO(raw)
+    if zipfile.is_zipfile(stream):
+        stream.seek(0)
+        with zipfile.ZipFile(stream) as archive:
+            canonical = "document/mindmap.xml"
+            candidates = []
+            for info in archive.infolist():
+                normalized = posixpath.normpath(
+                    info.filename.replace("\\", "/")
+                ).casefold()
+                if normalized == canonical.casefold():
+                    candidates.append(info)
+            if (
+                len(candidates) != 1
+                or candidates[0].filename != canonical
+                or candidates[0].is_dir()
+            ):
+                raise SmFsPrivacyError(
+                    "map archive must contain exactly one unambiguous "
+                    "document/mindmap.xml member"
+                )
+            return ET.fromstring(archive.read(candidates[0]))
+    return ET.fromstring(raw)
+
+
+def _blank_root_placeholder(
+    topic,
+    children: Mapping[str, Sequence[str]],
+    relation_topic_ids: Set[str],
+) -> bool:
+    topic_id = topic.get("id")
+    if (
+        label(topic)
+        or children.get(topic_id)
+        or topic_id in relation_topic_ids
+        or (topic.text or "").strip()
+    ):
+        return False
+    if any(
+        value
+        for key, value in topic.attrib.items()
+        if key not in ("id", "parent", "text", "guid") and str(value).strip()
+    ):
+        return False
+    # Links, notes, relations, or any other nested payload mean the root is not
+    # demonstrably blank even if its visible text happens to be empty.
+    return not list(topic)
+
+
+def _validated_topic_graph(xml):
+    topics = list(xml.findall(".//topic"))
+    if not topics:
+        raise SmFsPrivacyError("map has no topics")
+    topic_by_id = {}
+    for topic in topics:
+        topic_id = topic.get("id")
+        if (
+            not isinstance(topic_id, str)
+            or not topic_id.strip()
+            or topic_id == "-1"
+        ):
+            raise SmFsPrivacyError("map topic is missing an id")
+        if topic_id in topic_by_id:
+            raise SmFsPrivacyError(f"duplicate map topic id: {topic_id!r}")
+        topic_by_id[topic_id] = topic
+
+    children = defaultdict(list)
+    roots = []
+    for topic_id, topic in topic_by_id.items():
+        parent_id = topic.get("parent")
+        if parent_id in (None, "-1"):
+            roots.append(topic)
+            continue
+        if parent_id not in topic_by_id:
+            raise SmFsPrivacyError(
+                f"map topic {topic_id!r} has missing parent {parent_id!r}"
+            )
+        children[parent_id].append(topic_id)
+    if not roots:
+        raise SmFsPrivacyError("map has no root topic")
+
+    for start_id in topic_by_id:
+        seen = set()
+        topic_id = start_id
+        while topic_id is not None:
+            if topic_id in seen:
+                raise SmFsPrivacyError("map topic parent graph has a cycle")
+            seen.add(topic_id)
+            parent_id = topic_by_id[topic_id].get("parent")
+            topic_id = None if parent_id in (None, "-1") else parent_id
+
+    relation_topic_ids = {
+        topic_id
+        for relation in xml.findall(".//relation")
+        for topic_id in (relation.get("source"), relation.get("target"))
+        if topic_id is not None
+    }
+    if len(roots) == 1:
+        root_topic = roots[0]
+        extra_roots = False
+    else:
+        substantive = [
+            topic
+            for topic in roots
+            if not _blank_root_placeholder(
+                topic, children, relation_topic_ids
+            )
+        ]
+        if len(substantive) != 1:
+            raise SmFsPrivacyError(
+                f"cannot distinguish {len(roots)} root topics"
+            )
+        root_topic = substantive[0]
+        if any(
+            not _blank_root_placeholder(
+                topic, children, relation_topic_ids
+            )
+            for topic in roots
+            if topic is not root_topic
+        ):
+            raise SmFsPrivacyError("extra root topic is not a blank placeholder")
+        extra_roots = True
+    return topics, topic_by_id, children, root_topic, extra_roots
+
+
+def _base_record(
+    corpus_root: Path,
+    members: Tuple[Mapping[str, Path], Mapping[str, Optional[Path]]],
+    root_fd: int,
+    binding: CorpusMemberBinding,
+) -> Dict[str, Any]:
+    relative = binding.relative
+    path = corpus_root / PurePosixPath(relative)
+    raw = read_corpus_member(root_fd, relative, binding=binding)
+    record = {
+        "record_type": "map",
+        "relative_path": relative,
+        "file_sha256": sha256_bytes(raw),
+        "root_title": "",
+        "root_urls": [],
+        "classification": "unknown",
+        "reasons": [],
+        "model_review": None,
+        "unresolved_private_targets": [],
+    }
+    exact_dirs, access_dirs, broad_dirs = _private_word_components(Path(relative))
+    try:
+        xml = _load_smmx_bytes(raw)
+        topics, topic_by_id, children, root_topic, extra_roots = (
+            _validated_topic_graph(xml)
+        )
+        if extra_roots:
+            record["reasons"].append("extra_root_topics_ignored")
+        root_title = label(root_topic)
+        root_urls = sorted(set(_topic_links(root_topic, "urllink")))
+        record["root_title"] = root_title
+        record["root_urls"] = root_urls
+
+        public_root = any(pearltrees_url_kind(url) == "public" for url in root_urls)
+        private_link = any(
+            pearltrees_url_kind(url) == "private_unknown" for url in root_urls
+        )
+        access_prefix = _access_prefix(path.stem) or _access_prefix(root_title)
+        access_seed = bool(exact_dirs or access_dirs) or access_prefix
+        broad_private = bool(broad_dirs) or (
+            _contains_private_word(path.stem)
+            or _contains_private_word(root_title)
+        )
+        root_topic_evidence = (
+            bool(PRIVATE_OR_PRIVACY_WORD.search(root_title))
+            and not access_prefix
+        ) or any(
+            pearltrees_url_kind(url) != "private_unknown"
+            and _looks_like_privacy_topic_url(url)
+            for url in root_urls
+        )
+
+        if public_root and access_seed:
+            record["classification"] = "unknown"
+            record["reasons"].extend(
+                ("public_root_link", "access_marker_conflicts_with_public_root")
+            )
+        elif public_root:
+            record["classification"] = "public"
+            record["reasons"].append("public_root_link")
+            if broad_private:
+                record["reasons"].append("public_root_link_overrides_private_word")
+        elif access_seed and root_topic_evidence:
+            record["classification"] = "unknown"
+            record["reasons"].append("private_marker_with_topical_root")
+        elif access_seed:
+            record["classification"] = "private"
+            record["reasons"].append("private_dir_or_access_prefix")
+        elif private_link:
+            record["classification"] = "unknown"
+            record["reasons"].append("pearltrees_private_link_unknown")
+        elif broad_private:
+            record["classification"] = "unknown"
+            record["reasons"].append("private_word_marker_vs_topic")
+        else:
+            record["classification"] = "public"
+            record["reasons"].append("owner_default_no_private_signal")
+
+        private_targets = set()
+        unresolved = set()
+        for marker_id, marker in topic_by_id.items():
+            if not _exact_private_marker(label(marker)):
+                continue
+            if _topic_has_public_topical_link(marker):
+                continue
+            closure, frontier = set(), [marker_id]
+            while frontier:
+                topic_id = frontier.pop()
+                if topic_id in closure:
+                    continue
+                closure.add(topic_id)
+                frontier.extend(children.get(topic_id, ()))
+            for topic_id in closure:
+                topic = topic_by_id[topic_id]
+                for ref in _topic_links(topic, "cloudmapref"):
+                    target = resolve_cloudmapref(
+                        corpus_root, path, ref, members=members
+                    )
+                    if target is None:
+                        if ref != ".":
+                            unresolved.add(ref)
+                        continue
+                    if target.suffix.casefold() != ".smmx":
+                        unresolved.add(ref)
+                        continue
+                    private_targets.add(target.relative_to(corpus_root).as_posix())
+        record["_private_targets"] = sorted(private_targets)
+        record["unresolved_private_targets"] = sorted(unresolved)
+        if private_targets:
+            record["reasons"].append("contains_private_map_links")
+        if unresolved:
+            record["reasons"].append("unresolved_private_map_links")
+    except Exception as exc:
+        if exact_dirs or access_dirs or _access_prefix(path.stem):
+            record["classification"] = "private"
+            record["reasons"].append("private_path_without_readable_map")
+        else:
+            record["classification"] = "unknown"
+            record["reasons"].append("map_parse_error")
+        record["parse_error_type"] = type(exc).__name__
+        record["_private_targets"] = []
+    record["reasons"] = sorted(set(record["reasons"]))
+    return record
+
+
+def _smmx_paths(corpus_root: Path) -> List[Path]:
+    """Compatibility wrapper; production scans keep the returned root fd open."""
+
+    with open_corpus_root(corpus_root) as (root, root_fd):
+        return [
+            root / PurePosixPath(binding.relative)
+            for binding in smmx_member_bindings(root_fd)
+        ]
+
+
+def scan_maps(corpus_root: Path, *, workers: int = 8) -> List[Dict[str, Any]]:
+    if workers <= 0:
+        raise SmFsPrivacyError("workers must be positive")
+    with open_corpus_root(corpus_root) as (corpus_root, root_fd):
+        bindings = smmx_member_bindings(root_fd)
+        paths = [
+            corpus_root / PurePosixPath(binding.relative)
+            for binding in bindings
+        ]
+        members = _member_catalog(corpus_root, paths)
+        build_record = partial(_base_record, corpus_root, members, root_fd)
+        if workers == 1:
+            records = [build_record(binding) for binding in bindings]
+        else:
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                records = list(executor.map(build_record, bindings))
+    by_path = {record["relative_path"]: record for record in records}
+    for source in records:
+        for target_path in source.pop("_private_targets", ()):
+            target = by_path.get(target_path)
+            if target is None:
+                source["unresolved_private_targets"] = sorted(
+                    set(source["unresolved_private_targets"]) | {target_path}
+                )
+                source["reasons"] = sorted(
+                    set(source["reasons"]) | {"unresolved_private_map_links"}
+                )
+                continue
+            if "public_root_link" in target["reasons"]:
+                target["classification"] = "unknown"
+                target["reasons"] = sorted(
+                    set(target["reasons"])
+                    | {"private_cloud_child_conflicts_with_public_root"}
+                )
+                continue
+            target["classification"] = "private"
+            target["reasons"] = sorted(
+                set(target["reasons"]) | {"private_cloud_child"}
+            )
+    return records
+
+
+def review_task(record: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "qid": sha256_bytes(record["relative_path"].encode("utf-8"))[:20],
+        "relative_path": record["relative_path"],
+        "root_title": record.get("root_title", ""),
+        "root_urls": list(record.get("root_urls", ())),
+        "rule_reasons": list(record.get("reasons", ())),
+        "allowed_interpretations": sorted(INTERPRETATIONS),
+    }
+
+
+def build_review_prompt(tasks: Sequence[Mapping[str, Any]]) -> str:
+    return """You are classifying owner-controlled SimpleMind filing metadata.
+
+For each row, decide whether its use of "private" is:
+- access_control: a private copy/branch or access-control marker;
+- topical: an ordinary map whose subject happens to include "private", or an
+  ordinary map carrying an unreliable pearltrees.com/private export link;
+- uncertain: not enough evidence.
+
+A pearltrees.com/private/id... URL is NOT proof of privacy: this export has many
+normal STEM maps with that URL. A normal /ACCOUNT/SLUG/id... root link is public
+topical evidence. Private:, Private_, and Private - prefixes normally identify
+access-controlled copies. Rule reason glossary: private_dir_or_access_prefix
+means a filesystem/access-copy marker; private_marker_with_topical_root means
+that marker conflicts with a topical title or link; private_word_marker_vs_topic
+means the wording alone is ambiguous; pearltrees_private_link_unknown means the
+export URL is unreliable.
+
+Apply this precedence:
+1. An explicit access-copy name wins over an unreliable /private/id URL.
+2. An otherwise ordinary STEM title with only that unreliable URL is topical.
+3. A known subject use (privacy law, private-key cryptography, private methods)
+   with positive topical evidence is topical.
+4. A filesystem/access marker conflicting with a topical title, or a bare
+   "private ..." phrase with no decisive context, is uncertain.
+
+Synthetic examples:
+- Private - Lab Copy + private_dir_or_access_prefix => access_control.
+- Bayesian statistics + only pearltrees_private_link_unknown => topical.
+- exact Private folder + Private-key cryptography title => uncertain.
+
+Return ONLY an unfenced JSON array with exactly one object per input row.
+Preserve every qid exactly. Each object must have exactly qid, interpretation,
+and reason. Keep reason nonempty and at most 300 characters. No markdown.
+
+Rows:
+""" + json.dumps(list(tasks), ensure_ascii=False, sort_keys=True)
+
+
+def _parse_model_response(text: str, expected_qids: Set[str]) -> Dict[str, Dict[str, str]]:
+    stripped = (text or "").strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if len(lines) >= 3 and lines[-1].strip() == "```":
+            stripped = "\n".join(lines[1:-1])
+            if stripped.lstrip().startswith("json"):
+                stripped = stripped.lstrip()[4:].lstrip()
+    try:
+        rows = json.loads(stripped, object_pairs_hook=_strict_object)
+    except (json.JSONDecodeError, SmFsPrivacyError) as exc:
+        raise SmFsPrivacyError(f"model response is not strict JSON: {exc}") from exc
+    if not isinstance(rows, list):
+        raise SmFsPrivacyError("model response must be a JSON array")
+    out = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise SmFsPrivacyError("model response rows must be objects")
+        if set(row) != {"qid", "interpretation", "reason"}:
+            raise SmFsPrivacyError("model response row fields changed")
+        qid = row["qid"]
+        interpretation = row["interpretation"]
+        reason = row["reason"]
+        if qid not in expected_qids or qid in out:
+            raise SmFsPrivacyError("model response qid set changed")
+        if interpretation not in INTERPRETATIONS:
+            raise SmFsPrivacyError(f"invalid model interpretation: {interpretation!r}")
+        if not isinstance(reason, str) or not reason.strip() or len(reason) > 300:
+            raise SmFsPrivacyError("invalid model reason")
+        out[qid] = {"interpretation": interpretation, "reason": reason.strip()}
+    if set(out) != expected_qids:
+        raise SmFsPrivacyError("model response omitted review rows")
+    return out
+
+
+def apply_model_reviews(
+    records: List[Dict[str, Any]],
+    *,
+    provider: str,
+    model: str,
+    batch_size: int,
+    timeout: int,
+    call_llm: Callable[[str, str, str, int], Optional[str]],
+) -> Dict[str, int]:
+    # Benchmarking uses only build_review_prompt() and _parse_model_response()
+    # with synthetic rows. This legacy corpus-facing entry point is sealed off
+    # so no caller can accidentally serialize or transmit owner metadata.
+    del records, provider, model, batch_size, timeout, call_llm
+    raise SmFsPrivacyError(MODEL_REVIEW_DISABLED_REASON)
+
+
+def _source_snapshot(records: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
+    members = [
+        {
+            "relative_path": record["relative_path"],
+            "file_sha256": record["file_sha256"],
+        }
+        for record in records
+    ]
+    return {
+        "file_count": len(members),
+        "members_sha256": sha256_bytes(
+            b"".join(canonical_json_bytes(member) for member in members)
+        ),
+    }
+
+
+def _is_count(value: Any) -> bool:
+    return type(value) is int and value >= 0
+
+
+def _require_sorted_unique_strings(value: Any, field: str) -> None:
+    if (
+        not isinstance(value, list)
+        or any(not isinstance(item, str) for item in value)
+        or value != sorted(set(value))
+    ):
+        raise SmFsPrivacyError(
+            f"privacy index {field} must be sorted unique strings"
+        )
+
+
+def _validate_v1_record(record: Any) -> None:
+    if not isinstance(record, Mapping) or record.get("record_type") != "map":
+        raise SmFsPrivacyError("privacy index map row is malformed")
+    fields = set(record)
+    if not MAP_FIELDS.issubset(fields) or not fields.issubset(
+        MAP_FIELDS | MAP_OPTIONAL_FIELDS
+    ):
+        raise SmFsPrivacyError("privacy index v1 map fields changed")
+
+    relative = record.get("relative_path")
+    if not isinstance(relative, str) or not relative or "\\" in relative:
+        raise SmFsPrivacyError("privacy index map path is invalid")
+    relative_path = PurePosixPath(relative)
+    if (
+        relative_path.is_absolute()
+        or relative_path.as_posix() != relative
+        or any(part in ("", ".", "..") for part in relative_path.parts)
+        or relative_path.suffix.casefold() != ".smmx"
+    ):
+        raise SmFsPrivacyError("privacy index map path is invalid")
+    if not isinstance(record.get("file_sha256"), str) or not SHA256_HEX.fullmatch(
+        record["file_sha256"]
+    ):
+        raise SmFsPrivacyError("privacy index map digest is invalid")
+    if not isinstance(record.get("root_title"), str):
+        raise SmFsPrivacyError("privacy index root title is invalid")
+    _require_sorted_unique_strings(record.get("root_urls"), "root_urls")
+    _require_sorted_unique_strings(record.get("reasons"), "reasons")
+    _require_sorted_unique_strings(
+        record.get("unresolved_private_targets"),
+        "unresolved_private_targets",
+    )
+    if record.get("classification") not in CLASSIFICATIONS:
+        raise SmFsPrivacyError("privacy index map classification is invalid")
+    if record.get("model_review") is not None or any(
+        reason.startswith("model_") for reason in record["reasons"]
+    ):
+        raise SmFsPrivacyError("privacy index v1 cannot contain model review data")
+
+    parse_reasons = {
+        "map_parse_error",
+        "private_path_without_readable_map",
+    }
+    has_parse_error = bool(parse_reasons.intersection(record["reasons"]))
+    parse_error_type = record.get("parse_error_type")
+    if (
+        has_parse_error
+        and (
+            "parse_error_type" not in record
+            or not isinstance(parse_error_type, str)
+            or not parse_error_type
+        )
+    ) or (not has_parse_error and "parse_error_type" in record):
+        raise SmFsPrivacyError("privacy index parse-error metadata is invalid")
+
+
+def _derived_counts(records: Sequence[Mapping[str, Any]]) -> Dict[str, int]:
+    classifications = Counter(record["classification"] for record in records)
+    reasons = Counter(
+        reason for record in records for reason in record.get("reasons", ())
+    )
+    return {
+        "public": classifications["public"],
+        "private": classifications["private"],
+        "unknown": classifications["unknown"],
+        "observed": len(records),
+        "model_access_control": 0,
+        "model_topical": 0,
+        "model_uncertain": 0,
+        "map_parse_errors": reasons["map_parse_error"],
+        "unresolved_private_target_refs": sum(
+            len(record["unresolved_private_targets"]) for record in records
+        ),
+    }
+
+
+def _index_digest(
+    header: Mapping[str, Any], records: Sequence[Mapping[str, Any]]
+) -> str:
+    core = dict(header)
+    core.pop("index_sha256", None)
+    core["rows_sha256"] = sha256_bytes(
+        b"".join(canonical_json_bytes(record) for record in records)
+    )
+    return sha256_bytes(canonical_json_bytes(core))
+
+
+def _validate_v1_index(
+    header: Any,
+    records: Sequence[Any],
+    *,
+    verify_digest: bool,
+) -> None:
+    if not isinstance(header, Mapping) or header.get("record_type") != "header":
+        raise SmFsPrivacyError("privacy index header is missing")
+    if set(header) != HEADER_FIELDS:
+        raise SmFsPrivacyError("privacy index v1 header fields changed")
+    if header.get("schema") != SCHEMA or header.get("policy_id") != POLICY_ID:
+        raise SmFsPrivacyError("privacy index schema/policy changed")
+    corpus_root = header.get("corpus_root")
+    if (
+        not isinstance(corpus_root, str)
+        or not corpus_root
+        or not os.path.isabs(corpus_root)
+        or os.path.abspath(corpus_root) != corpus_root
+    ):
+        raise SmFsPrivacyError("privacy index corpus root is invalid")
+    for field in ("classifier_sha256", "parser_sha256", "index_sha256"):
+        value = header.get(field)
+        if not isinstance(value, str) or not SHA256_HEX.fullmatch(value):
+            raise SmFsPrivacyError(f"privacy index {field} is invalid")
+    if header.get("model") is not None:
+        raise SmFsPrivacyError("privacy index v1 cannot name a model")
+    if header.get("model_review_authorization") != {
+        "authorized": False,
+        "reason": MODEL_REVIEW_DISABLED_REASON,
+    }:
+        raise SmFsPrivacyError(
+            "privacy index v1 model-review authorization changed"
+        )
+
+    counts = header.get("counts")
+    if (
+        not isinstance(counts, Mapping)
+        or set(counts) != COUNT_FIELDS
+        or any(not _is_count(value) for value in counts.values())
+    ):
+        raise SmFsPrivacyError("privacy index v1 counts are invalid")
+    snapshot = header.get("source_snapshot")
+    if (
+        not isinstance(snapshot, Mapping)
+        or set(snapshot) != {"file_count", "members_sha256"}
+        or not _is_count(snapshot.get("file_count"))
+        or not isinstance(snapshot.get("members_sha256"), str)
+        or not SHA256_HEX.fullmatch(snapshot["members_sha256"])
+    ):
+        raise SmFsPrivacyError("privacy index source snapshot is invalid")
+
+    seen = set()
+    for record in records:
+        _validate_v1_record(record)
+        relative = record["relative_path"]
+        if relative in seen:
+            raise SmFsPrivacyError("privacy index map path is duplicated")
+        seen.add(relative)
+    if counts != _derived_counts(records):
+        raise SmFsPrivacyError("privacy index derived counts changed")
+    if snapshot != _source_snapshot(records):
+        raise SmFsPrivacyError("privacy index source snapshot changed")
+    if verify_digest and header["index_sha256"] != _index_digest(header, records):
+        raise SmFsPrivacyError("privacy index digest changed")
+
+
+def build_index(
+    corpus_root: Path,
+    *,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    batch_size: int = 20,
+    timeout: int = 120,
+    workers: int = 8,
+    call_llm: Optional[Callable[[str, str, str, int], Optional[str]]] = None,
+) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    if bool(provider) != bool(model):
+        raise SmFsPrivacyError("--provider and --model must be supplied together")
+    if provider or call_llm is not None:
+        raise SmFsPrivacyError(MODEL_REVIEW_DISABLED_REASON)
+
+    classifier_sha256 = sha256_file(Path(__file__))
+    parser_sha256 = sha256_file(PARSER_PATH)
+    records = scan_maps(corpus_root, workers=workers)
+    if sha256_file(Path(__file__)) != classifier_sha256:
+        raise SmFsPrivacyError("classifier changed while the index was being built")
+    if sha256_file(PARSER_PATH) != parser_sha256:
+        raise SmFsPrivacyError("SimpleMind parser changed while the index was being built")
+    header = {
+        "record_type": "header",
+        "schema": SCHEMA,
+        "policy_id": POLICY_ID,
+        "corpus_root": str(Path(os.path.abspath(str(corpus_root)))),
+        "source_snapshot": _source_snapshot(records),
+        "classifier_sha256": classifier_sha256,
+        "parser_sha256": parser_sha256,
+        "model": None,
+        "model_review_authorization": {
+            "authorized": False,
+            "reason": MODEL_REVIEW_DISABLED_REASON,
+        },
+        "counts": _derived_counts(records),
+    }
+    header["index_sha256"] = _index_digest(header, records)
+    _validate_v1_index(header, records, verify_digest=True)
+    return header, records
+
+
+def write_index(path: Path, header: Mapping[str, Any], records: Sequence[Mapping[str, Any]]) -> None:
+    _validate_v1_index(header, records, verify_digest=True)
+    data = canonical_json_bytes(dict(header)) + b"".join(
+        canonical_json_bytes(dict(record)) for record in records
+    )
+    if path.exists():
+        raise FileExistsError(
+            f"refusing to replace sealed privacy index: {path}; choose a new path"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(path.parent, 0o700)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    installed = False
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.link(temporary, path)
+        installed = True
+        directory_fd = os.open(str(path.parent), os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        if installed:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+        raise
+    finally:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+
+
+def load_index(path: Path) -> Tuple[Dict[str, Any], Dict[str, Dict[str, Any]]]:
+    try:
+        lines = _read_regular_file_no_follow(path).splitlines()
+    except SmFsPrivacyError as exc:
+        raise SmFsPrivacyError(f"cannot read privacy index: {path}") from exc
+    if not lines:
+        raise SmFsPrivacyError("privacy index is empty")
+    try:
+        values = [
+            json.loads(line.decode("utf-8"), object_pairs_hook=_strict_object)
+            for line in lines
+        ]
+    except (UnicodeDecodeError, json.JSONDecodeError, SmFsPrivacyError) as exc:
+        raise SmFsPrivacyError(f"privacy index is malformed: {exc}") from exc
+    header = values[0]
+    records = values[1:]
+    _validate_v1_index(header, records, verify_digest=True)
+    by_path = {}
+    for record in records:
+        by_path[record["relative_path"]] = record
+    return header, by_path
+
+
+def verify_index_source(
+    corpus_root: Path,
+    header: Mapping[str, Any],
+    by_path: Mapping[str, Mapping[str, Any]],
+    *,
+    workers: int = 8,
+) -> None:
+    """Re-derive the index with the exact classifier and byte-compare every row."""
+
+    corpus_root = Path(os.path.abspath(str(corpus_root)))
+    expected_root = header.get("corpus_root")
+    if expected_root != str(corpus_root):
+        raise SmFsPrivacyError("privacy index corpus root changed")
+    classifier_sha256 = sha256_file(Path(__file__))
+    parser_sha256 = sha256_file(PARSER_PATH)
+    if header.get("classifier_sha256") != classifier_sha256:
+        raise SmFsPrivacyError("privacy index classifier changed; rebuild the index")
+    if header.get("parser_sha256") != parser_sha256:
+        raise SmFsPrivacyError("privacy index SimpleMind parser changed; rebuild the index")
+    if workers <= 0:
+        raise SmFsPrivacyError("workers must be positive")
+
+    indexed_records = []
+    for relative, record in by_path.items():
+        if (
+            not isinstance(relative, str)
+            or not isinstance(record, Mapping)
+            or record.get("relative_path") != relative
+        ):
+            raise SmFsPrivacyError("privacy index map mapping is invalid")
+        indexed_records.append(record)
+    _validate_v1_index(header, indexed_records, verify_digest=True)
+
+    derived_records = scan_maps(corpus_root, workers=workers)
+    if sha256_file(Path(__file__)) != classifier_sha256:
+        raise SmFsPrivacyError("classifier changed while the index was verified")
+    if sha256_file(PARSER_PATH) != parser_sha256:
+        raise SmFsPrivacyError(
+            "SimpleMind parser changed while the index was verified"
+        )
+    derived_by_path = {
+        record["relative_path"]: record for record in derived_records
+    }
+    if set(by_path) != set(derived_by_path):
+        raise SmFsPrivacyError("privacy index is stale: map set changed")
+    for relative, derived in derived_by_path.items():
+        if canonical_json_bytes(by_path[relative]) != canonical_json_bytes(derived):
+            if by_path[relative].get("file_sha256") != derived["file_sha256"]:
+                raise SmFsPrivacyError(
+                    "privacy index is stale: map contents changed"
+                )
+            raise SmFsPrivacyError(
+                "privacy index record differs from exact classifier output"
+            )
+    _validate_v1_index(header, derived_records, verify_digest=False)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default="/mnt/c/Users/johnc/Dropbox/root")
+    parser.add_argument(
+        "--out", default=os.path.expanduser("~/mu_data/sm_fs_privacy_index.jsonl")
+    )
+    parser.add_argument("--workers", type=int, default=8)
+    args = parser.parse_args(argv)
+    header, records = build_index(
+        Path(args.root),
+        workers=args.workers,
+    )
+    write_index(Path(args.out), header, records)
+    counts = header["counts"]
+    print(
+        "SimpleMind privacy index: "
+        f"{counts['public']} public, {counts['private']} private, "
+        f"{counts['unknown']} unknown -> {args.out}"
+    )
+    print(
+        "Review perimeter: "
+        f"{counts['map_parse_errors']} unreadable maps; "
+        f"{counts['unresolved_private_target_refs']} unresolved references "
+        "below explicit private markers"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/test_benchmark_sm_fs_privacy_local.py
+++ b/prototypes/mu_cosine/test_benchmark_sm_fs_privacy_local.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Focused tests for the synthetic-only local privacy benchmark."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import benchmark_sm_fs_privacy_local as benchmark
+
+
+PROVENANCE = {
+    "model": {
+        "tag": "test:4b",
+        "digest": "0123456789ab",
+        "ollama_version": "ollama version is 0.test",
+        "ollama_cli": "/test/ollama",
+    },
+    "repo_commit": "a" * 40,
+    "endpoint": "http://127.0.0.1:11434",
+    "sources": {
+        "classifier_sha256": "b" * 64,
+        "evaluator_sha256": "c" * 64,
+        "llm_bridge_sha256": "d" * 64,
+    },
+}
+
+
+def _response(*, wrong_first_label: bool = False) -> str:
+    rows = []
+    for index, case in enumerate(benchmark.synthetic_cases()):
+        interpretation = case["expected"]
+        if wrong_first_label and index == 0:
+            interpretation = "uncertain"
+        rows.append(
+            {
+                "qid": case["task"]["qid"],
+                "interpretation": interpretation,
+                "reason": "synthetic test response",
+            }
+        )
+    return json.dumps(rows)
+
+
+def _install_fake_model(monkeypatch, response: str) -> None:
+    monkeypatch.setattr(
+        benchmark,
+        "_provenance_snapshot",
+        lambda _model: copy.deepcopy(PROVENANCE),
+    )
+
+    def fake_call(
+        _prompt,
+        _model,
+        _timeout,
+        *,
+        response_schema,
+        max_output_tokens,
+        think,
+        metadata_out,
+    ):
+        assert response_schema["minItems"] == 12
+        assert response_schema["maxItems"] == 12
+        assert max_output_tokens == 2048
+        assert think is False
+        metadata_out.update(
+            {"done_reason": "stop", "eval_count": 71, "total_duration": 73}
+        )
+        return response
+
+    monkeypatch.setattr(benchmark, "call_ollama_json", fake_call)
+
+
+def test_benchmark_main_seals_strict_pass_with_bound_provenance(
+    tmp_path, monkeypatch
+):
+    _install_fake_model(monkeypatch, _response())
+    output = tmp_path / "private" / "benchmark.json"
+
+    assert (
+        benchmark.main(
+            [
+                "--model",
+                "test:4b",
+                "--repetitions",
+                "2",
+                "--out",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["schema"] == "unifyweaver.sm-fs-privacy-synthetic-benchmark.v2"
+    assert report["strict_pass"] is True
+    assert report["decision"] == "benchmark_gate_passed_lock_not_implemented"
+    assert report["model"] == PROVENANCE["model"]
+    assert report["repo_commit"] == PROVENANCE["repo_commit"]
+    assert {
+        key: report[key] for key in PROVENANCE["sources"]
+    } == PROVENANCE["sources"]
+    assert report["review_eligible_total_per_run"] == 7
+    assert all(run["review_eligible_correct"] == 7 for run in report["runs"])
+    assert all(
+        run["ollama_eval"]
+        == {"done_reason": "stop", "eval_count": 71, "total_duration": 73}
+        for run in report["runs"]
+    )
+
+
+def test_benchmark_main_records_fail_without_authorizing_pilot(
+    tmp_path, monkeypatch
+):
+    _install_fake_model(monkeypatch, _response(wrong_first_label=True))
+    output = tmp_path / "benchmark.json"
+
+    assert (
+        benchmark.main(
+            ["--model", "test:4b", "--repetitions", "1", "--out", str(output)]
+        )
+        == 2
+    )
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["strict_pass"] is False
+    assert report["decision"] == "advisory_pilot_not_allowed"
+
+
+def test_benchmark_main_refuses_to_replace_an_artifact(tmp_path, monkeypatch):
+    _install_fake_model(monkeypatch, _response())
+    output = tmp_path / "benchmark.json"
+    output.write_text("existing\n", encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="File exists"):
+        benchmark.main(
+            ["--model", "test:4b", "--repetitions", "1", "--out", str(output)]
+        )
+    assert output.read_text(encoding="utf-8") == "existing\n"
+
+
+def test_benchmark_main_rejects_midrun_provenance_change(
+    tmp_path, monkeypatch
+):
+    before = copy.deepcopy(PROVENANCE)
+    after = copy.deepcopy(PROVENANCE)
+    after["model"]["digest"] = "fedcba987654"
+    snapshots = iter((before, after))
+    monkeypatch.setattr(
+        benchmark, "_provenance_snapshot", lambda _model: next(snapshots)
+    )
+
+    def fake_call(*_args, metadata_out, **_kwargs):
+        metadata_out["done_reason"] = "stop"
+        return _response()
+
+    monkeypatch.setattr(benchmark, "call_ollama_json", fake_call)
+    output = tmp_path / "benchmark.json"
+
+    with pytest.raises(RuntimeError, match="provenance changed"):
+        benchmark.main(
+            ["--model", "test:4b", "--repetitions", "1", "--out", str(output)]
+        )
+    assert not output.exists()
+
+
+def test_provenance_snapshot_requires_resolved_model_and_commit(monkeypatch):
+    monkeypatch.setattr(
+        benchmark,
+        "_model_identity",
+        lambda _model: {
+            "tag": "test:4b",
+            "digest": "",
+            "ollama_version": "",
+            "ollama_cli": "/test/ollama",
+        },
+    )
+    with pytest.raises(RuntimeError, match="model identity"):
+        benchmark._provenance_snapshot("test:4b")
+
+    monkeypatch.setattr(
+        benchmark,
+        "_model_identity",
+        lambda _model: copy.deepcopy(PROVENANCE["model"]),
+    )
+    monkeypatch.setattr(benchmark, "_command_text", lambda _command: "")
+    with pytest.raises(RuntimeError, match="repository commit"):
+        benchmark._provenance_snapshot("test:4b")

--- a/prototypes/mu_cosine/test_sm_fs_filing.py
+++ b/prototypes/mu_cosine/test_sm_fs_filing.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Focused durability and e5-cache tests for ``sm_fs_filing``."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+
+import pytest
+import torch
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import mu_attention
+import sm_fs_filing
+from sm_fs_filing import (
+    E5_MODEL,
+    E5_REVISION,
+    UnsafePrivatePathError,
+    _atomic_json,
+    build_private_e5_tables,
+    filing_provenance,
+    prepare_private_cache,
+)
+
+
+def test_atomic_json_removes_linked_final_when_directory_fsync_fails(
+    tmp_path, monkeypatch
+):
+    ledger = tmp_path / "private" / "ledger.json"
+    real_fsync = os.fsync
+
+    def fail_directory_fsync(descriptor):
+        if stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            raise OSError("synthetic pre-durability failure")
+        return real_fsync(descriptor)
+
+    monkeypatch.setattr(os, "fsync", fail_directory_fsync)
+    with pytest.raises(OSError, match="pre-durability"):
+        _atomic_json(ledger, {"frozen": True})
+
+    assert not os.path.lexists(ledger)
+    assert list(ledger.parent.iterdir()) == []
+
+
+def test_atomic_json_is_private_durable_and_never_replaces(tmp_path):
+    ledger = tmp_path / "private" / "ledger.json"
+    _atomic_json(ledger, {"frozen": True})
+
+    assert json.loads(ledger.read_text(encoding="utf-8")) == {"frozen": True}
+    assert stat.S_IMODE(ledger.stat().st_mode) == 0o600
+    assert stat.S_IMODE(ledger.parent.stat().st_mode) == 0o700
+    assert not list(ledger.parent.glob(f".{ledger.name}.*"))
+    with pytest.raises(FileExistsError, match="refusing to replace"):
+        _atomic_json(ledger, {"frozen": False})
+
+
+@pytest.mark.parametrize("kind", ("ledger", "cache"))
+@pytest.mark.parametrize("dangling", (False, True))
+def test_private_artifacts_reject_symlink_targets(tmp_path, kind, dangling):
+    private = tmp_path / "private"
+    private.mkdir(mode=0o700)
+    victim = tmp_path / ("missing" if dangling else "victim")
+    if not dangling:
+        victim.write_text("do not touch", encoding="utf-8")
+    target = private / f"{kind}.dat"
+    target.symlink_to(victim)
+
+    with pytest.raises(UnsafePrivatePathError, match="symlink.*target"):
+        if kind == "ledger":
+            _atomic_json(target, {"unsafe": True})
+        else:
+            prepare_private_cache(target)
+    if dangling:
+        assert not victim.exists()
+    else:
+        assert victim.read_text(encoding="utf-8") == "do not touch"
+    assert target.is_symlink()
+
+
+def test_private_artifacts_reject_symlink_and_nonprivate_parents(tmp_path):
+    real_parent = tmp_path / "real"
+    real_parent.mkdir(mode=0o700)
+    linked_parent = tmp_path / "linked"
+    linked_parent.symlink_to(real_parent, target_is_directory=True)
+    with pytest.raises(UnsafePrivatePathError, match="symlink parent"):
+        _atomic_json(linked_parent / "ledger.json", {})
+
+    public_parent = tmp_path / "public"
+    public_parent.mkdir(mode=0o700)
+    public_parent.chmod(0o755)
+    with pytest.raises(UnsafePrivatePathError, match="mode 0700"):
+        prepare_private_cache(public_parent / "cache.pt")
+
+    writable_ancestor = tmp_path / "writable-ancestor"
+    writable_ancestor.mkdir(mode=0o700)
+    writable_ancestor.chmod(0o777)
+    private_leaf = writable_ancestor / "private"
+    private_leaf.mkdir(mode=0o700)
+    with pytest.raises(UnsafePrivatePathError, match="writable ancestor"):
+        prepare_private_cache(private_leaf / "cache.pt")
+
+
+def _fake_e5_builder(observed):
+    def build(names, **kwargs):
+        observed.update(kwargs)
+        matrix = torch.eye(len(names), dtype=torch.float32)
+        return matrix, matrix.clone(), {
+            name: index for index, name in enumerate(names)
+        }
+
+    return build
+
+
+def test_private_cache_rebuild_is_sanitized_atomic_and_hashed(
+    tmp_path, monkeypatch
+):
+    cache = prepare_private_cache(tmp_path / "private" / "e5.pt")
+    cache.write_bytes(b"not a torch cache")
+    observed = {}
+    monkeypatch.setattr(
+        sm_fs_filing, "build_e5_tables", _fake_e5_builder(observed)
+    )
+
+    query, passage, idx, cache_sha256 = build_private_e5_tables(
+        ["Folder", "One"], cache, batch_size=7
+    )
+
+    assert set(observed) == {
+        "cache_path",
+        "batch_size",
+        "model_name",
+        "model_revision",
+    }
+    assert observed["batch_size"] == 7
+    assert observed["model_name"] == E5_MODEL
+    assert observed["model_revision"] == E5_REVISION
+    assert Path(observed["cache_path"]).parent != cache.parent
+    assert query.shape == passage.shape == (2, 2)
+    assert idx == {"Folder": 0, "One": 1}
+    assert stat.S_IMODE(cache.stat().st_mode) == 0o600
+    assert cache_sha256 == hashlib.sha256(cache.read_bytes()).hexdigest()
+    payload = torch.load(cache, map_location="cpu", weights_only=True)
+    assert payload["model_name"] == E5_MODEL
+    assert payload["model_revision"] == E5_REVISION
+    assert payload["names"] == ["Folder", "One"]
+    assert not list(cache.parent.glob(f".{cache.name}.build.*"))
+
+
+def test_private_cache_reuse_uses_safe_payload_without_rebuilding(
+    tmp_path, monkeypatch
+):
+    names = ["Folder", "One"]
+    cache = prepare_private_cache(tmp_path / "private" / "e5.pt")
+    payload = {
+        "names": names,
+        "human": names,
+        "model_name": E5_MODEL,
+        "model_revision": E5_REVISION,
+        "query": torch.eye(2, dtype=torch.float32),
+        "passage": torch.eye(2, dtype=torch.float32),
+    }
+    torch.save(payload, cache)
+
+    monkeypatch.setattr(
+        sm_fs_filing,
+        "build_e5_tables",
+        lambda *_args, **_kwargs: pytest.fail("valid cache was rebuilt"),
+    )
+    query, passage, idx, digest = build_private_e5_tables(names, cache)
+
+    assert torch.equal(query, payload["query"])
+    assert torch.equal(passage, payload["passage"])
+    assert idx == {"Folder": 0, "One": 1}
+    assert digest == hashlib.sha256(cache.read_bytes()).hexdigest()
+
+
+def test_private_cache_swap_between_deserialization_and_hash_is_rejected(
+    tmp_path, monkeypatch
+):
+    names = ["Folder", "One"]
+    private = tmp_path / "private"
+    cache = prepare_private_cache(private / "e5.pt")
+    original_payload = {
+        "names": names,
+        "human": names,
+        "model_name": E5_MODEL,
+        "model_revision": E5_REVISION,
+        "query": torch.eye(2, dtype=torch.float32),
+        "passage": torch.eye(2, dtype=torch.float32),
+    }
+    replacement_payload = {
+        **original_payload,
+        "query": torch.flip(original_payload["query"], dims=(0,)),
+        "passage": torch.flip(original_payload["passage"], dims=(0,)),
+    }
+    torch.save(original_payload, cache)
+    replacement = private / "replacement.pt"
+    torch.save(replacement_payload, replacement)
+    replacement.chmod(0o600)
+
+    real_load = mu_attention.torch.load
+    swapped = False
+
+    def load_then_swap(*args, **kwargs):
+        nonlocal swapped
+        payload = real_load(*args, **kwargs)
+        if not swapped:
+            os.replace(replacement, cache)
+            swapped = True
+        return payload
+
+    monkeypatch.setattr(mu_attention.torch, "load", load_then_swap)
+    monkeypatch.setattr(
+        sm_fs_filing,
+        "build_e5_tables",
+        lambda *_args, **_kwargs: pytest.fail(
+            "a replacement race must be rejected, not rebuilt"
+        ),
+    )
+
+    with pytest.raises(UnsafePrivatePathError, match="replaced"):
+        build_private_e5_tables(names, cache)
+    assert swapped
+    assert torch.equal(
+        real_load(cache, map_location="cpu", weights_only=True)["query"],
+        replacement_payload["query"],
+    )
+
+
+def test_newly_installed_cache_swap_before_hash_is_rejected(
+    tmp_path, monkeypatch
+):
+    names = ["Folder", "One"]
+    private = tmp_path / "private"
+    cache = prepare_private_cache(private / "e5.pt")
+    replacement = private / "replacement.pt"
+    replacement_payload = {
+        "names": names,
+        "human": names,
+        "model_name": E5_MODEL,
+        "model_revision": E5_REVISION,
+        "query": torch.flip(torch.eye(2, dtype=torch.float32), dims=(0,)),
+        "passage": torch.flip(torch.eye(2, dtype=torch.float32), dims=(0,)),
+    }
+    torch.save(replacement_payload, replacement)
+    replacement.chmod(0o600)
+
+    observed = {}
+    monkeypatch.setattr(
+        sm_fs_filing, "build_e5_tables", _fake_e5_builder(observed)
+    )
+    real_load = mu_attention.torch.load
+    swapped = False
+
+    def load_then_swap(*args, **kwargs):
+        nonlocal swapped
+        payload = real_load(*args, **kwargs)
+        if not swapped:
+            os.replace(replacement, cache)
+            swapped = True
+        return payload
+
+    monkeypatch.setattr(mu_attention.torch, "load", load_then_swap)
+
+    with pytest.raises(UnsafePrivatePathError, match="replaced"):
+        build_private_e5_tables(names, cache)
+    assert swapped
+    assert observed["model_name"] == E5_MODEL
+    assert observed["model_revision"] == E5_REVISION
+
+
+def test_mu_attention_cache_deserialization_uses_weights_only(
+    tmp_path, monkeypatch
+):
+    cache = tmp_path / "cache.pt"
+    names = ["One"]
+    torch.save(
+        {
+            "names": names,
+            "human": names,
+            "model_name": E5_MODEL,
+            "model_revision": E5_REVISION,
+            "query": torch.ones(1, 2),
+            "passage": torch.ones(1, 2),
+        },
+        cache,
+    )
+    real_load = mu_attention.torch.load
+    observed = {}
+
+    def recording_load(*args, **kwargs):
+        observed.update(kwargs)
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(mu_attention.torch, "load", recording_load)
+    mu_attention.build_e5_tables(
+        names,
+        cache_path=str(cache),
+        model_revision=E5_REVISION,
+    )
+    assert observed["weights_only"] is True
+
+
+def test_filing_provenance_binds_model_source_cache_and_runtime():
+    provenance = filing_provenance("a" * 64)
+    assert provenance["e5_model_id"] == "intfloat/e5-small-v2"
+    assert provenance["e5_revision"] == E5_REVISION
+    assert provenance["mu_attention_sha256"] == hashlib.sha256(
+        (HERE / "mu_attention.py").read_bytes()
+    ).hexdigest()
+    assert provenance["e5_cache_sha256"] == "a" * 64
+    assert set(provenance["runtime_versions"]) == {
+        "python",
+        "numpy",
+        "torch",
+        "sentence_transformers",
+        "transformers",
+    }
+    assert all(
+        value is None or isinstance(value, str)
+        for value in provenance["runtime_versions"].values()
+    )
+
+
+def test_main_seals_cache_hash_and_provenance_before_scoring(
+    tmp_path, monkeypatch
+):
+    rows = [
+        {
+            "title": "One",
+            "dir": "Folder",
+            "path": "Folder",
+            "privacy": "public",
+        }
+    ]
+    header = {
+        "schema": "sm-fs-privacy-test",
+        "policy_id": "test-policy",
+        "index_sha256": "b" * 64,
+        "counts": {"unresolved_private_target_refs": 0},
+    }
+    monkeypatch.setattr(
+        sm_fs_filing,
+        "load_or_build_privacy_index",
+        lambda *_args: (header, {}),
+    )
+    monkeypatch.setattr(
+        sm_fs_filing,
+        "discover_filing_rows",
+        lambda *_args: (
+            rows,
+            {"public": 1, "private": 0, "unknown": 0},
+        ),
+    )
+    cache_hash = "c" * 64
+
+    def fake_private_build(names, _path, batch_size):
+        assert batch_size == 128
+        matrix = torch.eye(len(names), dtype=torch.float32)
+        return (
+            matrix,
+            matrix,
+            {name: index for index, name in enumerate(names)},
+            cache_hash,
+        )
+
+    monkeypatch.setattr(
+        sm_fs_filing, "build_private_e5_tables", fake_private_build
+    )
+    ledger = tmp_path / "private" / "ledger.json"
+    sm_fs_filing.main(
+        [
+            "--root",
+            str(tmp_path / "corpus"),
+            "--privacy-index",
+            str(tmp_path / "unused.jsonl"),
+            "--privacy-policy",
+            "public-only",
+            "--min-maps",
+            "1",
+            "--holdout-frac",
+            "0",
+            "--ledger",
+            str(ledger),
+            "--e5-cache",
+            str(tmp_path / "private" / "e5.pt"),
+        ]
+    )
+    value = json.loads(ledger.read_text(encoding="utf-8"))
+    assert value["provenance"]["e5_cache_sha256"] == cache_hash
+    assert value["provenance"]["e5_model_id"] == E5_MODEL
+    assert value["provenance"]["e5_revision"] == E5_REVISION
+    assert "mu_attention_sha256" in value["provenance"]
+    assert "runtime_versions" in value["provenance"]

--- a/prototypes/mu_cosine/test_sm_fs_freeze.py
+++ b/prototypes/mu_cosine/test_sm_fs_freeze.py
@@ -1,8 +1,42 @@
-"""Fixture tests for sm_fs_freeze.py: privacy fallback, split isolation, duplicates, reproduction."""
+"""Fixture tests for content-bound privacy views, races, and reproduction."""
+import hashlib
 import json
 import os
+from pathlib import Path
+import xml.etree.ElementTree as ET
+import zipfile
 
+import pytest
 import sm_fs_freeze
+import sm_fs_privacy
+from sm_fs_privacy import build_index, write_index
+
+
+def write_map(path, title, urls=()):
+    document = ET.Element("mindmap")
+    root = ET.SubElement(
+        document, "topic", {"id": "0", "parent": "-1", "text": title}
+    )
+    for url in urls:
+        ET.SubElement(root, "link", {"urllink": url})
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("document/mindmap.xml", ET.tostring(document))
+
+
+def write_unresolved_private_marker_map(path):
+    document = ET.Element("mindmap")
+    ET.SubElement(
+        document, "topic", {"id": "0", "parent": "-1", "text": "Index"}
+    )
+    ET.SubElement(
+        document, "topic", {"id": "1", "parent": "0", "text": "private"}
+    )
+    holder = ET.SubElement(
+        document, "topic", {"id": "2", "parent": "1", "text": ""}
+    )
+    ET.SubElement(holder, "link", {"cloudmapref": "missing/Target.smmx"})
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("document/mindmap.xml", ET.tostring(document))
 
 
 def make_tree(tmp_path):
@@ -19,26 +53,189 @@ def make_tree(tmp_path):
         d = tmp_path / p
         d.mkdir(parents=True, exist_ok=True)
         for m in maps:
-            (d / f"{m}.smmx").write_text("<x/>")
+            write_map(d / f"{m}.smmx", m)
+    write_map(
+        tmp_path / "Subjects" / "sci" / "private_notes" / "Hidden.smmx",
+        "Hidden",
+        ("https://www.pearltrees.com/private/id222?access=synthetic",),
+    )
     return tmp_path
 
 
-def run(tmp_path, out):
-    sm_fs_freeze.main(["--fs-root", str(tmp_path), "--out-dir", str(out),
-                       "--holdout-frac", "0.4", "--split-seed", "0"])
+def run(
+    tmp_path,
+    out,
+    *,
+    privacy_index,
+    policy=None,
+    holdout_frac="0.4",
+    allow_degenerate_holdout=False,
+):
+    args = [
+        "--fs-root", str(tmp_path),
+        "--out-dir", str(out),
+        "--holdout-frac", holdout_frac,
+        "--split-seed", "0",
+        "--training-privacy-policy",
+        policy or "public-only",
+        "--privacy-index", str(privacy_index),
+    ]
+    if allow_degenerate_holdout:
+        args.append("--allow-degenerate-holdout")
+    sm_fs_freeze.main(args)
     return json.load(open(out / "ledger.json"))
 
 
-def test_privacy_fallback_and_split_isolation(tmp_path):
-    led = run(make_tree(tmp_path), tmp_path / "out")
-    paths = [r["map_path"] for r in led["rows"]]
-    assert not any("Private/" in p or "private_notes" in p for p in paths)   # fallback filter
-    assert led["privacy_source"] == "fallback_substring"
-    # split isolation: no explore destination inside any reserved subtree block
+def build_privacy_index(root, path):
+    header, records = build_index(Path(root), workers=1)
+    write_index(Path(path), header, records)
+    return header
+
+
+@pytest.mark.parametrize("value", ("-1", "2", "nan", "inf", "-inf", "0", "1"))
+def test_holdout_fraction_fails_closed_before_reading_inputs(tmp_path, value):
+    with pytest.raises(ValueError, match="holdout"):
+        sm_fs_freeze.main(
+            [
+                "--fs-root",
+                str(tmp_path / "missing-corpus"),
+                "--privacy-index",
+                str(tmp_path / "missing-index"),
+                    "--out-dir",
+                    str(tmp_path / "out"),
+                    f"--holdout-frac={value}",
+            ]
+        )
+
+
+def test_nonendpoint_degenerate_waiver_is_rejected():
+    with pytest.raises(ValueError, match="valid only.*0 or 1"):
+        sm_fs_freeze._validate_holdout_fraction(
+            0.4,
+            allow_degenerate=True,
+        )
+
+
+def test_realized_single_lineage_split_fails_closed():
+    with pytest.raises(ValueError, match="realized split"):
+        sm_fs_freeze.derive_split(
+            [{"dest": "Synthetic/Only"}],
+            0.4,
+            0,
+        )
+
+
+def test_zero_usable_training_targets_require_diagnostic_waiver():
+    with pytest.raises(ValueError, match="no usable training targets"):
+        sm_fs_freeze._validate_training_target_count(
+            0,
+            allow_degenerate=False,
+        )
+    sm_fs_freeze._validate_training_target_count(
+        0,
+        allow_degenerate=True,
+    )
+
+
+def test_source_map_discovery_rejects_symlinks(tmp_path):
+    tree = tmp_path / "tree"
+    tree.mkdir()
+    target = tmp_path / "target.smmx"
+    write_map(target, "Target")
+    (tree / "Alias.smmx").symlink_to(target)
+
+    with pytest.raises(ValueError, match="refusing symlink corpus member"):
+        sm_fs_freeze._smmx_paths(tree)
+
+
+def test_source_verifier_keeps_original_root_across_path_swap(
+    tmp_path, monkeypatch
+):
+    tree = tmp_path / "tree"
+    (tree / "Branch").mkdir(parents=True)
+    write_map(tree / "Branch" / "Original.smmx", "Original")
+    _header, records = build_index(tree, workers=1)
+    index = {record["relative_path"]: record for record in records}
+
+    replacement = tmp_path / "replacement"
+    (replacement / "Branch").mkdir(parents=True)
+    write_map(replacement / "Branch" / "Original.smmx", "Replacement")
+    detached = tmp_path / "detached-tree"
+    real_members = sm_fs_privacy.smmx_member_bindings
+
+    def swap_root(root_fd):
+        members = real_members(root_fd)
+        tree.rename(detached)
+        tree.symlink_to(replacement, target_is_directory=True)
+        return members
+
+    monkeypatch.setattr(sm_fs_privacy, "smmx_member_bindings", swap_root)
+    observed = list(sm_fs_freeze._iter_verified_source_maps(tree, index))
+    assert [relative for relative, *_rest in observed] == [
+        "Branch/Original.smmx"
+    ]
+    assert observed[0][2] == index["Branch/Original.smmx"]["file_sha256"]
+
+
+def rewrite_ledger_and_rebind_manifest(out, edit, manifest_edit=None):
+    ledger_path = out / "ledger.json"
+    manifest_path = out / "manifest.json"
+    ledger = json.loads(ledger_path.read_bytes())
+    edit(ledger)
+    ledger_bytes = (
+        json.dumps(ledger, ensure_ascii=False, indent=0, sort_keys=True)
+        + "\n"
+    ).encode("utf-8")
+    ledger_path.write_bytes(ledger_bytes)
+
+    manifest = json.loads(manifest_path.read_bytes())
+    manifest["outputs"]["ledger.json"] = {
+        "bytes": len(ledger_bytes),
+        "sha256": hashlib.sha256(ledger_bytes).hexdigest(),
+    }
+    if manifest_edit is not None:
+        manifest_edit(manifest, ledger)
+    core = dict(manifest)
+    core.pop("manifest_sha256", None)
+    manifest["manifest_sha256"] = hashlib.sha256(
+        sm_fs_freeze.canonical_json_bytes(core)
+    ).hexdigest()
+    manifest_path.write_bytes(sm_fs_freeze.canonical_json_bytes(manifest))
+
+
+def assert_catalog_closes_rows_and_targets(ledger, target_path):
+    catalog = set(ledger["catalog"])
+    for row in ledger["rows"]:
+        assert row["dest"] in catalog
+        parts = row["dest"].split("/")
+        assert {
+            "/".join(parts[:depth]) for depth in range(1, len(parts) + 1)
+        }.issubset(catalog)
+    for line in target_path.read_text().splitlines():
+        if not line.startswith("#"):
+            assert line.split("\t")[2] in catalog
+
+
+def test_content_addressed_privacy_and_split_isolation(tmp_path):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    led = run(tree, tmp_path / "out", privacy_index=privacy_path)
+    assert led["privacy_source"] == "content_addressed_index"
+    assert {row["classification"] for row in led["rows"]} == {"public"}
+    assert not any(path == "Private" or path.startswith("Private/") for path in led["catalog"])
+    assert "Subjects/sci/private_notes" not in led["catalog"]
+    assert_catalog_closes_rows_and_targets(
+        led, tmp_path / "out" / "lineage_fs_targets.tsv"
+    )
+    # split isolation is bidirectional across the destination lineage.
     res = {r["dest"] for r in led["rows"] if r["split"] == "reserved"}
     exp = {r["dest"] for r in led["rows"] if r["split"] == "explore"}
     for e in exp:
-        assert not any(e == d or e.startswith(d + "/") for d in res)
+        assert not any(
+            e == d or e.startswith(d + "/") or d.startswith(e + "/")
+            for d in res
+        )
     # all maps of one destination share a split side
     side = {}
     for r in led["rows"]:
@@ -46,24 +243,574 @@ def test_privacy_fallback_and_split_isolation(tmp_path):
 
 
 def test_duplicate_titles_stay_distinct_and_targets_explore_only(tmp_path):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
     out = tmp_path / "out"
-    led = run(make_tree(tmp_path), out)
+    led = run(tree, out, privacy_index=privacy_path)
     jazz = [r for r in led["rows"] if r["title"] == "Jazz"]
     assert len(jazz) == 2 and len({r["map_path"] for r in jazz}) == 2       # exact-path identity
     hdr = open(out / "lineage_fs_targets.tsv").read().splitlines()
     assert "lineage(fs,decay=0.85)" in hdr[0]                                # process expression
-    explore_titles = {r["title"] for r in led["rows"] if r["split"] == "explore"}
+    explore_paths = {r["map_path"] for r in led["rows"] if r["split"] == "explore"}
     for ln in hdr:
         if ln.startswith("#"):
             continue
-        assert ln.split("\t")[0] in explore_titles                           # explore-only targets
+        assert ln.split("\t")[0] in explore_paths                            # explore-only targets
 
 
 def test_reproducible_membership(tmp_path):
     t = make_tree(tmp_path)
-    l1 = run(t, tmp_path / "o1")
-    l2 = run(t, tmp_path / "o2")
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(t, privacy_path)
+    l1 = run(t, tmp_path / "o1", privacy_index=privacy_path)
+    l2 = run(t, tmp_path / "o2", privacy_index=privacy_path)
     m1 = {(r["map_path"], r["split"]) for r in l1["rows"]}
     assert m1 == {(r["map_path"], r["split"]) for r in l2["rows"]}           # identical membership
     assert l1["tree_snapshot"] == l2["tree_snapshot"]
     assert l1["e5_revision"] == l2["e5_revision"]
+
+
+def test_content_addressed_index_binds_public_only_training_targets(tmp_path):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    privacy_header = build_privacy_index(tree, privacy_path)
+    out = tmp_path / "out"
+    ledger = run(
+        tree,
+        out,
+        privacy_index=privacy_path,
+        policy="public-only",
+        holdout_frac="0",
+        allow_degenerate_holdout=True,
+    )
+
+    assert ledger["privacy_source"] == "content_addressed_index"
+    assert ledger["privacy_index"]["index_sha256"] == privacy_header["index_sha256"]
+    assert ledger["training_privacy_policy"] == "public-only"
+    by_title = {row["title"]: row for row in ledger["rows"]}
+    assert "Secrets" not in by_title
+    assert "Hidden" not in by_title
+    assert ledger["privacy_index"]["observed_counts"] == {
+        classification: privacy_header["counts"][classification]
+        for classification in ("private", "public", "unknown")
+        if privacy_header["counts"][classification]
+    }
+
+    targets = (out / "lineage_fs_targets.tsv").read_text().splitlines()
+    data = [line.split("\t") for line in targets if not line.startswith("#")]
+    assert data
+    assert {row[-1] for row in data} == {"public"}
+    assert not any(row[1] in {"Secrets", "Hidden"} for row in data)
+
+
+def test_private_only_training_is_separate_and_keeps_exact_identity(tmp_path):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    out = tmp_path / "out"
+    ledger = run(
+        tree,
+        out,
+        privacy_index=privacy_path,
+        policy="private-only",
+        holdout_frac="0",
+        allow_degenerate_holdout=True,
+    )
+
+    targets = (out / "lineage_fs_targets.tsv").read_text().splitlines()
+    data = [line.split("\t") for line in targets if not line.startswith("#")]
+    assert data
+    assert {row[-1] for row in data} == {"private"}
+    assert {row["classification"] for row in ledger["rows"]} == {"private"}
+    assert ledger["catalog"] == sm_fs_freeze.catalog_for_rows(ledger["rows"])
+    assert all(
+        len(row) == 7
+        and row[0].endswith(".smmx")
+        and "/" in row[0]
+        and row[2]
+        for row in data
+    )
+    assert_catalog_closes_rows_and_targets(
+        ledger, out / "lineage_fs_targets.tsv"
+    )
+
+
+def test_private_only_excludes_unreadable_private_map_from_targets(tmp_path):
+    tree = make_tree(tmp_path)
+    broken = tree / "Private" / "journal" / "Unreadable.smmx"
+    broken.write_bytes(b"")
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    out = tmp_path / "out"
+    ledger = run(
+        tree,
+        out,
+        privacy_index=privacy_path,
+        policy="private-only",
+        holdout_frac="0",
+        allow_degenerate_holdout=True,
+    )
+
+    unreadable = next(
+        row for row in ledger["rows"] if row["title"] == "Unreadable"
+    )
+    assert unreadable["training_usable"] is False
+    target_text = (out / "lineage_fs_targets.tsv").read_text()
+    assert "Unreadable.smmx" not in target_text
+
+
+def test_public_only_refuses_unaudited_fallback(tmp_path):
+    tree = make_tree(tmp_path)
+    with pytest.raises(
+        ValueError, match="requires a content-addressed privacy index"
+    ):
+        run(
+            tree,
+            tmp_path / "out",
+            privacy_index=tmp_path / "missing.jsonl",
+            policy="public-only",
+        )
+
+
+def test_freezer_rejects_index_after_source_change(tmp_path):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    write_map(tree / "Subjects" / "art" / "music" / "Jazz.smmx", "Changed")
+    with pytest.raises(ValueError, match="map contents changed"):
+        run(tree, tmp_path / "out", privacy_index=privacy_path)
+
+
+def test_mixed_case_smmx_member_cannot_vanish_from_bundle(tmp_path):
+    tree = make_tree(tmp_path)
+    lower = tree / "Subjects" / "art" / "paint" / "Oil.smmx"
+    mixed = lower.with_name("Oil.SmMx")
+    lower.rename(mixed)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+
+    ledger = run(
+        tree,
+        tmp_path / "out",
+        privacy_index=privacy_path,
+        holdout_frac="0",
+        allow_degenerate_holdout=True,
+    )
+
+    row = next(row for row in ledger["rows"] if row["title"] == "Oil")
+    assert row["map_path"] == "Subjects/art/paint/Oil.SmMx"
+    assert row["sha256"] == hashlib.sha256(mixed.read_bytes()).hexdigest()
+
+
+def test_policy_eligible_root_map_is_rejected_instead_of_silently_omitted(
+    tmp_path,
+):
+    tree = make_tree(tmp_path)
+    write_map(tree / "AtRoot.smmx", "At root")
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    out = tmp_path / "out"
+
+    with pytest.raises(ValueError, match="has no destination"):
+        run(tree, out, privacy_index=privacy_path)
+    assert not out.exists()
+
+
+def test_source_change_after_initial_check_is_rejected_at_inclusion(
+    tmp_path, monkeypatch
+):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    target = tree / "Subjects" / "art" / "music" / "Jazz.smmx"
+    original_verify = sm_fs_freeze.verify_index_source
+    calls = 0
+
+    def verify_then_race(*args, **kwargs):
+        nonlocal calls
+        original_verify(*args, **kwargs)
+        calls += 1
+        if calls == 1:
+            write_map(target, "Changed after initial verification")
+
+    monkeypatch.setattr(
+        sm_fs_freeze, "verify_index_source", verify_then_race
+    )
+    out = tmp_path / "out"
+    with pytest.raises(ValueError, match="map contents changed"):
+        run(tree, out, privacy_index=privacy_path)
+    assert not out.exists()
+
+
+def test_policy_eligible_member_removed_after_initial_check_is_rejected(
+    tmp_path, monkeypatch
+):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    target = tree / "Subjects" / "art" / "paint" / "Oil.smmx"
+    original_verify = sm_fs_freeze.verify_index_source
+    calls = 0
+
+    def verify_then_remove(*args, **kwargs):
+        nonlocal calls
+        original_verify(*args, **kwargs)
+        calls += 1
+        if calls == 1:
+            target.unlink()
+
+    monkeypatch.setattr(
+        sm_fs_freeze, "verify_index_source", verify_then_remove
+    )
+    out = tmp_path / "out"
+    with pytest.raises(ValueError, match="map set changed"):
+        run(tree, out, privacy_index=privacy_path)
+    assert not out.exists()
+
+
+def test_public_only_blocks_unresolved_private_target_without_waiver(tmp_path):
+    tree = make_tree(tmp_path)
+    write_unresolved_private_marker_map(
+        tree / "Subjects" / "sci" / "phy" / "Unresolved.smmx"
+    )
+    privacy_path = tmp_path / "privacy.jsonl"
+    header = build_privacy_index(tree, privacy_path)
+    assert header["counts"]["unresolved_private_target_refs"] == 1
+    with pytest.raises(ValueError, match="unresolved private target"):
+        run(tree, tmp_path / "out", privacy_index=privacy_path)
+
+
+def test_cross_lineage_rows_are_excluded_bidirectionally():
+    rows = [
+        {"dest": "A/B", "split": "reserved"},
+        {"dest": "A/B/C", "split": "explore"},
+        {"dest": "A", "split": "explore"},
+        {"dest": "X/Y", "split": "explore"},
+    ]
+    assert sm_fs_freeze.exclude_cross_lineage(rows) == 2
+    assert [row["split"] for row in rows] == [
+        "reserved",
+        "cross_lineage_excluded",
+        "cross_lineage_excluded",
+        "explore",
+    ]
+
+
+def test_frozen_outputs_are_private_and_no_replace(tmp_path):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    out = tmp_path / "out"
+    run(tree, out, privacy_index=privacy_path)
+    assert (out.stat().st_mode & 0o777) == 0o700
+    assert ((out / "ledger.json").stat().st_mode & 0o777) == 0o600
+    assert ((out / "lineage_fs_targets.tsv").stat().st_mode & 0o777) == 0o600
+    assert ((out / "manifest.json").stat().st_mode & 0o777) == 0o600
+    with pytest.raises(FileExistsError, match="refusing to replace"):
+        run(tree, out, privacy_index=privacy_path)
+
+
+def test_bundle_verifier_rejects_hardlinked_artifact(tmp_path):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    out = tmp_path / "out"
+    run(tree, out, privacy_index=privacy_path)
+    os.link(out / "ledger.json", tmp_path / "ledger-hardlink.json")
+
+    with pytest.raises(ValueError, match="exactly one hard link"):
+        sm_fs_freeze.verify_private_bundle(out)
+
+
+def test_bundle_verifier_rejects_symlink_swap_during_descriptor_read(
+    tmp_path, monkeypatch
+):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    out = tmp_path / "out"
+    run(tree, out, privacy_index=privacy_path)
+    ledger_path = out / "ledger.json"
+    replacement = tmp_path / "replacement-ledger.json"
+    replacement.write_bytes(ledger_path.read_bytes())
+    replacement.chmod(0o600)
+
+    original_read = sm_fs_freeze.os.read
+    swapped = False
+
+    def read_then_swap(descriptor, size):
+        nonlocal swapped
+        data = original_read(descriptor, size)
+        if data and not swapped:
+            swapped = True
+            ledger_path.unlink()
+            ledger_path.symlink_to(replacement)
+        return data
+
+    monkeypatch.setattr(sm_fs_freeze.os, "read", read_then_swap)
+    with pytest.raises(ValueError, match="changed while being read"):
+        sm_fs_freeze.verify_private_bundle(out)
+    assert swapped
+
+
+def test_binding_manifest_round_trip_and_provenance(tmp_path):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    privacy_header = build_privacy_index(tree, privacy_path)
+    out = tmp_path / "out"
+    ledger = run(
+        tree,
+        out,
+        privacy_index=privacy_path,
+        policy="public-only",
+        holdout_frac="0",
+        allow_degenerate_holdout=True,
+    )
+
+    manifest = sm_fs_freeze.verify_private_bundle(
+        out, privacy_index=privacy_path
+    )
+    assert manifest["schema"] == sm_fs_freeze.BUNDLE_SCHEMA
+    assert manifest["parameters"] == {
+        "allow_degenerate_holdout": True,
+        "allow_unresolved_private_targets": False,
+        "decay": sm_fs_freeze.DECAY,
+        "fs_root": str(tree.resolve()),
+        "holdout_frac": 0.0,
+        "process_expression": sm_fs_freeze.EXPR,
+        "split_seed": 0,
+        "training_privacy_policy": "public-only",
+    }
+    assert ledger["allow_degenerate_holdout"] is True
+    assert any(
+        "diagnostic" in limitation for limitation in ledger["limitations"]
+    )
+    assert manifest["inputs"]["privacy_index"]["provenance"][
+        "index_sha256"
+    ] == privacy_header["index_sha256"]
+    privacy_bytes = privacy_path.read_bytes()
+    expected_input_artifact = {
+        "bytes": len(privacy_bytes),
+        "sha256": hashlib.sha256(privacy_bytes).hexdigest(),
+    }
+    assert (
+        manifest["inputs"]["privacy_index"]["artifact"]
+        == expected_input_artifact
+    )
+    assert (
+        ledger["privacy_index"]["artifact"] == expected_input_artifact
+    )
+    assert (
+        ledger["privacy_index"]["path"]
+        == manifest["inputs"]["privacy_index"]["path"]
+        == str(privacy_path.resolve())
+    )
+    assert manifest["e5_revision"] == sm_fs_freeze.E5_REVISION
+    assert set(manifest["code"]) == {
+        "mu_attention.py",
+        "sm_fs_freeze.py",
+        "sm_fs_privacy.py",
+    }
+    assert all(
+        len(record["sha256"]) == 64 for record in manifest["code"].values()
+    )
+    assert manifest["tree_snapshot"] == ledger["tree_snapshot"]
+    for name in ("ledger.json", "lineage_fs_targets.tsv"):
+        payload = (out / name).read_bytes()
+        assert manifest["outputs"][name] == {
+            "bytes": len(payload),
+            "sha256": hashlib.sha256(payload).hexdigest(),
+        }
+
+
+def test_all_reserved_diagnostic_bundle_round_trips(tmp_path):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    out = tmp_path / "all-reserved"
+    ledger = run(
+        tree,
+        out,
+        privacy_index=privacy_path,
+        policy="public-only",
+        holdout_frac="1",
+        allow_degenerate_holdout=True,
+    )
+
+    manifest = sm_fs_freeze.verify_private_bundle(
+        out,
+        privacy_index=privacy_path,
+    )
+    assert ledger["counts"]["explore"] == 0
+    assert ledger["counts"]["reserved"] == len(ledger["rows"])
+    assert manifest["target_rows"] == 0
+    assert manifest["parameters"]["allow_degenerate_holdout"] is True
+    assert any(
+        "diagnostic" in limitation for limitation in ledger["limitations"]
+    )
+
+
+def test_bundle_verifier_rederives_rehashed_split_and_counts(tmp_path):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    out = tmp_path / "out"
+    run(tree, out, privacy_index=privacy_path)
+
+    def alter_nontraining_split(ledger):
+        row = next(
+            row for row in ledger["rows"] if row["split"] == "reserved"
+        )
+        row["split"] = "cross_lineage_excluded"
+        ledger["counts"] = {
+            split: sum(
+                candidate["split"] == split
+                for candidate in ledger["rows"]
+            )
+            for split in (
+                "explore",
+                "reserved",
+                "cross_lineage_excluded",
+            )
+        }
+
+    rewrite_ledger_and_rebind_manifest(
+        out,
+        alter_nontraining_split,
+        lambda manifest, ledger: manifest.update(counts=ledger["counts"]),
+    )
+
+    with pytest.raises(ValueError, match="deterministic split mismatch"):
+        sm_fs_freeze.verify_private_bundle(out)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (("sha256", "0" * 64), ("classification", "unknown")),
+)
+def test_bundle_verifier_rederives_ledger_privacy_fields_from_live_inputs(
+    tmp_path, field, value
+):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    out = tmp_path / "out"
+    run(tree, out, privacy_index=privacy_path)
+
+    rewrite_ledger_and_rebind_manifest(
+        out, lambda ledger: ledger["rows"][0].update({field: value})
+    )
+
+    with pytest.raises(ValueError, match="privacy/source derivation mismatch"):
+        sm_fs_freeze.verify_private_bundle(
+            out, privacy_index=privacy_path
+        )
+
+
+def test_bundle_verifier_binds_manifest_input_artifact_to_ledger(tmp_path):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    out = tmp_path / "out"
+    run(tree, out, privacy_index=privacy_path)
+
+    rewrite_ledger_and_rebind_manifest(
+        out,
+        lambda ledger: ledger["privacy_index"]["artifact"].update(
+            sha256="0" * 64
+        ),
+    )
+
+    with pytest.raises(ValueError, match="manifest/ledger binding mismatch"):
+        sm_fs_freeze.verify_private_bundle(out)
+
+
+def test_bundle_verifier_rejects_artifact_and_privacy_input_tampering(tmp_path):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+
+    artifact_out = tmp_path / "artifact-out"
+    run(tree, artifact_out, privacy_index=privacy_path)
+    with (artifact_out / "lineage_fs_targets.tsv").open("ab") as stream:
+        stream.write(b"# tampered\n")
+    with pytest.raises(ValueError, match="artifact digest mismatch"):
+        sm_fs_freeze.verify_private_bundle(
+            artifact_out, privacy_index=privacy_path
+        )
+
+    input_out = tmp_path / "input-out"
+    run(tree, input_out, privacy_index=privacy_path)
+    with privacy_path.open("ab") as stream:
+        stream.write(b"\n")
+    with pytest.raises(ValueError, match="privacy-index binding mismatch"):
+        sm_fs_freeze.verify_private_bundle(
+            input_out, privacy_index=privacy_path
+        )
+
+
+def test_privacy_index_change_after_bound_read_uses_same_bytes_and_fails_install(
+    tmp_path, monkeypatch
+):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    original_parse = sm_fs_freeze._parse_privacy_index_bytes
+
+    def change_then_parse(bound_bytes):
+        with privacy_path.open("ab") as stream:
+            stream.write(b"\n")
+        return original_parse(bound_bytes)
+
+    monkeypatch.setattr(
+        sm_fs_freeze, "_parse_privacy_index_bytes", change_then_parse
+    )
+    out = tmp_path / "out"
+    with pytest.raises(ValueError, match="privacy-index binding mismatch"):
+        run(tree, out, privacy_index=privacy_path)
+    assert not out.exists()
+    assert not list(tmp_path.glob(".out.staging.*"))
+
+
+def test_source_change_after_payload_build_fails_before_install(
+    tmp_path, monkeypatch
+):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    target = tree / "Subjects" / "art" / "music" / "Jazz.smmx"
+    original_install = sm_fs_freeze.install_private_outputs
+
+    def change_then_install(out_dir, payloads, *, privacy_index):
+        write_map(target, "Changed after payload build")
+        return original_install(
+            out_dir, payloads, privacy_index=privacy_index
+        )
+
+    monkeypatch.setattr(
+        sm_fs_freeze, "install_private_outputs", change_then_install
+    )
+    out = tmp_path / "out"
+    with pytest.raises(ValueError, match="map contents changed"):
+        run(tree, out, privacy_index=privacy_path)
+    assert not out.exists()
+    assert not list(tmp_path.glob(".out.staging.*"))
+
+
+def test_atomic_install_failure_leaves_no_partial_bundle(tmp_path, monkeypatch):
+    tree = make_tree(tmp_path)
+    privacy_path = tmp_path / "privacy.jsonl"
+    build_privacy_index(tree, privacy_path)
+    out = tmp_path / "out"
+
+    def fail_rename(source, target):
+        raise RuntimeError("synthetic rename failure")
+
+    monkeypatch.setattr(
+        sm_fs_freeze, "_rename_directory_noreplace", fail_rename
+    )
+    with pytest.raises(RuntimeError, match="synthetic rename failure"):
+        run(tree, out, privacy_index=privacy_path)
+    assert not out.exists()
+    assert not list(tmp_path.glob(".out.staging.*"))

--- a/prototypes/mu_cosine/test_sm_fs_privacy.py
+++ b/prototypes/mu_cosine/test_sm_fs_privacy.py
@@ -1,0 +1,1009 @@
+#!/usr/bin/env python3
+"""Focused tests for the SimpleMind filesystem privacy triage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+
+import numpy as np
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import sm_fs_filing
+import sm_fs_privacy
+from sm_fs_filing import (
+    discover_filing_rows,
+    filing_provenance,
+    harden_private_cache,
+    prepare_private_cache,
+    require_public_privacy_perimeter,
+)
+from benchmark_sm_fs_privacy_local import score_response, synthetic_cases
+from sm_fs_privacy import (
+    MODEL_REVIEW_DISABLED_REASON,
+    PARSER_PATH,
+    SmFsPrivacyError,
+    apply_model_reviews,
+    build_index,
+    canonical_json_bytes,
+    load_index,
+    pearltrees_url_kind,
+    resolve_cloudmapref,
+    scan_maps,
+    sha256_bytes,
+    sha256_file,
+    verify_index_source,
+    write_index,
+)
+from mu_attention import E5_REVISION
+
+
+def _map_xml_bytes(topics):
+    document = ET.Element("mindmap")
+    for spec in topics:
+        attrs = {
+            "id": str(spec["id"]),
+            "parent": str(spec.get("parent", "-1")),
+            "text": spec.get("text", ""),
+        }
+        topic = ET.SubElement(document, "topic", attrs)
+        for url in spec.get("urls", ()):
+            ET.SubElement(topic, "link", {"urllink": url})
+        for ref in spec.get("refs", ()):
+            ET.SubElement(topic, "link", {"cloudmapref": ref})
+    return ET.tostring(document)
+
+
+def _write_map(path: Path, topics):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("document/mindmap.xml", _map_xml_bytes(topics))
+
+
+def _write_map_archive(path: Path, entries):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, payload in entries:
+            archive.writestr(name, payload)
+
+
+def _record_by_name(records, suffix):
+    return next(row for row in records if row["relative_path"].endswith(suffix))
+
+
+def _resealed_index_bytes(header, records):
+    resealed_header = json.loads(json.dumps(header))
+    resealed_records = json.loads(json.dumps(records))
+    core = dict(resealed_header)
+    core.pop("index_sha256", None)
+    core["rows_sha256"] = sha256_bytes(
+        b"".join(canonical_json_bytes(record) for record in resealed_records)
+    )
+    resealed_header["index_sha256"] = sha256_bytes(
+        canonical_json_bytes(core)
+    )
+    return canonical_json_bytes(resealed_header) + b"".join(
+        canonical_json_bytes(record) for record in resealed_records
+    )
+
+
+def test_pearltrees_private_export_link_is_unknown_not_private():
+    assert (
+        pearltrees_url_kind("https://www.pearltrees.com/private/id123?access=abc")
+        == "private_unknown"
+    )
+    assert (
+        pearltrees_url_kind(
+            "https://www.pearltrees.com/s243a/private-hacking/id456"
+        )
+        == "public"
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "ftp://www.pearltrees.com/s243a/topic/id456",
+        "https://evil@www.pearltrees.com/s243a/topic/id456",
+        "https://www.pearltrees.com:443/s243a/topic/id456",
+        "https://www.pearltrees.com/s243a/topic/extra/id456",
+        "https://www.pearltrees.com/s243a/private/id456",
+        "https://www.pearltrees.com/private/topic/id456",
+        "https://www.pearltrees.com/s243a/%70rivate/id456",
+        "https://www.pearltrees.com/s243a/%2Fprivate/id456",
+    ),
+)
+def test_pearltrees_public_url_grammar_rejects_noncanonical_and_private_paths(url):
+    assert pearltrees_url_kind(url) != "public"
+
+
+def test_smmx_zip_uses_exact_canonical_member_not_preceding_decoy(tmp_path):
+    _write_map_archive(
+        tmp_path / "Map.smmx",
+        (
+            (
+                "decoy/mindmap.xml",
+                _map_xml_bytes([{"id": 0, "text": "Private: decoy"}]),
+            ),
+            (
+                "document/mindmap.xml",
+                _map_xml_bytes([{"id": 0, "text": "Canonical public map"}]),
+            ),
+        ),
+    )
+    record = scan_maps(tmp_path, workers=1)[0]
+    assert record["root_title"] == "Canonical public map"
+    assert record["classification"] == "public"
+
+
+def test_smmx_zip_without_exact_canonical_member_fails_closed(tmp_path):
+    _write_map_archive(
+        tmp_path / "Map.smmx",
+        (
+            (
+                "decoy/mindmap.xml",
+                _map_xml_bytes([{"id": 0, "text": "Decoy"}]),
+            ),
+        ),
+    )
+    record = scan_maps(tmp_path, workers=1)[0]
+    assert record["classification"] == "unknown"
+    assert record["reasons"] == ["map_parse_error"]
+    assert record["parse_error_type"] == "SmFsPrivacyError"
+
+
+@pytest.mark.parametrize(
+    "alias",
+    (
+        "Document/mindmap.xml",
+        "document\\mindmap.xml",
+        "./document/mindmap.xml",
+        "document//mindmap.xml",
+        "other/../document/mindmap.xml",
+    ),
+)
+def test_smmx_zip_rejects_ambiguous_canonical_member_alias(tmp_path, alias):
+    _write_map_archive(
+        tmp_path / "Map.smmx",
+        (
+            (
+                "document/mindmap.xml",
+                _map_xml_bytes([{"id": 0, "text": "Canonical"}]),
+            ),
+            (
+                alias,
+                _map_xml_bytes([{"id": 0, "text": "Ambiguous"}]),
+            ),
+        ),
+    )
+    record = scan_maps(tmp_path, workers=1)[0]
+    assert record["classification"] == "unknown"
+    assert record["reasons"] == ["map_parse_error"]
+    assert record["parse_error_type"] == "SmFsPrivacyError"
+
+
+def test_smmx_zip_rejects_duplicate_canonical_zipinfo_entries(tmp_path):
+    path = tmp_path / "Map.smmx"
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        _write_map_archive(
+            path,
+            (
+                (
+                    "document/mindmap.xml",
+                    _map_xml_bytes([{"id": 0, "text": "First"}]),
+                ),
+                (
+                    "document/mindmap.xml",
+                    _map_xml_bytes([{"id": 0, "text": "Second"}]),
+                ),
+            ),
+        )
+    record = scan_maps(tmp_path, workers=1)[0]
+    assert record["classification"] == "unknown"
+    assert record["reasons"] == ["map_parse_error"]
+    assert record["parse_error_type"] == "SmFsPrivacyError"
+
+
+def test_public_topical_root_conflicts_with_private_directory(tmp_path):
+    _write_map(
+        tmp_path / "Synthetic" / "Private" / "Private Foobarology.smmx",
+        [
+            {
+                "id": 0,
+                "text": "Private Foobarology",
+                "urls": (
+                    "https://www.pearltrees.com/example/foobarology/id456",
+                ),
+            }
+        ],
+    )
+    record = scan_maps(tmp_path)[0]
+    assert record["classification"] == "unknown"
+    assert "access_marker_conflicts_with_public_root" in record["reasons"]
+
+
+def test_extra_blank_root_does_not_hide_canonical_root(tmp_path):
+    _write_map(
+        tmp_path / "Map.smmx",
+        [
+            {
+                "id": 0,
+                "text": "Map",
+                "urls": ("https://www.pearltrees.com/s243a/map/id456",),
+            },
+            {"id": 99, "text": ""},
+        ],
+    )
+    record = scan_maps(tmp_path)[0]
+    assert record["classification"] == "public"
+    assert "extra_root_topics_ignored" in record["reasons"]
+
+
+@pytest.mark.parametrize(
+    "topics",
+    (
+        [
+            {"id": 0, "text": "Map"},
+            {"id": 0, "parent": 0, "text": "duplicate"},
+        ],
+        [
+            {"id": "", "text": "Map"},
+        ],
+        [
+            {"id": 0, "text": "Map"},
+            {"id": 1, "parent": 999, "text": "orphan"},
+        ],
+        [
+            {"id": 0, "text": "Map"},
+            {"id": 1, "parent": 2, "text": "cycle one"},
+            {"id": 2, "parent": 1, "text": "cycle two"},
+        ],
+        [
+            {"id": 0, "text": "Map"},
+            {
+                "id": 99,
+                "text": "",
+                "urls": ("https://example.com/not-blank",),
+            },
+        ],
+        [
+            {"id": 0, "text": "Map"},
+            {"id": 99, "text": ""},
+            {"id": 100, "parent": 99, "text": "hidden child"},
+        ],
+        [
+            {"id": 0, "text": "Map"},
+            {"id": 99, "text": "second root"},
+        ],
+    ),
+)
+def test_invalid_topic_identity_parent_graph_or_extra_root_fails_closed(
+    tmp_path, topics
+):
+    _write_map(tmp_path / "Map.smmx", topics)
+    record = scan_maps(tmp_path, workers=1)[0]
+    assert record["classification"] == "unknown"
+    assert "map_parse_error" in record["reasons"]
+    assert record["parse_error_type"] == "SmFsPrivacyError"
+
+
+def test_private_directory_and_access_prefix_identify_private_duplicate(tmp_path):
+    _write_map(
+        tmp_path / "Synthetic" / "Private" / "Private_Zorbifold.smmx",
+        [
+            {
+                "id": 0,
+                "text": "Private: Zorbifold notes",
+                "urls": ("https://www.pearltrees.com/private/id789?access=abc",),
+            }
+        ],
+    )
+    record = scan_maps(tmp_path)[0]
+    assert record["classification"] == "private"
+    assert "private_dir_or_access_prefix" in record["reasons"]
+
+
+@pytest.mark.parametrize(
+    "directory",
+    ("Private_Research", "Private: Research", "Private - Research"),
+)
+def test_access_prefix_directory_components_fail_closed(tmp_path, directory):
+    _write_map(
+        tmp_path / directory / "Ordinary map.smmx",
+        [{"id": 0, "text": "Ordinary map"}],
+    )
+    record = scan_maps(tmp_path)[0]
+    assert record["classification"] == "private"
+    assert "private_dir_or_access_prefix" in record["reasons"]
+
+
+def test_access_prefix_directory_and_public_link_conflict_is_unknown(tmp_path):
+    _write_map(
+        tmp_path / "Private_Research" / "Ordinary map.smmx",
+        [
+            {
+                "id": 0,
+                "text": "Ordinary map",
+                "urls": (
+                    "https://www.pearltrees.com/s243a/ordinary-map/id42",
+                ),
+            }
+        ],
+    )
+    record = scan_maps(tmp_path)[0]
+    assert record["classification"] == "unknown"
+    assert "access_marker_conflicts_with_public_root" in record["reasons"]
+
+
+def test_private_marker_targets_specific_linked_map_not_its_public_parent(tmp_path):
+    public_parent = tmp_path / "Parent.smmx"
+    source = tmp_path / "index" / "Index.smmx"
+    private_target = tmp_path / "private-maps" / "Course copy.smmx"
+    _write_map(public_parent, [{"id": 0, "text": "Public parent"}])
+    _write_map(
+        private_target,
+        [
+            {"id": 0, "text": "Course copy"},
+            {
+                "id": 1,
+                "parent": 0,
+                "text": "Navigate up",
+                "refs": ("../Parent.smmx",),
+            },
+        ],
+    )
+    _write_map(
+        source,
+        [
+            {"id": 0, "text": "Index"},
+            {"id": 1, "parent": 0, "text": "private"},
+            {"id": 2, "parent": 1, "text": "Course"},
+            {
+                "id": 3,
+                "parent": 2,
+                "text": "",
+                "refs": ("../private-maps/Course copy.smmx",),
+            },
+        ],
+    )
+    records = scan_maps(tmp_path)
+    assert _record_by_name(records, "Course copy.smmx")["classification"] == "private"
+    assert "private_cloud_child" in _record_by_name(
+        records, "Course copy.smmx"
+    )["reasons"]
+    assert _record_by_name(records, "Parent.smmx")["classification"] == "public"
+
+
+def test_public_root_conflict_with_private_cloud_child_is_unknown(tmp_path):
+    target = tmp_path / "Public target.smmx"
+    _write_map(
+        target,
+        [
+            {
+                "id": 0,
+                "text": "Public target",
+                "urls": (
+                    "https://www.pearltrees.com/s243a/public-target/id456",
+                ),
+            }
+        ],
+    )
+    _write_map(
+        tmp_path / "Index.smmx",
+        [
+            {"id": 0, "text": "Index"},
+            {"id": 1, "parent": 0, "text": "private"},
+            {
+                "id": 2,
+                "parent": 1,
+                "text": "",
+                "refs": ("Public target.smmx",),
+            },
+        ],
+    )
+    record = _record_by_name(scan_maps(tmp_path), "Public target.smmx")
+    assert record["classification"] == "unknown"
+    assert "private_cloud_child_conflicts_with_public_root" in record["reasons"]
+
+
+def test_topical_private_key_in_exact_private_directory_is_ambiguous(tmp_path):
+    _write_map(
+        tmp_path / "Private" / "Private-key cryptography.smmx",
+        [{"id": 0, "text": "Private-key cryptography"}],
+    )
+    record = scan_maps(tmp_path)[0]
+    assert record["classification"] == "unknown"
+    assert "private_marker_with_topical_root" in record["reasons"]
+
+
+def test_topical_privacy_link_does_not_mark_cloud_target_private(tmp_path):
+    target = tmp_path / "Target.smmx"
+    _write_map(target, [{"id": 0, "text": "Target"}])
+    _write_map(
+        tmp_path / "Index.smmx",
+        [
+            {"id": 0, "text": "Index"},
+            {
+                "id": 1,
+                "parent": 0,
+                "text": "private",
+                "urls": ("https://en.wikipedia.org/wiki/Privacy",),
+            },
+            {"id": 2, "parent": 1, "text": "", "refs": ("Target.smmx",)},
+        ],
+    )
+    records = scan_maps(tmp_path)
+    assert _record_by_name(records, "Target.smmx")["classification"] == "public"
+
+
+def test_unrelated_public_link_does_not_disable_private_marker(tmp_path):
+    target = tmp_path / "Target.smmx"
+    _write_map(target, [{"id": 0, "text": "Target"}])
+    _write_map(
+        tmp_path / "Index.smmx",
+        [
+            {"id": 0, "text": "Index"},
+            {
+                "id": 1,
+                "parent": 0,
+                "text": "private",
+                "urls": ("https://example.com/unrelated",),
+            },
+            {"id": 2, "parent": 1, "text": "", "refs": ("Target.smmx",)},
+        ],
+    )
+    record = _record_by_name(scan_maps(tmp_path), "Target.smmx")
+    assert record["classification"] == "private"
+    assert "private_cloud_child" in record["reasons"]
+
+
+def test_virtual_root_cloudref_and_outside_ref_resolution(tmp_path):
+    source = tmp_path / "branch" / "Source.smmx"
+    source.parent.mkdir(parents=True)
+    inside = resolve_cloudmapref(tmp_path, source, "/root/other/Target.smmx")
+    assert inside == tmp_path / "other" / "Target.smmx"
+    assert resolve_cloudmapref(tmp_path, source, "../../../outside.smmx") is None
+    assert resolve_cloudmapref(tmp_path, source, ".") is None
+
+
+def test_legacy_root_relative_cloudref_is_resolved_when_unambiguous(tmp_path):
+    source = tmp_path / "branch" / "Source.smmx"
+    source.parent.mkdir(parents=True)
+    target = tmp_path / "Subjects" / "Target.smmx"
+    _write_map(target, [{"id": 0, "text": "Target"}])
+    assert (
+        resolve_cloudmapref(tmp_path, source, "Subjects/Target.smmx")
+        == target
+    )
+
+
+def test_case_different_private_cloud_target_resolves_to_canonical_member(
+    tmp_path,
+):
+    target = tmp_path / "Targets" / "Target.smmx"
+    _write_map(target, [{"id": 0, "text": "Target"}])
+    _write_map(
+        tmp_path / "Index.smmx",
+        [
+            {"id": 0, "text": "Index"},
+            {"id": 1, "parent": 0, "text": "private"},
+            {
+                "id": 2,
+                "parent": 1,
+                "text": "",
+                "refs": ("targets/target.smmx",),
+            },
+        ],
+    )
+    records = scan_maps(tmp_path, workers=1)
+    source = _record_by_name(records, "Index.smmx")
+    canonical_target = _record_by_name(records, "Targets/Target.smmx")
+    assert source["unresolved_private_targets"] == []
+    assert canonical_target["classification"] == "private"
+    assert "private_cloud_child" in canonical_target["reasons"]
+
+
+def test_missing_private_cloud_target_is_counted_unresolved(tmp_path):
+    _write_map(
+        tmp_path / "Index.smmx",
+        [
+            {"id": 0, "text": "Index"},
+            {"id": 1, "parent": 0, "text": "private"},
+            {
+                "id": 2,
+                "parent": 1,
+                "text": "",
+                "refs": ("Missing/Target.smmx",),
+            },
+        ],
+    )
+    header, records = build_index(tmp_path, workers=1)
+    assert records[0]["unresolved_private_targets"] == [
+        "Missing/Target.smmx"
+    ]
+    assert "unresolved_private_map_links" in records[0]["reasons"]
+    assert header["counts"]["unresolved_private_target_refs"] == 1
+
+
+def test_apply_model_reviews_cannot_emit_corpus_metadata(tmp_path):
+    _write_map(
+        tmp_path / "STEM" / "MMSE.smmx",
+        [
+            {
+                "id": 0,
+                "text": "Minimum mean square error",
+                "urls": ("https://www.pearltrees.com/private/id222?access=x",),
+            }
+        ],
+    )
+    records = scan_maps(tmp_path)
+    before = json.loads(json.dumps(records))
+    called = False
+
+    def must_not_call(*_args):
+        nonlocal called
+        called = True
+        return "[]"
+
+    with pytest.raises(SmFsPrivacyError, match="model review is disabled"):
+        apply_model_reviews(
+            records,
+            provider="ollama-json",
+            model="phi3:latest",
+            batch_size=20,
+            timeout=11,
+            call_llm=must_not_call,
+        )
+    assert called is False
+    assert records == before
+
+
+def test_corpus_model_review_is_disabled_without_verified_lock(tmp_path):
+    _write_map(tmp_path / "Map.smmx", [{"id": 0, "text": "Map"}])
+    called = False
+
+    def must_not_call(*_args):
+        nonlocal called
+        called = True
+        return "[]"
+
+    with pytest.raises(SmFsPrivacyError, match="verified passing benchmark lock"):
+        build_index(
+            tmp_path,
+            provider="ollama-json",
+            model="qwen3:4b",
+            call_llm=must_not_call,
+        )
+    assert called is False
+
+
+def test_corpus_model_review_rejects_hosted_provider_with_same_closed_gate(
+    tmp_path,
+):
+    _write_map(tmp_path / "Map.smmx", [{"id": 0, "text": "Map"}])
+    with pytest.raises(SmFsPrivacyError, match="verified passing benchmark lock"):
+        build_index(
+            tmp_path,
+            provider="openai",
+            model="gpt-test",
+            call_llm=lambda *_args: "[]",
+        )
+
+
+def test_symlink_corpus_member_is_rejected(tmp_path):
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    external = tmp_path / "External.smmx"
+    _write_map(external, [{"id": 0, "text": "External"}])
+    (corpus / "Alias.smmx").symlink_to(external)
+    with pytest.raises(SmFsPrivacyError, match="symlink corpus member"):
+        scan_maps(corpus, workers=1)
+
+
+def test_record_read_uses_no_follow_even_after_discovery(
+    tmp_path, monkeypatch
+):
+    corpus = tmp_path / "corpus"
+    member = corpus / "Map.smmx"
+    _write_map(member, [{"id": 0, "text": "Map"}])
+    external = tmp_path / "External.smmx"
+    _write_map(external, [{"id": 0, "text": "External"}])
+    real_members = sm_fs_privacy.smmx_member_bindings
+
+    def swap_file(root_fd):
+        bindings = real_members(root_fd)
+        member.unlink()
+        member.symlink_to(external)
+        return bindings
+
+    monkeypatch.setattr(
+        sm_fs_privacy,
+        "smmx_member_bindings",
+        swap_file,
+    )
+    with pytest.raises(SmFsPrivacyError, match="symlink corpus member"):
+        scan_maps(corpus, workers=1)
+
+
+def test_retained_root_descriptor_defeats_root_path_swap(
+    tmp_path, monkeypatch
+):
+    corpus = tmp_path / "corpus"
+    _write_map(corpus / "Original.smmx", [{"id": 0, "text": "Original"}])
+    replacement = tmp_path / "replacement"
+    _write_map(
+        replacement / "Original.smmx",
+        [{"id": 0, "text": "Replacement"}],
+    )
+    detached = tmp_path / "detached-corpus"
+    real_members = sm_fs_privacy.smmx_member_bindings
+
+    def swap_root(root_fd):
+        members = real_members(root_fd)
+        corpus.rename(detached)
+        corpus.symlink_to(replacement, target_is_directory=True)
+        return members
+
+    monkeypatch.setattr(sm_fs_privacy, "smmx_member_bindings", swap_root)
+    records = scan_maps(corpus, workers=1)
+    assert [record["root_title"] for record in records] == ["Original"]
+
+
+def test_parent_swap_to_symlink_fails_closed(tmp_path, monkeypatch):
+    corpus = tmp_path / "corpus"
+    parent = corpus / "Branch"
+    _write_map(parent / "Map.smmx", [{"id": 0, "text": "Original"}])
+    replacement = tmp_path / "replacement"
+    _write_map(
+        replacement / "Map.smmx",
+        [{"id": 0, "text": "Replacement"}],
+    )
+    detached = corpus / "Detached"
+    real_members = sm_fs_privacy.smmx_member_bindings
+
+    def swap_parent(root_fd):
+        members = real_members(root_fd)
+        parent.rename(detached)
+        parent.symlink_to(replacement, target_is_directory=True)
+        return members
+
+    monkeypatch.setattr(sm_fs_privacy, "smmx_member_bindings", swap_parent)
+    with pytest.raises(SmFsPrivacyError, match="symlink corpus directory"):
+        scan_maps(corpus, workers=1)
+
+
+def test_parent_swap_to_real_directory_fails_identity_binding(
+    tmp_path, monkeypatch
+):
+    corpus = tmp_path / "corpus"
+    parent = corpus / "Branch"
+    _write_map(parent / "Map.smmx", [{"id": 0, "text": "Original"}])
+    replacement = tmp_path / "replacement"
+    _write_map(
+        replacement / "Map.smmx",
+        [{"id": 0, "text": "Replacement"}],
+    )
+    detached = corpus / "Detached"
+    real_members = sm_fs_privacy.smmx_member_bindings
+
+    def swap_parent(root_fd):
+        bindings = real_members(root_fd)
+        parent.rename(detached)
+        replacement.rename(parent)
+        return bindings
+
+    monkeypatch.setattr(sm_fs_privacy, "smmx_member_bindings", swap_parent)
+    with pytest.raises(SmFsPrivacyError, match="directory identity changed"):
+        scan_maps(corpus, workers=1)
+
+
+def test_smmx_named_directory_is_rejected(tmp_path):
+    (tmp_path / "LooksLikeMap.smmx").mkdir()
+    with pytest.raises(SmFsPrivacyError, match="non-regular corpus member"):
+        scan_maps(tmp_path, workers=1)
+
+
+def test_stable_read_allows_drvfs_hydration_ctime_atime_churn(
+    tmp_path, monkeypatch
+):
+    member = tmp_path / "Map.smmx"
+    _write_map(member, [{"id": 0, "text": "Map"}])
+    expected = member.read_bytes()
+    real_fstat = sm_fs_privacy.os.fstat
+    calls = 0
+
+    class HydratedStat:
+        def __init__(self, base, shift):
+            self._base = base
+            self.st_ctime_ns = base.st_ctime_ns + shift
+            self.st_atime_ns = base.st_atime_ns + shift
+
+        def __getattr__(self, name):
+            return getattr(self._base, name)
+
+    def hydrating_fstat(fd):
+        nonlocal calls
+        calls += 1
+        return HydratedStat(real_fstat(fd), calls)
+
+    monkeypatch.setattr(sm_fs_privacy.os, "fstat", hydrating_fstat)
+    assert sm_fs_privacy._read_regular_file_no_follow(member) == expected
+    assert calls == 3
+
+
+def test_stable_read_rejects_different_consecutive_descriptor_bytes(
+    tmp_path, monkeypatch
+):
+    member = tmp_path / "Map.smmx"
+    _write_map(member, [{"id": 0, "text": "Map"}])
+    real_read_all = sm_fs_privacy._read_all_from_fd
+    calls = 0
+
+    def mutate_after_first_read(fd):
+        nonlocal calls
+        data = real_read_all(fd)
+        calls += 1
+        if calls == 1:
+            member.write_bytes(b"X" * len(data))
+        return data
+
+    monkeypatch.setattr(
+        sm_fs_privacy, "_read_all_from_fd", mutate_after_first_read
+    )
+    with pytest.raises(SmFsPrivacyError, match="file bytes changed"):
+        sm_fs_privacy._read_regular_file_no_follow(member)
+
+
+def test_unreadable_map_is_unknown_and_does_not_abort_scan(tmp_path):
+    broken = tmp_path / "Broken.smmx"
+    broken.write_bytes(b"not a zip")
+    record = scan_maps(tmp_path)[0]
+    assert record["classification"] == "unknown"
+    assert record["reasons"] == ["map_parse_error"]
+    assert record["parse_error_type"]
+
+
+def test_index_roundtrip_binds_source_snapshot(tmp_path):
+    corpus = tmp_path / "corpus"
+    _write_map(corpus / "Folder" / "Map.smmx", [{"id": 0, "text": "Map"}])
+    header, records = build_index(corpus)
+    assert header["model"] is None
+    assert header["model_review_authorization"] == {
+        "authorized": False,
+        "reason": MODEL_REVIEW_DISABLED_REASON,
+    }
+    index = tmp_path / "privacy.jsonl"
+    write_index(index, header, records)
+    with pytest.raises(FileExistsError, match="refusing to replace"):
+        write_index(index, header, records)
+    loaded_header, by_path = load_index(index)
+    verify_index_source(corpus, loaded_header, by_path)
+    assert loaded_header["parser_sha256"] == sha256_file(PARSER_PATH)
+    stale_parser = dict(loaded_header)
+    stale_parser["parser_sha256"] = "0" * 64
+    with pytest.raises(SmFsPrivacyError, match="parser changed"):
+        verify_index_source(corpus, stale_parser, by_path)
+    (corpus / "Folder" / "Map.smmx").write_bytes(b"changed")
+    with pytest.raises(SmFsPrivacyError, match="map contents changed"):
+        verify_index_source(corpus, loaded_header, by_path)
+
+
+def test_load_rejects_resealed_v1_model_and_derived_metadata_tampering(
+    tmp_path,
+):
+    corpus = tmp_path / "corpus"
+    _write_map(corpus / "Map.smmx", [{"id": 0, "text": "Map"}])
+    original_header, original_records = build_index(corpus, workers=1)
+
+    def set_header_model(header, _records):
+        header["model"] = {"provider": "local", "name": "adversarial"}
+
+    def authorize_model_review(header, _records):
+        header["model_review_authorization"]["authorized"] = True
+
+    def add_row_model_review(_header, records):
+        records[0]["model_review"] = {
+            "provider": "local",
+            "model": "adversarial",
+        }
+
+    def alter_derived_counts(header, _records):
+        header["counts"]["public"] += 1
+
+    def alter_derived_snapshot(header, _records):
+        header["source_snapshot"]["file_count"] += 1
+
+    cases = (
+        ("header-model", set_header_model, "cannot name a model"),
+        ("authorization", authorize_model_review, "authorization changed"),
+        ("row-model", add_row_model_review, "model review data"),
+        ("counts", alter_derived_counts, "derived counts changed"),
+        ("snapshot", alter_derived_snapshot, "source snapshot changed"),
+    )
+    for name, mutate, message in cases:
+        header = json.loads(json.dumps(original_header))
+        records = json.loads(json.dumps(original_records))
+        mutate(header, records)
+        path = tmp_path / f"{name}.jsonl"
+        path.write_bytes(_resealed_index_bytes(header, records))
+        with pytest.raises(SmFsPrivacyError, match=message):
+            load_index(path)
+
+
+def test_verify_itself_enforces_v1_no_model_and_derived_counts(tmp_path):
+    corpus = tmp_path / "corpus"
+    _write_map(corpus / "Map.smmx", [{"id": 0, "text": "Map"}])
+    header, records = build_index(corpus, workers=1)
+    by_path = {record["relative_path"]: record for record in records}
+
+    by_path["Map.smmx"]["model_review"] = {"model": "adversarial"}
+    with pytest.raises(SmFsPrivacyError, match="model review data"):
+        verify_index_source(corpus, header, by_path, workers=1)
+
+    by_path["Map.smmx"]["model_review"] = None
+    bad_counts = json.loads(json.dumps(header))
+    bad_counts["counts"]["public"] += 1
+    with pytest.raises(SmFsPrivacyError, match="derived counts changed"):
+        verify_index_source(corpus, bad_counts, by_path, workers=1)
+
+
+def test_resealed_label_tampering_fails_exact_classifier_rederivation(
+    tmp_path,
+):
+    corpus = tmp_path / "corpus"
+    _write_map(corpus / "Map.smmx", [{"id": 0, "text": "Map"}])
+    header, records = build_index(corpus, workers=1)
+    assert records[0]["classification"] == "public"
+    records[0]["classification"] = "unknown"
+    header["counts"]["public"] = 0
+    header["counts"]["unknown"] = 1
+
+    index = tmp_path / "resealed-label.jsonl"
+    index.write_bytes(_resealed_index_bytes(header, records))
+    loaded_header, by_path = load_index(index)
+    with pytest.raises(
+        SmFsPrivacyError, match="differs from exact classifier output"
+    ):
+        verify_index_source(corpus, loaded_header, by_path, workers=1)
+
+
+def test_filing_policy_filters_private_but_can_retain_unknown(tmp_path):
+    root = tmp_path / "corpus"
+    _write_map(root / "Public" / "One.smmx", [{"id": 0, "text": "One"}])
+    _write_map(
+        root / "Private" / "Private_Two.smmx",
+        [{"id": 0, "text": "Private: Two"}],
+    )
+    broken = root / "Unknown" / "Three.smmx"
+    broken.parent.mkdir(parents=True)
+    broken.write_bytes(b"bad")
+    _, records = build_index(root)
+    by_path = {row["relative_path"]: row for row in records}
+
+    exclude_private, counts = discover_filing_rows(
+        root, by_path, "exclude-private"
+    )
+    assert {row["privacy"] for row in exclude_private} == {"public", "unknown"}
+    assert counts == {"public": 1, "private": 1, "unknown": 1}
+
+    public_only, _ = discover_filing_rows(root, by_path, "public-only")
+    assert [row["title"] for row in public_only] == ["One"]
+
+    all_local, _ = discover_filing_rows(root, by_path, "all-local")
+    assert len(all_local) == 3
+
+
+def test_public_filing_refuses_unresolved_private_targets():
+    header = {"counts": {"unresolved_private_target_refs": 2}}
+    with pytest.raises(SmFsPrivacyError, match="not authorized"):
+        require_public_privacy_perimeter(header, "public-only")
+    require_public_privacy_perimeter(header, "exclude-private")
+
+
+def test_embedding_cache_is_private(tmp_path):
+    cache = prepare_private_cache(tmp_path / "cache" / "embeddings.pt")
+    cache.write_bytes(b"synthetic")
+    cache.chmod(0o644)
+    harden_private_cache(cache)
+    assert (cache.parent.stat().st_mode & 0o777) == 0o700
+    assert (cache.stat().st_mode & 0o777) == 0o600
+
+
+def test_filing_provenance_pins_e5_and_generator_source():
+    provenance = filing_provenance()
+    assert provenance["e5_revision"] == E5_REVISION
+    assert provenance["sm_fs_filing_sha256"] == sha256_file(
+        HERE / "sm_fs_filing.py"
+    )
+
+
+def test_filing_runtime_passes_and_records_pinned_e5_revision(
+    tmp_path, monkeypatch
+):
+    corpus = tmp_path / "corpus"
+    _write_map(
+        corpus / "Folder" / "One.smmx",
+        [{"id": 0, "text": "One"}],
+    )
+    privacy_index = tmp_path / "privacy.jsonl"
+    header, records = build_index(corpus, workers=1)
+    write_index(privacy_index, header, records)
+    observed = {}
+
+    class ArrayResult:
+        def __init__(self, array):
+            self._array = array
+
+        def numpy(self):
+            return self._array
+
+    def fake_build_e5_tables(names, **kwargs):
+        observed.update(kwargs)
+        matrix = np.eye(len(names), dtype=np.float32)
+        return ArrayResult(matrix), ArrayResult(matrix), {
+            name: index for index, name in enumerate(names)
+        }
+
+    monkeypatch.setattr(
+        sm_fs_filing, "build_e5_tables", fake_build_e5_tables
+    )
+    ledger = tmp_path / "private" / "ledger.json"
+    sm_fs_filing.main(
+        [
+            "--root",
+            str(corpus),
+            "--privacy-index",
+            str(privacy_index),
+            "--privacy-policy",
+            "public-only",
+            "--min-maps",
+            "1",
+            "--holdout-frac",
+            "0",
+            "--ledger",
+            str(ledger),
+            "--e5-cache",
+            str(tmp_path / "private" / "e5.pt"),
+        ]
+    )
+    assert observed["model_revision"] == E5_REVISION
+    ledger_value = json.loads(ledger.read_text(encoding="utf-8"))
+    expected_provenance = filing_provenance()
+    assert {
+        key: ledger_value["provenance"][key] for key in expected_provenance
+    } == expected_provenance
+    assert re.fullmatch(
+        r"[0-9a-f]{64}",
+        ledger_value["provenance"]["e5_cache_sha256"],
+    )
+
+
+def test_synthetic_benchmark_is_balanced_and_strictly_scored():
+    cases = synthetic_cases()
+    assert len(cases) == 12
+    assert {
+        expected: sum(case["expected"] == expected for case in cases)
+        for expected in ("access_control", "topical", "uncertain")
+    } == {"access_control": 4, "topical": 4, "uncertain": 4}
+    response = json.dumps(
+        [
+            {
+                "qid": case["task"]["qid"],
+                "interpretation": case["expected"],
+                "reason": "synthetic expected label",
+            }
+            for case in cases
+        ]
+    )
+    score = score_response(response, cases)
+    assert score["raw_unfenced_json"] is True
+    assert score["schema_ok"] is True
+    assert score["correct"] == 12
+    assert score["review_eligible_correct"] == 7

--- a/scripts/llm_cli.py
+++ b/scripts/llm_cli.py
@@ -8,12 +8,25 @@ Single source of truth for calling an LLM across CLIs/APIs, so both the filing A
     text = call_llm(prompt, provider="claude", model="haiku")
 
 Providers: claude (Haiku via `claude -p`, default), gemini, agy (Antigravity/Gemini-backed),
-codex (OpenAI `codex exec`), openai, anthropic, ollama.
+codex (OpenAI `codex exec`), openai, anthropic, ollama, ollama-json.
 """
+import json
+import ipaddress
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import Optional
+from urllib import request
+from urllib.parse import urlsplit
+
+
+class _NoRedirectHandler(request.HTTPRedirectHandler):
+    """Reject redirects so private prompts never leave the validated origin."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
 
 
 def call_claude_cli(prompt: str, model: str = "haiku", timeout: int = 60) -> Optional[str]:
@@ -123,9 +136,121 @@ def call_anthropic_api(prompt: str, model: str = "claude-3-5-haiku-20241022", ti
         print(f"  Anthropic API error: {e}", file=sys.stderr); return None
 
 
+def resolve_ollama_cli() -> str:
+    """Resolve native Ollama or the Windows CLI exposed to WSL.
+
+    ``OLLAMA_CLI`` is the explicit override.  The Windows executable fallback
+    lets WSL connect to the Windows Ollama service through loopback instead of
+    requiring that service to listen on the WSL network interface.  Loopback
+    transport does not prove that the selected Ollama tag executes locally;
+    private-data callers must separately disable Ollama cloud features.
+    """
+
+    configured = os.environ.get("OLLAMA_CLI")
+    if configured:
+        return configured
+    native = shutil.which("ollama")
+    if native:
+        return native
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if os.environ.get("WSL_DISTRO_NAME") and local_app_data:
+        windows_cli = Path(local_app_data) / "Programs" / "Ollama" / "ollama.exe"
+        if windows_cli.is_file():
+            return str(windows_cli)
+    return "ollama"
+
+
+def resolve_windows_curl() -> Optional[str]:
+    """Return Windows curl for WSL→Windows-loopback API calls, if available."""
+
+    configured = os.environ.get("WINDOWS_CURL_CLI")
+    if configured:
+        return configured
+    candidate = Path("/mnt/c/Windows/System32/curl.exe")
+    if os.environ.get("WSL_DISTRO_NAME") and candidate.is_file():
+        return str(candidate)
+    return None
+
+
+def local_ollama_endpoint() -> str:
+    """Return a canonical loopback-only Ollama endpoint.
+
+    Reject userinfo, proxies disguised as paths, and non-loopback hosts rather
+    than relying on substring parsing of ``OLLAMA_HOST``.  This constrains only
+    the client-to-server hop; Ollama cloud models can still be proxied by a
+    loopback server unless cloud features are disabled on that server.
+    """
+
+    configured = os.environ.get("OLLAMA_HOST", "http://127.0.0.1:11434").strip()
+    if "://" not in configured:
+        configured = "http://" + configured
+    parsed = urlsplit(configured)
+    if (
+        parsed.scheme.casefold() != "http"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("Ollama JSON endpoint must be a plain loopback HTTP origin")
+    try:
+        hostname = parsed.hostname
+    except ValueError as exc:
+        raise ValueError("Ollama JSON endpoint has an invalid hostname") from exc
+    if not hostname:
+        raise ValueError("Ollama JSON endpoint has no hostname")
+    normalized_host = hostname.casefold()
+    if normalized_host == "localhost":
+        # Do not leave loopback isolation dependent on DNS or a hosts-file
+        # mapping.  The transport always connects to a numeric loopback.
+        normalized_host = "127.0.0.1"
+    else:
+        try:
+            address = ipaddress.ip_address(normalized_host)
+            if not address.is_loopback:
+                raise ValueError("Ollama JSON endpoint is not loopback")
+            normalized_host = str(address)
+        except ValueError as exc:
+            raise ValueError("Ollama JSON endpoint is not loopback") from exc
+    try:
+        port = parsed.port or 11434
+    except ValueError as exc:
+        raise ValueError("Ollama JSON endpoint has an invalid port") from exc
+    rendered_host = f"[{normalized_host}]" if ":" in normalized_host else normalized_host
+    return f"http://{rendered_host}:{port}"
+
+
+def _require_local_ollama_model(model: str, timeout: int) -> Optional[str]:
+    cli = resolve_ollama_cli()
+    available = subprocess.run(
+        [cli, "show", model],
+        capture_output=True,
+        text=True,
+        timeout=min(timeout, 30),
+    )
+    if available.returncode != 0:
+        print(
+            f"  Ollama model is not installed locally: {model!r}",
+            file=sys.stderr,
+        )
+        return None
+    return cli
+
+
 def call_ollama(prompt: str, model: str = "llama3.1", timeout: int = 120) -> Optional[str]:
     try:
-        r = subprocess.run(["ollama", "run", model, prompt], capture_output=True, text=True, timeout=timeout)
+        cli = _require_local_ollama_model(model, timeout)
+        if cli is None:
+            return None
+        # `ollama run` pulls an absent model. Privacy/evaluation callers must
+        # instead name a model that was deliberately installed beforehand.
+        r = subprocess.run(
+            [cli, "run", model, prompt],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
         if r.returncode == 0:
             return r.stdout.strip()
         print(f"  Ollama error: {r.stderr[:200]}", file=sys.stderr); return None
@@ -137,9 +262,139 @@ def call_ollama(prompt: str, model: str = "llama3.1", timeout: int = 120) -> Opt
         print(f"  Exception: {e}", file=sys.stderr); return None
 
 
+def call_ollama_json(
+    prompt: str,
+    model: str = "llama3.1",
+    timeout: int = 120,
+    *,
+    response_schema: Optional[dict] = None,
+    max_output_tokens: int = 2048,
+    think: bool = False,
+    metadata_out: Optional[dict] = None,
+) -> Optional[str]:
+    """Call Ollama's non-streaming JSON API.
+
+    The Windows CLI emits terminal animation bytes when captured from WSL.
+    Calling the Windows-loopback API through Windows curl avoids that transport
+    corruption and asks Ollama to constrain the model response to valid JSON.
+    """
+
+    try:
+        if metadata_out is not None:
+            if not isinstance(metadata_out, dict):
+                raise ValueError("metadata_out must be a dict")
+            metadata_out.clear()
+        if (
+            not isinstance(max_output_tokens, int)
+            or isinstance(max_output_tokens, bool)
+            or max_output_tokens <= 0
+        ):
+            raise ValueError("max_output_tokens must be a positive integer")
+        endpoint = local_ollama_endpoint() + "/api/generate"
+        ollama_cli = _require_local_ollama_model(model, timeout)
+        if ollama_cli is None:
+            return None
+        payload = json.dumps(
+            {
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+                "format": response_schema if response_schema is not None else "json",
+                "think": bool(think),
+                "options": {
+                    "temperature": 0,
+                    "seed": 0,
+                    "num_predict": max_output_tokens,
+                },
+            }
+        ).encode("utf-8")
+        windows_curl = (
+            resolve_windows_curl()
+            if str(ollama_cli).casefold().endswith(".exe")
+            else None
+        )
+        if windows_curl:
+            result = subprocess.run(
+                [
+                    windows_curl,
+                    "--disable",
+                    "--silent",
+                    "--show-error",
+                    "--fail-with-body",
+                    "--noproxy",
+                    "*",
+                    "--max-redirs",
+                    "0",
+                    endpoint,
+                    "-H",
+                    "Content-Type: application/json",
+                    "--data-binary",
+                    "@-",
+                ],
+                input=payload,
+                capture_output=True,
+                timeout=timeout,
+            )
+            if result.returncode != 0:
+                error = result.stderr.decode("utf-8", "replace")[:200]
+                print(f"  Ollama JSON API error: {error}", file=sys.stderr)
+                return None
+            outer_text = result.stdout.decode("utf-8")
+        else:
+            api_request = request.Request(
+                endpoint,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            opener = request.build_opener(
+                request.ProxyHandler({}),
+                _NoRedirectHandler(),
+            )
+            with opener.open(api_request, timeout=timeout) as response:
+                outer_text = response.read().decode("utf-8")
+        outer = json.loads(outer_text)
+        if not isinstance(outer, dict):
+            raise ValueError("Ollama response is not an object")
+        if outer.get("error"):
+            raise ValueError(f"Ollama returned an error: {outer['error']}")
+        if outer.get("done") is not True:
+            raise ValueError("Ollama response did not finish")
+        done_reason = outer.get("done_reason")
+        if done_reason == "length":
+            raise ValueError("Ollama response exhausted the output-token budget")
+        model_response = outer.get("response")
+        if not isinstance(model_response, str):
+            raise ValueError("Ollama response field is missing")
+        json.loads(model_response)
+        if metadata_out is not None:
+            metadata_out.update(
+                {
+                    key: outer[key]
+                    for key in (
+                        "done_reason",
+                        "eval_count",
+                        "eval_duration",
+                        "prompt_eval_count",
+                        "prompt_eval_duration",
+                        "load_duration",
+                        "total_duration",
+                    )
+                    if key in outer
+                }
+            )
+        return model_response.strip()
+    except subprocess.TimeoutExpired:
+        print(f"  Timeout after {timeout}s", file=sys.stderr); return None
+    except FileNotFoundError:
+        print("  Ollama/Windows curl bridge not found", file=sys.stderr); return None
+    except Exception as e:
+        print(f"  Ollama JSON exception: {e}", file=sys.stderr); return None
+
+
 _DISPATCH = {"claude": call_claude_cli, "gemini": call_gemini_cli, "agy": call_agy_cli,
              "codex": call_codex_cli, "openai": call_openai_api, "anthropic": call_anthropic_api,
-             "ollama": call_ollama}
+             "ollama": call_ollama, "ollama-json": call_ollama_json}
 PROVIDERS = list(_DISPATCH)
 
 # ── token accounting ── so a harness can measure total tokens per completed task (tokens-per-correct-filing).

--- a/tests/test_llm_cli.py
+++ b/tests/test_llm_cli.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Focused tests for the shared local-LLM bridge."""
+
+from pathlib import Path
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+import subprocess
+import sys
+import threading
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import llm_cli
+
+
+def test_resolve_ollama_cli_uses_windows_executable_from_wsl(tmp_path, monkeypatch):
+    local_app_data = tmp_path / "AppData" / "Local"
+    windows_cli = local_app_data / "Programs" / "Ollama" / "ollama.exe"
+    windows_cli.parent.mkdir(parents=True)
+    windows_cli.write_bytes(b"placeholder")
+    monkeypatch.delenv("OLLAMA_CLI", raising=False)
+    monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+    monkeypatch.setenv("LOCALAPPDATA", str(local_app_data))
+    monkeypatch.setattr(llm_cli.shutil, "which", lambda _name: None)
+
+    assert llm_cli.resolve_ollama_cli() == str(windows_cli)
+
+
+def test_call_ollama_requires_preinstalled_model(monkeypatch):
+    calls = []
+
+    def fake_run(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 1, "", "model not found")
+
+    monkeypatch.setattr(llm_cli, "resolve_ollama_cli", lambda: "/fake/ollama.exe")
+    monkeypatch.setattr(llm_cli.subprocess, "run", fake_run)
+
+    assert llm_cli.call_ollama("synthetic prompt", "phi3:missing", 60) is None
+    assert calls == [["/fake/ollama.exe", "show", "phi3:missing"]]
+
+
+def test_call_ollama_runs_installed_model(monkeypatch):
+    calls = []
+
+    def fake_run(command, **_kwargs):
+        calls.append(command)
+        if command[1] == "show":
+            return subprocess.CompletedProcess(command, 0, "installed", "")
+        return subprocess.CompletedProcess(command, 0, '{"classification":"public"}', "")
+
+    monkeypatch.setattr(llm_cli, "resolve_ollama_cli", lambda: "/fake/ollama.exe")
+    monkeypatch.setattr(llm_cli.subprocess, "run", fake_run)
+
+    assert (
+        llm_cli.call_ollama("synthetic prompt", "phi3:latest", 60)
+        == '{"classification":"public"}'
+    )
+    assert calls == [
+        ["/fake/ollama.exe", "show", "phi3:latest"],
+        ["/fake/ollama.exe", "run", "phi3:latest", "synthetic prompt"],
+    ]
+
+
+def test_call_ollama_json_uses_nonstreaming_windows_bridge(monkeypatch):
+    calls = []
+    inner = '[{"qid":"q1","interpretation":"topical","reason":"synthetic"}]'
+    outer = json.dumps({"response": inner, "done": True}).encode()
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        if command[1] == "show":
+            return subprocess.CompletedProcess(command, 0, b"installed", b"")
+        return subprocess.CompletedProcess(command, 0, outer, b"")
+
+    monkeypatch.setattr(llm_cli, "resolve_ollama_cli", lambda: "/fake/ollama.exe")
+    monkeypatch.setattr(llm_cli, "resolve_windows_curl", lambda: "/fake/curl.exe")
+    monkeypatch.setattr(llm_cli.subprocess, "run", fake_run)
+
+    assert llm_cli.call_ollama_json("synthetic prompt", "qwen3:4b", 60) == inner
+    assert calls[0][0] == ["/fake/ollama.exe", "show", "qwen3:4b"]
+    curl_command, curl_kwargs = calls[1]
+    assert curl_command == [
+        "/fake/curl.exe",
+        "--disable",
+        "--silent",
+        "--show-error",
+        "--fail-with-body",
+        "--noproxy",
+        "*",
+        "--max-redirs",
+        "0",
+        "http://127.0.0.1:11434/api/generate",
+        "-H",
+        "Content-Type: application/json",
+        "--data-binary",
+        "@-",
+    ]
+    payload = json.loads(curl_kwargs["input"])
+    assert payload == {
+        "model": "qwen3:4b",
+        "prompt": "synthetic prompt",
+        "stream": False,
+        "format": "json",
+        "think": False,
+        "options": {"temperature": 0, "seed": 0, "num_predict": 2048},
+    }
+    assert curl_kwargs["timeout"] == 60
+
+
+def test_call_ollama_json_binds_reasoning_and_output_budget(monkeypatch):
+    calls = []
+    outer = json.dumps({"response": "[]", "done": True}).encode()
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        if command[1] == "show":
+            return subprocess.CompletedProcess(command, 0, b"installed", b"")
+        return subprocess.CompletedProcess(command, 0, outer, b"")
+
+    monkeypatch.setattr(llm_cli, "resolve_ollama_cli", lambda: "/fake/ollama.exe")
+    monkeypatch.setattr(llm_cli, "resolve_windows_curl", lambda: "/fake/curl.exe")
+    monkeypatch.setattr(llm_cli.subprocess, "run", fake_run)
+
+    assert (
+        llm_cli.call_ollama_json(
+            "synthetic prompt",
+            "deepseek-r1:8b",
+            60,
+            max_output_tokens=4096,
+            think=True,
+        )
+        == "[]"
+    )
+    payload = json.loads(calls[1][1]["input"])
+    assert payload["think"] is True
+    assert payload["options"]["num_predict"] == 4096
+
+
+def test_call_ollama_json_exposes_completion_metadata(monkeypatch):
+    outer = json.dumps(
+        {
+            "response": "[]",
+            "done": True,
+            "done_reason": "stop",
+            "eval_count": 17,
+            "eval_duration": 23,
+            "prompt_eval_count": 41,
+            "prompt_eval_duration": 43,
+            "load_duration": 47,
+            "total_duration": 53,
+            "context": [1, 2, 3],
+        }
+    ).encode()
+
+    def fake_run(command, **_kwargs):
+        if command[1] == "show":
+            return subprocess.CompletedProcess(command, 0, b"installed", b"")
+        return subprocess.CompletedProcess(command, 0, outer, b"")
+
+    monkeypatch.setattr(llm_cli, "resolve_ollama_cli", lambda: "/fake/ollama.exe")
+    monkeypatch.setattr(llm_cli, "resolve_windows_curl", lambda: "/fake/curl.exe")
+    monkeypatch.setattr(llm_cli.subprocess, "run", fake_run)
+    metadata = {"stale": True}
+
+    assert (
+        llm_cli.call_ollama_json(
+            "synthetic prompt", "qwen3:4b", 60, metadata_out=metadata
+        )
+        == "[]"
+    )
+    assert metadata == {
+        "done_reason": "stop",
+        "eval_count": 17,
+        "eval_duration": 23,
+        "prompt_eval_count": 41,
+        "prompt_eval_duration": 43,
+        "load_duration": 47,
+        "total_duration": 53,
+    }
+
+
+def test_call_ollama_json_rejects_length_truncation(monkeypatch):
+    outer = json.dumps(
+        {"response": "[]", "done": True, "done_reason": "length"}
+    ).encode()
+
+    def fake_run(command, **_kwargs):
+        if command[1] == "show":
+            return subprocess.CompletedProcess(command, 0, b"installed", b"")
+        return subprocess.CompletedProcess(command, 0, outer, b"")
+
+    monkeypatch.setattr(llm_cli, "resolve_ollama_cli", lambda: "/fake/ollama.exe")
+    monkeypatch.setattr(llm_cli, "resolve_windows_curl", lambda: "/fake/curl.exe")
+    monkeypatch.setattr(llm_cli.subprocess, "run", fake_run)
+    metadata = {"stale": True}
+
+    assert (
+        llm_cli.call_ollama_json(
+            "synthetic prompt", "qwen3:4b", 60, metadata_out=metadata
+        )
+        is None
+    )
+    assert metadata == {}
+
+
+def test_call_ollama_json_rejects_invalid_output_budget(monkeypatch):
+    monkeypatch.setattr(
+        llm_cli,
+        "_require_local_ollama_model",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("model lookup must not run")
+        ),
+    )
+    assert (
+        llm_cli.call_ollama_json(
+            "synthetic prompt",
+            "qwen3:4b",
+            60,
+            max_output_tokens=0,
+        )
+        is None
+    )
+
+
+def test_call_ollama_json_rejects_malformed_inner_json(monkeypatch):
+    outer = json.dumps({"response": "not-json", "done": True}).encode()
+
+    def fake_run(command, **_kwargs):
+        if command[1] == "show":
+            return subprocess.CompletedProcess(command, 0, b"installed", b"")
+        return subprocess.CompletedProcess(command, 0, outer, b"")
+
+    monkeypatch.setattr(llm_cli, "resolve_ollama_cli", lambda: "/fake/ollama.exe")
+    monkeypatch.setattr(llm_cli, "resolve_windows_curl", lambda: "/fake/curl.exe")
+    monkeypatch.setattr(llm_cli.subprocess, "run", fake_run)
+
+    assert llm_cli.call_ollama_json("synthetic prompt", "qwen3:4b", 60) is None
+
+
+def test_local_ollama_endpoint_rejects_remote_and_userinfo(monkeypatch):
+    bad_hosts = [
+        "http://example.com:11434",
+        "http://127.0.0.1:11434@evil.example",
+        "https://127.0.0.1:11434",
+        "http://127.0.0.1:11434/api",
+        "http://127.0.0.1:11434/",
+        "http://127.0.0.1:11434?proxy=1",
+        "http://127.0.0.1:11434#fragment",
+    ]
+    for configured in bad_hosts:
+        monkeypatch.setenv("OLLAMA_HOST", configured)
+        try:
+            llm_cli.local_ollama_endpoint()
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"unsafe endpoint was accepted: {configured}")
+
+
+def test_local_ollama_endpoint_accepts_loopback_forms(monkeypatch):
+    expected = {
+        "127.0.0.1": "http://127.0.0.1:11434",
+        "localhost:22000": "http://127.0.0.1:22000",
+        "http://LOCALHOST:22001": "http://127.0.0.1:22001",
+        "http://[::1]:11435": "http://[::1]:11435",
+    }
+    for configured, canonical in expected.items():
+        monkeypatch.setenv("OLLAMA_HOST", configured)
+        assert llm_cli.local_ollama_endpoint() == canonical
+
+
+def test_call_ollama_json_native_transport_disables_proxy(monkeypatch):
+    inner = '[{"qid":"q1","interpretation":"topical","reason":"synthetic"}]'
+    outer = json.dumps({"response": inner, "done": True}).encode()
+    opened = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return outer
+
+    class FakeOpener:
+        def open(self, api_request, timeout):
+            opened["url"] = api_request.full_url
+            opened["timeout"] = timeout
+            return FakeResponse()
+
+    def fake_build_opener(*handlers):
+        opened["handlers"] = handlers
+        return FakeOpener()
+
+    monkeypatch.setattr(llm_cli, "_require_local_ollama_model", lambda *_args: "/usr/bin/ollama")
+    monkeypatch.setattr(llm_cli, "resolve_windows_curl", lambda: "/fake/curl.exe")
+    monkeypatch.setattr(llm_cli.request, "build_opener", fake_build_opener)
+
+    assert llm_cli.call_ollama_json("synthetic prompt", "qwen3:4b", 60) == inner
+    assert opened["url"] == "http://127.0.0.1:11434/api/generate"
+    assert opened["timeout"] == 60
+    assert any(
+        isinstance(handler, llm_cli.request.ProxyHandler)
+        for handler in opened["handlers"]
+    )
+    assert any(
+        isinstance(handler, llm_cli._NoRedirectHandler)
+        for handler in opened["handlers"]
+    )
+
+
+def test_call_ollama_json_native_transport_denies_redirect(monkeypatch):
+    redirected = []
+
+    class RedirectingHandler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(302)
+            self.send_header("Location", "/redirected")
+            self.end_headers()
+
+        def do_GET(self):
+            redirected.append(self.path)
+            body = json.dumps({"response": "[]", "done": True}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format, *_args):
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), RedirectingHandler)
+    worker = threading.Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    monkeypatch.setenv("OLLAMA_HOST", f"http://127.0.0.1:{server.server_port}")
+    monkeypatch.setattr(
+        llm_cli,
+        "_require_local_ollama_model",
+        lambda *_args: "/usr/bin/ollama",
+    )
+    try:
+        assert llm_cli.call_ollama_json("synthetic prompt", "qwen3:4b", 60) is None
+        assert redirected == []
+    finally:
+        server.shutdown()
+        worker.join(timeout=5)
+        server.server_close()
+
+
+def test_call_ollama_json_rejects_incomplete_outer_response(monkeypatch):
+    outer = json.dumps({"response": "[]", "done": False}).encode()
+
+    def fake_run(command, **_kwargs):
+        if command[1] == "show":
+            return subprocess.CompletedProcess(command, 0, b"installed", b"")
+        return subprocess.CompletedProcess(command, 0, outer, b"")
+
+    monkeypatch.setattr(llm_cli, "resolve_ollama_cli", lambda: "/fake/ollama.exe")
+    monkeypatch.setattr(llm_cli, "resolve_windows_curl", lambda: "/fake/curl.exe")
+    monkeypatch.setattr(llm_cli.subprocess, "run", fake_run)
+
+    assert llm_cli.call_ollama_json("synthetic prompt", "qwen3:4b", 60) is None


### PR DESCRIPTION
## Summary

- replace the historical substring-only SimpleMind privacy filter with a local, rule-authoritative three-state index (`public`, `private`, `unknown`)
- bind every index row to exact source bytes, parser/classifier revisions, and a reproducible source snapshot; fail closed on malformed graphs, ambiguous links, symlinks, ancestor/file identity swaps, or source drift
- make the v2 freezer consume and independently rederive that index, producing separate mode-0600, no-replace `public-only` and `private-only` training bundles with exact path identities and verified lineage-blocked splits
- harden the filing/E5 cache path so tensors, hashes, and provenance all come from the same descriptor-bound bytes
- add a synthetic-only structured-Ollama benchmark with fixed decoding, truncation detection, before/after provenance binding, and no implicit model pulls
- retain Gemma 4 E2B and Qwen3 4B as distinct candidates for a future advisory privacy-ranking study

## Privacy and scientific boundary

This does **not** certify that a map is publicly available. `public` means only that the owner's stated metadata policy found no private signal. Unreadable, structurally invalid, ambiguous, and conflicting cases remain `unknown`.

Corpus model review is disabled in this version. No private corpus row was sent to an API or local model, and model output cannot change an index classification. The synthetic benchmark is development smoke evidence, not an accuracy estimate or confirmatory test; neither candidate passes its 12/12 gate.

A future two-model reviewer would rank only the `unknown` queue. Fuzzy scores are not treated as probabilities: each family is calibrated under lineage-blocked cross-fitting, the learned joint posterior is primary, and a prior-corrected PoE is a control because the two models are correlated. Evaluation uses an independently selected untouched outer-lineage sample.

The local rule-only scan bound 4,385 maps:

- 3,612 public-policy
- 7 private
- 766 unknown
- 691 unreadable or structurally invalid maps
- 2 unresolved references below explicit private markers

Only aggregates and hashes are committed; per-map paths, titles, source data, and benchmark artifacts remain local. Loopback transport is not treated as proof of local inference; any future private-data pilot must also verify that Ollama cloud features are disabled.

## Validation

- `154 passed` across the privacy, freezer, filing, local-LLM bridge, historical filing-privacy, SimpleMind campaign, and P1-ledger suites
- real-corpus descriptor-bound scan reproduced the same 4,385-map aggregate inventory
- prior local index comparison reproduced identical membership and every row
- adversarial coverage for canonical-archive ambiguity, duplicate graph IDs, source hydration churn, root/ancestor/file identity swaps, `.smmx` directories, symlink/hardlink swaps, cache replacement, requested and realized degenerate splits, resealed split tampering, no-replace installation, length-truncated model output, and mid-run provenance changes

## Review focus

The highest-risk surface is the private-corpus boundary: retained root descriptors, ancestor/file inode-chain binding, source-to-index rederivation, diagnostic holdout waivers, and the rule that model output remains advisory only.