### PR TITLE
mu_cosine: freezer --exclude-map — audited owner exclusion (clears the 2-map privacy gate)

### DIFF
--- a/prototypes/mu_cosine/sm_fs_freeze.py
+++ b/prototypes/mu_cosine/sm_fs_freeze.py
@@ -378,11 +378,19 @@ def _verify_ledger_against_privacy_source(
 
     verify_index_source(corpus_root, privacy_header, index)
     policy = ledger.get("training_privacy_policy")
+    sealed_exclusions = ledger.get("owner_excluded_maps") or []
+    if not (isinstance(sealed_exclusions, list)
+            and all(isinstance(x, str) for x in sealed_exclusions)
+            and sealed_exclusions == sorted(set(sealed_exclusions))):
+        raise ValueError("training bundle owner exclusions are malformed")
     expected = {}
     observed_privacy = Counter()
     for relative, _path, digest, indexed in _iter_verified_source_maps(
         corpus_root, index
     ):
+        if relative in sealed_exclusions:
+            observed_privacy["owner_excluded"] += 1
+            continue
         classification = indexed["classification"]
         observed_privacy[classification] += 1
         if not training_privacy_allows(classification, policy):
@@ -698,6 +706,7 @@ def build_bundle_manifest(
     training_privacy_policy,
     allow_unresolved_private_targets,
     allow_degenerate_holdout,
+    owner_excluded_maps=(),
 ):
     privacy_index = _absolute_path(privacy_index)
     if not _valid_artifact_record(privacy_index_artifact):
@@ -709,6 +718,7 @@ def build_bundle_manifest(
                 allow_unresolved_private_targets
             ),
             "allow_degenerate_holdout": bool(allow_degenerate_holdout),
+            "owner_excluded_maps": sorted(owner_excluded_maps),
             "decay": DECAY,
             "fs_root": str(_absolute_path(fs_root)),
             "holdout_frac": holdout_frac,
@@ -871,6 +881,7 @@ def verify_private_bundle(out_dir, privacy_index=None):
         "decay",
         "fs_root",
         "holdout_frac",
+        "owner_excluded_maps",
         "process_expression",
         "split_seed",
         "training_privacy_policy",
@@ -910,6 +921,10 @@ def verify_private_bundle(out_dir, privacy_index=None):
         (
             ledger.get("unresolved_private_targets_waived"),
             parameters.get("allow_unresolved_private_targets"),
+        ),
+        (
+            ledger.get("owner_excluded_maps"),
+            parameters.get("owner_excluded_maps"),
         ),
         (
             ledger_privacy.get("index_sha256"),
@@ -1095,7 +1110,20 @@ def main(argv=None):
             "recorded in the ledger and normally forbidden for public-only output"
         ),
     )
+    ap.add_argument(
+        "--exclude-map",
+        action="append",
+        default=[],
+        metavar="RELPATH",
+        help=(
+            "owner exclusion: drop this indexed map from the corpus entirely (repeatable). "
+            "Each path must exist in the privacy index; exclusions are sealed into the "
+            "ledger and manifest, and an excluded map's unresolved private-target refs no "
+            "longer trip the public-only gate (the referring map itself is gone)"
+        ),
+    )
     a = ap.parse_args(argv)
+    owner_exclusions = sorted(set(a.exclude_map))
     a.holdout_frac = _validate_holdout_fraction(
         a.holdout_frac,
         allow_degenerate=a.allow_degenerate_holdout,
@@ -1120,24 +1148,44 @@ def main(argv=None):
         f"(policy {privacy_header['policy_id']}, "
         f"digest {privacy_header['index_sha256'][:16]})"
     )
+    missing_exclusions = [rel for rel in owner_exclusions if rel not in index]
+    if missing_exclusions:
+        raise ValueError(
+            f"--exclude-map path(s) not present in the privacy index: "
+            f"{missing_exclusions[:3]}"
+        )
     unresolved = privacy_header.get("counts", {}).get(
         "unresolved_private_target_refs", 0
     )
+    excluded_refs = sum(
+        len(index[rel].get("unresolved_private_targets") or [])
+        for rel in owner_exclusions
+    )
+    effective_unresolved = max(0, unresolved - excluded_refs)
+    if owner_exclusions:
+        print(
+            f"owner exclusions: {len(owner_exclusions)} map(s) dropped "
+            f"({excluded_refs} unresolved private-target ref(s) retired with them)"
+        )
     if (
         a.training_privacy_policy == "public-only"
-        and unresolved
+        and effective_unresolved
         and not a.allow_unresolved_private_targets
     ):
         raise ValueError(
-            f"privacy index has {unresolved} unresolved private target "
+            f"privacy index has {effective_unresolved} unresolved private target "
             "reference(s); resolve them or record an explicit owner waiver"
         )
 
     rows = []
     observed_privacy = Counter()
