### PR TITLE
mu_cosine: reversible typed tokenizer (encoder step 2, part 1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,8 @@ jobs:
         # corpus either way.
         run: |
           python3 -m pytest -q prototypes/mu_cosine/test_process_expression_contract.py \
-            prototypes/mu_cosine/test_process_expression_envelope.py
+            prototypes/mu_cosine/test_process_expression_envelope.py \
+            prototypes/mu_cosine/test_process_expression_tokenizer.py
 
       - name: Run F# WAM target tests (codegen + dotnet smoke + LMDB conformance)
         env:

--- a/prototypes/mu_cosine/process_expression_tokenizer.py
+++ b/prototypes/mu_cosine/process_expression_tokenizer.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Reversible typed tokenizer for process expressions — step 2, part 1.
+
+``DESIGN_expression_encoder_future.md`` §3.1 requires a stream where
+
+    canonical AST -> tokens -> AST -> canonical bytes
+
+round-trips exactly, with a finite versioned vocabulary and an explicit
+256-byte literal fallback.  No hashing, no subword tokenization, and no
+unknown-token replacement is permitted anywhere on the reconstruction path.
+
+Two separations keep this honest:
+
+* **Structure is inherited, not reinvented.** The token *strings* come from
+  ``process_expression_contract.token_stream`` — the fixture authority sealed in
+  ``PROCESS_EXPRESSION_GOLDEN_v2.json``.  This module assigns IDs to those
+  strings and defines the inverse.  It therefore cannot drift from the sealed
+  bundle by construction, which is the whole reason the bundle was frozen first.
+* **The vocabulary is versioned independently of the grammar** (§3.1).
+  ``VOCAB_VERSION`` moves when the ID assignment changes;
+  ``CONTRACT_VERSION`` moves when the structure does.
+
+What this module is *not*: it is not the encoder, and the exactness it
+guarantees is a serialization property.  Per
+``DESIGN_process_expression_generator.md`` §5.0 the learned decoder is graded by
+tolerance — "close is good" applies to the model, never to this layer.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import os
+import sys
+from typing import Any, Iterator, Mapping, Sequence
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from process_cards import REGISTRY, Node, canonical, parse, validate
+from process_expression_contract import (
+    CONTRACT_VERSION,
+    ContractError,
+    ResolvedNode,
+    resolve,
+    token_stream,
+)
+
+#: Bumped when the ID assignment changes.  Independent of CONTRACT_VERSION,
+#: which tracks the structure those IDs are assigned to.
+VOCAB_VERSION = "tok-v1"
+
+#: Bounds the indexed structural tokens.  Deliberately wider than the measured
+#: envelope (arity 3, list length 2, one modifier, no pins) so the vocabulary
+#: does not need re-versioning for a slightly larger generated corpus.  A value
+#: beyond these bounds fails closed rather than wrapping — §8 of the position
+#: note forbids clipping or reusing a final in-range code.
+MAX_INDEX = 16
+
+_LIST_ELEMENT_TYPE = {"number_list": "number", "int_list": "int"}
+
+
+class TokenizerError(ValueError):
+    """A token stream could not be built, decoded, or round-tripped."""
+
+
+# --------------------------------------------------------------------------
+# vocabulary
+# --------------------------------------------------------------------------
+
+
+def _vocabulary_terms() -> list[str]:
+    """Every token string the contract can emit, in a frozen order.
+
+    Derived from the pinned registry rather than collected from a corpus: the
+    vocabulary is finite and knowable in advance, so nothing here depends on
+    which expressions happen to have been generated.
+    """
+
+    terms: list[str] = ["<BOS>", "<EOS>"]
+    terms += [
+        "<NODE>", "</NODE>",
+        "<ARGS>", "</ARGS>",
+        "<KWARGS>", "</KWARGS>",
+        "<MODS>", "</MODS>",
+        "<PINS>", "</PINS>",
+        "<LIST>", "</LIST>",
+        "<INT>", "</INT>",
+        "<NUMBER>", "</NUMBER>",
+        "<STRING>", "</STRING>",
+        "</ARG>", "</KW>", "</ITEM>", "</MOD>", "</PIN>",
+    ]
+    terms += ["<KIND:atom>", "<KIND:apply>"]
+    terms += [f"<NAME:{name}>" for name in sorted(REGISTRY)]
+    terms += [f"<OUTPUT:{output}>" for output in sorted({s.output for s in REGISTRY.values()})]
+    keys = sorted({key for s in REGISTRY.values() for key in s.kwargs})
+    terms += [f"<KW:{key}>" for key in keys]
+    for index in range(MAX_INDEX):
+        terms += [f"<ARG:{index}>", f"<ITEM:{index}>", f"<MOD:{index}>", f"<PIN:{index}>"]
+    # Explicit 256-byte fallback: every literal payload byte has a token.
+    terms += [f"BYTE:0x{value:02x}" for value in range(256)]
+
+    if len(set(terms)) != len(terms):
+        raise TokenizerError("vocabulary contains a duplicate term")
+    return terms
+
+
+@dataclass(frozen=True)
+class Vocabulary:
+    version: str
+    contract_version: str
+    terms: tuple[str, ...]
+    id_by_term: Mapping[str, int]
+    term_by_id: Mapping[int, str]
+
+    @property
+    def size(self) -> int:
+        return len(self.terms)
+
+    @property
+    def digest(self) -> str:
+        payload = "\n".join(
+            [self.version, self.contract_version, *self.terms]
+        ).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+
+def build_vocabulary() -> Vocabulary:
+    terms = tuple(_vocabulary_terms())
+    return Vocabulary(
+        version=VOCAB_VERSION,
+        contract_version=CONTRACT_VERSION,
+        terms=terms,
+        id_by_term={term: index for index, term in enumerate(terms)},
+        term_by_id=dict(enumerate(terms)),
+    )
+
+
+VOCAB = build_vocabulary()
+
+
+# --------------------------------------------------------------------------
+# encoding
+# --------------------------------------------------------------------------
+
+
+def encode_terms(node: ResolvedNode) -> tuple[str, ...]:
+    """The contract's structural stream, unchanged."""
+
+    return tuple(token.token for token in token_stream(node))
+
+
+def encode(node: ResolvedNode, vocab: Vocabulary = VOCAB) -> tuple[int, ...]:
+    ids = []
+    for term in encode_terms(node):
+        try:
+            ids.append(vocab.id_by_term[term])
+        except KeyError as exc:
+            # An out-of-vocabulary structural token means an index exceeded
+            # MAX_INDEX.  Fail closed: no hashing, no bucketing, no UNK.
+            raise TokenizerError(f"token outside the frozen vocabulary: {term}") from exc
+    return tuple(ids)
+
+
+def encode_expression(expression: str, vocab: Vocabulary = VOCAB) -> tuple[int, ...]:
+    return encode(resolve(parse(expression)), vocab)
+
+
+# --------------------------------------------------------------------------
+# decoding
+# --------------------------------------------------------------------------
+
+
+class _Cursor:
+    def __init__(self, terms: Sequence[str]):
+        self.terms = list(terms)
+        self.position = 0
+
+    def peek(self) -> str:
+        if self.position >= len(self.terms):
+            raise TokenizerError("token stream ended early")
+        return self.terms[self.position]
+
+    def take(self) -> str:
+        term = self.peek()
+        self.position += 1
+        return term
+
+    def expect(self, term: str) -> str:
+        actual = self.take()
+        if actual != term:
+            raise TokenizerError(f"expected {term}, got {actual}")
+        return actual
+
+    def accept(self, term: str) -> bool:
+        if self.position < len(self.terms) and self.terms[self.position] == term:
+            self.position += 1
+            return True
+        return False
+
+    @property
+    def exhausted(self) -> bool:
+        return self.position >= len(self.terms)
+
+
+def _tagged(term: str, prefix: str) -> str:
+    if not term.startswith(prefix) or not term.endswith(">"):
+        raise TokenizerError(f"expected a {prefix}…> token, got {term}")
+    return term[len(prefix) : -1]
+
+
+def _take_payload(cursor: _Cursor, closing: str) -> bytes:
+    payload = bytearray()
+    while not cursor.accept(closing):
+        term = cursor.take()
+        if not term.startswith("BYTE:0x"):
+            raise TokenizerError(f"expected a literal byte, got {term}")
+        payload.append(int(term[7:], 16))
+    return bytes(payload)
+
+
+def _value_from(kind: str, payload: bytes) -> Any:
+    text = payload.decode("utf-8")
+    if kind == "string":
+        return text
+    if kind == "int":
+        return int(text)
+    if kind == "number":
+        # The declared kind is `number`, but the canonical lexical form decides
+        # int-vs-float: `margin(t=1)` renders "1" and must decode back to the
+        # int 1, or the canonical string — and therefore the identity — moves.
+        return float(text) if any(ch in text for ch in ".eE") else int(text)
+    raise TokenizerError(f"unsupported scalar kind: {kind!r}")
+
+
+def _decode_value(cursor: _Cursor, kind: str) -> Any:
+    if cursor.accept("<LIST>"):
+        element_kind = _LIST_ELEMENT_TYPE.get(kind)
+        if element_kind is None:
+            raise TokenizerError(f"list payload for non-list kind {kind!r}")
+        items = []
+        while not cursor.accept("</LIST>"):
+            index = int(_tagged(cursor.take(), "<ITEM:"))
+            if index != len(items):
+                raise TokenizerError("list item indices must be contiguous")
+            items.append(_decode_value(cursor, element_kind))
+            cursor.expect("</ITEM>")
+        return tuple(items)
+
+    opener = cursor.take()
+    mapping = {"<INT>": ("int", "</INT>"), "<NUMBER>": ("number", "</NUMBER>"),
+               "<STRING>": ("string", "</STRING>")}
+    if opener not in mapping:
+        raise TokenizerError(f"expected a value token, got {opener}")
+    tagged_kind, closing = mapping[opener]
+    if tagged_kind != kind:
+        # The stream's own tag must agree with the registry-declared kind.
+        raise TokenizerError(
+            f"stream declares {tagged_kind!r} for a field registered {kind!r}"
+        )
+    return _value_from(kind, _take_payload(cursor, closing))
+
+
+def _decode_node(cursor: _Cursor) -> Node:
+    cursor.expect("<NODE>")
+    kind = _tagged(cursor.take(), "<KIND:")
+    name = _tagged(cursor.take(), "<NAME:")
+    output = _tagged(cursor.take(), "<OUTPUT:")
+    if name not in REGISTRY:
+        raise TokenizerError(f"unregistered name in stream: {name}")
+    signature = REGISTRY[name]
+    if output != signature.output:
+        raise TokenizerError(f"{name} output {output!r} contradicts the registry")
+    if kind not in ("atom", "apply"):
+        raise TokenizerError(f"unknown KIND: {kind!r}")
+
+    cursor.expect("<ARGS>")
+    args = []
+    while not cursor.accept("</ARGS>"):
+        index = int(_tagged(cursor.take(), "<ARG:"))
+        if index != len(args):
+            raise TokenizerError("argument indices must be contiguous")
+        args.append(_decode_node(cursor))
+        cursor.expect("</ARG>")
+
+    cursor.expect("<KWARGS>")
+    kwargs = []
+    while not cursor.accept("</KWARGS>"):
+        key = _tagged(cursor.take(), "<KW:")
+        spec = signature.kwargs.get(key)
+        if spec is None:
+            raise TokenizerError(f"unknown kwarg for {name}: {key}")
+        kwargs.append((key, _decode_value(cursor, spec.kind)))
+        cursor.expect("</KW>")
+
+    cursor.expect("<MODS>")
+    mods = []
+    while not cursor.accept("</MODS>"):
+        index = int(_tagged(cursor.take(), "<MOD:"))
+        if index != len(mods):
+            raise TokenizerError("modifier indices must be contiguous")
+        mods.append(_take_payload(cursor, "</MOD>").decode("ascii"))
+
+    cursor.expect("<PINS>")
+    pins = []
+    while not cursor.accept("</PINS>"):
+        index = int(_tagged(cursor.take(), "<PIN:"))
+        if index != len(pins):
+            raise TokenizerError("pin indices must be contiguous")
+        pins.append(_take_payload(cursor, "</PIN>").decode("ascii"))
+
+    cursor.expect("</NODE>")
+
+    node = Node(name, tuple(args), tuple(sorted(kwargs)), tuple(mods), tuple(pins))
+    # KIND is derived, so it must agree with what the registry implies rather
+    # than being taken on the stream's word (§3.1).
+    implied = "apply" if (node.args or node.kwargs) or (
+        signature.operator and not signature.atom
+    ) else "atom"
+    if implied != kind:
+        raise TokenizerError(f"{name} KIND {kind!r} contradicts the registry")
+    return node
+
+
+def decode_terms(terms: Sequence[str]) -> Node:
+    cursor = _Cursor(terms)
+    cursor.expect("<BOS>")
+    node = _decode_node(cursor)
+    cursor.expect("<EOS>")
+    if not cursor.exhausted:
+        raise TokenizerError("trailing tokens after <EOS>")
+    return validate(node)
+
+
+def decode(ids: Sequence[int], vocab: Vocabulary = VOCAB) -> Node:
+    terms = []
+    for token_id in ids:
+        try:
+            terms.append(vocab.term_by_id[token_id])
+        except KeyError as exc:
+            raise TokenizerError(f"token id outside the vocabulary: {token_id}") from exc
+    return decode_terms(terms)
+
+
+def round_trip(expression: str, vocab: Vocabulary = VOCAB) -> str:
+    """Encode then decode, returning the canonical string of the result."""
+
+    decoded = decode(encode_expression(expression, vocab), vocab)
+    return canonical(decoded)
+
+
+def assert_round_trips(expression: str, vocab: Vocabulary = VOCAB) -> None:
+    original = canonical(parse(expression))
+    recovered = round_trip(expression, vocab)
+    if recovered != original:
+        raise TokenizerError(
+            f"round trip changed the canonical identity: {original!r} -> {recovered!r}"
+        )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    import argparse
+
+    from process_cards import PROCESSES
+
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--expression", action="append", default=[])
+    parser.add_argument("--all-registered", action="store_true")
+    args = parser.parse_args(argv)
+
+    print(f"vocabulary {VOCAB.version} / contract {VOCAB.contract_version}")
+    print(f"  size {VOCAB.size}  digest {VOCAB.digest[:32]}…")
+    expressions = list(args.expression)
+    if args.all_registered or not expressions:
+        expressions += list(PROCESSES.values())
+    for expression in expressions:
+        ids = encode_expression(expression)
+        assert_round_trips(expression)
+        print(f"  ok  {len(ids):4d} tokens  {canonical(parse(expression))}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prototypes/mu_cosine/process_expression_tokenizer.py
+++ b/prototypes/mu_cosine/process_expression_tokenizer.py
@@ -217,17 +217,29 @@ def _take_payload(cursor: _Cursor, closing: str) -> bytes:
     return bytes(payload)
 
 
+def _controlled(fn, description: str):
+    """Convert model-produced bytes; any host exception fails through TokenizerError."""
+    try:
+        return fn()
+    except TokenizerError:
+        raise
+    except Exception as exc:
+        raise TokenizerError(f"malformed {description}: {exc}") from exc
+
+
 def _value_from(kind: str, payload: bytes) -> Any:
-    text = payload.decode("utf-8")
+    text = _controlled(lambda: payload.decode("utf-8"), "utf-8 value payload")
     if kind == "string":
         return text
     if kind == "int":
-        return int(text)
+        return _controlled(lambda: int(text), "integer payload")
     if kind == "number":
         # The declared kind is `number`, but the canonical lexical form decides
         # int-vs-float: `margin(t=1)` renders "1" and must decode back to the
         # int 1, or the canonical string — and therefore the identity — moves.
-        return float(text) if any(ch in text for ch in ".eE") else int(text)
+        return _controlled(
+            lambda: float(text) if any(ch in text for ch in ".eE") else int(text),
+            "numeric payload")
     raise TokenizerError(f"unsupported scalar kind: {kind!r}")
 
 
@@ -297,7 +309,8 @@ def _decode_node(cursor: _Cursor) -> Node:
         index = int(_tagged(cursor.take(), "<MOD:"))
         if index != len(mods):
             raise TokenizerError("modifier indices must be contiguous")
-        mods.append(_take_payload(cursor, "</MOD>").decode("ascii"))
+        payload = _take_payload(cursor, "</MOD>")
+        mods.append(_controlled(lambda: payload.decode("ascii"), "modifier payload"))
 
     cursor.expect("<PINS>")
     pins = []
@@ -305,7 +318,8 @@ def _decode_node(cursor: _Cursor) -> Node:
         index = int(_tagged(cursor.take(), "<PIN:"))
         if index != len(pins):
             raise TokenizerError("pin indices must be contiguous")
-        pins.append(_take_payload(cursor, "</PIN>").decode("ascii"))
+        payload = _take_payload(cursor, "</PIN>")
+        pins.append(_controlled(lambda: payload.decode("ascii"), "pin payload"))
 
     cursor.expect("</NODE>")
 

--- a/prototypes/mu_cosine/test_process_expression_tokenizer.py
+++ b/prototypes/mu_cosine/test_process_expression_tokenizer.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Reversibility and fail-closed tests for the process-expression tokenizer.
+
+The governing requirement (``DESIGN_expression_encoder_future.md`` §3.1) is that
+``canonical AST -> tokens -> AST`` round-trips for every registry example and
+every generated row, with a finite versioned vocabulary and no hashing, subword
+splitting, or unknown-token replacement anywhere on the reconstruction path.
+
+Round-trips are asserted on the **canonical identity string**, not on the token
+list, because that is what process identity is derived from.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+import process_cards as pc
+from process_cards import PROCESSES, REGISTRY
+from process_expression_contract import (
+    CONTRACT_VERSION,
+    CURRENT_GOLDEN_BUNDLE,
+    REQUIRED_COVERAGE_CASES,
+    load_golden,
+    resolve_expression,
+)
+from process_expression_tokenizer import (
+    MAX_INDEX,
+    VOCAB,
+    VOCAB_VERSION,
+    TokenizerError,
+    Vocabulary,
+    assert_round_trips,
+    build_vocabulary,
+    decode,
+    decode_terms,
+    encode,
+    encode_expression,
+    encode_terms,
+    round_trip,
+)
+
+GOLDEN_PATH = ROOT / CURRENT_GOLDEN_BUNDLE
+
+ALL_CASES = {**PROCESSES, **REQUIRED_COVERAGE_CASES}
+
+
+# --------------------------------------------------------------------------
+# vocabulary
+# --------------------------------------------------------------------------
+
+
+def test_vocabulary_is_finite_deterministic_and_versioned():
+    first, second = build_vocabulary(), build_vocabulary()
+    assert first.terms == second.terms
+    assert first.digest == second.digest
+    assert first.version == VOCAB_VERSION
+    # Versioned independently of the grammar/structure contract.
+    assert first.contract_version == CONTRACT_VERSION
+    assert first.version != first.contract_version
+
+
+def test_vocabulary_covers_the_full_byte_fallback():
+    """256 byte tokens: literal payloads never need an UNK or a hash bucket."""
+
+    byte_terms = [t for t in VOCAB.terms if t.startswith("BYTE:0x")]
+    assert len(byte_terms) == 256
+    assert {int(t[7:], 16) for t in byte_terms} == set(range(256))
+
+
+def test_vocabulary_is_derived_from_the_registry_not_a_corpus():
+    for name in REGISTRY:
+        assert f"<NAME:{name}>" in VOCAB.id_by_term
+    for output in {s.output for s in REGISTRY.values()}:
+        assert f"<OUTPUT:{output}>" in VOCAB.id_by_term
+    for key in {k for s in REGISTRY.values() for k in s.kwargs}:
+        assert f"<KW:{key}>" in VOCAB.id_by_term
+
+
+def test_ids_are_dense_and_bijective():
+    assert sorted(VOCAB.term_by_id) == list(range(VOCAB.size))
+    for term, index in VOCAB.id_by_term.items():
+        assert VOCAB.term_by_id[index] == term
+
+
+# --------------------------------------------------------------------------
+# agreement with the sealed bundle
+# --------------------------------------------------------------------------
+
+
+def test_token_strings_reproduce_the_sealed_golden_bundle():
+    """The tokenizer inherits structure; it must not have reinvented it."""
+
+    document = load_golden(GOLDEN_PATH)
+    assert document["contract_version"] == CONTRACT_VERSION
+    for row in document["rows"]:
+        expected = [line.split("\t", 1)[0] for line in row["tokens"]]
+        actual = list(encode_terms(resolve_expression(row["expression"])))
+        assert actual == expected, row["name"]
+
+
+def test_every_golden_row_round_trips_to_its_canonical_identity():
+    for row in load_golden(GOLDEN_PATH)["rows"]:
+        assert round_trip(row["expression"]) == row["canonical_identity_string"], row["name"]
+
+
+@pytest.mark.parametrize("name,expression", sorted(ALL_CASES.items()))
+def test_registry_examples_and_coverage_cases_round_trip(name, expression):
+    assert_round_trips(expression)
+
+
+def test_round_trip_preserves_the_full_digest():
+    from process_identity import full_ast_digest, full_ast_digest_for_expression
+
+    for expression in ALL_CASES.values():
+        decoded = decode(encode_expression(expression))
+        assert full_ast_digest(decoded) == full_ast_digest_for_expression(expression)
+
+
+# --------------------------------------------------------------------------
+# the cases where a naive decoder silently changes identity
+# --------------------------------------------------------------------------
+
+
+def test_integer_spelled_number_decodes_back_to_an_integer():
+    """`margin(t=1)` must not come back as `1.0`.
+
+    The field is registered `number`, but the canonical lexical form is `1`.
+    Decoding to a float would render `1.0`, changing the canonical string and
+    therefore the process digest — a silent identity change, which is exactly
+    what the reversibility requirement exists to prevent.
+    """
+
+    decoded = decode(encode_expression("margin(t=1)"))
+    assert decoded.kwargs == (("t", 1),)
+    assert isinstance(decoded.kwargs[0][1], int)
+    assert pc.canonical(decoded) == "margin(t=1)"
+
+    # And a genuinely fractional value stays a float.
+    fractional = decode(encode_expression("margin(t=0.03)"))
+    assert isinstance(fractional.kwargs[0][1], float)
+    assert pc.canonical(fractional) == "margin(t=0.03)"
+
+
+def test_elided_default_round_trips_through_the_resolved_stream():
+    """`lineage(graph)` streams its resolved default and comes back identical."""
+
+    assert round_trip("lineage(graph)") == "lineage(graph,decay=0.85)"
+    assert pc.canonical(pc.parse("lineage(graph)")) == "lineage(graph,decay=0.85)"
+
+
+def test_utf8_and_escaped_strings_survive_byte_exactly():
+    for expression in (
+        'routing(e5,haiku,t=[0.02],menus=[10],manifest="héllo·wörld")',
+        'routing(e5,haiku,t=[0.02],menus=[10],manifest="a\\"b\\\\c")',
+    ):
+        assert_round_trips(expression)
+    decoded = decode(
+        encode_expression('routing(e5,haiku,t=[0.02],menus=[10],manifest="héllo·wörld")')
+    )
+    assert dict(decoded.kwargs)["manifest"] == "héllo·wörld"
+
+
+def test_negative_numbers_and_pins_round_trip():
+    assert_round_trips("lineage(graph,decay=-0.5)")
+    assert_round_trips("lineage(graph,decay=0.85)@run/2026-07-25")
+    decoded = decode(encode_expression("lineage(graph,decay=0.85)@run/2026-07-25"))
+    assert decoded.pins == ("run/2026-07-25",)
+
+
+def test_atom_and_dual_role_round_trip():
+    assert round_trip("e5") == "e5"                      # nullary atom
+    assert round_trip("e5(margin(t=0.03))") == "e5(margin(t=0.03))"   # operator
+    assert round_trip("llm.subcat") == "llm.subcat"      # modifier-carrying atom
+
+
+# --------------------------------------------------------------------------
+# fail closed
+# --------------------------------------------------------------------------
+
+
+def test_unknown_token_id_is_rejected():
+    with pytest.raises(TokenizerError, match="outside the vocabulary"):
+        decode([VOCAB.size + 1])
+
+
+def test_index_beyond_the_frozen_bound_fails_closed_rather_than_wrapping():
+    """An over-wide expression is rejected, never clipped or wrapped.
+
+    `blend` is variadic with no upper bound, so an arity past MAX_INDEX is
+    constructible and must fail at encode time rather than silently reusing a
+    final in-range code — the behavior the position note forbids.
+    """
+
+    assert f"<ARG:{MAX_INDEX - 1}>" in VOCAB.id_by_term
+    assert f"<ARG:{MAX_INDEX}>" not in VOCAB.id_by_term
+
+    from process_expression_contract import resolve
+
+    wide = pc.Node("blend", tuple(pc.Node("luna") for _ in range(MAX_INDEX + 1)))
+    pc.validate(wide)  # the grammar permits it; the vocabulary does not
+    with pytest.raises(TokenizerError, match="outside the frozen vocabulary"):
+        encode(resolve(wide))
+
+    # Just inside the bound still encodes.
+    narrow = pc.Node("blend", tuple(pc.Node("luna") for _ in range(MAX_INDEX - 1)))
+    assert encode(resolve(narrow))
+
+
+def test_stream_kind_must_agree_with_the_registry():
+    terms = list(encode_terms(resolve_expression("lineage(graph,decay=0.85)")))
+    swapped = ["<KIND:atom>" if t == "<KIND:apply>" else t for t in terms]
+    with pytest.raises(TokenizerError, match="KIND"):
+        decode_terms(swapped)
+
+
+def test_stream_output_must_agree_with_the_registry():
+    terms = list(encode_terms(resolve_expression("kalman(luna.D,luna.S)")))
+    swapped = ["<OUTPUT:score>" if t == "<OUTPUT:target-set>" else t for t in terms]
+    with pytest.raises(TokenizerError, match="contradicts the registry"):
+        decode_terms(swapped)
+
+
+def test_value_tag_must_agree_with_the_declared_kind():
+    terms = list(encode_terms(resolve_expression("menu(graph,n=10)")))
+    swapped = [
+        "<NUMBER>" if t == "<INT>" else "</NUMBER>" if t == "</INT>" else t
+        for t in terms
+    ]
+    with pytest.raises(TokenizerError, match="registered"):
+        decode_terms(swapped)
+
+
+def test_unknown_kwarg_and_unregistered_name_are_rejected():
+    terms = list(encode_terms(resolve_expression("lineage(graph,decay=0.85)")))
+    with pytest.raises(TokenizerError, match="unknown kwarg"):
+        decode_terms(["<KW:n>" if t == "<KW:decay>" else t for t in terms])
+
+
+def test_truncated_and_trailing_streams_are_rejected():
+    terms = list(encode_terms(resolve_expression("kalman(luna.D,luna.S)")))
+    with pytest.raises(TokenizerError, match="ended early"):
+        decode_terms(terms[:-3])
+    with pytest.raises(TokenizerError, match="trailing tokens"):
+        decode_terms(terms + ["<BOS>"])
+
+
+def test_non_contiguous_indices_are_rejected():
+    terms = list(encode_terms(resolve_expression("kalman(luna.D,luna.S)")))
+    broken = ["<ARG:1>" if t == "<ARG:0>" else t for t in terms]
+    with pytest.raises(TokenizerError, match="contiguous"):
+        decode_terms(broken)
+
+
+def test_missing_bos_is_rejected():
+    terms = list(encode_terms(resolve_expression("graph")))
+    with pytest.raises(TokenizerError, match="expected <BOS>"):
+        decode_terms(terms[1:])
+
+
+def test_every_emitted_term_is_a_vocabulary_member():
+    """No hashing, bucketing, or unknown-token substitution can hide here.
+
+    Asserted behaviorally rather than by grepping the source: every term the
+    contract emits for every known case resolves to a real vocabulary ID, and
+    the reverse map returns it unchanged.
+    """
+
+    for expression in ALL_CASES.values():
+        for term in encode_terms(resolve_expression(expression)):
+            assert term in VOCAB.id_by_term
+            assert VOCAB.term_by_id[VOCAB.id_by_term[term]] == term

--- a/prototypes/mu_cosine/test_process_expression_tokenizer.py
+++ b/prototypes/mu_cosine/test_process_expression_tokenizer.py
@@ -313,3 +313,13 @@ def test_malformed_model_bytes_fail_through_tokenizer_error():
     bad_m = ["BYTE:0xff" if t == "BYTE:0x44" else t for t in mbase]   # 'D' -> 0xff
     with pytest.raises(TokenizerError, match="modifier payload"):
         decode_terms(bad_m)
+
+    # 4. non-ascii byte inside a PIN payload.  Pins decode as ascii like
+    # modifiers do, but through a separate call site, so the guard needs its own
+    # regression rather than inheriting case 3's coverage.
+    pbase = list(encode_terms(
+        resolve_expression("lineage(graph,decay=0.85)@run/2026-07-25")))
+    assert pbase.count("BYTE:0x72") == 1          # 'r' occurs only in the pin
+    bad_p = ["BYTE:0xff" if t == "BYTE:0x72" else t for t in pbase]
+    with pytest.raises(TokenizerError, match="pin payload"):
+        decode_terms(bad_p)

--- a/prototypes/mu_cosine/test_process_expression_tokenizer.py
+++ b/prototypes/mu_cosine/test_process_expression_tokenizer.py
@@ -276,3 +276,40 @@ def test_every_emitted_term_is_a_vocabulary_member():
         for term in encode_terms(resolve_expression(expression)):
             assert term in VOCAB.id_by_term
             assert VOCAB.term_by_id[VOCAB.id_by_term[term]] == term
+
+
+def test_malformed_model_bytes_fail_through_tokenizer_error():
+    """Vocabulary-valid but semantically malformed byte payloads must raise TokenizerError,
+    never a raw host exception (UnicodeDecodeError/ValueError). Regression for the 0xff leak."""
+    base = list(encode_terms(resolve_expression(
+        'routing(e5,sonnet,manifest="x",menus=[10],t=[0.02])')))
+
+    def swap_payload(terms, open_tag, close_tag, payload_terms):
+        out, i = [], 0
+        while terms[i] != open_tag:
+            out.append(terms[i])
+            i += 1
+        out.append(terms[i])
+        i += 1
+        while not terms[i].startswith(close_tag):
+            i += 1                                    # drop original payload bytes
+        out.extend(payload_terms)
+        out.extend(terms[i:])
+        return out
+
+    # 1. lone 0xff inside a STRING payload: vocabulary-valid, invalid utf-8
+    bad = swap_payload(base, "<STRING>", "</STRING>", ["BYTE:0xff"])
+    with pytest.raises(TokenizerError, match="utf-8 value payload"):
+        decode_terms(bad)
+
+    # 2. non-numeric bytes under a NUMBER tag
+    nbase = list(encode_terms(resolve_expression("menu(graph,n=10)")))
+    bad_n = ["BYTE:0x78" if t == "BYTE:0x31" else t for t in nbase]   # '1' -> 'x'
+    with pytest.raises(TokenizerError, match="payload"):
+        decode_terms(bad_n)
+
+    # 3. non-ascii byte inside a MOD payload
+    mbase = list(encode_terms(resolve_expression("kalman(luna.D,luna.S)")))
+    bad_m = ["BYTE:0xff" if t == "BYTE:0x44" else t for t in mbase]   # 'D' -> 0xff
+    with pytest.raises(TokenizerError, match="modifier payload"):
+        decode_terms(bad_m)


### PR DESCRIPTION
Reversible typed tokenizer, encoder step 2 part 1.

## Scope

`tok-v1` over **frozen v0.3 / pec-v2**. The vocabulary is derived from the registry, not from a corpus. Both sealed golden bundles are unchanged and verified:

- `PROCESS_EXPRESSION_GOLDEN_v1.json` — `b053351a2a419ac58b7ab644afe15c60543846ce8b9d5a3d9bcbc332ca24db29`
- `PROCESS_EXPRESSION_GOLDEN_v2.json` — `85e6421f5a1347fca5937d1243dc01500a9aa5b7221571b4918248e57ece6344`

The governing requirement (`DESIGN_expression_encoder_future.md` §3.1) is that canonical AST → tokens → AST round-trips for every registry example and every generated row, with a finite versioned vocabulary and no hashing, subword splitting, or unknown-token replacement anywhere on the reconstruction path. Round-trips are asserted on the **canonical identity string**, not on the token list, because that is what process identity is derived from.

## Architectural boundary

This tokenizer targets the frozen v0.3 grammar. It was **not** adapted to `process_expression_vnext` (#4019), and neither the vocabulary nor the sealed bundle was changed on account of that merge. vNext is an experimental frontend that mints no identity-bearing bytes; `tok-v1` operates over the contract that is actually frozen.

## Refresh onto current `main`

Merged current `main` (through the #4019 merge at `e306869`). The only conflict was `.github/workflows/test.yml`, resolved **additively** — the process-expression CI step retains every suite already on `main` and appends the tokenizer suite:

```
test_process_expression_contract.py
test_process_expression_envelope.py
test_process_cards.py
test_process_expression_p1_protocol.py
test_process_expression_vnext_frontend.py
test_process_expression_tokenizer.py
```

## Decoder hardening

A vocabulary-valid `BYTE:0xff` inside a string payload leaked a raw `UnicodeDecodeError` instead of the tokenizer's controlled error type. All four model-produced byte payloads — string/utf-8, numeric, modifier ascii, pin ascii — now fail through `TokenizerError`, each with its own regression. Pins decode at a separate call site from modifiers, so they carry a separate test rather than inheriting the modifier's coverage.

## Status — what this does *not* authorize

- **Part 2 enumeration remains PAUSED** pending the rulings requested in #4013. An earlier revision of this description claimed it was "still unblocked"; that claim was wrong and is removed.
- This PR does not authorize generator work, model training, or vNext activation.

## Validation on the refreshed branch

- **416 passed** — combined process-expression and filing suites (`contract`, `envelope`, `process_cards`, `p1_protocol`, `vnext_frontend`, `tokenizer`, `filing_path_decision`, `filing_privacy`, `pearltrees_filing_v1`, `sm_fs_filing`, `sm_fs_protocols`, `sm_fs_privacy`)
- Both sealed hashes verified unchanged
- `git diff --check` clean
- CI green on `186f405`