### PR TITLE
mu_cosine: pin the abstain-reason forward-compatibility property

### DIFF
--- a/prototypes/mu_cosine/test_filing_path_decision.py
+++ b/prototypes/mu_cosine/test_filing_path_decision.py
@@ -957,6 +957,44 @@ def test_select_existing_is_never_reported_as_censored(world):
         )
 
 
+def test_validate_accepts_gated_reasons_that_stage_a_cannot_emit(world):
+    """The emission/validation split is deliberate, so pin it.
+
+    ``_build_decision`` enforces the Stage A subset; ``validate_decision`` keeps
+    the full ``ABSTAIN_REASONS`` set so a later stage's receipt still parses
+    under this schema version.  Without this test, tidying ``validate_decision``
+    to use ``STAGE_A_ABSTAIN_REASONS`` would break forward compatibility with no
+    failure anywhere.
+    """
+
+    from filing_path_decision import ABSTAIN_REASONS, STAGE_A_ABSTAIN_REASONS
+
+    gated = set(ABSTAIN_REASONS) - set(STAGE_A_ABSTAIN_REASONS)
+    assert gated == {
+        "proposal_need_uncertain",
+        "outside_calibration_support",
+        "privacy_restricted_naming",
+    }
+
+    template = decide_stage_a(_build(world))
+    for reason in sorted(gated):
+        receipt = template["search_receipt"]
+        later_stage = {
+            **template,
+            "decision": ABSTAIN,
+            "payload": {
+                "reason_code": reason,
+                "candidate_ids_considered": [_typed("10")],
+            },
+            "search_receipt": receipt,
+            "search_receipt_sha256": sha256_bytes(canonical_json_bytes(dict(receipt))),
+        }
+        later_stage.pop("decision_sha256", None)
+        later_stage["decision_sha256"] = sha256_bytes(canonical_json_bytes(later_stage))
+        # Schema-level validation accepts it; only emission is stage-restricted.
+        assert validate_decision(later_stage)["payload"]["reason_code"] == reason
+
+
 def test_public_data_receipt_is_still_held_to_exact_binding(world):
     """A supplied receipt is never waved through just because data is public."""
 


### PR DESCRIPTION
## Summary

Closes the one loose end from the review of #4001. Filing track only, no encoder changes.

The emission/validation split in `filing_path_decision.py` is deliberate:

- `_build_decision` enforces the **Stage A subset** — only `ambiguous_existing`, `resource_censored`, and `no_eligible_candidate` are emittable;
- `validate_decision` keeps the **full `ABSTAIN_REASONS` set**, so a later stage's receipt still parses under this schema version.

Only the emission side was tested. Tidying `validate_decision` to use `STAGE_A_ABSTAIN_REASONS` would have silently broken forward compatibility with no test failing anywhere — exactly the kind of property that needs pinning rather than commenting.

The new test builds a decision carrying each gated reason code and asserts `validate_decision` accepts it, so the schema-level and stage-level rules stay distinguishable by something other than a comment.

## Validation

56 passed in `test_filing_path_decision.py`; 147 across the filing and encoder suites together. Whitespace check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xCXhV5sHDsMiDyU5q7Hqg

---
_Generated by [Claude Code](https://claude.ai/code/session_017xCXhV5sHDsMiDyU5q7Hqg)_