### PR TITLE
mu_cosine: address post-merge review of #4000

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,11 @@ jobs:
 
       - name: Run process-expression contract fixture tests
         # Identity helpers plus the frozen AST/token/role-path golden vectors.
-        # Pure stdlib over process_cards — no embedder, no torch, no corpus.
+        # The modules under test import only process_cards; the suite also
+        # imports process_expression_p1_protocol in one test, to prove the
+        # digest matches the frozen P1 convention, which pulls numpy via
+        # routed_policy. numpy is installed above. No embedder, torch, or
+        # corpus either way.
         run: |
           python3 -m pytest -q prototypes/mu_cosine/test_process_expression_contract.py
 

--- a/docs/design/ARCHITECTURE_filing_engine.md
+++ b/docs/design/ARCHITECTURE_filing_engine.md
@@ -1,6 +1,6 @@
 # Filing-engine architecture
 
-Last updated: 2026-07-18
+Last updated: 2026-07-25
 
 This is the map of the filing system that has materialized across the
 `mu_cosine` work. It is an exploratory architecture document, not a
@@ -46,6 +46,7 @@ history. Promotion protocols and audits belong in separate documents and PRs.
 | RANK-004 | `OPEN` | **Owner: engineering-lane; evaluation boundary: rigor-lane.** Build a placement-blind candidate generator that mixes e5 retrieval with structural candidates such as ancestors, siblings through common parents, and permitted topology-only sources. | Resolve by freezing the generator before held results, improving recall at matched `K=50`, and then improving prospective node-disjoint filing MRR under [PR #3875](https://github.com/s243a/UnifyWeaver/pull/3875). No placement count, filing label, or judge outcome may enter eligibility. |
 | RANK-005 | `OPEN` | **Owner: rigor-lane; implementation support: engineering-lane.** Better bounded graph domains are the second priority lever because the current two-hop feature is dominated by its artificial boundary. | Resolve with nested-domain comparisons against a larger exact-Dirichlet reference: raw Green responses, normalized screening values, candidate ranks, cut-current/envelope diagnostics, conditioning, memory, and runtime must all be reported. See [local grounded diffusion](LOCAL_GROUNDED_DIFFUSION.md). |
 | RANK-006 | `DEFAULT` | Route escalation using the e5 top-one minus top-two score margin. Treat existing curves as descriptive, and do not call the margin a calibrated probability. | [Filing v1 report §5](../../prototypes/mu_cosine/REPORT_pearltrees_filing_v1.md) found the e5 margin useful while tuned μ margins were not; the correlated-calibration pattern is summarized in the [uncertainty playbook](../../prototypes/mu_cosine/DESIGN_uncertainty_estimation_playbook.md). |
+| RANK-007 | `DECIDED` | A folder is identified by a typed stable ID, never by its title; titles and breadcrumbs are display attributes resolved through that ID, and the catalog's recorded canonical/principal path is authoritative for an existing folder. Duplicate titles are distinct candidates. | Existing practice made explicit rather than a new choice: [`routed_queries.py`](../../prototypes/mu_cosine/routed_queries.py) grades with `primary_grading: exact_destination_id` and keeps `best_title_equivalent_destination` only as a sensitivity arm; `CORP-002`/`DR-001` fix the principal-parent rule that path authority rests on. Row added because [`DESIGN_filing_path_decoder_handoff.md`](../../prototypes/mu_cosine/DESIGN_filing_path_decoder_handoff.md) §0 cited this rule as standing architecture while no atomic row stated it. |
 
 ## 2. Geometry layer
 
@@ -204,3 +205,4 @@ resolution column is a compact evidence contract, not a protocol.
 | 2026-07-18 | Initial architecture map assembled from PRs #3648–#3875 and the candidate-skeleton/graph-judge-v2 design discussion. |
 | 2026-07-18 | Split mathematical identities from decisions, including a separate union-of-anchors convention; added empirical evidence envelopes and scale-triggered revisit events; demoted regime-dependent cheap-judge economics and the untested Nomic preference to working defaults. |
 | 2026-07-19 | Refined `GEOM-006` from semantic edge creation to graph-derived exterior closure: semantics is only an optional search filter, while topology licenses edges and resistance/Schur response sets their strength; explicitly allowed a zero-bridge result after common-parent retention; recorded `GEOM-010` so memoized loop collisions cannot be mistaken for cut points. |
+| 2026-07-25 | Added `RANK-007` recording typed-stable-ID folder identity and catalog path authority. This documents existing grading practice rather than adopting a new rule: the filing path decoder handoff cited it as standing architecture while no atomic row stated it. |

--- a/prototypes/mu_cosine/DESIGN_filing_path_decoder_handoff.md
+++ b/prototypes/mu_cosine/DESIGN_filing_path_decoder_handoff.md
@@ -12,9 +12,10 @@ retained as research history. This contract follows the standing decisions in
 - frozen, revision-pinned e5 is the filing-ranking backbone;
 - learned μ heads currently serve calibration, label fusion, and conflict
   routing, not primary filing ranking;
-- an existing folder is identified by a typed stable ID, never by its title;
-  and
-- the recorded canonical/principal path is authoritative for that folder.
+- an existing folder is identified by a typed stable ID, never by its title
+  (`RANK-007`); and
+- the recorded canonical/principal path is authoritative for that folder
+  (`RANK-007`, resting on `CORP-002`/`DR-001`).
 
 “Decoder” here means a **selective search and proposal policy over a frozen
 filing catalog**. It is not the reconstruction decoder in

--- a/prototypes/mu_cosine/README.md
+++ b/prototypes/mu_cosine/README.md
@@ -16,6 +16,37 @@ This is a **separate project, prototyped on a branch** — it is Python/ML, not 
 > calibrated-joint-posterior + margin-gate approach and the six pitfalls (correlated sources, margin-not-level,
 > held-out node-disjoint, …) the project learned the slow way. Don't hand-set independent confidence weights.
 
+### Two tracks with different entry tickets
+
+Two separate workstreams live under this directory. They share a directory, not a dependency —
+read only the chain you need.
+
+**Process-expression track** (the little DSL like `e5(routing(e5,haiku,t=[0.02],menus=[10]))` that
+names a composed scoring pipeline, and the planned learned encoder for it). Background needed:
+[`process_cards.py`](process_cards.py) alone.
+
+| step | where |
+|---|---|
+| grammar, typed registry, canonicalization, lossless identity | [`DESIGN_process_expression_language.md`](DESIGN_process_expression_language.md), [`process_cards.py`](process_cards.py) (#3982) |
+| P0–P4 empirical ladder and the deterministic P3 baseline | [`DESIGN_process_expression_implementation.md`](DESIGN_process_expression_implementation.md) |
+| encoder/position theory, gated behind frozen P1 + plateaued P3 | [`DESIGN_expression_encoder_future.md`](DESIGN_expression_encoder_future.md), [`DESIGN_tree_position_encoding_theory.md`](DESIGN_tree_position_encoding_theory.md) (#3983, #3995) |
+| step 1 — identity helpers and frozen golden vectors | [`process_identity.py`](process_identity.py), [`process_expression_contract.py`](process_expression_contract.py), `PROCESS_EXPRESSION_GOLDEN_v1.json` (#4000) |
+
+`process_identity` and `process_expression_contract` import nothing but `process_cards` — no filing
+stack, no embedder, no torch, no corpus. Keeping that surface small is deliberate: it leaves the
+option of extracting this track as a standalone package if the encoder work matures.
+
+**Filing-decision track** (choose a folder for a bookmark). Background needed: the routed-task
+chain, because Stage A is *additive over* it by design rather than a parallel baseline.
+
+| step | where |
+|---|---|
+| content-bound task/pick/policy primitives, `routed-task.v2` | [`routed_policy.py`](routed_policy.py), [`routed_queries.py`](routed_queries.py) |
+| privacy index and public-only catalog | [`filing_privacy.py`](filing_privacy.py) |
+| standing architecture decisions | [`ARCHITECTURE_filing_engine.md`](../../docs/design/ARCHITECTURE_filing_engine.md) |
+| handoff contract, staged A–E | [`DESIGN_filing_path_decoder_handoff.md`](DESIGN_filing_path_decoder_handoff.md) (#3995) |
+| Stage A — `SELECT_EXISTING` / `ABSTAIN`, no mutation | [`filing_path_decision.py`](filing_path_decision.py) (#4000) |
+
 ## Status & handoff (read this first)
 
 **Status:** merged to `main` (via #3280); the torch port + direct-embedding comparison are folded in

--- a/prototypes/mu_cosine/filing_path_decision.py
+++ b/prototypes/mu_cosine/filing_path_decision.py
@@ -72,12 +72,28 @@ ABSTAIN = "ABSTAIN"
 DECISIONS = (SELECT_EXISTING, PROPOSE_NEW, ABSTAIN)
 
 #: §1.3 reason codes.  These are operational outputs, not scientific findings.
+#:
+#: Stage A can currently emit only the three in ``STAGE_A_ABSTAIN_REASONS``.
+#: The rest are declared here on purpose rather than added later: they belong
+#: to stages that are gated, not unimplemented, and a reader looking for their
+#: emitters should find this note instead of hunting.  ``proposal_need_uncertain``
+#: and ``outside_calibration_support`` become reachable only once a proposal
+#: calibration artifact exists (§2, §10); ``privacy_restricted_naming`` only
+#: once a namer runs, which Stage A has no path to (§6).
 ABSTAIN_REASONS = (
     "ambiguous_existing",
     "proposal_need_uncertain",
     "outside_calibration_support",
     "resource_censored",
     "privacy_restricted_naming",
+    "no_eligible_candidate",
+)
+
+#: The subset Stage A can actually produce.  Validation accepts the full set so
+#: a later stage's receipt still parses under this schema version.
+STAGE_A_ABSTAIN_REASONS = (
+    "ambiguous_existing",
+    "resource_censored",
     "no_eligible_candidate",
 )
 
@@ -535,16 +551,20 @@ def check_external_naming(
 
     if receipt is None:
         return None
+
+    # Three classes, three outcomes, stated separately so the intent is not
+    # carried by fall-through:
+    #   unknown  -> refuse outright; authorization cannot stand in for a
+    #               missing classification (§6).
+    #   private  -> a receipt is *required*, and must bind this exact request.
+    #   public   -> a receipt is not required, but one that is supplied is held
+    #               to the same binding rules rather than waved through.
     if privacy_class == "unknown":
         raise FilingPathError(
             "unknown-privacy data is local-only; owner authorization cannot "
             "substitute for a missing privacy classification"
         )
-    if privacy_class == "public":
-        # Certified-public data does not need a private-content receipt, but a
-        # supplied receipt must still bind this exact request.
-        pass
-    elif privacy_class != "private":
+    if privacy_class not in ("public", "private"):
         raise FilingPathError(f"unsupported privacy class: {privacy_class!r}")
 
     for field in (
@@ -878,6 +898,14 @@ def decide_stage_a(verified: VerifiedRequest) -> dict[str, Any]:
     ``allowed_roots`` — are skipped and recorded, never re-scored.  The scan is
     bounded; on exhaustion it returns the deterministic ``best_so_far`` rather
     than the last iterate.
+
+    Invariant worth stating because the schema does not imply it: a
+    ``SELECT_EXISTING`` receipt always carries ``resource_censored: false``.
+    The scan breaks the moment it finds an eligible candidate, so the budget
+    check cannot fire on a successful pass.  Censoring is therefore only ever
+    observable on an abstention, and skipping later candidates after a hit is
+    the objective working as defined, not truncation.  ``_build_decision``
+    enforces this rather than leaving it to a reader.
     """
 
     policy = verified.policy
@@ -1022,8 +1050,16 @@ def _build_decision(
     if decision not in (SELECT_EXISTING, ABSTAIN):
         # Stage A has no reachable proposal path; §10 keeps it gated.
         raise FilingPathError(f"Stage A cannot emit {decision}")
-    if decision == ABSTAIN and payload.get("reason_code") not in ABSTAIN_REASONS:
-        raise FilingPathError(f"unknown abstain reason: {payload.get('reason_code')!r}")
+    if decision == ABSTAIN and payload.get("reason_code") not in STAGE_A_ABSTAIN_REASONS:
+        raise FilingPathError(
+            f"Stage A cannot emit abstain reason {payload.get('reason_code')!r}"
+        )
+    if decision == SELECT_EXISTING and search_receipt.get("resource_censored"):
+        # See decide_stage_a: a successful scan breaks before the budget check,
+        # so this combination means the search loop was changed incompatibly.
+        raise FilingPathError(
+            "a censored search cannot also report a selected folder"
+        )
     record = {
         "schema": DECISION_SCHEMA,
         "record_type": "filing_path_decision",

--- a/prototypes/mu_cosine/test_filing_path_decision.py
+++ b/prototypes/mu_cosine/test_filing_path_decision.py
@@ -926,6 +926,61 @@ def test_confirmation_requires_user_and_an_unchanged_catalog(world):
     assert len(record["confirmation_sha256"]) == 64
 
 
+def test_select_existing_is_never_reported_as_censored(world):
+    """A successful scan breaks before the budget check can fire."""
+
+    from filing_path_decision import STAGE_A_ABSTAIN_REASONS, _build_decision
+
+    decision = decide_stage_a(_build(world))
+    assert decision["decision"] == SELECT_EXISTING
+    assert decision["search_receipt"]["resource_censored"] is False
+
+    verified = _build(world)
+    with pytest.raises(FilingPathError, match="censored search cannot also report"):
+        _build_decision(
+            verified,
+            decision=SELECT_EXISTING,
+            payload=decision["payload"],
+            search_receipt={**decision["search_receipt"], "resource_censored": True},
+            evidence_summary={},
+        )
+    # Stage A declines to mint a reason code belonging to a gated stage.
+    assert "proposal_need_uncertain" not in STAGE_A_ABSTAIN_REASONS
+    with pytest.raises(FilingPathError, match="Stage A cannot emit abstain reason"):
+        _build_decision(
+            verified,
+            decision=ABSTAIN,
+            payload={"reason_code": "proposal_need_uncertain",
+                     "candidate_ids_considered": []},
+            search_receipt=decision["search_receipt"],
+            evidence_summary={},
+        )
+
+
+def test_public_data_receipt_is_still_held_to_exact_binding(world):
+    """A supplied receipt is never waved through just because data is public."""
+
+    verified = _build(world)
+    bad = _naming_receipt("9" * 64, "b" * 64, "c" * 64)
+    with pytest.raises(FilingPathError, match="different request"):
+        check_external_naming(
+            privacy_class="public",
+            request_sha256=verified.request_sha256,
+            item_content_sha256="b" * 64,
+            inherited_privacy_receipt_sha256="c" * 64,
+            receipt=bad,
+        )
+    # ...and an unrecognised class is rejected rather than falling through.
+    with pytest.raises(FilingPathError, match="unsupported privacy class"):
+        check_external_naming(
+            privacy_class="confidential",
+            request_sha256="a" * 64,
+            item_content_sha256="b" * 64,
+            inherited_privacy_receipt_sha256="c" * 64,
+            receipt=_naming_receipt("a" * 64, "b" * 64, "c" * 64),
+        )
+
+
 def test_search_receipt_digest_binds_the_recorded_search(world):
     decision = json.loads(json.dumps(decide_stage_a(_build(world))))
     decision["search_receipt"]["node_expansions"] = 99


### PR DESCRIPTION
## Summary

Follow-up to the merged #4000, acting on external review. No behavior change to the decision path — two invariants that were already true by construction are now enforced and tested rather than left for a reader to infer, and one CI comment that was factually wrong is corrected.

**Architecture**

- Add `RANK-007`: a folder is identified by a typed stable ID, never by its title; the catalog's recorded canonical/principal path is authoritative; duplicate titles are distinct candidates. Plus a dated change-log entry.

  This documents existing practice rather than adopting a new rule — `routed_queries.py` already grades with `primary_grading: exact_destination_id` and keeps title equivalence only as a sensitivity arm. `DESIGN_filing_path_decoder_handoff.md` §0 had cited the rule as standing architecture while no atomic row stated it; §0 now cites `RANK-007` directly. Uses the existing layer-prefix ID convention rather than opening an `IDENT-` namespace.

**`filing_path_decision.py`**

- Stage A can emit only three of the six §1.3 abstain reasons, and now says so and enforces it. The other three belong to *gated* stages, not unimplemented ones: `proposal_need_uncertain` and `outside_calibration_support` become reachable only with a proposal calibration artifact, `privacy_restricted_naming` only once a namer runs. `validate_decision` still accepts the full set so a later stage's receipt parses under this schema version.
- Enforce the invariant that a `SELECT_EXISTING` receipt is never censored. The scan breaks on the first eligible candidate, so the budget check cannot fire on a successful pass — the schema previously implied a combination that cannot occur. Skipping later candidates after a hit is the objective working as defined, not truncation.
- Restructure `check_external_naming` so the unknown / private / public outcomes are stated separately instead of carried by a fall-through `pass`. Behavior is unchanged: a receipt supplied for public data is still held to exact binding, and an unrecognised class is now rejected explicitly rather than by omission.

**CI**

- Correct the process-expression step comment. The modules under test import only `process_cards`, but the *suite* imports `process_expression_p1_protocol` in one test — the one proving the digest matches the frozen P1 convention — which pulls numpy via `routed_policy`. The previous "pure stdlib over process_cards" wording was wrong about the suite. numpy is already installed by the step above, so CI was passing for the right reason but described incorrectly.

**README**

- Add a two-track reader's guide. The process-expression and filing-decision workstreams share a directory, not a dependency, and neither was mentioned in the README at all. The guide states each track's entry ticket, so the encoder work can be read without the routed-task chain.

  This is the presentational fix for a real on-ramp problem: `process_identity` and `process_expression_contract` import nothing but `process_cards` — verified, not assumed — while Stage A is coupled to `routed-task.v2` *by design*, because being additive over the parent is its entire value proposition. Decoupling it would mean reimplementing the provenance primitives, which is the "second convention" failure these documents exist to prevent.

## Validation

168 passed (2 new tests). Workflow YAML validates, whitespace checks pass, all relative Markdown links in the touched docs resolve.

## Not included, deliberately

- **Splitting future work per workstream.** Agreed, and it applies to the *next* PRs: Stage B and encoder step 2 share no code and should ship separately. #4000 combined them only because #3995's two §11 sections authorized their first steps simultaneously.
- **`sys.path.insert` in the prototype modules.** Consistent with existing `mu_cosine` style; changing it is a directory-wide refactor, not a follow-up to this review.
- **Encoder step 2.** Still open on one question: whether the generator enumerates exhaustively up to measured caps or samples under a seeded scheme. Current lean is exhaustive over structure with a small fixed numeric grid, which keeps the golden fixtures the full contract rather than a sample of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xCXhV5sHDsMiDyU5q7Hqg

---
_Generated by [Claude Code](https://claude.ai/code/session_017xCXhV5sHDsMiDyU5q7Hqg)_