+    excluded_set = set(owner_exclusions)
     for relative, _path, digest, indexed in _iter_verified_source_maps(
         fs_root, index
     ):
+        if relative in excluded_set:
+            observed_privacy["owner_excluded"] += 1
+            continue
         classification = indexed["classification"]
         observed_privacy[classification] += 1
         if not training_privacy_allows(
@@ -1156,7 +1204,8 @@ def main(argv=None):
     expected_policy_members = {
         relative
         for relative, record in index.items()
-        if training_privacy_allows(
+        if relative not in excluded_set
+        and training_privacy_allows(
             record["classification"], a.training_privacy_policy
         )
     }
@@ -1217,6 +1266,7 @@ def main(argv=None):
         "unresolved_private_targets_waived": bool(
             a.allow_unresolved_private_targets
         ),
+        "owner_excluded_maps": owner_exclusions,
         "limitations": ["ancestor components above destination level shared across splits "
                         "(transductive at ancestor level)",
                         "public classification is an owner risk-policy decision, not independent "
@@ -1298,6 +1348,7 @@ def main(argv=None):
         training_privacy_policy=a.training_privacy_policy,
         allow_unresolved_private_targets=a.allow_unresolved_private_targets,
         allow_degenerate_holdout=a.allow_degenerate_holdout,
+        owner_excluded_maps=owner_exclusions,
     )
     payloads = {
         "ledger.json": ledger_bytes,

--- a/prototypes/mu_cosine/test_sm_fs_freeze.py
+++ b/prototypes/mu_cosine/test_sm_fs_freeze.py
@@ -578,6 +578,7 @@ def test_binding_manifest_round_trip_and_provenance(tmp_path):
         "decay": sm_fs_freeze.DECAY,
         "fs_root": str(tree.resolve()),
         "holdout_frac": 0.0,
+        "owner_excluded_maps": [],
         "process_expression": sm_fs_freeze.EXPR,
         "split_seed": 0,
         "training_privacy_policy": "public-only",
@@ -814,3 +815,36 @@ def test_atomic_install_failure_leaves_no_partial_bundle(tmp_path, monkeypatch):
         run(tree, out, privacy_index=privacy_path)
     assert not out.exists()
     assert not list(tmp_path.glob(".out.staging.*"))
+
+
+def test_owner_exclusion_retires_unresolved_refs_and_is_sealed(tmp_path):
+    tree = make_tree(tmp_path)
+    bad = tree / "Subjects" / "sci" / "phy" / "mech" / "Dangling.smmx"
+    write_unresolved_private_marker_map(bad)
+    privacy_path = tmp_path / "privacy.jsonl"
+    header = build_privacy_index(tree, privacy_path)
+    assert header["counts"]["unresolved_private_target_refs"] >= 1
+    # without exclusion: public-only freeze fails closed on the unresolved ref
+    with pytest.raises(ValueError, match="unresolved private target"):
+        run(tree, tmp_path / "o1", privacy_index=privacy_path)
+    # unknown path fails closed
+    with pytest.raises(ValueError, match="not present in the privacy index"):
+        sm_fs_freeze.main([
+            "--fs-root", str(tree), "--out-dir", str(tmp_path / "o2"),
+            "--privacy-index", str(privacy_path),
+            "--exclude-map", "Nope/Missing.smmx",
+        ])
+    # exclusion clears the gate, drops the map, and seals the decision
+    sm_fs_freeze.main([
+        "--fs-root", str(tree), "--out-dir", str(tmp_path / "o3"),
+        "--holdout-frac", "0.4", "--split-seed", "0",
+        "--training-privacy-policy", "public-only",
+        "--privacy-index", str(privacy_path),
+        "--exclude-map", "Subjects/sci/phy/mech/Dangling.smmx",
+    ])
+    led = json.loads((tmp_path / "o3" / "ledger.json").read_bytes())
+    man = json.loads((tmp_path / "o3" / "manifest.json").read_bytes())
+    assert led["owner_excluded_maps"] == ["Subjects/sci/phy/mech/Dangling.smmx"]
+    assert man["parameters"]["owner_excluded_maps"] == led["owner_excluded_maps"]
+    assert all(r["map_path"] != "Subjects/sci/phy/mech/Dangling.smmx" for r in led["rows"])
+    assert led["privacy_index"]["observed_counts"].get("owner_excluded") == 1


### PR DESCRIPTION
Owner decided to exclude the 2 maps with unresolved private-target refs (targets deleted from corpus; nothing recoverable) rather than waive. Adds an audited, sealed exclusion mechanism to sol's hardened freezer: index-membership fail-closed, retired refs no longer trip the public-only gate, ledger↔manifest cross-check pair, verification-side re-derivation honors sealed exclusions. 40/40 tests. sol may want to review as the freezer owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fB4ZfA4bW4XNEnboUncgc