### PR TITLE
docs(mu_cosine): harden process-expression and filing-decoder handoffs

### DIFF
--- a/prototypes/mu_cosine/DESIGN_expression_encoder_future.md
+++ b/prototypes/mu_cosine/DESIGN_expression_encoder_future.md
@@ -1,75 +1,445 @@
-# Expression Encoder–Decoder (FUTURE WORK — do not schedule before the P1 gate)
+# Process-Expression Encoder and Reconstruction Decoder — Deferred Implementation Handoff
 
-**Status: future-work design capture, 2026-07-24.** Not part of the current P0–P4 ladder and not
-to interrupt the frozen P1 protocol (#3982's rigor contract). Sits at "P3.5": pursue only if
-P1 passes (expression conditioning earns its keep) AND P3's deterministic composition plateaus.
-Self-contained enough to hand to a separate agent with spare inference; the handoff needs only
-this doc, the companion `DESIGN_tree_position_encoding_theory.md`, and the current-art references
-below.
+**Status: future work, 2026-07-24; amended as an implementation handoff.** This remains outside
+the active P0–P4 ladder. Do not schedule it unless both activation gates hold:
 
-## Current art (what exists today, and its limits)
+1. the frozen P1 primary shows that structured expression conditioning earns its keep over flat
+   process tokens; and
+2. P3's deterministic AST composition has been implemented and has plateaued under its frozen
+   multi-process and cross-corpus LOCO evaluation.
 
-- `DESIGN_process_expression_{language,philosophy,implementation}.md` + `process_cards.py` (P0,
-  PR #3980): the process-expression grammar with registry-driven lexing. **Today the grammar is
-  used ONLY for canonicalization and token identification** — lossless identity (canonical AST +
-  ast_sha) and deterministic card rendering (V0–V3). "Self-parsing" in #3980 means only that the
-  parser must parse the spec's own examples (acceptance test), not a formal novelty.
-- Embedding today: rendered card string → frozen e5 → NameFunctionCond residual. The
-  implementation doc flags e5-on-formal-strings as a leap of faith at V2/V3; P2 adds an
-  NL-template arm to test it.
-- P3 (planned): DETERMINISTIC composition — node embedding = card-e5(operator) + Σ fixed
-  position-weighted child embeddings; stochastic elements seeded by SHA-256 of the canonical AST.
-  No learning anywhere in the composition.
-- `ARCHITECTURE_filing_engine.md` rows this feeds: FUSE-003 (name-conditioned identity — the
-  motivation), OPENQ-012 (cross-corpus transfer of process conditioning — the forest question).
+If either gate fails, archive this design. A learned encoder is not a way to rescue a failed
+conditioning premise. The P1/P3 results used to activate the design are thereby exposed design
+evidence; they cannot later be relabeled as the learned encoder's untouched test.
 
-## The proposal (owner's design, from the 2026-07-24 Perplexity/Sonnet-5 discussion)
+Companion contracts:
 
-A small transformer over the PARSED, TOKENIZED, CANONICALIZED expression, trained with a dual
-objective:
+- `DESIGN_process_expression_language.md` — grammar, typed registry, canonicalization, and the
+  lossless-identity/lossy-card distinction;
+- `DESIGN_process_expression_implementation.md` and `PROTOCOL_process_expression_p1.md` — the
+  empirical ladder and activation evidence;
+- `DESIGN_tree_position_encoding_theory.md` — candidate compression operators for tree
+  positions; the complete role-path contract below is authoritative where depth×breadth alone is
+  insufficient;
+- `DESIGN_path_operator.md` — fixed Fourier features plus FiLM for continuous process parameters;
+- `DESIGN_filing_path_decoder_handoff.md` — the separate active contract for selective filing
+  search and new-folder proposals; `DESIGN_lineage_decoder.md` is its historical predecessor.
+  Neither is the reconstruction decoder specified here.
 
+## 1. Purpose and non-goals
+
+The proposed component maps a parsed process expression to a reusable conditioning
+representation, while an auxiliary decoder verifies that the representation retains the
+expression's compositional structure:
+
+```text
+canonical typed AST -> typed token/role-path stream -> encoder -> bottleneck z
+                                                           |-> view-conditioned e5 alignment
+                                                           `-> grammar-constrained AST reconstruction
 ```
-canonical AST ──tokenize──▶ transformer encoder ──▶ latent z
-                                        ├─▶ MLP alignment head  → ê5(card)   (match frozen e5 of the rendered card)
-                                        └─▶ cotrained decoder   → canonical string (reconstruction)
+
+The intended gain is zero-shot conditioning of unseen but structurally familiar compositions.
+The component does **not** execute process expressions, infer their factory fingerprints,
+generate folder paths, create folders, or replace filing candidate search.
+
+## 2. Identity is outside the learned bottleneck
+
+`z` is a **derived, lossy conditioning representation**. It is never a process identifier, cache
+identity, provenance key, or proof of equality. Numerically equal or nearby vectors do not make
+two processes identical.
+
+The lossless identity contract remains:
+
+```text
+canonical AST bytes
++ exact REGISTRY_VERSION
++ full 64-hex AST digest
++ factory/manifest fingerprint
 ```
 
-1. **Alignment head:** keeps z anchored to e5's semantic space — the μ-stack's conditioning
-   pathway (NameFunctionCond's W) continues to work unchanged, consuming ê5 instead of e5.
-2. **Reconstruction decoder:** forces z to preserve the compositional structure e5 may collapse
-   (the V2/V3 leap-of-faith risk). Structural echo worth preserving in any implementation: the
-   decoder enforces exactly the language spec's LOSSLESS-IDENTITY vs LOSSY-CARD split — z is the
-   identity, the alignment head's output is the card.
-3. **Variant:** CLIP-style contrastive training between (formal-expression encoding, NL-template
-   rendering fed to e5) instead of a fixed MLP map — learns WHICH structural distinctions are
-   semantically meaningful to e5 rather than assuming a mapping.
+Use the full digest already frozen by `PROTOCOL_process_expression_p1.md`:
 
-## Why training cost is smaller than it looks
+```text
+sha256((REGISTRY_VERSION + "|" + canonical_identity_string).encode("utf-8"))
+```
 
-The encoder/decoder pretrain ENTIRELY SYNTHETICALLY: the grammar + registry generate unlimited
-valid expressions (combinatorial composition of operators, judges, kwargs); e5-small alignment
-targets cost one cheap inference pass per sample. Judge labels are needed only for the downstream
-μ-head fine-tune, which is the small real ledger P1 already uses. The expensive open question is
-coverage: how many synthetic samples before the compositional space is dense enough that unseen
-real expressions interpolate.
+A deployed process identity also binds that digest to the factory/manifest fingerprint that
+realizes the label distribution. Callers must retain the canonical bytes and both fingerprints,
+not only a digest. Changing this serialization requires an explicit identity-version migration;
+this handoff does not silently introduce a second digest convention.
 
-## Why this could matter (the generalization argument)
+The current `process_cards.ast_sha()` returns a compact 16-hex convenience key and does not bind
+the factory fingerprint. It may remain useful inside current P0 caches, but it is not sufficient
+for this handoff's artifacts, split joins, residual lookup, or provenance. New artifacts use the
+full digest and fail closed on a compact-only identity.
 
-e5 generalizes over strings by surface similarity; a trained expression encoder generalizes over
-PROGRAMS by structure. If OPENQ-012's cross-corpus arm shows expression conditioning transfers,
-this encoder is the natural next step — compositional generalization to unseen process
-combinations (`kalman(sonnet.D, luna.S)` never seen, both parents seen) is precisely what the
-reconstruction objective buys and what surface-string e5 cannot.
+Grammar-valid synthetic expressions need not have executable factories. Their records therefore
+carry a `synthetic_sample_digest` binding the full AST digest to an immutable
+`generator_spec_sha256`, and are marked `synthetic_only`. The later corpus manifest records the
+generated rows and their digests; it is not an input to its own generation. Synthetic rows cannot
+be promoted to deployed process identities without a separately verified factory/manifest
+fingerprint.
 
-## Gates and sequencing (explicit, to protect the current lanes)
+## 3. Frozen input interface
 
-1. P1 frozen primary must pass (expressions vs flat tokens). If it fails, this direction is moot.
-2. P3 deterministic superposition must be tried first; this design activates on plateau.
-3. The position-encoding component is specified separately in
-   `DESIGN_tree_position_encoding_theory.md` (depth⊗breadth factorization; Kronecker vs
-   convolution; learned bilinear recommendation) — the encoder should adopt whichever variant
-   that doc's ablation ladder selects.
-4. Evaluation inherits the amended P3 protocol: multi-process LOCO + cross-corpus LOCO
-   (OPENQ-012), against the four controls (frozen-string e5, additive bag-of-nodes, flat token,
-   unconditional) — plus one new control: NL-template e5 (P2's arm), which is the strongest
-   no-new-architecture baseline this design must beat to justify its cost.
+The encoder accepts a resolved canonical AST data-transfer object, not raw user text and not a
+V0–V3 card. Construct it deterministically as:
+
+```text
+validated process_cards.Node + pinned registry bytes
+    -> resolve every registry default and derived signature field
+    -> sort kwargs canonically
+    -> resolved canonical AST DTO
+```
+
+`Node` itself does not store resolved defaults, `KIND`, or `OUTPUT`; the transform derives them
+from the exact pinned registry. The DTO serializes every resolved kwarg, not only `node.kwargs`.
+Unknown names, modifiers, kwargs, output types, malformed pins, non-finite numerics, or unsupported
+literal shapes are errors.
+
+### 3.1 Reversible typed-AST stream
+
+Version the tokenizer independently of the grammar. Its canonical stream is:
+
+```text
+<BOS>
+  <NODE> <KIND:atom|apply> <NAME:id> <OUTPUT:type>
+    <ARGS>   (<ARG:i> NODE </ARG>)*                         </ARGS>
+    <KWARGS> (<KW:key> VALUE </KW>)*                        </KWARGS>
+    <MODS>   (<MOD:i> CANONICAL_ASCII_BYTES </MOD>)*        </MODS>
+    <PINS>   (<PIN:i> CANONICAL_ASCII_BYTES </PIN>)*        </PINS>
+  </NODE>
+<EOS>
+
+VALUE :=
+    <INT> CANONICAL_ASCII_BYTES </INT>
+  | <NUMBER> CANONICAL_ASCII_BYTES </NUMBER>
+  | <STRING> UTF8_BYTES </STRING>
+  | <LIST> (<ITEM:i> VALUE </ITEM>)* </LIST>
+```
+
+`NAME`, `OUTPUT`, kwarg keys, and structural delimiters have finite, versioned vocabulary IDs.
+Literal payloads use an explicit 256-byte fallback with start/end delimiters; no hashing,
+subword tokenization, or unknown-token replacement is allowed on the reconstruction path.
+Numbers use the canonical lexical form produced by the language specification. JSON strings use
+exact UTF-8 bytes. Modifiers and pins retain the current grammar's restricted ASCII forms. Thus
+stream -> AST -> canonical bytes is reversible.
+
+Derived tokens such as `OUTPUT:type` must agree with the pinned registry during both encoding and
+decoding. They do not override it. Atom/operator dual roles are distinguished by `KIND` and
+validated against the signature.
+
+### 3.2 Complete role-path positions
+
+Every token carries its complete typed path from the root, not merely `(depth, breadth)`. The root
+token has the empty path; `ROOT` is a distinguished token, not an edge step. Non-root path steps
+use this authoritative serialized schema:
+
+```text
+ARG(index, expected_output_type)
+KWARG(registry_kw_id, value_type)
+LIST_ITEM(index, element_type)
+MOD(index)
+PIN(index)
+LITERAL_BYTE(index)
+```
+
+For example, the first positional child, kwarg `decay`, and first list item are distinct even
+when they share a depth and local index. Depth is the path length; breadth is only the index
+inside one typed role. Positional encoding must consume the ordered role-step sequence and must
+not collapse it to an untyped `(k,j)` pair.
+
+The position-theory note's additive, HRR/convolution, bilinear, and Kronecker options are
+compression candidates after this lossless path has been defined. No implementation may claim
+that circular convolution is generally invertible after superposition, or use numerical
+separability as identity. Whichever candidate is selected must show zero structural aliases on
+the generator's finite supported role-path set; otherwise use an explicit role-path lookup or a
+less-compressed representation.
+
+### 3.3 Continuous numeric semantics
+
+Exact lexical number tokens remain in the stream for reconstruction. Separately, registry
+signatures must mark numeric fields as `continuous` or `discrete` and give every continuous field
+a finite semantic domain. A continuous scalar is normalized in that pinned domain, encoded with
+fixed sin/cos Fourier frequencies, and passed through a small FiLM module that modulates the
+owning node state, following `DESIGN_path_operator.md`.
+
+Frequencies, domains, normalization, and FiLM dimensions are manifest fields. Integers and list
+indices remain lexical unless their signature explicitly marks them continuous. Out-of-domain
+real values produce an OOD error or a separately registered OOD token; they are never silently
+clipped. This two-path design gives smooth parameter geometry without sacrificing exact
+reconstruction.
+
+## 4. Encoder, alignment heads, and decoder
+
+### 4.1 Encoder and bottleneck
+
+The first implementation is a small transformer encoder over the typed stream, with role-path
+and numeric features added before attention. Its pooled output is `z` with a pinned dimension.
+No private corpus text, filing title, judge outcome, or downstream target enters pretraining.
+
+Architectural bounds belong in the manifest: tokenizer/registry versions, maximum tokens/nodes,
+layers, heads, hidden width, bottleneck width, dropout, initialization, optimizer, and parameter
+count. Exceeding a bound is an explicit new experiment, not an invisible fallback.
+
+### 4.2 View-conditioned e5 alignment
+
+One shared alignment module receives `(z, view_id)` and predicts a vector for each eligible view:
+
+- formal V1;
+- formal V2;
+- formal V3; and
+- the versioned natural-language template view introduced by P2.
+
+For each view `v`, the target is the L2-normalized output of one exact, frozen e5 contract:
+
+```text
+t_v = normalize(E5_revision(exact_prefix_v || renderer_v(canonical_AST)))
+```
+
+The manifest pins the model repository and immutable revision, pooling rule, dtype, tokenizer
+revision, exact prefix including whitespace, renderer/template version, input normalization,
+output normalization, and maximum-length policy. Truncation is forbidden unless its policy is
+preregistered and recorded per row.
+
+V0 has no semantic card. It is **excluded from alignment pretraining** rather than treated as an
+empty-string teacher target. V0 remains downstream conditioning dropout only.
+
+The primary alignment loss is frozen before training (for example cosine distance on normalized
+vectors). A CLIP-style expression/template contrastive objective is an optional registered arm,
+not a silent replacement for direct alignment.
+
+Downstream integration names exactly one `deployment_view_id`, selected without outer labels, or
+a preregistered deterministic mixture with explicit weights. It never averages V1/V2/V3/NL
+predictions implicitly. That selected view, renderer/template version, and alignment-head digest
+become part of the `NameFunctionCond` adapter receipt.
+
+### 4.3 Reconstruction decoder
+
+The autoregressive decoder receives only:
+
+1. bottleneck `z`; and
+2. the already emitted output-token prefix.
+
+It receives no encoder token states, skip connections, source-token copy channel, rendered card,
+teacher e5 vector, canonical AST, or factory fingerprint. Teacher forcing may provide the gold
+output prefix during training, but evaluation is free-running from `<BOS>`.
+
+At each step a grammar-and-registry state machine masks invalid next tokens. A completed output
+must parse, type-check, and canonicalize to an AST. The primary reconstruction event is exact
+equality of canonical AST bytes and full AST digest, not surface-string similarity.
+
+This decoder reconstructs a **process expression only**. It has no
+`SELECT_EXISTING`, `PROPOSE_NEW`, or `ABSTAIN` actions and must not be described as the filing
+path decoder in `DESIGN_filing_path_decoder_handoff.md`.
+
+## 5. NameFunctionCond integration contract
+
+`NameFunctionCond` is currently index-only:
+
+```text
+forward(i) = W(name_e5[i]) + residual[i]
+```
+
+The learned encoder cannot be wired in by merely replacing the table. Add an explicit external
+vector adapter whose public input is a verified, content-bound record:
+
+```text
+EncodedProcess {
+    e
+    full_process_digest
+    factory_fingerprint | synthetic_only
+    encoder_checkpoint_sha256
+    deployment_view_id
+    alignment_receipt_sha256
+}
+
+forward_external(encoded_process)
+    = W(e) + residual[identity_to_row[full deployed identity]]  # registered identity
+    = W(e)                                                     # verified unseen identity
+```
+
+The alignment output dimension, dtype, normalization, and prefix/view convention must match the
+adapter contract. The module performs the full-identity-to-residual lookup internally; callers
+cannot supply or pair a raw residual index with an arbitrary vector. The mapping is sealed in the
+checkpoint receipt and fails closed on duplicate identities, reordered rows, or a claimed unseen
+identity that is already registered. Residual rows map by the full deployed process identity,
+never by rendered card or compact `ast_sha`. An unseen expression receives no invented
+nearest-neighbour residual.
+
+Before any learned output is used, a parity fixture supplies the existing frozen table vector
+through both indexed and external paths and requires bitwise equality where possible, otherwise a
+pinned numerical tolerance. This tests adapter wiring independently of encoder approximation.
+Existing checkpoints load with the adapter inactive. Activating encoder outputs is a new
+downstream arm; `W` is not assumed valid merely because vector dimensions match.
+
+## 6. Finite deterministic synthetic corpus
+
+"Synthetic" does not mean unlimited or unconstrained. First freeze a checked-in generator
+specification and its `generator_spec_sha256`; after generation, a separate content-addressed
+corpus manifest records the outputs. The specification freezes:
+
+- grammar, registry, tokenizer, renderer, and NL-template versions;
+- finite allowed operators, atom names, modifiers, placeholder pins, and kwarg domains;
+- maximum AST depth, nodes, positional arity, list length, string bytes, and token count;
+- finite numeric grids/distributions inside each registered semantic domain;
+- target sample counts, enumeration/sampling algorithm, seed derivation, duplicate policy, and
+  rejection counters; and
+- the exact train/dev/test structural partition.
+
+Pins, strings, and manifests use synthetic placeholders from a committed allowlist. The generator
+must not sample repository paths, bookmark titles, private names, real manifest IDs, environment
+variables, logs, or user data.
+
+Random choices are counter-based or seeded from `generator_spec_sha256` plus sample index. Rows
+are sorted by full AST digest and byte-identical across machines. Duplicate canonical ASTs are
+removed before splitting. Only then is the output corpus manifest hashed.
+
+### Structural LOCO partition
+
+Random expression-level splitting is insufficient. Define a structural template by replacing
+leaf identities and literal payloads with typed slots while preserving operators, nesting,
+argument roles, kwarg keys, modifiers, and list shape. Entire templates and registered
+composition families are assigned to one split only. Test contains preregistered held
+operator-composition and kwarg/list-shape families; no canonical AST or structural template may
+cross train/dev/test.
+
+The split verifier recomputes templates and fails closed on overlap. Downstream process and
+cross-corpus LOCO sets remain separate from this synthetic test and are not inspected during
+pretraining selection.
+
+### Sealed synthetic-test transaction
+
+The training worker receives only the train/dev projection: no test rows, test teacher vectors,
+test metrics, or test-cache paths. The frozen generator specification may name held structural
+families, but their realized rows and e5 targets are materialized or released only by a separate
+test transaction after the checkpoint, adapter, and evaluation code hashes are sealed.
+
+The transaction records its first read. Once any synthetic-test row, teacher target, or metric has
+been revealed, that test is burned for model or architecture selection. A decoder, objective,
+tokenizer, position arm, threshold, or checkpoint change after that reveal requires newly frozen
+held structural families; the same test may remain only a clearly labeled regression report.
+
+## 7. Objectives and controls
+
+Freeze loss definitions and weights in the run manifest:
+
+```text
+L = lambda_recon * grammar-masked token CE
+  + lambda_align * mean_v alignment_loss(A(z,v), t_v)
+  + optional registered auxiliary losses
+```
+
+Weights and checkpoints are selected on synthetic dev only. The synthetic test and downstream
+outer sets are single-use reports.
+
+Required controls/ablations:
+
+1. direct frozen formal-card e5;
+2. direct frozen NL-template e5;
+3. P3 deterministic composition;
+4. additive bag of AST nodes;
+5. flat process token and unconditional conditioning;
+6. shuffled e5 targets within compatible views;
+7. reconstruction-only and alignment-only training;
+8. untyped depth/breadth positions versus complete role paths; and
+9. lexical-only numerics versus lexical plus fixed-Fourier/FiLM numerics.
+
+The shuffled control must break AST-to-teacher correspondence without changing view counts or
+length strata. It is not a downstream label permutation.
+
+## 8. Evaluation and activation gates
+
+### Engineering gates
+
+These are exact and blocking:
+
+- canonical AST -> token stream -> AST round-trips every registry example and generated row;
+- generator and split manifests reproduce byte-for-byte;
+- no full-digest, canonical-AST, or structural-template overlap across splits;
+- zero grammar-invalid free-running decodes (grammar masking should make invalid syntax
+  unreachable);
+- all decoded outputs revalidate under the pinned registry;
+- adapter parity passes; and
+- artifact load rejects any digest, version, shape, dtype, normalization, prefix, cap, or
+  factory-fingerprint mismatch.
+
+### Scientific gates
+
+Before the first training run, a preregistration must freeze numeric reconstruction and alignment
+thresholds, training seeds, checkpoint selection, and the downstream decision. Report exact AST
+match, field/role accuracy, invalid/OOD rates, e5 cosine-error distribution by view, nearest
+teacher retrieval, and results by held structural family.
+
+The P3 multi-process and cross-corpus LOCO evidence used to declare a plateau is **design evidence
+and already exposed**. Reusing it for the learned encoder is necessarily exploratory/adaptive.
+It may be reported for continuity but cannot serve as a fresh outer comparison.
+
+Only after the encoder and checkpoint are frozen may a newly reserved post-activation process
+family, corpus, or prospective cohort be opened. Its primary comparison is the learned encoder
+against P3 deterministic composition and the strongest no-new-architecture baseline (formal or
+NL-template e5, selected without that new outer set). If no genuinely new evaluation population
+exists, the downstream result remains exploratory and cannot claim generalization. The learned
+path must satisfy the preregistered superiority target and the existing e5
+safety/noninferiority constraint. Multiple ablations are descriptive unless the preregistration
+supplies multiplicity handling.
+
+Failure of an engineering gate stops the run. Failure of a synthetic scientific gate blocks
+downstream evaluation. Failure of the downstream gate rolls back to deterministic P3 or frozen
+e5; it does not trigger tuning on the outer result. Success authorizes an implementation
+candidate, not automatic deployment.
+
+## 9. Artifacts and fail-closed provenance
+
+Each run emits a content-addressed bundle containing at least:
+
+- canonical generator specification, `generator_spec_sha256`, and corpus/split manifests;
+- full AST and synthetic-sample digests for every row;
+- registry, canonicalizer, tokenizer, renderer, and template digests;
+- frozen e5 model/revision, tokenizer, prefix, pooling, and normalization contract;
+- model/loss/optimizer config, seeds, dependency lock, hardware and peak-memory record;
+- checkpoint and adapter hashes;
+- train/dev worker-input projection, synthetic-dev selection ledger, sealed-test first-read
+  receipt, and synthetic-test report;
+- downstream preregistration and, if authorized, the one-shot LOCO report; and
+- machine-readable pass/fail records for every gate.
+
+Loaders recompute hashes from bytes and reject unknown/missing fields. A filename, branch name,
+compact hash, or self-reported manifest field is not provenance. Any intentional contract change
+creates a new bundle and new evaluation; it never mutates a sealed result.
+
+## 10. Privacy and resource envelope
+
+Synthetic pretraining uses only the public grammar/registry and synthetic allowlisted literals.
+No private filing data is needed. Real downstream rows retain the privacy and external-processing
+rules of their source corpus; neither expressions nor embeddings erase those restrictions.
+Private AST literals or derived representations may not be sent to an external model/API without
+separate authorization.
+
+The first implementation targets one consumer GPU or CPU execution with explicit caps and
+streamed generation; it must not require an in-memory "unlimited" corpus. Record model parameters,
+corpus bytes, wall time, peak host RAM, and peak device memory. An out-of-memory event is a failed
+run, not permission to shrink data/model or change precision post hoc.
+
+## 11. Delegable implementation sequence
+
+1. **Contract fixtures:** add full-digest/process-identity helpers and golden AST/token/role-path
+   vectors without changing current P0 behavior.
+2. **Tokenizer and generator:** implement reversible typed serialization, finite deterministic
+   generation, structural templates, LOCO splits, and overlap/privacy validators.
+3. **Model core:** implement the bounded encoder, complete role-path positions, lexical numeric
+   path, fixed-Fourier/FiLM semantic path, and bottleneck-only constrained decoder.
+4. **Teacher cache:** materialize V1/V2/V3/NL targets under the exact frozen e5 contract; prove V0
+   never enters it.
+5. **Adapter:** add the opt-in external-vector path to `NameFunctionCond`, identity-bound residual
+   lookup, migration/parity tests, and old-checkpoint compatibility.
+6. **Pretrain and freeze:** select on synthetic dev, seal once, then evaluate synthetic test.
+7. **Downstream study:** only if all prior gates and the original activation gates pass, freeze
+   a new post-activation evaluation population; execute it once. Reuse of the plateau evidence is
+   descriptive only.
+
+Minimum tests include grammar-example round trips, atom/operator dual roles, nested args/kwargs,
+lists, UTF-8/escaped strings, pins, numeric boundary/OOD cases, role-path non-aliasing, generator
+reproduction, structural split rejection, decoder no-skip enforcement, V0 teacher-cache
+rejection, shuffled-target control, adapter parity, unseen-residual zero behavior, artifact
+tampering, and old-checkpoint loading.

--- a/prototypes/mu_cosine/DESIGN_filing_path_decoder_handoff.md
+++ b/prototypes/mu_cosine/DESIGN_filing_path_decoder_handoff.md
@@ -1,0 +1,609 @@
+# Filing path decoder handoff
+
+**Status: prospective implementation contract; not an authorization to train,
+score an untouched set, create a folder, or mutate a graph.**
+
+This document replaces
+[`DESIGN_lineage_decoder.md`](DESIGN_lineage_decoder.md) as the implementation
+handoff for selective filing and new-folder proposals. The older document is
+retained as research history. This contract follows the standing decisions in
+[`ARCHITECTURE_filing_engine.md`](../../docs/design/ARCHITECTURE_filing_engine.md):
+
+- frozen, revision-pinned e5 is the filing-ranking backbone;
+- learned μ heads currently serve calibration, label fusion, and conflict
+  routing, not primary filing ranking;
+- an existing folder is identified by a typed stable ID, never by its title;
+  and
+- the recorded canonical/principal path is authoritative for that folder.
+
+“Decoder” here means a **selective search and proposal policy over a frozen
+filing catalog**. It is not the reconstruction decoder in
+[`DESIGN_expression_encoder_future.md`](DESIGN_expression_encoder_future.md).
+That other decoder maps a canonical process-expression AST to its canonical
+token sequence to test whether an expression latent preserved syntax. It does
+not select folders, infer novelty, name folders, or edit a filing graph. The
+two components may eventually exchange typed process metadata, but they do not
+share targets or acceptance tests.
+
+## 0. Reuse the landed filing-task authority
+
+This handoff extends the existing content-bound filing chain; it does not define a parallel
+baseline:
+
+- `routed_queries.py` and `routed_policy.py` produce and rederive
+  `unifyweaver.routed-task.v2`;
+- that parent task remains authoritative for source bytes, privacy certification, catalog,
+  population, ordered queries and candidate menus, frozen e5 ranker, policy tier, prompt, and
+  judge contract; and
+- `DESIGN_routed_execution_bundle.md` remains the only hosted-judge execution extension.
+
+The path-decision layer consumes a verified parent task and one exact row by QID. It may add graph
+and principal-path receipts, search limits, population-specific proposal calibration, and an
+advisory decision. It must not restate or override inherited source, privacy, candidate, ranking,
+or policy fields.
+Verification calls the existing v2 re-derivation path and byte-compares the parent before reading
+any supplement.
+
+Version 1 therefore covers the certified-public parent population. A future local-private parent
+contract may reuse the same additive decision layer, but it must bind private source inventory and
+privacy classification with equivalent rigor; a caller-provided privacy label is insufficient.
+This document does not weaken the public-only boundary of `routed-task.v2`.
+
+## 1. Decision surface
+
+Every successful inference emits exactly one of three decisions:
+
+1. **`SELECT_EXISTING`** — recommend one folder already present in the frozen
+   catalog.
+2. **`PROPOSE_NEW`** — recommend one or more provisional new folder segments
+   below a named existing parent.
+3. **`ABSTAIN`** — decline to select or propose because the evidence is
+   ambiguous, unsupported, resource-censored, or outside the calibrated
+   operating envelope.
+
+All three are advisory and require user confirmation. No decision authorizes
+an API call, folder creation, bookmark move, graph edit, or breadcrumb rewrite.
+An invalid input or provenance failure produces a blocked error receipt and no
+valid decision; it must not be disguised as an ordinary `ABSTAIN`.
+
+### 1.1 `SELECT_EXISTING`
+
+The selected object is a stable typed folder ID. Its display title and
+breadcrumb are looked up after selection from the same frozen catalog used for
+ranking. The engine must return the catalog's exact recorded
+canonical/principal path:
+
+```text
+selected folder_id
+        │
+        └── catalog lookup ──> authoritative path_ids and display titles
+```
+
+The model may search with title, semantic, lineage, or graph features, but it
+may not generate, repair, shorten, reorder, or substitute that breadcrumb.
+Duplicate titles are distinct candidates. A multi-parent folder keeps the
+principal-path policy and record chosen by the catalog builder; search-time
+graph traversal is not authority to replace it.
+
+### 1.2 `PROPOSE_NEW`
+
+A proposal anchors to an existing parent ID and appends a dynamically sized
+ordered list of provisional segments. The initial implementation should
+support one new leaf. The schema permits a longer proposed suffix so a later
+held-subtree study does not require a fixed-width redesign.
+
+A provisional segment has no remote folder ID. It receives only a local
+proposal ID, suggested display name, naming provenance, and privacy class.
+Pearltrees or another filing system assigns a durable ID only after explicit
+user approval and successful creation. Until then, the proposal is not part of
+the catalog or graph.
+
+### 1.3 `ABSTAIN`
+
+At minimum, distinguish:
+
+- `ambiguous_existing` — several existing folders remain plausible;
+- `proposal_need_uncertain` — applicable calibrated evidence does not separate
+  the proposal-needed regime from difficult-existing cases;
+- `outside_calibration_support`;
+- `resource_censored`;
+- `privacy_restricted_naming`; and
+- `no_eligible_candidate`.
+
+These reason codes are operational outputs, not scientific conclusions.
+
+## 2. Ambiguity is not novelty
+
+A small e5 top-one minus top-two margin says that the **observed candidates are
+hard to distinguish**. It does not say why. Common causes include duplicated
+titles, a broad query, two legitimate homes, incomplete text, or a genuinely
+missing folder. Therefore:
+
+- a low margin may route to `ABSTAIN` or optional user/LLM review;
+- it must not by itself trigger `PROPOSE_NEW`;
+- it must not be reported as a novelty probability; and
+- any probability of “no suitable folder exists” requires a separately fit
+  and evaluated model on prospectively adjudicated naturally absent cases.
+
+The simulated-absence protocol in §7 may test recovery and authorize only a
+clearly labeled, owner-reviewed research pilot. It does not create a live
+novelty probability. Ordinary `PROPOSE_NEW` remains disabled until a
+prospective naturally absent cohort has produced an applicable calibration
+artifact. Before that gate passes, the ordinary legal behavior is e5-based
+`SELECT_EXISTING` or `ABSTAIN`.
+
+## 3. Typed request contract
+
+The additive envelope is versioned as `unifyweaver.filing-path-request.v1`. It references one
+verified `routed-task.v2` parent and one exact QID; it does not copy the parent row into a new
+source of truth:
+
+```text
+FilingPathRequest {
+  schema_version
+  request_id
+  parent_task {
+    task_id
+    task_file_content_record
+    qid
+    row_sha256
+  }
+  path_supplement {
+    graph_snapshot_sha256
+    edge_table_sha256
+    principal_path_records_sha256
+    principal_path_policy_id
+    allowed_roots: [TypedId]
+  }
+  decision_policy_sha256
+  calibration_receipt_sha256 | null
+  search_limits {
+    maximum_search_nodes
+    maximum_search_steps
+  }
+  external_naming_authorization_receipt_sha256 | null
+}
+
+TypedId {
+  node_type
+  corpus_or_account
+  stable_value
+}
+```
+
+The parent v2 row supplies the typed item, its certified-public privacy receipt, ordered candidates,
+e5 scores, catalog and ranker receipts, policy, and content hashes. The new verifier must call the
+existing parent re-derivation path and require an exact QID join. A copied task ID or retyped
+candidate list is insufficient. It derives `row_sha256` from the canonical parent row after
+re-derivation; callers do not get to assert it.
+
+Titles and breadcrumbs are attributes resolved through `folder_id`; they are not join keys. The
+request must not duplicate a second, independently derived “best path.” If a display view is
+included for convenience, its ID sequence and content hash must match the authoritative path
+records.
+
+Graph provenance binds the topology snapshot separately from the principal
+path records. This permits outcome-blind structural search over a DAG while
+keeping the recorded principal breadcrumb authoritative for display and
+action.
+
+External naming authorization is a separate content-bound receipt, never a Boolean. It binds the
+owner authorization event, exact request and item-content hashes, inherited privacy receipt,
+provider/model/revision, fields permitted to leave the machine, purpose, scope, and expiry. A
+missing, expired, or mismatched receipt means local-only naming. The receipt is reverified
+immediately before any external call.
+
+## 4. Typed decision contract
+
+The output should be a discriminated union versioned as
+`unifyweaver.filing-path-decision.v1`:
+
+```text
+FilingPathDecision {
+  schema_version
+  request_id
+  request_sha256
+  parent_task_id
+  parent_task_file_sha256
+  parent_task_row_sha256
+  inherited_privacy_receipt_sha256
+  decision: SELECT_EXISTING | PROPOSE_NEW | ABSTAIN
+  catalog_snapshot_sha256
+  ranking_receipt_sha256
+  calibration_receipt_sha256 | null
+  search_receipt_sha256
+  external_naming_authorization_receipt_sha256 | null
+  requires_user_confirmation: true
+  evidence_summary
+  payload: SelectExisting | ProposeNew | Abstain
+}
+
+SelectExisting {
+  folder_id: TypedId
+  authoritative_path_ids: [TypedId]
+  path_source: frozen_principal_path_records
+  catalog_rank
+  e5_score
+  top_two_margin
+}
+
+ProposeNew {
+  anchor_parent_id: TypedId
+  authoritative_parent_path_ids: [TypedId]
+  proposed_segments: [
+    {
+      local_proposal_id
+      suggested_title
+      naming_method
+      inherited_privacy_class
+      privacy_derivation_receipt_sha256
+    }
+  ]
+  open_set_calibration_id
+  calibrated_open_set_score
+  operating_threshold_id
+}
+
+Abstain {
+  reason_code
+  candidate_ids_considered: [TypedId]
+}
+```
+
+`calibrated_open_set_score` may appear only when its calibration artifact
+matches the corpus, catalog construction, candidate generator, e5 revision,
+privacy policy, and evaluation regime of the request. It is not automatically
+a universal probability. The output may include display titles, but consumers
+must resolve actions by typed ID and recheck the current catalog immediately
+before presenting or applying them.
+
+## 5. Staged implementation
+
+Each stage is useful on its own. Later stages must demonstrate incremental
+value against the best earlier stage; they do not inherit authorization merely
+because they are more elaborate.
+
+### Stage A — frozen-e5 existing-folder baseline
+
+1. Reverify the `routed-task.v2` parent with the landed code path.
+2. Consume the parent row's frozen e5 candidate order; do not rebuild a parallel catalog or
+   ranker receipt.
+3. Return its top existing folder by typed ID and look up the stored principal path under the
+   path supplement.
+4. Optionally use a train-only selected margin threshold to `ABSTAIN`.
+5. Reproduce the current filing metrics and provenance before adding any new path-search or
+   novelty machinery.
+
+This is both the deployment-safe starting point and the rollback baseline.
+
+### Stage B — acceptable-set simulated-absence calibration
+
+First freeze an acceptable-folder set `A_q` for every eligible query using owner/human suitability
+labels or another independent, preregistered source. The recorded destination and title aliases
+alone are not an acceptable-set oracle: filing can have multiple legitimate homes, duplicate
+titles, or a suitable retained parent.
+
+A simulated positive removes **every** acceptable existing folder in `A_q` from the fold-wide
+training, calibration, candidate, graph-feature, alias, embedding, and cache inputs. If any
+retained folder is independently labeled acceptable, the case is not a positive. Queries whose
+acceptable set is unknown or disputed are excluded from decision-bearing calibration and reported
+separately.
+
+Build an explicit classifier or calibrated score for `acceptable_existing_folder_visible` versus
+`all_known_acceptable_folders_withheld`. Fit its features and threshold only on the
+training/calibration partition. e5 score shape, lexical coverage, catalog density, and
+outcome-blind structure are possible features; none is a probability without calibration.
+
+This is still **simulated catalog absence**, not proof of organic novelty. It
+may validate hidden-folder recovery and support a clearly labeled, bounded,
+owner-reviewed research pilot, but it cannot authorize a live claim that “no
+suitable folder exists.” That claim requires a later prospective cohort in
+which the owner or an independent adjudicator records suitability/new-folder
+need without constructing the label by deleting a known folder.
+
+Always run an **always-existing baseline** on the same examples: it selects the
+best available existing folder and never proposes. This control measures
+whether proposal improves the intended action rather than merely identifying
+hard queries. A margin-only proposal rule is another required control, not the
+default system.
+
+### Stage C — optional outcome-blind structural candidate search
+
+If candidate recall remains the binding ceiling, add catalog candidates using
+only frozen topology, principal/alternative-parent records, revision-pinned
+embeddings, and resource limits. Candidate eligibility and search budgets may
+not use placements or judge outcomes.
+
+Examples worth testing are ancestors, children, siblings through common
+parents, and a bounded graph/resistance search. These extend the set searched;
+they do not rewrite principal breadcrumbs. Compare at matched candidate and
+resource budgets before allowing downstream scoring to claim a benefit.
+
+### Stage D — hand-designed dynamic path search
+
+Treat a search state as a dynamically sized sequence of existing typed IDs
+plus, only after the proposal gate, an optional provisional suffix. Initialize
+from the e5 top candidates. Every existing-node transition must be a legal
+edge or an explicitly registered catalog transition.
+
+There is no fixed 26-slot representation. Maximum depth, node expansions, and
+steps are resource ceilings recorded in the receipt, not the semantics of a
+path. The search may revise an earlier branch, but a final existing-folder
+answer resolves to the catalog's stored principal path.
+
+Every iterative algorithm must retain a `best_so_far` state under its frozen
+objective and deterministic tie rule. On plateau, invalid transition,
+nonfinite score, timeout, or resource exhaustion, return that state if it is
+otherwise eligible, or `ABSTAIN`. Never return merely the last iterate.
+
+### Stage E — learned optimizer, only after a measured search gap
+
+A learned update policy is justified only if Stage D leaves a prespecified
+held gap that cannot be closed by more candidates or a stronger deterministic
+search at matched cost. Freeze the e5 backbone while selecting the policy,
+compare with the Stage-D best-so-far baseline, and preserve projection onto
+legal catalog states. The learned policy may suggest search moves; it never
+becomes the authority for existing breadcrumbs.
+
+## 6. Naming proposed folders
+
+Placement and naming are separate decisions. First choose
+`PROPOSE_NEW(anchor_parent_id, proposed_suffix)`; then generate one or more
+candidate display names. A poor or blocked namer must not force a different
+existing-folder selection.
+
+Use the least expansive naming mechanism that works:
+
+1. deterministic templates or extraction from the item and local sibling
+   vocabulary;
+2. a revision-pinned local embedding/model operating inside the same privacy
+   boundary; then
+3. an external model only for data certified public, or with a valid
+   content-bound owner-authorization receipt for the exact private request,
+   permitted fields, and provider/model revision.
+
+Private and unknown inputs default to local-only processing. Proposed titles,
+parent IDs, embeddings, prompts, model outputs, receipts, and calibration rows
+inherit the strictest privacy state of their sources. Private-derived artifacts
+remain outside Git and synchronized/public directories with restrictive local
+permissions. No external LLM may receive private data merely because its
+output is “only a name.”
+
+Privacy class is derived from the reverified parent and every additional
+source receipt; it is not accepted from a request field. For private data, the
+authorization receipt must itself bind that content-bound privacy derivation.
+Unknown data remains local-only: owner authorization cannot substitute for a
+missing privacy classification.
+
+The naming component emits suggestions, not a durable node. The user sees the
+existing parent breadcrumb, proposed suffix, alternatives, and privacy status
+before confirming or editing it.
+
+## 7. Evaluation contract
+
+Freeze a separate protocol and manifests before any decision-bearing outer
+score. Exploratory development results remain exploratory.
+
+### 7.1 Populations and splits
+
+Evaluate at least two strata:
+
+- **acceptable-existing stratum:** at least one folder in the independently frozen acceptable set
+  `A_q` remains eligible in the frozen catalog; and
+- **simulated-absence stratum:** every folder in `A_q` is removed fold-wide from training,
+  calibration, candidate generation, graph features, aliases, embeddings, and caches.
+
+Single-destination leaf removal without an acceptable-set audit is only a
+**hidden-node recovery diagnostic**. It is not open-set ground truth and
+cannot train or authorize `PROPOSE_NEW`. For an eligible simulated leaf case,
+retain the recorded principal parent only when it is not itself in `A_q`, and
+remove the acceptable leaves' IDs, titles, contents, placement-derived
+statistics, aliases, and embeddings from the visible fold. For proposed
+intermediate paths, hold out every acceptable subtree and all descendants'
+destination evidence. The latter is a separate, harder experiment and must
+not be inferred from leaf recovery.
+
+Use an exposure graph and node-disjoint partition so query IDs, destination
+folder IDs, held subtrees, and any shared placement units do not cross the
+relevant train/calibration/audit boundary. Threshold selection uses inner
+training/calibration only. The untouched outer simulated-absence set is read
+once.
+Freeze the candidate catalog before scoring.
+
+The simulated-absence manipulation changes only availability. It must not leave behind any
+withheld acceptable title embedding, recorded placement count, path feature containing a withheld
+node, cached candidate order, or alias keyed to a withheld ID. The acceptable-set ledger and its
+source remain sealed from the feature worker.
+
+A later prospective naturally absent/user-adjudicated cohort is a separate stratum and the only
+one capable of supporting a direct live-novelty claim.
+
+### 7.2 Required controls
+
+Run on identical manifests:
+
+1. frozen e5 top-1;
+2. the always-existing baseline;
+3. e5 plus margin-based abstention;
+4. a margin-only snap-or-propose rule;
+5. the calibrated simulated-absence decision and, only when available, a
+   separately calibrated prospective naturally absent decision;
+6. the calibrated decision without each added feature family; and
+7. when applicable, deterministic search versus learned optimizer at matched
+   candidate and resource budgets.
+
+### 7.3 Metrics
+
+Report the three actions rather than collapsing them:
+
+- exact folder-ID Recall@1 and MRR for `SELECT_EXISTING`;
+- coverage, selective risk, and AURC when abstention is enabled;
+- false-proposal rate on existing-folder cases;
+- proposal precision, recall, and precision-recall curve, reported separately
+  for simulated absence and prospectively adjudicated natural absence;
+- exact anchor-parent accuracy, longest-correct-prefix, and path edit distance
+  for `PROPOSE_NEW`;
+- calibration diagnostics with the exact simulated or prospective population
+  named for every proposal-need score;
+- action-confusion counts, including `ABSTAIN`;
+- node expansions, steps, runtime, peak memory, and resource censoring; and
+- paired typed-node-block uncertainty for the frozen primary contrast.
+
+Choose the primary action utility, costs, minimum practical effect, intervals,
+and multiplicity handling before the outer set is opened. AUROC alone is
+insufficient when missing folders are rare.
+
+### 7.4 Anti-circular grading
+
+Do not grade a proposed folder embedding solely by cosine under the same e5
+model that constructed or optimized that embedding. That establishes
+self-consistency, not recovery. e5 similarity may be printed as a diagnostic
+only when labeled circular.
+
+Decision-bearing proposal evaluation uses catalog facts independent of the
+proposal geometry: hidden parent ID, path prefix, exact held ID when
+applicable, and user action utility. Naming quality requires a separately
+pinned evaluator not used to generate or rank the name, deterministic lexical
+metrics with known limits, or blinded human review. An independent embedding
+model may be a sensitivity analysis if its revision and text contract were
+frozen before results.
+
+## 8. Provenance and fail-closed behavior
+
+Every run writes content-bound, no-replace artifacts:
+
+- request and ordered candidate manifests;
+- the reverified parent `routed-task.v2` content record and exact parent-row
+  digest;
+- graph, catalog, principal-path, privacy, and e5 receipts;
+- acceptable-set, split, and fold-wide removal manifests for simulated
+  evaluation, plus separate prospective-label provenance when applicable;
+- any external-naming authorization receipt and the privacy derivation it
+  binds;
+- feature, model, calibration, and threshold receipts;
+- per-step search trace including `best_so_far`;
+- complete action record and user-confirmation state; and
+- software commit, dependency versions, seeds, deterministic settings,
+  resource ceilings, runtime, and peak memory.
+
+Hashes establish byte identity, not privacy, provider authenticity, or
+scientific independence. Do not include private titles or paths in a public
+receipt merely to make it reproducible.
+
+Fail closed before inference or action on:
+
+- missing, duplicate, untyped, or title-only identities;
+- a stale or mismatched catalog, graph, path, privacy, ranker, or calibration
+  receipt;
+- a selected folder without an authoritative catalog path;
+- an invalid path transition, nonfinite score, or nondeterministic tie;
+- a proposal outside the exact simulated or prospective calibration support
+  claimed for it;
+- an external naming request for private data without a valid, exact
+  authorization receipt, or for unknown data under any circumstance;
+- an attempt to apply a decision without user confirmation; or
+- a catalog change between recommendation and confirmation.
+
+Ordinary ambiguity may produce `ABSTAIN`; provenance failures block the run.
+
+## 9. Implementation acceptance tests
+
+At minimum, tests must prove:
+
+1. duplicate titles remain separate and actions use typed IDs;
+2. an existing multi-parent folder returns the frozen principal breadcrumb,
+   even when search reached it through another edge;
+3. paths of depth 1, the current maximum, and greater than 26 round-trip
+   without a fixed-slot assumption;
+4. `SELECT_EXISTING`, `PROPOSE_NEW`, and `ABSTAIN` are mutually exclusive and
+   schema-valid;
+5. absence of an eligible candidate leaves no stale selected/proposed target;
+6. a low margin cannot authorize `PROPOSE_NEW` without a matching
+   population-specific calibration artifact;
+7. threshold fitting and feature selection cannot read outer
+   simulated-absence labels;
+8. simulated-absence construction removes every acceptable folder's IDs,
+   titles, paths, embeddings, aliases, contents, and placement-derived traces
+   fold-wide;
+9. the always-existing and margin-only controls run on byte-identical
+   manifests;
+10. a fixed-resource timeout returns the deterministically scored
+    `best_so_far`, not the last iterate;
+11. the request rederives its exact `routed-task.v2` parent and row rather than
+    accepting a duplicated baseline schema;
+12. private inputs cannot reach an external namer without an exact
+    content-bound receipt, and unknown inputs cannot reach one at all;
+13. stale hashes, malformed paths, illegal transitions, and nonfinite values
+    block;
+14. recommendation code cannot mutate the source graph or call a filing API;
+15. confirmation revalidates the catalog snapshot before any separately
+    authorized action; and
+16. the decision-bearing evaluator rejects same-e5-only grading of an
+    e5-constructed proposal.
+
+Property-based tests should generate dynamic-depth trees/DAGs, duplicate
+titles, alternative parents, and adversarial catalog reorderings. Transaction
+tests should cover prepare → verify → recommend, tamper rejection, and
+reproduction at identical hashes.
+
+## 10. Activation and stop gates
+
+1. **Contract gate:** land the schemas and a no-mutation interface before
+   implementing a proposal model.
+2. **Baseline gate:** reproduce the frozen-e5 existing-folder baseline with
+   exact IDs, authoritative breadcrumbs, and content-bound receipts. Stop and
+   fix provenance if it does not match.
+3. **Proposal gate:** preregister the acceptable-set simulated-absence study
+   before constructing its outer set. Passing it may authorize only the
+   labeled research pilot; ordinary `PROPOSE_NEW` and a live novelty
+   probability remain disabled until a separate prospective naturally absent
+   cohort meets its frozen calibration and false-proposal rule.
+4. **Candidate gate:** add structural search only if it improves outcome-blind
+   candidate coverage/stability at a matched budget. An empty increment is a
+   valid stopping result.
+5. **Optimizer gate:** add a learned optimizer only after deterministic search
+   leaves a prespecified held gap. Roll back unless it beats the best earlier
+   stage at matched resources under the frozen node-disjoint evaluation.
+6. **Deployment gate:** successful evaluation authorizes at most a
+   user-confirmed advisory pilot. Automatic graph mutation, private external
+   inference, new-corpus transfer, and public release each require a separate
+   authorization.
+
+## 11. Engineering handoff checklist
+
+The first engineering PR should implement only Stage A and the common request /
+decision schemas. It should:
+
+- rederive and consume one exact `routed-task.v2` parent row, preserving its
+  source, privacy, catalog, ordered-candidate, ranker, and policy authority;
+- add only the graph/principal-path supplement and decision receipt rather
+  than rebuilding a parallel baseline;
+- resolve top-1 by typed ID;
+- copy the authoritative principal path from the catalog;
+- emit `SELECT_EXISTING` or `ABSTAIN`;
+- produce a no-replace search/decision receipt;
+- expose no graph-mutation capability; and
+- include the identity, duplicate-title, principal-path, dynamic-depth,
+  provenance, and privacy tests above.
+
+The next PR should freeze the acceptable-set simulated-absence protocol and
+fixture builder. A later PR may implement only the labeled research-pilot
+proposal path. Ordinary `PROPOSE_NEW` waits for the separately frozen
+prospective naturally absent protocol and cohort. This ordering keeps each
+target from being defined after its results are visible.
+
+## 12. Explicitly deferred or rejected
+
+- Treating low margin as novelty probability — rejected.
+- Generating IDs or existing-folder breadcrumbs — rejected.
+- Replacing the stored parent walk with a learned/generated path — rejected.
+- A fixed 26-slot output — rejected.
+- Training a μ head as the default primary ranker — rejected absent new held
+  evidence.
+- Same-e5 proposal generation and decision-bearing grading — rejected as
+  circular.
+- Automatic folder creation or filing — outside this architecture.
+- External naming on private data by default — rejected.
+- Full text-autoregressive path generation — deferred until selective
+  search, population-specific proposal calibration, and compact local naming
+  all show a prespecified unmet need.

--- a/prototypes/mu_cosine/DESIGN_lineage_decoder.md
+++ b/prototypes/mu_cosine/DESIGN_lineage_decoder.md
@@ -1,5 +1,17 @@
 # Lineage Decoder — design sketch (FUTURE WORK, not an immediate priority)
 
+> **HISTORICAL DESIGN SKETCH — superseded for implementation.** Preserve this
+> document as research history, but do not implement from it. In particular,
+> frozen e5—not a `mu_lineage` head—is the current filing-ranking backbone; a
+> low top-two margin establishes ambiguity, not a probability that a folder is
+> missing; existing-folder breadcrumbs come from the frozen catalog's recorded
+> canonical/principal path rather than a generated path; and path depth is
+> dynamic rather than a fixed 26-slot output. The implementation handoff is
+> [`DESIGN_filing_path_decoder_handoff.md`](DESIGN_filing_path_decoder_handoff.md).
+> The process-expression reconstruction decoder is a separate model described
+> in
+> [`DESIGN_expression_encoder_future.md`](DESIGN_expression_encoder_future.md).
+
 Sketched during a training run, per the "would be cool to design for future work" note. This is the generative
 counterpart to the **retrieval** LINEAGE operator (`train_lineage.py`): instead of *picking* the best existing
 folder/path, a decoder *generates* the placement path — and, crucially, can **propose a folder that doesn't exist

--- a/prototypes/mu_cosine/DESIGN_process_expression_implementation.md
+++ b/prototypes/mu_cosine/DESIGN_process_expression_implementation.md
@@ -105,7 +105,10 @@ cohort with a structurally frozen catalog, collected AFTER this design is fixed.
   card-e5(operator) + Σ position-weighted child embeddings with fixed per-position weights; any
   stochastic element (e.g. dropout-style card sampling) is seeded by SHA-256 of the canonical AST,
   so identical expressions always embed identically. A small learned tree encoder follows only if
-  the deterministic superposition plateaus.
+  the deterministic superposition plateaus. The learned follow-on is specified separately in
+  `DESIGN_expression_encoder_future.md`; its complete typed-role-path position contract and
+  mathematically corrected ablation set are in `DESIGN_tree_position_encoding_theory.md`. Those
+  documents are implementation handoffs, not permission to bypass this phase's activation gate.
 - Zero-shot test (finding 9 — one held process proves nothing): PREREGISTERED
   leave-one-composition-out over SEVERAL held processes — at minimum {sonnet.lineage@N20,
   haiku@N10, kalman(luna.D, luna.S), one lineage-decay variant} — each evaluated against four

--- a/prototypes/mu_cosine/DESIGN_tree_position_encoding_theory.md
+++ b/prototypes/mu_cosine/DESIGN_tree_position_encoding_theory.md
@@ -1,73 +1,318 @@
-# Tree Position Encodings for Expression ASTs — Theory Note (FUTURE WORK)
+# Tree-Position Encodings for Process-Expression ASTs — Implementation Handoff
 
-**Status: theory capture, 2026-07-24 (owner + Perplexity/Sonnet-5 discussion).** Companion to
-`DESIGN_expression_encoder_future.md`; same gating (post-P1, post-P3-plateau). This note records
-the mathematical structure so a future implementer (possibly a separate agent) does not
-re-derive it.
+**Status: future-work design contract, revised 2026-07-25.** This is the position-encoding
+companion to [`DESIGN_expression_encoder_future.md`](DESIGN_expression_encoder_future.md).
+It inherits that document's gate: do not schedule this work unless the frozen P1 comparison
+supports expression conditioning and the deterministic P3 composition baseline has plateaued.
+This note changes no P1 or P3 protocol and authorizes no downstream claim.
 
-## The problem
+Current art remains:
 
-A node in an expression AST (`e5(routing(e5, sonnet.lineage, ...))`) is doubly positioned:
-**depth** k (operator vs argument vs sub-argument — abstraction level) and **breadth** j
-(which argument at that depth — role/order). P3's current plan collapses this to fixed scalar
-per-position weights. The question: how should a positional embedding represent (k, j) jointly?
+- [`process_cards.py`](process_cards.py): registry-driven parsing and canonicalization, plus the
+  current shortened `ast_sha` convenience identifier; it does not compose learned tree
+  embeddings. The future artifact contract below retains the canonical AST and a full SHA-256
+  digest rather than treating a shortened digest as lossless.
+- [`DESIGN_process_expression_implementation.md`](DESIGN_process_expression_implementation.md):
+  the P0–P4 ladder and deterministic P3 baseline.
+- [`ARCHITECTURE_filing_engine.md`](../../docs/design/ARCHITECTURE_filing_engine.md): FUSE-003 and OPENQ-012,
+  the eventual conditioning and cross-corpus consumers.
 
-## The factorization and the combination operator
+## 1. Structural authority: a typed root-to-node role path
 
-Give depth and breadth their own embedding vocabularies, d_k and b_j, and combine. The candidate
-combinations form a strict information hierarchy:
+The earlier shorthand `(depth, breadth)` is not a node identity. At depth 3, for example,
+`arg:0` below the first argument and `arg:0` below the second argument have the same local
+coordinates but different locations and often different meanings.
 
-| operation | output dim | information preserved | Gaussian analogy |
-|---|---|---|---|
-| Kronecker d ⊗ b | D_d · D_b | exact, fully separable joint | full joint covariance Σ |
-| circular convolution d ∗ b | D | Fourier-basis projection of the Kronecker | low-rank/diagonal Σ approximation |
-| learned bilinear W(d ⊗ b) | D | learned projection of the Kronecker | fitted low-rank Σ |
-| quadratic form dᵀA b | 1 | one interaction scalar | log-likelihood of the joint |
-| additive d + b | D | marginals only, no interactions | independence, Σ = diag |
+For every tokenized AST item `u`, freeze its complete root-to-item path
 
-**Key identity (the owner's question, answered affirmatively): circular convolution IS a
-dimensionality reduction of the Kronecker product** — a fixed linear projection. In the Fourier
-domain, F(d ∗ b)_n = F(d)_n · F(b)_n: the D²-dimensional outer product is contracted to D
-dimensions using the DFT matrix as the projection basis. Fixed (no training, approximately
-invertible — the holographic reduced representation / HRR construction), but the Fourier basis
-is not necessarily optimal for a given vocabulary.
+```
+p(u) = (rho_1, rho_2, ..., rho_k),    k = depth(u).
+```
 
-**The quadratic-form / joint-Gaussian analogy, made precise:** for zero-mean joint Gaussian x,
-−½ xᵀΣ⁻¹x = −½ vec(xxᵀ)ᵀ vec(Σ⁻¹) — the outer product xxᵀ is the rank-1 Kronecker self-product,
-and contracting against the precision matrix is a linear projection of the Kronecker product to a
-SCALAR: maximal compression, keeping exactly the information a score needs and nothing
-recoverable. Attention's qᵀk is this same object; multi-head attention learns D_head such
-projections in parallel — i.e., a learned partial recovery of the Kronecker structure. This
-places the whole design space on one axis: how much of the joint (depth × breadth) interaction
-structure do you keep, and is the projection fixed (Fourier) or learned (W)?
+Each `rho_t` is the typed role of the edge from the item at depth `t-1` to the item at depth
+`t`. The exact serialized role schema is authoritative in
+[`DESIGN_expression_encoder_future.md`](DESIGN_expression_encoder_future.md):
 
-## Separability requirement
+- `ARG(index, expected_output_type)` for positional expression children, with the registry's
+  positional type and zero-based index;
+- `KWARG(registry_kw_id, value_type)` for keyword values;
+- `LIST_ITEM(index, element_type)` for nested list items;
+- ordered `MOD(index)` and `PIN(index)` roles; and
+- `LITERAL_BYTE(index)` below exact literal payloads.
 
-Depth and breadth vocabularies must be DISTINCT (independent initializations; distinguishable
-subspaces). With a shared vocabulary the combination degenerates: the network cannot tell
-(depth=k, breadth=j) from other pairs producing the same product. This was the owner's own
-caveat and it is load-bearing — it is what makes the joint representation identifiable.
+The root token has the empty path. `<ROOT>` is a distinguished content token, not an edge role.
+This document's lower-case mathematical symbols denote those exact serialized roles; it does not
+define a second vocabulary.
 
-## Recommendation for THIS grammar
+The exact path is serialized in the example/split manifest and is recoverable from the resolved
+canonical AST. Sibling indices are local to their parent. Keyword roles use the canonical
+registry keyword ID, not the source-text order; canonicalization already sorts keywords. No
+modulo, clipping, or hash-bucket operation is allowed in this authoritative path.
 
-Expression trees here are shallow and narrow (depth ≤ ~4: operator → argument → sub-argument /
-kwarg; breadth ≤ ~8). Therefore:
+The pair
 
-- Full Kronecker is FEASIBLE (small vocabularies ⇒ manageable D_d·D_b) but likely wasteful.
-- **Learned bilinear W(d ⊗ b) is the recommended sweet spot**: a few hundred parameters,
-  exactly separable, discovers which depth×breadth interactions matter for this grammar instead
-  of assuming the Fourier basis. P3's fixed scalar position weights are its rank-degenerate
-  special case, so it slots into the existing ablation ladder rather than replacing it.
-- Preregistered ablation ladder when implemented: fixed-weight sum (P3 baseline) → additive
-  d + b → circular convolution (HRR) → learned bilinear → full Kronecker. Determinism contract
-  carries over: any stochastic element seeded by SHA-256 of the canonical AST.
+```
+(depth(u), local_role(u)) = (k, rho_k)
+```
 
-## Cautions
+is a useful **lossy feature**, not a coordinate system. Distinct paths can share it. Likewise,
+any learned position vector is a conditioning feature, never process identity. The canonical AST,
+registry version, factory/manifest fingerprint, and their full digests remain authoritative.
 
-- With ~922 labeled rows, NO learned position scheme is trainable from task labels alone — this
-  only becomes feasible on the synthetic-pretraining path of the encoder–decoder design
-  (grammar-generated expressions, reconstruction + e5-alignment objectives).
-- Current art references: `process_cards.py` (P0 — canonicalization/token identification only,
-  no embeddings composed today), `DESIGN_process_expression_implementation.md` P3 (deterministic
-  superposition), `ARCHITECTURE_filing_engine.md` OPENQ-012 (cross-corpus transfer — the
-  evaluation any position scheme ultimately serves).
+## 2. Encoder input contract
+
+The implementation may represent the path as a sequence rather than forcing it into one vector.
+For each AST item it must expose:
+
+```
+path_role_ids : [max_path_length]  # root-to-item, in order
+path_mask     : [max_path_length]  # true entries only; padding is not a role
+depth         : integer
+parent_index  : integer or ROOT
+local_role_id : integer
+```
+
+The expression encoder consumes the ordered role sequence or an equivalent parent-pointer tree
+whose message-passing steps preserve that order. A commutative sum of edge-role vectors alone
+does not meet this contract: it maps `(rho_a, rho_b)` and `(rho_b, rho_a)` to the same value.
+
+For the operator comparisons below, let
+
+- `d_k in R^(D_d)` be the table code for edge depth `k`;
+- `b_rho in R^(D_b)` be the table code for typed role `rho`;
+- `K_d` and `K_r` be the frozen depth and role vocabulary sizes; and
+- `C(d_k, b_rho)` be the local edge feature.
+
+The table parameter count is
+
+```
+P_tables = K_d D_d + K_r D_b.
+```
+
+Unless stated otherwise, parameter counts below are **in addition** to `P_tables`. Biases are
+counted explicitly. The same order-sensitive path aggregator and the same content encoder must be
+held fixed within an ablation; otherwise the comparison is not a position-operator comparison.
+
+## 3. Local depth-by-role combination operators
+
+The operations below combine the depth and typed-role code for one edge. None of them, by itself,
+represents the complete path.
+
+| family | definition | output dimension | trainable parameters beyond tables |
+|---|---|---:|---:|
+| Concatenation | `C(d,b) = [d ; b]` | `D_d + D_b` | `0` |
+| Outer/Kronecker feature | `C(d,b)_(i,j) = d_i b_j` | `D_d D_b` | `0` |
+| Circular convolution | `C(d,b)_t = sum_i d_i b_((t-i) mod D)`; requires `D_d=D_b=D` | `D` | `0` |
+| Dense learned bilinear tensor | `C(d,b)_o = sum_(i,j) W_(o,i,j) d_i b_j + c_o` | `D_o` | `D_o D_d D_b + D_o` |
+| Scalar bilinear | `C(d,b) = d^T A b + c` | `1` | `D_d D_b + 1` |
+| Addition | `C(d,b) = d + b`; requires `D_d=D_b=D` | `D` | `0` |
+| Rank-`R` factorized bilinear | `C(d,b) = H ((U d) elementwise_mul (V b)) + c` | `D_o` | `R(D_d + D_b + D_o) + D_o` |
+
+For the factorized form,
+
+```
+U in R^(R x D_d),  V in R^(R x D_b),  H in R^(D_o x R),  c in R^(D_o).
+```
+
+It is a CP-style rank-`R` factorization of the dense three-way tensor. `R`, `D_o`, and whether
+biases are used must be frozen in the run manifest; silently changing them changes the model
+class.
+
+For an explicit fixed-projection view of circular convolution, choose the outer-feature vector
+
+```
+x = vec(d b^T),    x_(i,j) = d_i b_j,
+```
+
+with the `(i,j)` coordinate order frozen. Then
+
+```
+d circular_conv b = P x,
+P_(t,(i,j)) = 1 if i+j = t (mod D), else 0.
+```
+
+Thus circular convolution is one particular fixed linear projection of the outer feature. Any
+normalization factor is part of the operator definition and must be pinned; the formula above is
+unnormalized.
+
+These families do **not** form a strict information hierarchy. Concatenation allows direct
+recovery of its two input codes. An outer feature has scale ambiguity and need not identify an
+unknown pair. A lower-dimensional projection can still separate every pair in a finite frozen
+vocabulary, while a higher-dimensional learned representation can collide or overfit. “More
+dimensions” and “more interactions” are capacity statements, not guaranteed information or
+accuracy orderings.
+
+## 4. Complete-path composition
+
+For `p(u) = (rho_1, ..., rho_k)`, form the ordered edge sequence
+
+```
+e_t = C(d_t, b_(rho_t)),    t = 1..k.
+```
+
+Feed `(e_1, ..., e_k)` and its mask to the shared order-sensitive path encoder, or make the same
+information available through parent-indexed tree attention. The root uses a frozen root token.
+The output `g(p(u))` may be concatenated with the content token or used as an attention bias, but
+the choice must be common across the registered operator ablation.
+
+This separation is load-bearing:
+
+1. the exact typed role path specifies location;
+2. `C` controls how depth and the role at one edge interact; and
+3. the path encoder controls how successive edges compose.
+
+Do not call `g(p)` lossless or collision-free unless that property is established for the frozen,
+finite manifest. It is a learned feature. The exact path and AST digest remain available for
+auditing even when two vectors are numerically equal.
+
+## 5. What HRR unbinding does—and does not—provide
+
+Let `z = d circular_conv b`. In the Fourier domain,
+
+```
+DFT(z) = DFT(d) elementwise_mul DFT(b).
+```
+
+If **one key is known**, and its Fourier coefficients are nonzero and suitably conditioned, the
+other code can be recovered by Fourier-domain division. With random unitary or approximately
+orthogonal codebooks, circular correlation is often used as an approximate unbinding operation.
+Those are codebook and known-key assumptions.
+
+Given only `z`, the unknown pair `(d,b)` is not generally recoverable: many factorizations produce
+the same product, and scale/phase ambiguities remain. Therefore this design must not describe HRR
+as making the pair “approximately invertible.” Its practical question is empirical separation of
+the finite registered depth-role pairs and paths.
+
+## 6. Limited analogies
+
+The outer feature is useful because a bilinear cross-energy is linear in it:
+
+```
+d^T A b = inner_product(A, d b^T).
+```
+
+For a joint Gaussian whose precision matrix has a depth/role cross-block, a term of this form can
+appear in its quadratic energy. That does **not** make `d b^T` a covariance matrix, nor does it
+model the Gaussian self-terms or normalization. The analogy is limited to representing a
+cross-interaction.
+
+Likewise, an attention logit after learned projections is a scalar bilinear form
+
+```
+(W_q d)^T (W_k b).
+```
+
+Multiple heads learn multiple such scores and use them to mix value vectors. They do not, in
+general, recover or retain the full outer product. Attention is therefore an example of learned
+bilinear scoring, not evidence for an information hierarchy among the operators above.
+
+## 7. Typing and identifiability
+
+Depth codes and edge-role codes use separate tables and separate parameter namespaces. This
+prevents the trivial role swap that a shared table plus a commutative operator would permit:
+“depth 2” cannot be looked up as “arg 2.” It does **not** make the learned factors statistically
+identifiable. Permutations, rescalings, rotations, sign changes, and compensating changes in a
+downstream projection can leave model outputs unchanged.
+
+Consequently:
+
+- interpret downstream behavior, not individual embedding coordinates;
+- never use a position vector as a cache or process key; and
+- bind artifacts to the canonical AST digest, registry/canonicalizer versions, split manifest,
+  tokenizer version, and position-encoder configuration.
+
+## 8. Measured envelope and overflow behavior
+
+Do not encode the earlier informal claims that the grammar is “depth <= 4” or “breadth <= 8” as
+facts. Before implementation, scan:
+
+1. every registered current process;
+2. every process in the frozen downstream ledger;
+3. the synthetic generator's proposed train/dev/test manifests; and
+4. each value/list token emitted by the proposed tokenizer.
+
+Record at least maximum and empirical distributions for AST depth, positional arity, list length,
+keyword count, modifier count, pin count, and typed-path length. Freeze the resulting table sizes
+and limits before fitting.
+
+The overflow policy must also be frozen. The recommended confirmatory behavior is fail closed:
+reject an expression whose path depth or role index exceeds the manifest envelope, report the
+count and hashes, and do not clip, wrap, or reuse the final in-range code. A preregistered
+`OVERFLOW` role is permissible for an explicitly exploratory deployment, but it is lossy and its
+rate must be reported. Expanding a table creates a new model revision and requires a new manifest.
+
+## 9. Required ablation and diagnostics
+
+Preregister one primary downstream metric. Screen the following position variants only on
+synthetic train/dev and downstream inner data:
+
+1. no learned position feature;
+2. lossy `(depth, local_role)` only;
+3. complete typed path with concatenation;
+4. complete typed path with addition;
+5. complete typed path with circular convolution;
+6. complete typed path with rank-`R` factorized bilinear interaction;
+7. complete typed path with dense bilinear interaction; and
+8. the unprojected outer feature, if its memory and downstream projection fit the frozen resource
+   envelope.
+
+The scalar bilinear form is a diagnostic interaction-score arm, not a drop-in vector replacement
+unless the downstream interface explicitly accepts one scalar.
+
+Within that inner screen, run both:
+
+- a **matched-output/matched-budget comparison**, choosing `D_d`, `D_b`, `D_o`, and `R` on inner
+  data so total trainable parameters are as close as the preregistered tolerance permits; and
+- an **unmatched native-capacity diagnostic**, clearly labeled exploratory.
+
+Freeze one selected position arm before any held evaluation. The held comparison contains that
+arm, the deterministic P3 position rule, and the no-learned-position baseline—not all eight
+variants. This avoids spending the outer set on architecture search.
+
+For every screened arm report table parameters, operator parameters, path-aggregator parameters,
+total trainable parameters, output dimensions, peak memory, and measured inference cost. Do not
+claim an operator win when only its parameter budget changed.
+
+Before any downstream score, test the representation itself on the frozen manifest:
+
+- exact duplicate-vector count under a pinned numerical tolerance;
+- nearest distinct-path cosine and Euclidean distance distributions;
+- minimum distance and the identities of the closest distinct paths;
+- numerical rank and conditioning of the finite code matrix, labeled diagnostic rather than an
+  identifiability proof;
+- deterministic inference with dropout disabled, plus reproducible training under pinned
+  run/global seeds and deterministic-operation settings; and
+- overflow count and rate.
+
+Canonical-AST-derived randomness remains appropriate for the deterministic P3 baseline and
+synthetic sample generation. Do not use it to freeze one dropout mask per example while training
+the learned encoder.
+
+Required path-order tests include:
+
+- sibling swaps change the exact path and the encoded feature for ordered positional arguments;
+- `(rho_a, rho_b)` differs from `(rho_b, rho_a)` when both are valid paths;
+- nodes sharing `(depth, local_role)` but having different ancestors remain distinguishable in
+  the complete-path arms;
+- keyword source order canonicalizes to the same keyword-role path;
+- padding and a real role never share a mask state; and
+- registered commutative operators receive permutation invariance only if the canonicalizer
+  explicitly normalizes that operator. Do not infer commutativity from a function name.
+
+## 10. Exit criteria and handoff artifacts
+
+An implementation PR is complete only when it emits:
+
+- the typed-role vocabulary and digest;
+- measured envelope and overflow policy;
+- tokenizer, registry, canonicalizer, split, and synthetic-generator digests;
+- the exact operator equations, dimensions, ranks, normalizations, seeds, and parameter counts;
+- path-order, determinism, overflow, and collision test results; and
+- a cross-reference from the encoder/decoder handoff to the selected position arm.
+
+Selection occurs on inner data only. The P3 LOCO/cross-corpus evidence that triggered this
+follow-on is already exposed and can support only an adaptive/exploratory comparison. A newly
+reserved post-activation process family, corpus, or prospective cohort stays untouched until the
+whole encoder configuration, including its position arm, has been frozen. Passing these checks
+licenses evaluation of the position feature; it does not establish compositional generalization,
+improve a filing metric, or authorize deployment.


### PR DESCRIPTION
## Summary

Turn the deferred process-expression encoder sketch into an implementable handoff:

keep canonical AST identity outside the lossy latent;

define resolved typed-AST tokens and complete role paths;

separate exact numeric reconstruction from smooth numeric conditioning;

specify view-conditioned alignment and a bottleneck-only grammar decoder;

require sealed structural splits and an identity-safe NameFunctionCond adapter.


## Correct the tree-position design:

give exact operator equations and parameter counts;

clarify the limits of convolution/HRR unbinding;

distinguish complete paths from lossy depth/local-role features;

restrict architecture screening to inner data before freezing one held-test arm.


Add a filing path-decision handoff that extends—not duplicates—the existing routed-task.v2 authority:

preserve catalog-recorded breadcrumbs for existing folders;

define SELECT_EXISTING, PROPOSE_NEW, and ABSTAIN;

separate acceptable-set simulated absence from genuine prospective novelty;

require content-bound privacy and external-authorization receipts;

retain deterministic best_so_far rollback and prohibit graph mutation.


Mark the older lineage-decoder sketch as historical and cross-link the implementation ladder.


## Scientific boundaries

Latents and position vectors are conditioning features, never identity or cache keys.

The evidence that activates encoder development is already exposed; a fresh post-activation population is required for an untouched outer comparison.

Artificially withholding acceptable folders does not establish that no suitable folder naturally exists.

Simulated absence may support only a labeled, owner-reviewed research pilot; ordinary live proposals require prospective naturally absent examples.

Private external naming requires an exact content-bound authorization receipt. Unknown privacy remains local-only.

This PR changes documentation only. It performs no training, scoring, provider calls, or graph mutation.


## Validation

45 passed:

test_process_cards.py

test_process_expression_p1_protocol.py


Relative Markdown links verified.

Staged and rebased diffs pass whitespace checks.


## Review focus

Full process-identity and internal residual-lookup contract.

Exact typed role-path schema and corrected position-operator mathematics.

Additive integration with routed-task.v2.

Boundary between simulated catalog absence and prospective live novelty.

Privacy derivation and external-naming authorization receipts.