### PR TITLE
plawk: fix string scalars assigned inside an if / loop body

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -196,15 +196,24 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    SSA/phi scalar machinery), the RHS is built into a buffer and interned at
    assignment, and a read/print resolves the id to text — id 0 is the unset
    sentinel, printed as empty. Numeric and string scalars coexist in one
-   program. Tests: `tests/test_plawk_strscalar.pl`. *Still open (follow-on):*
-   string comparison / guards on a string scalar (`END { if (s == "c") … }`
-   declines). Accumulation `x = x $1` DOES work (verified against gawk --
-   this was listed as open in error). **Known bug, not just a gap:** a string
-   scalar assigned inside an `if` body (`{ if (NR > 1) s = $1 } END { print s }`)
-   compiles but prints `0` instead of the text -- the nested assignment does
-   not classify the slot as string-valued, so it lands in an i64 slot. Wrong
-   output rather than a decline, so it needs fixing before the rest of the
-   string-scalar follow-ons.)
+   program. Tests: `tests/test_plawk_strscalar.pl`. **String scalars in an `if` / loop body landed.**
+   `{ if (NR > 1) s = $1 } END { print s }` used to compile and print `0`
+   instead of the text: the slot collector descends into `if` branches and
+   foreach / while / do-while bodies, but the string-name and strnum
+   collectors looked at TOP-LEVEL rule-body actions only, so the slot existed
+   while its TYPE was decided by a view that never saw the assignment. All
+   three now walk one shared `plawk_scalar_nested_action/2`, at any nesting
+   depth. Fixing the reach exposed a second, PRE-EXISTING bug (no nesting
+   needed): a name written both as a field copy and as a string
+   (`{ s = "x"; s = $1 }`) types as a string slot -- a literal write
+   disqualifies strnum -- but the field-copy STORE had only a strnum clause,
+   so it fell through to the generic NUMERIC store and printing resolved atom
+   id 0 to empty. String and strnum slots both hold an interned atom id, so
+   both write paths now sit behind `plawk_slot_holds_text/1`. Tests:
+   `tests/test_plawk_nested_string_scalar.pl`. Accumulation `x = x $1` also
+   works (it was listed as open in error).
+   *Still open (follow-on):* string comparison / guards on a string scalar
+   (`END { if (s == "c") … }` declines).)
 6. **`delete arr[k]` — LANDED (field key).** `delete arr[$k]` removes the entry
    keyed by field k, matching the counted inc `arr[$k]++`. The runtime primitive
    `@wam_assoc_i64_delete` does **backward-shift deletion** on the linear-probing

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -6906,6 +6906,16 @@ plawk_slot_name(scalar_counter(Name), Name).
 plawk_slot_name(scalar_double(Name), Name).
 % A string scalar's slot holds an interned atom id (an i64); the id 0 is the
 % "unset" sentinel, printed as the empty string.
+%% plawk_slot_holds_text(+Slot) is semidet.
+%  Slot kinds whose i64 payload is an interned ATOM ID rather than a number: a
+%  string scalar and a strnum scalar share that representation, and differ only
+%  in comparison-time dispatch (lexical vs POSIX strnum). Every WRITE path must
+%  therefore treat them alike -- keeping them behind one guard is what stops a
+%  store emitter from handling one kind and silently mis-storing the other as a
+%  number.
+plawk_slot_holds_text(scalar_string(_Name)).
+plawk_slot_holds_text(scalar_strnum(_Name)).
+
 plawk_slot_name(scalar_string(Name), Name).
 % A strnum scalar (POSIX numeric-string duality, PLAWK_STRNUM_DUALITY.md): a
 % value copied from a strnum source (a field for now) that compares numerically
@@ -7291,15 +7301,45 @@ plawk_scalar_typed_slots(Rules, Names, Slots) :-
     ord_subtract(Strings0, Strnums, Strings),
     maplist(plawk_scalar_typed_slot(Doubles, Strings, Strnums), Names, Slots).
 
