### PR TITLE
plawk: printf in an END block

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -30,7 +30,7 @@ only (runtime pending) · ❌ missing.
 | Feature | Status | Notes |
 |---|---|---|
 | `print` (fields, literals, `NR`/`NF`, `length`/`substr`/`index`/`tolower`/`toupper`, arithmetic, **concatenation**) | ✅ | constant fields (`print 1`, `print "x"`) + juxtaposition concat (`print $1 $2`) landed. **Per-record print from an assoc-mutating rule (no `END` needed)**: `{ c[$1]++; print $1, c[$1] }` (a running count) and `{ split($0,a,","); print a[1] }` (print an element) compile — previously an assoc program had to be END-tethered (a rule that mutated a table *and* printed per-record was rejected unless the program also had an `END { print arr[…] }`). Body-print fields: `$N` (N>0), `$0` (the whole record), `arr[N]` (integer element — split/positional tables keyed by position; str values resolve to text, i64 counters print numerically), `arr[$k]` (field-keyed lookup), a **string literal** (its bytes ride the assoc rule chain's global channel; printed via `%s`, so a `%` in the literal is verbatim), and scalar reads — in a comma-separated print list **or glued by juxtaposition-concat** (`print "x=" c[$1]` → `x=5`; the concat parts print adjacently with no separator, reusing the per-field emitters) |
-| `printf` | ✅ | standard `%[flags][width][.precision][length]conv`: integers `d`/`i`/`x`/`X`/`o`/`u` + `c` (code point), floats `f`/`g`/`e`/`F`/`G`/`E`, strings `%s`; flags `-+ 0#`, width, precision. Field-slice `%s` takes width but not precision (non-terminated buffer); `%c` needs a numeric arg |
+| `printf` | ✅ | standard `%[flags][width][.precision][length]conv`: integers `d`/`i`/`x`/`X`/`o`/`u` + `c` (code point), floats `f`/`g`/`e`/`F`/`G`/`E`, strings `%s`; flags `-+ 0#`, width, precision. Field-slice `%s` takes width but not precision (non-terminated buffer); `%c` needs a numeric arg. **Works in a rule body and in an `END` block** (`END { printf "%d items\n", n }`, arguments reading the final scalar slots); a bare integer literal argument is accepted in both. `BEGIN { printf … }` is still a parse error (its own action grammar) |
 | var assignment, `+=`, `++`, `//` | ✅ | indexed native scalar slots |
 | `if` / `else` (chains) | ✅ | field/pattern guards (`$1 > 2`, `$0 ~ /re/`), scalar-variable conditions (`if (i > 2)`, `if (i < n && j > 0)`) in rule bodies, loops, **and `END`**, **and string guards on a string scalar** (`if (s == "text")` — `==`/`!=` via interned atom-id compare, `<`/`<=`/`>`/`>=` via `strcmp` — a single comparison, not combined with `&&`/`||`). **POSIX strnum duality is partially landed**: a scalar copied from a field (`x = $1`) that is only printed or compared against another such strnum or a string literal is typed `scalar_strnum` and compares **numerically or lexically by its runtime content** (`x=$1;y=$2; if (x>y)` gives `10 9`→numeric, `10 9x`→lexical, via `@wam_strnum_cmp`). Comparison against an **integer literal** works too (`if (x > 3)`, `if (n == 5)` via `@wam_strnum_cmp_int` — `"abc" > 3` lexically true, `"5x" == 5` false), and a strnum read in **pure arithmetic** is coerced to a number (`y = x + 1` — i64 via the same field parser as before, so byte-identical; f64 via `strtod`), letting a field copy be used in both arithmetic and a string/number comparison. A plain copy `z = x` **propagates** strnum-ness (transitively through chains). Names read in a string concat / call / ternary / index still stay on the plain i64 path via a greatest-fixpoint read-use gate — no regressions. **Split-array elements compare too**: in an `END` for-in filter `for (k in a) { if (a[k] CMP …) … }`, a str-valued (split / `as assoc(str)`) element compares against **an integer** via `@wam_strnum_cmp_int` on its text (numeric when it looks like a number, else lexical) instead of a raw i64 icmp on its atom id — which had silently compared registry positions (a bug); and against **a string literal** — `==`/`!=` via canonical atom-id `icmp eq/ne` (the literal interned from a module constant), the **ordering** ops (`a[k] < "x"` etc.) via `strcmp` on the element text. A **float-literal** RHS (`a[k] < 3.5`) compares via `@wam_strnum_cmp_double` on a str element, or widens an i64 counter to `double` + `fcmp`. Counter tables (`arr[k]++`, a genuine i64) keep the plain icmp for integer RHS. **Non-field strnum sources landed**: a scalar from a command-line argument (`x = ARGV[N]`) or a getline read (`getline v < "file"`, `s = getline v < "file"`) is a strnum too — `if (x > 5)` dispatches through `@wam_strnum_cmp_int` on its text (previously it compared the interned atom id — every value looked "big", a bug). A candidate whose reads are unsupported (e.g. used in a concat) deactivates to a plain string scalar (its prior behaviour), so activation never regresses. Remaining: general rule-body `arr[N]` element reads (outside the compilable surface — only the for-in contexts read elements); nested-block field copies (blocked on a pre-existing nested-assignment control-flow limitation). See `PLAWK_STRNUM_DUALITY.md` for the representation and phased plan |
 | `for (k in arr)` | ✅ | assoc for-in (rule body + END). **NR guards on group-by rules now work** (`NR > 1 { c[$1]++ } END { for (k in c) print k, c[k] }`, the skip-a-header idiom; also `NR==2, NR==3` ranges and the multi-for-in / accumulate END shapes) — the assoc-END drivers now emit the per-record `%current_nr` counter when a rule references NR (byte-identical when it does not); previously a rule NR guard referenced an undefined `%current_nr` and clang failed. The decode-into-struct END driver declines cleanly on NR (a follow-on). **Multiple for-in loops in one END block landed** (`END { for (a in c) print a, c[a]; for (b in d) print b, d[b] }`) — the "dump several tables" idiom: a general multi-statement END parser rule (statements separated by `;`/newline) plus a driver that chains the loops (each walks its own table with index-suffixed labels; loop 0 keeps the historical unsuffixed names so single-loop IR is byte-identical; the last loop frees all tables and returns). v1 each statement is a for-in printing the key and/or `arr[k]` lookups; a for-in print with a string literal declines cleanly (a follow-on). **Multiple plain prints in an END block also landed** (`{ s+=$1; n++ } END { print s; print n }`, scalar chain) — each print is emitted independently and per-print renamed so its SSA/globals stay unique (single-print IR byte-identical); NR and concat work in the prints. An assoc-table program with a multi-print END, or a mixed for-in/print END, remains a follow-on (declines) |
@@ -146,9 +146,28 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    takes flags/width and rides `.*` for its length, so a user precision on a
    field is a clean compile error (buffer safety) — a follow-on. `%c` needs a
    numeric arg (a string arg's first-char form is a follow-on). Tests:
-   `tests/test_plawk_printf.pl`. *Still open (follow-on):* `%c` on a string
-   (first char), precision on a field slice, `*`-width (width from an arg), and
-   `printf` in a `BEGIN`/`END` block (a separate driver gap).
+   `tests/test_plawk_printf.pl`. **`printf` in an `END` block landed** -- `END { printf "%d items\n", n }`.
+   `printf` was not in the END statement grammar at all, so even
+   `END { printf "hi\n" }` was a PARSE ERROR rather than a clean decline. END
+   runs after the record loop, so an argument cannot slice `$0`/`$N`; the
+   arguments read the FINAL scalar slots exactly as an END `print` field does
+   (i64 counters, double slots, string/strnum slots resolved from their
+   interned id, `NR`, string / integer / float literals, and scalar
+   arithmetic). It composes with `print` in the same END block in either
+   order, and appends no ORS -- the format is the whole output contract.
+   Everything after the arguments (kind inference, the awk->C format
+   rewrite, the format global, the `@printf` call) is shared with the
+   record-context printf via `plawk_printf_from_arg_pairs/4`: two argument
+   producers, one consumer, so a format fix cannot land in one context
+   only. A **bare integer literal argument** now works in both contexts too
+   (`printf "%d\n", 42` -- a bare float already did; `print 1` still renders a
+   constant as its text, which is right for print and wrong for a `%d`
+   conversion). Tests: `tests/test_plawk_end_printf.pl`.
+   *Still open (follow-on):* `%c` on a string
+   (first char), precision on a field slice, `*`-width (width from an arg),
+   `printf` in a **`BEGIN`** block (still a parse error -- BEGIN has its own
+   action grammar and print emitter), and an END printf argument that reads a
+   field or an assoc element (both decline cleanly).
 4. **`exit [n]` — LANDED.** A rule-level `exit` / `exit N` stops the record loop,
    runs END, and returns N (default 0). It reuses the rule-level stream-break
    path (`break_close_stream` → END → `ret`), adding an exit code stored in
@@ -178,8 +197,14 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    assignment, and a read/print resolves the id to text — id 0 is the unset
    sentinel, printed as empty. Numeric and string scalars coexist in one
    program. Tests: `tests/test_plawk_strscalar.pl`. *Still open (follow-on):*
-   a scalar-var concat operand (`x = x $1` accumulation), string scalars in an
-   `if`/loop body, and string comparison/guards on a string scalar.)
+   string comparison / guards on a string scalar (`END { if (s == "c") … }`
+   declines). Accumulation `x = x $1` DOES work (verified against gawk --
+   this was listed as open in error). **Known bug, not just a gap:** a string
+   scalar assigned inside an `if` body (`{ if (NR > 1) s = $1 } END { print s }`)
+   compiles but prints `0` instead of the text -- the nested assignment does
+   not classify the slot as string-valued, so it lands in an i64 slot. Wrong
+   output rather than a decline, so it needs fixing before the rest of the
+   string-scalar follow-ons.)
 6. **`delete arr[k]` — LANDED (field key).** `delete arr[$k]` removes the entry
    keyed by field k, matching the counted inc `arr[$k]++`. The runtime primitive
    `@wam_assoc_i64_delete` does **backward-shift deletion** on the linear-probing

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -701,21 +701,23 @@ plawk_program_native_driver_ir(
             NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
-% Multiple plain prints in an END block (`END { print a; print b }`), scalar
-% chain. Same driver wiring as the single-print scalar clause above, but the END
-% is a sequence of prints, each emitted (and per-print renamed) by
-% plawk_scalar_end_prints_ir. The `[_,_|_]` + all-prints guard keeps it disjoint
-% from the single-print clause and from the for-in / accumulate END shapes (which
-% are not plain prints). A mixed for-in/print END declines (plawk_end_print_list
-% fails), a follow-on.
+% A sequence of plain output statements in an END block, scalar chain: multiple
+% prints (`END { print a; print b }`), a `printf` (`END { printf "%d\n", n }`),
+% or a mix. Same driver wiring as the single-print scalar clause above, but the
+% END is a statement list, each statement emitted (and per-statement renamed) by
+% plawk_scalar_end_prints_ir. The guard excludes a lone plain print -- the
+% dedicated clause above owns that shape and stays byte-identical -- and
+% plawk_end_output_list/2 rejects for-in / if ENDs, keeping this disjoint from
+% those drivers. A mixed for-in/print END declines, a follow-on.
 plawk_program_native_driver_ir(
-    program(BeginClauses, Rules0, [end(Prints)]),
+    program(BeginClauses, Rules0, [end(Statements)]),
     InputPath,
     DriverIR
 ) :-
-    Prints = [_, _ | _],
-    plawk_end_print_list(Prints, PrintFieldsList),
-    append(PrintFieldsList, AllFields),
+    Statements = [_ | _],
+    Statements \= [print(_)],
+    plawk_end_output_list(Statements, StatementExprs),
+    append(StatementExprs, AllFields),
     plawk_resolve_writebin_rules(BeginClauses, Rules0, Rules1, WritebinPlan),
     plawk_record_descriptor(BeginClauses, FieldSeparator),
     plawk_resolve_dynrec_view_rules(Rules1, Rules1b),
@@ -727,7 +729,7 @@ plawk_program_native_driver_ir(
     plawk_writebin_entry_lines(WritebinPlan, WritebinEntryIR),
     plawk_join_nonempty_ir([BeginIR0, WritebinEntryIR], BeginIR),
     plawk_record_program_ok(FieldSeparator, Rules, AllFields),
-    plawk_scalar_end_prints_ir(Prints, StatePlan, OutputSeparator, EndPrintIR,
+    plawk_scalar_end_prints_ir(Statements, StatePlan, OutputSeparator, EndPrintIR,
         StringGlobalIR),
     plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, OutputSeparator,
         RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
@@ -13432,6 +13434,11 @@ plawk_rule_body_print_field(environ(Key)) :- string(Key).
 plawk_rule_body_print_field(argv_at(N)) :- integer(N), N >= 0.
 plawk_rule_body_print_field(special('ARGC')).
 plawk_rule_body_print_field(int(field(_))).
+% a bare integer literal -- reachable only as a printf ARGUMENT (`printf
+% "%d\n", 42`); `print 1` renders the constant as text instead. integer/1 keeps
+% it disjoint from the int(field(N)) truncation builtin above.
+plawk_rule_body_print_field(int(Value)) :-
+    integer(Value).
 plawk_rule_body_print_field(Expr) :-
     plawk_i64_general_binary_expr(Expr).
 plawk_rule_body_print_field(Expr) :-
@@ -16648,6 +16655,129 @@ plawk_scalar_end_prints_ir_([print(Fields) | Rest], I, StatePlan, OutputSeparato
     plawk_end_print_suffix_rename(I, RawGlobal, Global),
     I1 is I + 1,
     plawk_scalar_end_prints_ir_(Rest, I1, StatePlan, OutputSeparator, Blocks, Globals).
+% `printf` in END. Unlike `print` it takes no OFS between arguments and appends
+% no ORS -- the format string is the entire output contract -- so it does not go
+% through the print-field emitters at all; it emits its own arguments and shares
+% the format rewriter with the record-context printf.
+plawk_scalar_end_prints_ir_([printf(string(Format), Args) | Rest], I, StatePlan,
+        OutputSeparator, [Block | Blocks], [Global | Globals]) :-
+    plawk_end_printf_ir(Format, Args, StatePlan, RawGlobal-RawBlock),
+    plawk_end_print_suffix_rename(I, RawBlock, Block),
+    plawk_end_print_suffix_rename(I, RawGlobal, Global),
+    I1 is I + 1,
+    plawk_scalar_end_prints_ir_(Rest, I1, StatePlan, OutputSeparator, Blocks, Globals).
+
+%% plawk_end_printf_ir(+Format, +Args, +StatePlan, -GlobalIR-IR)
+%
+%  `END { printf "fmt", args }`. END runs after the record loop, so there is no
+%  current record and an argument cannot slice `$0`/`$N`; the arguments read the
+%  FINAL scalar slot values (`%final_slot_N`, established by the break-close
+%  phi) exactly as an END `print` field does. Everything after the arguments --
+%  argument kinds, the awk->C format rewrite, the format global, the `@printf`
+%  call -- is the shared plawk_printf_from_arg_pairs/4, so a format rewrite fix
+%  lands in both contexts at once.
+%
+%  The emitted names are all `plawk_end_printf`-prefixed, which contains
+%  `end_`, so plawk_end_print_suffix_rename/3 uniquifies them across multiple
+%  END statements the same way it does for prints. `%final_slot_N` and
+%  `%plawk_nr` are defined OUTSIDE this block and contain no `end_`, so the
+%  rename leaves them alone.
+plawk_end_printf_ir(Format, Args, StatePlan, Pair) :-
+    phrase(plawk_end_printf_arg_pairs(Args, StatePlan, plawk_end_printf, 0),
+        ArgPairs),
+    plawk_printf_from_arg_pairs(ArgPairs, Format, plawk_end_printf, Pair).
+
+plawk_end_printf_arg_pairs([], _StatePlan, _Prefix, _Index) -->
+    [].
+plawk_end_printf_arg_pairs([Arg | Args], StatePlan, Prefix, Index) -->
+    { plawk_end_printf_arg(Arg, StatePlan, Prefix, Index, GlobalParts, SetupParts,
+          CallArgs),
+      plawk_join_nonempty_ir(GlobalParts, GlobalIR),
+      plawk_join_nonempty_ir(SetupParts, SetupIR),
+      NextIndex is Index + 1
+    },
+    [GlobalIR-(SetupIR-CallArgs)],
+    plawk_end_printf_arg_pairs(Args, StatePlan, Prefix, NextIndex).
+
+%% plawk_end_printf_arg(+Arg, +StatePlan, +Prefix, +Index, -Globals, -Setup,
+%%     -CallArgs) is semidet.
+%  One END printf argument, lowered to the printf call-argument vocabulary
+%  (`i64(IR)` / `f64(IR)` / `string_ptr(IR)`). Fails for anything END cannot
+%  reach (a field read, say), so the driver declines rather than emitting a
+%  printf over an undefined value.
+
+% A double scalar slot passes as a native double (%g / %f / %e conversions).
+plawk_end_printf_arg(var(Name), StatePlan, _Prefix, _Index, [], [],
+        [f64(ValueIR)]) :-
+    plawk_state_slot_lookup(StatePlan, Name, SlotIndex, scalar_double(_)),
+    !,
+    format(atom(ValueIR), '%final_slot_~w', [SlotIndex]).
+% A string / strnum scalar slot holds an interned atom id: resolve it to text
+% for `%s`. Id 0 is the unset sentinel and must print as empty rather than
+% resolving to whatever atom 0 is -- the shared `"%s\0"` global's trailing NUL
+% is a ready-made empty C string, the same trick the END print path uses.
+plawk_end_printf_arg(var(Name), StatePlan, Prefix, Index, [], Setup,
+        [string_ptr(PtrIR)]) :-
+    plawk_state_slot_lookup(StatePlan, Name, SlotIndex, Slot),
+    ( Slot = scalar_string(_) ; Slot = scalar_strnum(_) ),
+    !,
+    format(atom(ValueIR), '%final_slot_~w', [SlotIndex]),
+    format(atom(Base), '~w_arg~w', [Prefix, Index]),
+    format(atom(StrS), '  %~w_s = call i8* @wam_atom_to_string(i64 ~w)',
+        [Base, ValueIR]),
+    format(atom(StrE), '  %~w_empty = icmp eq i64 ~w, 0', [Base, ValueIR]),
+    format(atom(StrSel),
+        '  %~w_ptr = select i1 %~w_empty, i8* getelementptr ([3 x i8], [3 x i8]* @.plawk_surface_print_string, i64 0, i64 2), i8* %~w_s',
+        [Base, Base, Base]),
+    format(atom(PtrIR), '%~w_ptr', [Base]),
+    Setup = [StrS, StrE, StrSel].
+% Any other scalar slot is an i64 counter.
+plawk_end_printf_arg(var(Name), StatePlan, _Prefix, _Index, [], [],
+        [i64(ValueIR)]) :-
+    plawk_state_slot_lookup(StatePlan, Name, SlotIndex, _Slot),
+    !,
+    format(atom(ValueIR), '%final_slot_~w', [SlotIndex]).
+plawk_end_printf_arg(special('NR'), StatePlan, _Prefix, _Index, [], [],
+        [i64(ValueIR)]) :-
+    !,
+    plawk_end_nr_value(StatePlan, ValueIR).
+% A string literal argument gets its own module global.
+plawk_end_printf_arg(string(Value), _StatePlan, Prefix, Index, [GlobalIR], [PtrLine],
+        [string_ptr(PtrIR)]) :-
+    !,
+    format(atom(GlobalName), '~w_arg~w_str', [Prefix, Index]),
+    llvm_emit_c_string_global(GlobalName, Value, GlobalIR, _StringLen, BytesLen),
+    format(atom(PtrIR), '%~w_arg~w_str_ptr', [Prefix, Index]),
+    format(atom(PtrLine),
+        '  ~w = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0',
+        [PtrIR, BytesLen, BytesLen, GlobalName]).
+% An integer / float literal or scalar arithmetic over the final slots: reuse
+% the shared expression emitters after substituting the reads, exactly as the
+% END expression PRINT path does, so `printf "%d\n", n + 1` and
+% `printf "%.2f\n", total / n` work wherever `print n + 1` does.
+plawk_end_printf_arg(Expr, StatePlan, Prefix, Index, [], SetupParts, [CallArg]) :-
+    plawk_end_printf_value_expr(Expr),
+    plawk_substitute_end_reads(Expr, StatePlan, Substituted),
+    format(atom(Base), '~w_arg~w', [Prefix, Index]),
+    (   plawk_expr_is_double(Substituted)
+    ->  plawk_f64_expr_ir(Substituted, 32, Base, Base, ValueIR, [], SetupParts),
+        CallArg = f64(ValueIR)
+    ;   plawk_i64_expr_ir(Substituted, 32, Base, Base, ValueIR, [], SetupParts),
+        CallArg = i64(ValueIR)
+    ).
+
+%% plawk_end_printf_value_expr(+Expr) is semidet.
+%  An END printf argument that lowers through the numeric expression emitters:
+%  an integer or float literal, or scalar arithmetic over slots / NR (the same
+%  operand surface `print` accepts in END).
+plawk_end_printf_value_expr(int(Value)) :-
+    integer(Value).
+plawk_end_printf_value_expr(float_const(Mantissa, Denominator)) :-
+    integer(Mantissa),
+    integer(Denominator),
+    Denominator > 0.
+plawk_end_printf_value_expr(Expr) :-
+    plawk_end_scalar_expr(Expr).
 
 % Suffix a print's `end_`-prefixed SSA/globals (and its `end_print_string_N`
 % literal globals) so multiple END prints do not collide. I=0 is unchanged
@@ -16659,11 +16789,16 @@ plawk_end_print_suffix_rename(I, IR0, IR) :-
     format(atom(Repl), 'end~w_', [I]),
     plawk_atom_replace_all(IR0, 'end_', Repl, IR).
 
-% Every element of an END statement list is a plain print; collect their fields.
-% Fails on any non-print element, so a mixed for-in/print END declines cleanly.
-plawk_end_print_list([], []).
-plawk_end_print_list([print(Fields) | Rest], [Fields | More]) :-
-    plawk_end_print_list(Rest, More).
+% Every element of an END statement list is a plain output statement -- a
+% `print` or a `printf`; collect the expressions each one reads (print fields /
+% printf arguments) so the scalar state plan keeps a slot for every scalar the
+% END touches. Fails on any other element (a for-in, an if), so those END shapes
+% fall through to their own drivers or decline cleanly.
+plawk_end_output_list([], []).
+plawk_end_output_list([print(Fields) | Rest], [Fields | More]) :-
+    plawk_end_output_list(Rest, More).
+plawk_end_output_list([printf(string(_Format), Args) | Rest], [Args | More]) :-
+    plawk_end_output_list(Rest, More).
 
 %% END { if (COND) print ...; [else print ...] } support ---------------------
 
@@ -18154,8 +18289,23 @@ plawk_prefixed_print_action_ir(Fields, FieldSeparator, OutputSeparator, Prefix, 
     plawk_join_nonempty_ir(GlobalParts, GlobalIR),
     atomic_list_concat(BodyParts, '\n', IR).
 
-plawk_prefixed_printf_action_ir(Format, Args, FieldSeparator, Prefix, GlobalIR-IR) :-
+plawk_prefixed_printf_action_ir(Format, Args, FieldSeparator, Prefix, Pair) :-
     phrase(plawk_printf_arg_pairs(Args, FieldSeparator, Prefix, 0), ArgPairs),
+    plawk_printf_from_arg_pairs(ArgPairs, Format, Prefix, Pair).
+
+%% plawk_printf_from_arg_pairs(+ArgPairs, +Format, +Prefix, -GlobalIR-IR)
+%
+%  Everything downstream of the ARGUMENTS: infer each call argument's kind,
+%  rewrite the awk format to a C printf format against those kinds, then emit
+%  the format global and the `@printf` call. Argument-shape agnostic -- an
+%  ArgPair is `GlobalIR-(SetupIR-CallArgs)` with CallArgs drawn from the
+%  plawk_printf_call_arg_kind/2 vocabulary -- so record-context arguments
+%  (plawk_printf_arg_pairs//4, which can slice the current record) and
+%  END-context arguments (plawk_end_printf_arg_pairs//4, which read final
+%  scalar slots because END has no record) share ONE format rewriter and call
+%  emitter. Two producers, one consumer, so the format rewrite cannot drift
+%  between the two contexts.
+plawk_printf_from_arg_pairs(ArgPairs, Format, Prefix, GlobalIR-IR) :-
     pairs_keys_values(ArgPairs, ArgGlobalParts, ArgInfoPairs),
     pairs_keys_values(ArgInfoPairs, ArgSetupParts, ArgCallArgLists),
     append(ArgCallArgLists, CallArgs),
@@ -18436,6 +18586,17 @@ plawk_emit_print_expr_for_context(special('NF'), FieldSeparator, Context,
     plawk_print_expr_value_base(Context, nf, Base),
     plawk_print_expr_output_names(Context, nf, FmtPrefix, PrintPrefix),
     plawk_i64_expr_ir(nf, FieldSeparator, Base, Base, ValueIR, GlobalParts, SetupParts).
+
+% A bare integer literal (a printf argument -- `printf "%d\n", 42`). Guarded by
+% integer/1 so it stays disjoint from the `int(field(N))` truncation builtin
+% below.
+plawk_emit_print_expr_for_context(int(Value), _FieldSeparator, Context,
+        i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
+    integer(Value),
+    plawk_print_expr_value_base(Context, int, Base),
+    plawk_print_expr_output_names(Context, int, FmtPrefix, PrintPrefix),
+    plawk_i64_expr_ir(int(Value), 0, Base, Base, ValueIR, GlobalParts,
+        SetupParts).
 
 plawk_emit_print_expr_for_context(int(field(FieldIndex)), FieldSeparator, Context,
         i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -2021,6 +2021,13 @@ end_action(unsupported_getline(end(Action))) -->
 end_action(Action) -->
     if_action(Action),
     !.
+% `END { printf "fmt", args }` -- tried BEFORE print_action so the longer
+% keyword wins (otherwise `print` would match the prefix of `printf` and leave
+% a stray `f`). END has no current record, so the args are scalar-context
+% expressions; codegen decides which shapes it can lower.
+end_action(Action) -->
+    printf_action(Action),
+    !.
 end_action(Action) -->
     print_action(Action).
 
@@ -3521,7 +3528,17 @@ printf_arg_expr(Ternary) -->
     ternary_expr(Ternary),
     !.
 printf_arg_expr(Expr) -->
-    field_expr(Expr).
+    field_expr(Expr),
+    !.
+% A bare INTEGER literal argument (`printf "%d\n", 42`). Last, so an expression
+% starting with a digit (`1 + 2`) still goes to field_expr's arithmetic surface
+% first. `print 1` renders a constant as its TEXT, which is fine for print but
+% wrong for printf -- a `%d`/`%x`/`%f` conversion needs the number, not a string
+% -- so this yields the `int(Value)` numeric leaf the i64 expression emitter
+% already understands. A bare FLOAT literal was already accepted (via
+% field_expr's float_literal_expr); this closes the integer half.
+printf_arg_expr(int(Value)) -->
+    signed_integer_value(Value).
 
 print_fields([Field | Fields]) -->
     print_field_expr(Field),

--- a/tests/test_plawk_end_printf.pl
+++ b/tests/test_plawk_end_printf.pl
@@ -1,0 +1,278 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk: `printf` in an END block -- `END { printf "%d items\n", n }`.
+%
+% Before this, `printf` was not in the END statement grammar at all, so even
+% `END { printf "hi\n" }` was a PARSE ERROR (exit 2) rather than a clean
+% decline -- plawk called a valid awk program malformed.
+%
+% END runs after the record loop, so there is no current record: an argument
+% cannot slice `$0`/`$N`. Arguments read the FINAL scalar slot values, exactly
+% as an END `print` field does -- i64 counters, double slots (%f/%g), string /
+% strnum slots (an interned atom id resolved to text, id 0 printing empty), NR,
+% string literals, integer and float literals, and scalar arithmetic over those.
+%
+% Everything after the arguments -- the awk->C format rewrite, the format
+% global, the `@printf` call -- is shared with the record-context printf
+% (plawk_printf_from_arg_pairs/4): two argument producers, one consumer, so a
+% format fix cannot land in one context and not the other.
+%
+% gawk 5.2 is the oracle for every expectation here.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+% Three records: "a 1" / "b 2" / "c 3".
+input("a 1\nb 2\nc 3\n").
+
+:- begin_tests(plawk_end_printf).
+
+% --- parsing ---------------------------------------------------------------
+
+% `printf` is an END statement, sitting beside `print` in the same list.
+test(end_printf_parses) :-
+    plawk_parse_string("{ n++ } END { printf \"%d\\n\", n }\n",
+        program([], [rule(always, [inc(var(n))])],
+            [end([printf(string("%d\n"), [var(n)])])])),
+    !.
+
+% `printf` must be tried before `print` in the END grammar, or `print` matches
+% the keyword prefix and leaves a stray `f`.
+test(end_printf_not_confused_with_print) :-
+    plawk_parse_string("{ n++ } END { print n; printf \"%d\\n\", n }\n",
+        program([], [rule(always, [inc(var(n))])],
+            [end([print([var(n)]), printf(string("%d\n"), [var(n)])])])),
+    !.
+
+% A lone plain print is untouched -- it still parses to the same single-print
+% END shape its own (byte-identical) driver clause owns.
+test(single_print_end_shape_unchanged) :-
+    plawk_parse_string("{ n++ } END { print n }\n",
+        program([], [rule(always, [inc(var(n))])], [end([print([var(n)])])])),
+    !.
+
+% --- output, against gawk --------------------------------------------------
+
+% No arguments: the format IS the output, and printf appends no newline of its
+% own (the "\n" here is the format's).
+test(printf_no_args, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"hi\\n\" }\n", "hi\n"),
+    !.
+
+% The classic: report an accumulated counter.
+test(printf_counter, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"%d items\\n\", n }\n", "3 items\n"),
+    !.
+
+% printf does NOT append ORS -- two printfs run together on one line, and only
+% the trailing "\n" in the second format ends it.
+test(printf_appends_no_newline, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"%d,\", n; printf \"%d\\n\", n + 1 }\n",
+        "3,4\n"),
+    !.
+
+% String literal argument (%s) and a literal `%%`.
+test(printf_string_literal_arg, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"%s!\\n\", \"done\" }\n", "done!\n"),
+    !.
+
+test(printf_percent_escape, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"100%%\\n\" }\n", "100%\n"),
+    !.
+
+% Several arguments of mixed kinds in one call.
+test(printf_mixed_args, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"%s %d %s\\n\", \"a\", n, \"z\" }\n",
+        "a 3 z\n"),
+    !.
+
+% NR in END is the final record count.
+test(printf_nr, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"NR=%d\\n\", NR }\n", "NR=3\n"),
+    !.
+
+% Scalar arithmetic over the final slots, same operand surface `print` accepts.
+test(printf_scalar_arithmetic, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"%d\\n\", n + 1 }\n", "4\n"),
+    !.
+
+% A double-valued slot passes as a native double, so %f precision applies.
+test(printf_double_slot, [condition(clang_available)]) :-
+    run_end("{ d = $2 / 2 } END { printf \"%.2f\\n\", d }\n", "1.50\n"),
+    !.
+
+% Division promotes to double in awk, so `n / 2` with n=3 is 1.50, not 1.
+test(printf_division_promotes_to_double, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"%.2f\\n\", n / 2 }\n", "1.50\n"),
+    !.
+
+% A string scalar's slot holds an interned atom id; %s resolves it to text.
+test(printf_string_scalar, [condition(clang_available)]) :-
+    run_end("{ s = $1 } END { printf \"%s!\\n\", s }\n", "c!\n"),
+    !.
+
+% A string scalar that IS assigned but holds id 0 (the unset sentinel) prints
+% empty rather than resolving to whatever atom 0 happens to be.
+test(printf_empty_string_scalar_is_empty, [condition(clang_available)]) :-
+    run_end("{ s = \"\" } END { printf \"[%s]\\n\", s }\n", "[]\n"),
+    !.
+
+% A NEVER-ASSIGNED variable has no scalar slot to read, so printf declines.
+% gawk prints "[]" (an uninitialised value is the empty string in string
+% context); plawk's END `print` prints "[0]" for the same program, because an
+% unassigned name lands in an i64 slot defaulting to 0. Both are the same
+% pre-existing uninitialised-scalar gap as the absent-array-element work, and
+% neither matches gawk -- printf declines rather than committing to the wrong
+% one of the two. Pinned so the follow-on that adds the dual value updates it.
+test(printf_never_assigned_var_declines) :-
+    build_status("{ n++ } END { printf \"[%s]\\n\", s }\n", 3),
+    !.
+
+% Flags / width / precision reach the C format unchanged.
+test(printf_width_flag, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"[%5d]\\n\", n }\n", "[    3]\n"),
+    !.
+
+test(printf_hex_conversion, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"%x\\n\", n }\n", "3\n"),
+    !.
+
+% --- print and printf in one END block ------------------------------------
+
+test(print_then_printf, [condition(clang_available)]) :-
+    run_end("{ n++ } END { print \"count:\"; printf \"%d\\n\", n }\n",
+        "count:\n3\n"),
+    !.
+
+% The printf leaves the line open and the following print closes it -- proof the
+% two statement kinds share one END block without either resetting the other.
+test(printf_then_print, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"%d \", n; print \"done\" }\n", "3 done\n"),
+    !.
+
+% --- integer literal printf arguments (both contexts) ---------------------
+
+% A bare INTEGER literal argument. `print 1` renders a constant as its text,
+% which is fine for print but wrong for a `%d`/`%x`/`%f` conversion, so a printf
+% argument yields the numeric int(Value) leaf instead. A bare FLOAT literal was
+% already accepted; this closes the integer half in BOTH contexts.
+test(printf_integer_literal_arg_in_end, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"%d\\n\", 42 }\n", "42\n"),
+    !.
+
+test(printf_integer_literal_arg_in_rule, [condition(clang_available)]) :-
+    run_prog("{ printf \"%d\\n\", 42 }\n", "42\n42\n42\n"),
+    !.
+
+test(printf_float_literal_arg, [condition(clang_available)]) :-
+    run_end("{ n++ } END { printf \"%.2f\\n\", 3.5 }\n", "3.50\n"),
+    !.
+
+% `print 1` still renders the constant as text -- unchanged by the above.
+test(print_integer_constant_unchanged, [condition(clang_available)]) :-
+    run_prog("{ print 1 }\n", "1\n1\n1\n"),
+    !.
+
+% --- clean declines (no miscompile) ---------------------------------------
+
+% END has no current record, so a field argument cannot be lowered. gawk keeps
+% $0 in END; plawk declines (status 3) rather than printing a stale or undefined
+% slice. A follow-on, together with END field reads generally.
+test(end_printf_field_arg_declines) :-
+    build_status("{ n++ } END { printf \"%s\\n\", $1 }\n", 3),
+    !.
+
+% An assoc element as an END printf argument is not wired yet -- declines
+% cleanly rather than reaching the printf call with a raw table value.
+test(end_printf_assoc_arg_declines) :-
+    build_status("{ c[$1]++ } END { printf \"%d\\n\", c[\"a\"] }\n", 3),
+    !.
+
+% --- IR shape --------------------------------------------------------------
+
+% The END printf reads a FINAL slot value (established by the break-close phi),
+% not a record slice, and emits no ORS terminator of its own.
+test(end_printf_ir_reads_final_slot) :-
+    plawk_parse_string("{ n++ } END { printf \"%d\\n\", n }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i64 %final_slot_0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'plawk_end_printf_fmt'))),
+    !.
+
+% Multiple END statements must not collide: each statement's `end_`-prefixed
+% names are suffixed by its index, so the second printf's format global and
+% call are distinct from the first's.
+test(end_printf_statements_get_distinct_names) :-
+    plawk_parse_string("{ n++ } END { printf \"%d,\", n; printf \"%d\\n\", n }\n",
+        Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_end_printf_fmt'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_end1_printf_fmt'))),
+    !.
+
+:- end_tests(plawk_end_printf).
+
+% --- helpers ---------------------------------------------------------------
+
+odir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_end_printf', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+% Build Src, run it over the shared input, and require Expected byte-for-byte
+% (printf output is separator-sensitive, so no sorting or trimming here).
+run_end(Src, Expected) :-
+    run_prog(Src, Expected).
+
+run_prog(Src, Expected) :-
+    odir(Dir),
+    input(Input),
+    % Remove any binary a previous test left behind, so a build that unexpectedly
+    % declines cannot silently run a stale executable and "pass".
+    directory_file_path(Dir, 'ep_bin', StaleBin),
+    ( exists_file(StaleBin) -> delete_file(StaleBin) ; true ),
+    build(Dir, 'ep', Src, Bin, In, Input),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out),
+    close(PS),
+    process_wait(Pid, exit(0)),
+    assertion(Out == Expected).
+
+build(Dir, Name, Src, Bin, In, Input) :-
+    directory_file_path(Dir, Name, Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], 0),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)).
+
+% Build only, asserting the CLI status (3 = parses but outside the compilable
+% surface -- a clean decline, distinct from 2 = parse error).
+build_status(Src, ExpectedStatus) :-
+    odir(Dir),
+    directory_file_path(Dir, 'ep_decline', Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], ExpectedStatus).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
`END { printf "%d items\n", n }` — one of the most common awk idioms — was a **parse error** (exit 2), not a clean decline. `printf` was not in the END statement grammar at all, so even `END { printf "hi\n" }` made plawk call a valid awk program malformed.

## What works now

END runs after the record loop, so there is no current record and an argument cannot slice `$0`/`$N`. The arguments read the **final scalar slot values** (`%final_slot_N`, established by the break-close phi) exactly as an END `print` field does:

| argument | example | output |
|---|---|---|
| i64 counter | `END { printf "%d items\n", n }` | `3 items` |
| double slot | `{ d = $2 / 2 } END { printf "%.2f\n", d }` | `1.50` |
| string / strnum slot | `{ s = $1 } END { printf "%s!\n", s }` | `c!` |
| `NR` | `END { printf "NR=%d\n", NR }` | `NR=3` |
| string literal | `END { printf "%s!\n", "done" }` | `done!` |
| int / float literal | `END { printf "%.2f\n", 3.5 }` | `3.50` |
| scalar arithmetic | `END { printf "%d\n", n + 1 }` | `4` |

It composes with `print` in the same END block in either order, and appends **no ORS** — the format string is the whole output contract, so `END { printf "%d,", n; printf "%d\n", n + 1 }` prints `3,4` on one line. Every expectation was checked against gawk 5.2.

## Structure

Everything downstream of the arguments — call-argument kind inference, the awk→C format rewrite, the format global, the `@printf` call — is factored out of the record-context emitter into `plawk_printf_from_arg_pairs/4` and shared:

- **producer 1** `plawk_printf_arg_pairs//4` — record context, can slice the current record
- **producer 2** `plawk_end_printf_arg_pairs//4` — END context, reads final slots
- **one consumer** — so a format-rewrite fix cannot land in one context and not the other

That's deliberately the same anti-drift shape as the `plawk_posarray_producer/3` table from the audit PR: the property (here, how a format is rewritten against argument kinds) gets computed in exactly one place.

## Also closed: a bare integer literal argument

Found on the way — a bare **float** literal was already an accepted printf argument but a bare **integer** was not, in *either* context: `printf "%d\n", 42` was a parse error even in a rule body. `print 1` renders a constant as its **text**, which is right for print and wrong for a `%d`/`%x`/`%f` conversion, so a printf argument now yields the numeric `int(Value)` leaf the i64 expression emitter already understands. Both contexts verified against gawk; `print 1` is unchanged.

## Clean declines (status 3, not miscompiles)

- **a field argument in END** — gawk keeps `$0` in END; plawk will not print an undefined slice.
- **an assoc element argument** — not wired yet.
- **a never-assigned variable** — worth flagging: gawk prints empty, and plawk's END `print` prints `0` for the same program (an unassigned name lands in an i64 slot). **Neither matches gawk**, so printf declines rather than committing to the wrong one of the two. Pinned by a test so the uninitialised-dual-value follow-on updates it.

`BEGIN { printf … }` remains a parse error — BEGIN has its own action grammar, print emitter, and no scalar slots — and is the natural next increment.

## No regressions

The existing END shapes (single print, multi print, string scalar) emit **byte-identical IR**, verified by golden dump diff against the merge base. The single-plain-print END keeps its own dedicated driver clause; the generalized clause explicitly excludes that shape.

`tests/test_plawk_end_printf.pl` — 28 tests: parsing (including that `printf` must beat `print` on the keyword prefix), each argument kind, ORS behaviour, print/printf mixing in both orders, per-statement name uniquing, the clean declines, and IR shape. The runner deletes any prior binary before building, so a build that unexpectedly declines cannot silently run a stale executable and "pass" — which is exactly how one bad expectation hid itself during development.

Suites green: `printf`, `end_printf`, `multi_print_end`, `end_if`, `surface_end_scalar_exprs`, `strscalar`, `ternary`, `exit`, `surface_forin_end_print`, `multi_forin_end`, `delete`, `subsep`, `absent_key_read`, `expr_pattern`, `scalar_pattern`.

## Two stale doc entries corrected

While verifying the follow-on list I found the feature audit was wrong on two counts, both now fixed in `PLAWK_AWK_FEATURE_AUDIT.md`:

1. `x = x $1` string accumulation **already works** (`{ s = s $1 } END { print s }` → `abc`, matching gawk) — it was listed as open.
2. A string scalar assigned inside an `if` body — `{ if (NR > 1) s = $1 } END { print s }` — **compiles but prints `0` instead of the text**. The nested assignment doesn't classify the slot as string-valued, so it lands in an i64 slot. That's a **wrong-output bug, not a gap**; confirmed present at the merge base, so it's pre-existing and outside this PR, but it's now recorded as a bug rather than as an unimplemented feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_