+%% plawk_scalar_nested_action(+Action, -Inner) is nondet.
+%
+%  Action itself, plus every action nested inside it at any depth: both `if`
+%  branches, and foreach / while / do-while bodies.
+%
+%  The scalar collectors that ask "which names does this rule write, and how?"
+%  must all walk the SAME shape. plawk_scalar_update_name_expr/3 descends into
+%  these containers (so a name assigned only inside a branch does get a slot)
+%  while plawk_scalar_string_names/2 used to look at top-level actions only --
+%  so the slot existed but its TYPE was decided by a collector that never saw
+%  the assignment, and `{ if (NR > 1) s = $1 } END { print s }` silently printed
+%  `0` (the i64 default) instead of the text. Sharing this walker is what keeps
+%  the two views from drifting again.
+plawk_scalar_nested_action(Action, Action).
+plawk_scalar_nested_action(if(_Pattern, ThenActions, ElseActions), Inner) :-
+    (   member(Action, ThenActions)
+    ;   member(Action, ElseActions)
+    ),
+    plawk_scalar_nested_action(Action, Inner).
+plawk_scalar_nested_action(foreach_loop(_Layout, Body), Inner) :-
+    member(Action, Body),
+    plawk_scalar_nested_action(Action, Inner).
+plawk_scalar_nested_action(while_loop(_Cond, Body), Inner) :-
+    member(Action, Body),
+    plawk_scalar_nested_action(Action, Inner).
+plawk_scalar_nested_action(do_while_loop(Body, _Cond), Inner) :-
+    member(Action, Body),
+    plawk_scalar_nested_action(Action, Inner).
+
 % A scalar is string-typed when it is assigned a string RHS (`x = $1 $2` or
-% `x = "text"`), tracked separately from the double/counter fixpoint. v1 looks
-% at top-level rule-body assignments; a nested (if/loop-body) string assignment
-% is a follow-on.
+% `x = "text"`), tracked separately from the double/counter fixpoint. Walks
+% nested if/loop bodies via plawk_scalar_nested_action/2, matching the slot
+% collector's reach -- a string assigned only inside a branch is still a string.
 plawk_scalar_string_names(Rules, Strings) :-
     findall(Name,
         ( member(rule(_Pattern, Actions0), Rules),
           plawk_trim_control_tails(Actions0, Actions),
-          member(Action, Actions),
+          member(Action0, Actions),
+          plawk_scalar_nested_action(Action0, Action),
           plawk_scalar_action_update(Action, Name, set_str(_Src))
         ),
         Names0),
@@ -7403,10 +7443,18 @@ plawk_strnum_validly_sourced(Rules, Set, Name) :-
 % bodies are excluded: plawk does not yet correctly propagate a value assigned
 % in a nested block to a later statement, so activating strnum there would ride
 % on that unsupported control-flow shape).
+% Every action a rule performs, nested if/loop bodies included (via the shared
+% plawk_scalar_nested_action/2 walker). All five strnum sites -- disqualifiers,
+% field/external sources, copy-grow, and the read-use gate -- enumerate through
+% here, so widening the reach widens them together: a nested `x = $N` can seed
+% strnum-ness, and a nested READ is equally visible to the gate, so a name whose
+% nested read is unsupported still deactivates rather than activating on a
+% half-seen program.
 plawk_strnum_rule_action(Rules, Action) :-
     member(rule(_Pattern, Actions0), Rules),
     plawk_trim_control_tails(Actions0, Actions),
-    member(Action, Actions).
+    member(Action0, Actions),
+    plawk_scalar_nested_action(Action0, Action).
 
 % A strnum FIELD source: a bare field copy `x = $N` (the seed of strnum-ness).
 % Both surface shapes for a field read (`field(N)` and `int(field(N))`) count.
@@ -15336,30 +15384,33 @@ plawk_scalar_update_operation_ir(set_str(gsub_str(Global, Regex, Repl)), scalar_
          Base, ReplBytes, ReplBytes, ReplName,
          NextValue, Base, Base, Base, CacheName, Base, ReplLen, GlobalBool]),
     atomic_list_concat([PatGlobal, ReplGlobal, CacheGlobal], '\n', GlobalIR).
-plawk_scalar_update_operation_ir(set_str(Src), scalar_string(_Name), FieldSeparator,
+% A string RHS into a text-holding slot. A strnum slot stores the same interned
+% atom id as a string slot (the runtime call yields an id via
+% plawk_str_build_ir); only comparison-time dispatch differs (strnum vs string).
+% So the store is identical for both -- the slot's KIND, not this op, drives the
+% numeric-vs-lexical choice.
+plawk_scalar_update_operation_ir(set_str(Src), Slot, FieldSeparator,
         Prefix, SlotIndex, OpIndex, _InputValue, NextValue, GlobalIR-IR) :-
+    plawk_slot_holds_text(Slot),
     !,
     format(atom(Base), '~w_slot_~w_op_~w_str', [Prefix, SlotIndex, OpIndex]),
     plawk_str_build_ir(Src, FieldSeparator, Base, NextValue, GlobalParts, SetupLines),
     plawk_join_nonempty_ir(GlobalParts, GlobalIR),
     atomic_list_concat(SetupLines, '\n', IR).
-% An ARGV/getline strnum slot stores the same interned atom id as a string slot
-% (the runtime call yields an id via plawk_str_build_ir); only comparison-time
-% dispatch differs (strnum vs string). So the store is identical to the string
-% case -- the slot's kind, not this op, drives the numeric-vs-lexical choice.
-plawk_scalar_update_operation_ir(set_str(Src), scalar_strnum(_Name), FieldSeparator,
-        Prefix, SlotIndex, OpIndex, _InputValue, NextValue, GlobalIR-IR) :-
-    !,
-    format(atom(Base), '~w_slot_~w_op_~w_str', [Prefix, SlotIndex, OpIndex]),
-    plawk_str_build_ir(Src, FieldSeparator, Base, NextValue, GlobalParts, SetupLines),
-    plawk_join_nonempty_ir(GlobalParts, GlobalIR),
-    atomic_list_concat(SetupLines, '\n', IR).
-% strnum assignment `x = $N`: intern the field's raw text into an atom id (the
-% strnum slot repr), retaining the bytes so a later comparison can decide
-% numeric vs lexical. Matched specifically before the generic i64 set. The
-% record is %line in this scope (as in the concat path).
-plawk_scalar_update_operation_ir(set(field_i64(FieldIndex)), scalar_strnum(_Name),
+% A field copy `x = $N` into a text-holding slot: intern the field's raw bytes
+% into an atom id, retaining them so a later comparison can decide numeric vs
+% lexical. Matched specifically before the generic i64 set. The record is %line
+% in this scope (as in the concat path).
+%
+% This used to be restricted to a strnum slot, so a name written BOTH as a field
+% copy and as a string (`{ s = "x"; s = $1 }` -- string wins the slot kind, since
+% a literal write disqualifies strnum) fell through to the generic NUMERIC store:
+% the slot got the field's numeric value (0 for non-numeric text), and printing
+% it resolved atom id 0 to empty. Both kinds hold an interned id, so both take
+% this store.
+plawk_scalar_update_operation_ir(set(field_i64(FieldIndex)), Slot,
         FieldSeparator, Prefix, SlotIndex, OpIndex, _InputValue, NextValue, ''-IR) :-
+    plawk_slot_holds_text(Slot),
     !,
     format(atom(Base), '~w_slot_~w_op_~w_snum', [Prefix, SlotIndex, OpIndex]),
     format(atom(NextValue), '%~w_id', [Base]),

--- a/tests/test_plawk_nested_string_scalar.pl
+++ b/tests/test_plawk_nested_string_scalar.pl
@@ -1,0 +1,230 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk: a string scalar assigned inside an `if` / loop body.
+%
+% `{ if (NR > 1) s = $1 } END { print s }` compiled and printed `0` instead of
+% the field text -- WRONG OUTPUT, not a decline. Two collectors asked
+% overlapping questions about the same rules and walked different shapes:
+%
+%   * plawk_scalar_update_name_expr/3 descends into `if` branches and
+%     foreach / while / do-while bodies, so the name DID get a slot;
+%   * plawk_scalar_string_names/2 and the strnum collector's action enumerator
+%     looked at TOP-LEVEL rule-body actions only, so the name's TYPE was decided
+%     by a view that never saw the assignment.
+%
+% The slot therefore existed as a plain i64 counter and the END print rendered
+% the default 0. Both collectors now walk the shared plawk_scalar_nested_action/2
+% helper, so the slot and its type are decided over the same actions.
+%
+% Fixing the reach exposed a second, PRE-EXISTING bug (present at the merge base
+% with no nesting involved): a name written both as a field copy and as a string
+% (`{ s = "x"; s = $1 }`) types as a string slot, because a literal write
+% disqualifies strnum -- but the field-copy STORE only had a strnum clause, so it
+% fell through to the generic numeric store, put the field's numeric value (0 for
+% non-numeric text) in the slot, and printing resolved atom id 0 to empty. String
+% and strnum slots both hold an interned atom id, so both write paths are now
+% behind plawk_slot_holds_text/1.
+%
+% gawk 5.2 is the oracle for every expectation here.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+% Three records: "a 1" / "b 2" / "c 3". The last record's $1 is "c", so a guard
+% of NR > 1 leaves "c" in the slot at END.
+input("a 1\nb 2\nc 3\n").
+
+:- begin_tests(plawk_nested_string_scalar).
+
+% --- the reported bug ------------------------------------------------------
+
+% A bare field copy inside an `if` body. Printed `0` before.
+test(if_body_field_copy, [condition(clang_available)]) :-
+    run("{ if (NR > 1) s = $1 } END { print s }\n", "c\n"),
+    !.
+
+% A string literal inside an `if` body.
+test(if_body_string_literal, [condition(clang_available)]) :-
+    run("{ if (NR > 1) s = \"hit\" } END { print s }\n", "hit\n"),
+    !.
+
+% A concatenation inside an `if` body.
+test(if_body_concat, [condition(clang_available)]) :-
+    run("{ if (NR > 1) s = $1 $2 } END { print s }\n", "c3\n"),
+    !.
+
+% Arbitrary nesting depth, not just one level.
+test(nested_if_in_if, [condition(clang_available)]) :-
+    run("{ if (NR > 1) { if (NR > 2) s = $1 } } END { print s }\n", "c\n"),
+    !.
+
+% A while body, not just an if body -- the shared walker covers foreach /
+% while / do-while too.
+test(while_body_field_copy, [condition(clang_available)]) :-
+    run("{ i = 0; while (i < 1) { t = $1; i++ } } END { print t }\n", "c\n"),
+    !.
+
+% The value reaches an END printf argument as text, not as a number.
+test(if_body_string_reaches_end_printf, [condition(clang_available)]) :-
+    run("{ if (NR > 1) s = $1 } END { printf \"[%s]\\n\", s }\n", "[c]\n"),
+    !.
+
+% --- the mixed field-copy + string case -----------------------------------
+
+% A name written BOTH ways inside branches. A literal write disqualifies strnum,
+% so the slot is string-typed; the field-copy write must still intern the text.
+test(if_else_field_copy_and_literal, [condition(clang_available)]) :-
+    run("{ if (NR > 1) s = $1; else s = \"first\" } END { print s }\n", "c\n"),
+    !.
+
+% The same mixed shape with NO nesting at all -- this was broken at the merge
+% base too, and is the second bug the reach fix exposed. Field copy last wins.
+test(top_level_mixed_literal_then_field, [condition(clang_available)]) :-
+    run("{ s = \"x\"; s = $1 } END { print s }\n", "c\n"),
+    !.
+
+% Literal last wins, the order that already worked.
+test(top_level_mixed_field_then_literal, [condition(clang_available)]) :-
+    run("{ s = $1; s = \"x\" } END { print s }\n", "x\n"),
+    !.
+
+% --- regressions: shapes that already worked ------------------------------
+
+test(top_level_field_copy, [condition(clang_available)]) :-
+    run("{ s = $1 } END { print s }\n", "c\n"),
+    !.
+
+test(top_level_string_literal, [condition(clang_available)]) :-
+    run("{ s = \"x\" } END { print s }\n", "x\n"),
+    !.
+
+test(string_accumulation, [condition(clang_available)]) :-
+    run("{ s = s $1 } END { print s }\n", "abc\n"),
+    !.
+
+% A numeric counter incremented inside an `if` body must stay an i64 counter --
+% widening the STRING collector's reach must not make numeric names string-typed.
+test(if_body_counter_stays_numeric, [condition(clang_available)]) :-
+    run("{ if (NR > 1) n++ } END { print n }\n", "2\n"),
+    !.
+
+% A double slot assigned in an `if` body stays double.
+test(if_body_double_stays_double, [condition(clang_available)]) :-
+    run("{ if (NR > 1) d = $2 / 2 } END { print d }\n", "1.5\n"),
+    !.
+
+% --- slot typing, directly -------------------------------------------------
+
+% The string-name collector sees a nested assignment. This is the specific
+% disagreement that caused the bug: the slot collector always saw it.
+test(nested_string_assignment_is_collected) :-
+    Rules = [rule(always, [if(cmp(special('NR'), gt, int(1)),
+                              [set(var(s), string("x"))], [])])],
+    plawk_native_codegen:plawk_scalar_string_names(Rules, Strings),
+    assertion(Strings == [s]),
+    !.
+
+% A nested field copy seeds strnum-ness, so `s` types as a text-holding slot
+% rather than an i64 counter.
+test(nested_field_copy_types_as_text) :-
+    Rules = [rule(always, [if(cmp(special('NR'), gt, int(1)),
+                              [set(var(s), field(1))], [])])],
+    plawk_native_codegen:plawk_scalar_typed_slots(Rules, [s], Slots),
+    assertion(Slots = [Slot]),
+    Slots = [Slot],
+    assertion(plawk_native_codegen:plawk_slot_holds_text(Slot)),
+    !.
+
+% A nested increment still types as a plain counter (no over-widening).
+test(nested_increment_types_as_counter) :-
+    Rules = [rule(always, [if(cmp(special('NR'), gt, int(1)),
+                              [inc(var(n))], [])])],
+    plawk_native_codegen:plawk_scalar_typed_slots(Rules, [n], Slots),
+    assertion(Slots == [scalar_counter(n)]),
+    !.
+
+% Both text-holding slot kinds are behind one guard, so a write emitter cannot
+% support one and silently mis-store the other as a number.
+test(both_text_slot_kinds_recognised) :-
+    assertion(plawk_native_codegen:plawk_slot_holds_text(scalar_string(x))),
+    assertion(plawk_native_codegen:plawk_slot_holds_text(scalar_strnum(x))),
+    assertion(\+ plawk_native_codegen:plawk_slot_holds_text(scalar_counter(x))),
+    assertion(\+ plawk_native_codegen:plawk_slot_holds_text(scalar_double(x))),
+    !.
+
+% The nested walker yields the container itself plus every action at any depth,
+% for each container kind the scalar collectors care about.
+test(nested_action_walker_reaches_every_depth) :-
+    Inner = set(var(s), field(1)),
+    forall(member(Container,
+               [ if(cmp(special('NR'), gt, int(1)), [Inner], [])
+               , if(cmp(special('NR'), gt, int(1)), [], [Inner])
+               , while_loop(cmp(var(i), lt, int(1)), [Inner])
+               , do_while_loop([Inner], cmp(var(i), lt, int(1)))
+               , foreach_loop(layout, [Inner])
+               , if(cmp(special('NR'), gt, int(1)),
+                    [if(cmp(special('NR'), gt, int(2)), [Inner], [])], [])
+               ]),
+        ( plawk_native_codegen:plawk_scalar_nested_action(Container, Inner)
+        -> true
+        ;  format(user_error, "~nnot reached in: ~q~n", [Container]), fail
+        )),
+    !.
+
+% --- IR shape --------------------------------------------------------------
+
+% A nested field copy interns the field's bytes rather than storing its numeric
+% value: the store goes through @wam_intern_atom, not the generic `add i64 0`.
+test(nested_field_copy_ir_interns) :-
+    plawk_parse_string("{ if (NR > 1) s = $1 } END { print s }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_intern_atom'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value'))),
+    !.
+
+:- end_tests(plawk_nested_string_scalar).
+
+% --- helpers ---------------------------------------------------------------
+
+odir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_nested_string_scalar', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+% Build Src, run it over the shared input, require Expected byte-for-byte.
+run(Src, Expected) :-
+    odir(Dir),
+    input(Input),
+    directory_file_path(Dir, 'ns_bin', StaleBin),
+    % A build that unexpectedly declines must not silently run a stale binary.
+    ( exists_file(StaleBin) -> delete_file(StaleBin) ; true ),
+    directory_file_path(Dir, 'ns', Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    cli([build, Prog, '-o', StaleBin], 0),
+    process_create(StaleBin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out),
+    close(PS),
+    process_wait(Pid, exit(0)),
+    assertion(Out == Expected).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
`{ if (NR > 1) s = $1 } END { print s }` compiled and printed `0` instead of the field text — **wrong output, not a decline**. This is the bug I flagged at the end of #4002.

## Cause — the same drift shape a third time

Two collectors asked overlapping questions about the same rules and walked **different shapes**:

| collector | descends into `if` / loop bodies? | decides |
|---|---|---|
| `plawk_scalar_update_name_expr/3` | **yes** | whether the name gets a slot |
| `plawk_scalar_string_names/2` | no — top level only | whether the slot is string-typed |
| `plawk_strnum_rule_action/2` | no — top level only | whether the slot is strnum-typed |

So the name got a slot from the descending collector, while its **type** was decided by two views that never saw the assignment. It fell through to a plain i64 counter, and the END print rendered the default `0`.

All three now walk one shared `plawk_scalar_nested_action/2`, at any nesting depth. Routing the strnum enumerator through it widens its five call sites together, which matters for correctness in both directions: a nested `x = $N` can seed strnum-ness, **and** a nested read is equally visible to the read-use gate — so a name whose nested read is unsupported still deactivates rather than activating on a half-seen program.

## A second, pre-existing bug the fix exposed

Once nested assignments were visible, `{ if (NR > 1) s = $1; else s = "first" }` went from a clean decline to printing **empty**. Tracking that down found a bug with no nesting involved at all, present at the merge base:

```awk
{ s = "x"; s = $1 } END { print s }     # plawk: empty      gawk: c
```

A name written both as a field copy and as a string types as a **string** slot (a literal write disqualifies strnum) — but the field-copy store only had a `scalar_strnum` clause. It fell through to the generic **numeric** store, put the field's numeric value (`0` for non-numeric text) in the slot, and printing resolved atom id 0 to empty.

String and strnum slots both hold an interned atom id and differ only in comparison-time dispatch, so both write paths — the field copy and the string RHS — now sit behind one `plawk_slot_holds_text/1` guard instead of duplicated per-kind clauses. That's the same consolidation as the previous two PRs: the per-kind duplication is exactly what let one kind be handled and the other silently mis-stored.

Without this, the nested mixed shape would have shipped as wrong output where it used to decline — a regression in error class, which is why it's in the same PR rather than deferred.

## Verified against gawk 5.2

| program | before | after / gawk |
|---|---|---|
| `{ if (NR > 1) s = $1 } END { print s }` | `0` | `c` |
| `{ if (NR > 1) s = "hit" } END { print s }` | `0` | `hit` |
| `{ if (NR > 1) s = $1 $2 } END { print s }` | `0` | `c3` |
| `{ if (NR>1) {if (NR>2) s = $1} } END { print s }` | `0` | `c` |
| `{ i=0; while (i<1) { t = $1; i++ } } END { print t }` | `0` | `c` |
| `{ if (NR>1) s = $1; else s = "first" } END { print s }` | declined | `c` |
| `{ s = "x"; s = $1 } END { print s }` | empty | `c` |
| `{ if (NR > 1) s = $1 } END { printf "[%s]\n", s }` | `[0]` | `[c]` |

Numeric counters and double slots assigned inside an `if` body still type numerically (`{ if (NR>1) n++ }` → `2`, `{ if (NR>1) d = $2/2 }` → `1.5`) — widening the string collector's reach must not make numeric names string-typed, and there are tests pinning that.

## Tests

`tests/test_plawk_nested_string_scalar.pl` — 20 tests: the behaviours above, direct slot-typing assertions (the nested assignment is now visible to the string collector; a nested increment still types as a counter), a walker test covering every container kind at depth (both `if` branches, `while`, `do-while`, `foreach`, and `if`-in-`if`), and an IR-shape test that the nested field copy goes through `@wam_intern_atom` rather than the generic numeric store.

Suites green: `strscalar`, `strnum`, `strnum_src`, `strguard`, `scalar_if`, `if_bodies`, `while`, `loop_control`, `foreach_tuples`, `argv`, `getline`, `getline_main`, `getline_record`, `forin_val_strnum`, `scalar_pattern`, `expr_pattern`, `end_printf`, `printf`, `sprintf`, `multi_print_end`, `end_if`, `surface_end_scalar_exprs`, `exit`, `ternary`.

`BEGIN { printf … }` is next, as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_