### PR TITLE
PERF-R-CA-IDTABLE: direct in-memory integer adjacency table for R CA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,6 +265,14 @@ jobs:
         run: |
           swipl -q -f init.pl -s tests/test_wam_r_ca_direct_lookup.pl -g "run_tests, halt" -t "halt(1)"
 
+      - name: Measure PERF-R-CA-IDTABLE scale-300 timing
+        run: |
+          mkdir -p /tmp/wam-bench/r-ed-300
+          swipl -q -s examples/benchmark/generate_wam_r_effective_distance_benchmark.pl -- \
+            data/benchmark/300/facts.pl /tmp/wam-bench/r-ed-300 kernels_on functions
+          ( cd /tmp/wam-bench/r-ed-300/R && \
+            Rscript run_effective_distance.R "$GITHUB_WORKSPACE/data/benchmark/300" 3 )
+
       - name: Run full R classic conformance
         run: |
           swipl -q -f init.pl -s tests/test_wam_cross_target_conformance.pl -g "run_tests" -t halt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,14 +265,6 @@ jobs:
         run: |
           swipl -q -f init.pl -s tests/test_wam_r_ca_direct_lookup.pl -g "run_tests, halt" -t "halt(1)"
 
-      - name: Measure PERF-R-CA-IDTABLE scale-300 timing
-        run: |
-          mkdir -p /tmp/wam-bench/r-ed-300
-          swipl -q -s examples/benchmark/generate_wam_r_effective_distance_benchmark.pl -- \
-            data/benchmark/300/facts.pl /tmp/wam-bench/r-ed-300 kernels_on functions
-          ( cd /tmp/wam-bench/r-ed-300/R && \
-            Rscript run_effective_distance.R "$GITHUB_WORKSPACE/data/benchmark/300" 3 )
-
       - name: Run full R classic conformance
         run: |
           swipl -q -f init.pl -s tests/test_wam_cross_target_conformance.pl -g "run_tests" -t halt

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -833,7 +833,7 @@ Add each target to the scale-300 effective-distance matrix in
 
 ### BENCH-R: Add R row to effective-distance scale-300 matrix ✅
 - **Lever:** Effective-distance benchmark rows  **Target:** R  **Size:** L  **Depends on:** —
-- **Status:** Done — `examples/benchmark/generate_wam_r_effective_distance_benchmark.pl`, guarded Rscript harness block, scale-300 matrix row + subsection in `WAM_CROSS_TARGET_BENCHMARK_RESULTS.md` (hosted-CI query_ms=3679 median / total_ms=4344 after STACK; prior IDCACHE hosted median was 4812/5610; reference parity match). Initial BENCH-R branch `cursor/bench-r-effective-distance-f421`; optimized by PERF-R-CA-DIRECT, IDDFS, IDCACHE, and STACK. PERF-R-CA-PATHMARK profiled/declined (membership not a post-STACK hotspot).
+- **Status:** Done — `examples/benchmark/generate_wam_r_effective_distance_benchmark.pl`, guarded Rscript harness block, scale-300 matrix row + subsection in `WAM_CROSS_TARGET_BENCHMARK_RESULTS.md` (hosted-CI query_ms=3679 median / total_ms=4344 after STACK; IDTABLE same-host cloud-agent 2729→2607 query ≈1.05×; prior IDCACHE hosted median was 4812/5610; reference parity match). Initial BENCH-R branch `cursor/bench-r-effective-distance-f421`; optimized by PERF-R-CA-DIRECT, IDDFS, IDCACHE, STACK, and IDTABLE. PATHMARK profiled/declined.
 
 ---
 

--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -833,7 +833,7 @@ Add each target to the scale-300 effective-distance matrix in
 
 ### BENCH-R: Add R row to effective-distance scale-300 matrix ✅
 - **Lever:** Effective-distance benchmark rows  **Target:** R  **Size:** L  **Depends on:** —
-- **Status:** Done — `examples/benchmark/generate_wam_r_effective_distance_benchmark.pl`, guarded Rscript harness block, scale-300 matrix row + subsection in `WAM_CROSS_TARGET_BENCHMARK_RESULTS.md` (hosted-CI query_ms=3679 median / total_ms=4344 after STACK; IDTABLE same-host cloud-agent 2729→2607 query ≈1.05×; prior IDCACHE hosted median was 4812/5610; reference parity match). Initial BENCH-R branch `cursor/bench-r-effective-distance-f421`; optimized by PERF-R-CA-DIRECT, IDDFS, IDCACHE, STACK, and IDTABLE. PATHMARK profiled/declined.
+- **Status:** Done — `examples/benchmark/generate_wam_r_effective_distance_benchmark.pl`, guarded Rscript harness block, scale-300 matrix row + subsection in `WAM_CROSS_TARGET_BENCHMARK_RESULTS.md` (hosted-CI IDTABLE query_ms=3412 median / total_ms=4076, 1.08× / 1.07× vs hosted STACK 3679/4344; prior IDCACHE hosted median was 4812/5610; reference parity match). Initial BENCH-R branch `cursor/bench-r-effective-distance-f421`; optimized by PERF-R-CA-DIRECT, IDDFS, IDCACHE, STACK, and IDTABLE. PATHMARK profiled/declined.
 
 ---
 

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -62,9 +62,9 @@ default 4096), and explicit `auto` (codegen resolves via shared
 - Effective-distance cross-target matrix row populated (BENCH-R): scale-300
   `emit_mode(functions)` + auto `category_ancestor/4` kernel, reference
   parity match — see `docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md`.
-  Further optimized by PERF-R-CA-DIRECT / IDDFS / IDCACHE / STACK / IDTABLE
-  (hosted-CI STACK median query_ms=3679; IDTABLE adds in-memory adjacency
-  table, ~1.05× same-host vs STACK).
+  Further optimized by PERF-R-CA-DIRECT / IDDFS / IDCACHE / STACK / IDTABLE.
+  Hosted-CI IDTABLE median query_ms=3412 / total_ms=4076, 1.08× / 1.07×
+  vs hosted STACK 3679/4344.
 
 ## Path forward
 
@@ -74,5 +74,5 @@ default 4096), and explicit `auto` (codegen resolves via shared
 ## Document status
 
 Fleet-aligned snapshot updated for PERF-R-CA-IDTABLE (2026-07-26): optional
-`id_table` adjacency on indexed FactSources; primary GHA fleet row still
-STACK (3679) pending hosted IDTABLE remeasure. PATHMARK remains declined.
+lazy-on-first-CA `id_table` adjacency on indexed FactSources; hosted remeasure
+3412/4076 with 271-row parity. PATHMARK remains declined.

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -62,8 +62,9 @@ default 4096), and explicit `auto` (codegen resolves via shared
 - Effective-distance cross-target matrix row populated (BENCH-R): scale-300
   `emit_mode(functions)` + auto `category_ancestor/4` kernel, reference
   parity match — see `docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md`.
-  Further optimized by PERF-R-CA-DIRECT / IDDFS / IDCACHE / STACK (hosted-CI
-  median query_ms=3679 after iterative ID DFS, 1.31× vs IDCACHE).
+  Further optimized by PERF-R-CA-DIRECT / IDDFS / IDCACHE / STACK / IDTABLE
+  (hosted-CI STACK median query_ms=3679; IDTABLE adds in-memory adjacency
+  table, ~1.05× same-host vs STACK).
 
 ## Path forward
 
@@ -72,7 +73,6 @@ default 4096), and explicit `auto` (codegen resolves via shared
 
 ## Document status
 
-Fleet-aligned snapshot updated for PERF-R-CA-STACK (2026-07-25): iterative
-integer-ID DFS frame stack, remeasured in hosted CI. PERF-R-CA-PATHMARK
-was profiled and declined (path membership ~1% Rprof self post-STACK; trial
-counts path showed no speedup; no production change).
+Fleet-aligned snapshot updated for PERF-R-CA-IDTABLE (2026-07-26): optional
+`id_table` adjacency on indexed FactSources; primary GHA fleet row still
+STACK (3679) pending hosted IDTABLE remeasure. PATHMARK remains declined.

--- a/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
+++ b/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
@@ -411,8 +411,26 @@ follow-up to STACK. Post-STACK Rprof on a Cursor cloud agent attributes only
 was dominated by per-check `proc.time` overhead. A trial dense+sparse count
 implementation preserved 271-row parity but did not beat same-host STACK
 (query median 2660 → 2673 ms). The speculative production change was not
-retained. Remaining CA cost is the iterative `hops_ids` loop body and cached
-`lookup_ids`, with lowered WAM `step`/orchestration outside the kernel.
+retained.
+
+PERF-R-CA-IDTABLE adds an optional in-memory integer adjacency table
+(`id_table`) on indexed FactSources so the CA loop reads parent-id vectors by
+list index instead of invoking `lookup_ids` ~516k times. Dense slots cover
+fact-derived atom ids (capped at 65536); sparse/high ids use hashed overflow.
+Lazy/cached LMDB remain on-demand (no `id_table`). Microbench on this host:
+516k cached closure calls ~0.41 s vs direct list reads ~0.055 s. Same-host
+scale-300 3-rep (Cursor cloud agent, R 4.3.3; 271-row parity):
+
+| Stage | query_ms | total_ms | samples |
+|-------|----------|----------|---------|
+| STACK baseline | 2729 | 3255 | 3299, 2729, 2661 |
+| After IDTABLE | 2607 | 3186 | 3158, 2607, 2601 |
+
+Query ≈ 1.05×; total also improved (table setup ~0.03 s / ~151 KiB). Post-change
+Rprof: `lookup_ids` absent from the hot list; `hops_ids` ≈ 25% self / 32% total
+(`mem.total` ≈ 683). Primary fleet row above remains the GitHub-hosted STACK
+median (3679 / 4344) until a hosted IDTABLE remeasure is recorded. Residual
+cost is the iterative DFS body and lowered WAM `step`/orchestration.
 
 #### Reproduction
 

--- a/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
+++ b/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
@@ -344,7 +344,7 @@ python3 /tmp/wam-bench/python-300/main.py data/benchmark/300 3
 
 ### R WAM (functions mode)
 
-Measured 2026-07-25 in hosted GitHub Actions using
+Measured 2026-07-26 in hosted GitHub Actions using
 `generate_wam_r_effective_distance_benchmark.pl`
 with `emit_mode(functions)`, auto-detected `category_ancestor/4` kernel
 (fleet hops layout), and `category_parent/2` FactSource via
@@ -354,10 +354,10 @@ R 4.3.3, single-core.
 
 | Scale | query_ms | total_ms | rows | Cores | vs reference |
 |-------|----------|----------|------|-------|--------------|
-| 300 | 3679 | 4344 | 271 | 1 | match (`normalize_three_column_float_rows`, 6 dp) |
+| 300 | 3412 | 4076 | 271 | 1 | match (`normalize_three_column_float_rows`, 6 dp) |
 
 `query_ms` is the 3-run median of article×root enumeration only
-(samples: 4475, 3679, 3554). `total_ms` is setup (Rscript startup +
+(samples: 4078, 3412, 3268). `total_ms` is setup (Rscript startup +
 generated-program / FactSource load + article/root TSV load) plus that
 median query. Output validated against
 `data/benchmark/300/reference_output.tsv` with canonical sort and 6-decimal
@@ -415,11 +415,14 @@ retained.
 
 PERF-R-CA-IDTABLE adds an optional in-memory integer adjacency table
 (`id_table`) on indexed FactSources so the CA loop reads parent-id vectors by
-list index instead of invoking `lookup_ids` ~516k times. Dense slots cover
-fact-derived atom ids (capped at 65536); sparse/high ids use hashed overflow.
-Lazy/cached LMDB remain on-demand (no `id_table`). Microbench on this host:
-516k cached closure calls ~0.41 s vs direct list reads ~0.055 s. Same-host
-scale-300 3-rep (Cursor cloud agent, R 4.3.3; 271-row parity):
+list index instead of invoking `lookup_ids` ~516k times. Registration remains
+cheap: because all arity>=2 in-memory FactSources receive the capability, the
+table is materialized lazily on first CA use rather than for unrelated
+predicates. Dense slots cover fact-derived atom ids (capped at 65536);
+sparse/high ids use hashed overflow. Lazy/cached LMDB remain on-demand (no
+`id_table`). Microbench on this host: 516k cached closure calls ~0.41 s vs
+direct list reads ~0.055 s. Same-host scale-300 3-rep (Cursor cloud agent,
+R 4.3.3; 271-row parity):
 
 | Stage | query_ms | total_ms | samples |
 |-------|----------|----------|---------|
@@ -428,9 +431,12 @@ scale-300 3-rep (Cursor cloud agent, R 4.3.3; 271-row parity):
 
 Query ≈ 1.05×; total also improved (table setup ~0.03 s / ~151 KiB). Post-change
 Rprof: `lookup_ids` absent from the hot list; `hops_ids` ≈ 25% self / 32% total
-(`mem.total` ≈ 683). Primary fleet row above remains the GitHub-hosted STACK
-median (3679 / 4344) until a hosted IDTABLE remeasure is recorded. Residual
-cost is the iterative DFS body and lowered WAM `step`/orchestration.
+(`mem.total` ≈ 683). A subsequent GitHub-hosted run measured IDTABLE at
+3412 / 4076 (samples: 4078, 3412, 3268), 1.08× faster in query time and 1.07×
+faster overall than hosted STACK 3679 / 4344, with the same 271-row reference
+parity. This is about 18.3× faster than the original hosted R query result of
+62595 ms. Residual cost is the iterative DFS body and lowered WAM
+`step`/orchestration.
 
 #### Reproduction
 

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3172,18 +3172,23 @@ WamRuntime$category_ancestor_hops_rec <- function(program, state, edge_atom_id,
   invisible(NULL)
 }
 
-# Integer-ID DFS with downward depth (PERF-R-CA-IDDFS / STACK).
+# Integer-ID DFS with downward depth (PERF-R-CA-IDDFS / STACK / IDTABLE).
 # Iterative frame stack avoids R recursive dispatch and copy-on-write of the
-# path vector on every descent. Semantics match the former recursive ID path:
-# path-local cycle checks (not a global visited set), emit depth+1 when root
-# is among parents, continue through root when the contract does, single hop
-# buffer (IntTerm only at the WAM boundary).
+# path vector on every descent. When an in-memory id_table capability is
+# present, parent vectors are read by list index (no per-node R closure).
+# Semantics match the former recursive ID path: path-local cycle checks
+# (not a global visited set), emit depth+1 when root is among parents,
+# continue through root when the contract does, single hop buffer.
 WamRuntime$category_ancestor_hops_ids <- function(lookup_ids, start_id, root_id,
                                                    visited, vlen0, max_depth,
-                                                   out) {
+                                                   out, id_table = NULL) {
   max_depth <- as.integer(max_depth)
   vlen0 <- as.integer(vlen0)
   root_id <- as.integer(root_id)
+  use_table <- !is.null(id_table)
+  dense <- if (use_table) id_table$dense else NULL
+  dense_cap <- if (use_table) as.integer(id_table$dense_cap) else 0L
+  overflow <- if (use_table) id_table$overflow else NULL
   # Path slots up to max_depth (enter at vlen == max_depth - 1 may write +1).
   need <- max(max_depth + 1L, vlen0, 8L)
   if (length(visited) < need) length(visited) <- need
@@ -3208,7 +3213,21 @@ WamRuntime$category_ancestor_hops_ids <- function(lookup_ids, start_id, root_id,
     if (do_enter) {
       root_seen <- cur_vlen > 0L &&
         any(visited[seq_len(cur_vlen)] == root_id)
-      cur_parents <- lookup_ids(cat_id)
+      if (use_table) {
+        aid <- as.integer(cat_id)
+        if (!is.na(aid) && aid >= 0L && aid < dense_cap) {
+          hit <- dense[[aid + 1L]]
+          cur_parents <- if (is.null(hit)) integer(0) else hit
+        } else if (!is.na(aid)) {
+          ok <- as.character(aid)
+          cur_parents <- if (exists(ok, envir = overflow, inherits = FALSE))
+            get(ok, envir = overflow, inherits = FALSE) else integer(0)
+        } else {
+          cur_parents <- integer(0)
+        }
+      } else {
+        cur_parents <- lookup_ids(cat_id)
+      }
       if (!root_seen && length(cur_parents) > 0L &&
           any(cur_parents == root_id)) {
         n <- out$n + 1L
@@ -3291,15 +3310,16 @@ WamRuntime$category_ancestor <- function(program, state, key, edge_pred,
   edge_atom_id <- WamRuntime$intern(table, edge_pred)
   cap <- WamRuntime$get_arg1_capability(program, edge_key)
   lookup_ids <- if (!is.null(cap)) cap$lookup_ids else NULL
+  id_table <- if (!is.null(cap)) cap$id_table else NULL
   parent_lookup <- if (!is.null(cap)) cap$lookup else NULL
 
   out_terms <- list()
-  if (!is.null(lookup_ids)) {
+  if (!is.null(lookup_ids) || !is.null(id_table)) {
     # ID-native path: convert Visited once, downward depth, integer buffer.
     # Depth is the full Prolog list length, even though only atom entries
     # participate in cycle membership. Keep non-atoms as the zero sentinel
     # so this fast path has the same max_depth semantics as the TermValue
-    # and iterate_goal paths.
+    # and iterate_goal paths. Prefer id_table when present (PERF-R-CA-IDTABLE).
     vlen0 <- length(visited_elems)
     visited_ids <- integer(max(8L, vlen0))
     for (i in seq_along(visited_elems)) {
@@ -3313,7 +3333,7 @@ WamRuntime$category_ancestor <- function(program, state, key, edge_pred,
     out$n <- 0L
     WamRuntime$category_ancestor_hops_ids(
       lookup_ids, as.integer(src_v$id), as.integer(root_v$id),
-      visited_ids, vlen0, as.integer(max_depth), out)
+      visited_ids, vlen0, as.integer(max_depth), out, id_table)
     if (out$n > 0L) {
       out_terms <- vector("list", out$n)
       for (i in seq_len(out$n)) out_terms[[i]] <- IntTerm(out$buf[[i]])
@@ -4390,18 +4410,20 @@ WamRuntime$build_fact_indexes <- function(facts, arity) {
 
 # ----------------------------------------------------------
 # Bound-arg1 parent-lookup capability
-# (PERF-R-CA-DIRECT / IDDFS / IDCACHE)
+# (PERF-R-CA-DIRECT / IDDFS / IDCACHE / IDTABLE)
 # ----------------------------------------------------------
 # Registry: program$arg1_lookups["pred/arity"] -> capability list:
 #   list(lookup = function(key_term) -> list(atom TermValues) | NULL,
-#        lookup_ids = function(atom_id) -> integer vector of parent ids | NULL)
+#        lookup_ids = function(atom_id) -> integer vector of parent ids | NULL,
+#        id_table = list(dense, overflow, dense_cap) | NULL)
 # Installed by codegen after fact tables / FactSources are built — never
 # by guessing pred_*_indexes names from a kernel. lookup_ids enables the
-# integer-ID DFS; lookup alone keeps the TermValue path; neither falls
-# back to iterate_goal. Atom-only parents match collect_parents filtering.
-# In-memory indexed lookup_ids memoizes parent-id vectors by numeric atom
-# id inside the capability closure (PERF-R-CA-IDCACHE). Lazy/cached LMDB
-# capabilities stay on-demand and retain their existing cache policy.
+# integer-ID DFS; id_table (when present) lets the CA loop read parent
+# vectors by list index without a per-node closure; lookup alone keeps
+# the TermValue path; neither falls back to iterate_goal. Atom-only
+# parents match collect_parents filtering. In-memory indexed sources may
+# pre-materialize id_table (PERF-R-CA-IDTABLE) and keep lookup_ids as a
+# thin reader over it. Lazy/cached LMDB stay on-demand (no id_table).
 WamRuntime$arg1_parent_terms_from_tuples <- function(tuples) {
   n <- length(tuples)
   if (n == 0L) return(list())
@@ -4461,6 +4483,77 @@ WamRuntime$make_indexed_arg1_parent_lookup <- function(facts, indexes) {
   }
 }
 
+# Eager in-memory adjacency table for atom-id -> ordered parent-id vectors.
+# Dense list covers ids 0 .. dense_cap-1 (intern ids are 0-based). dense_cap
+# is derived from atom ids present in the fact table (capped), never from an
+# arbitrary query-time id. Higher ids use a hashed overflow env.
+WamRuntime$make_indexed_arg1_parent_id_table <- function(facts, indexes) {
+  if (is.null(indexes) || length(indexes) < 1L) return(NULL)
+  idx0 <- indexes[[1L]]
+  max_id <- -1L
+  for (tup in facts) {
+    for (term in tup) {
+      if (!is.null(term) && !is.null(term$tag) && identical(term$tag, "atom")) {
+        id <- as.integer(term$id)
+        if (!is.na(id) && id > max_id) max_id <- id
+      }
+    }
+  }
+  dense_cap <- as.integer(min(max(max_id + 1L, 1L), 65536L))
+  dense <- vector("list", dense_cap)
+  overflow <- new.env(hash = TRUE, parent = emptyenv())
+  for (bk in ls(idx0, all.names = TRUE)) {
+    if (!startsWith(bk, "a")) next
+    aid <- suppressWarnings(as.integer(substring(bk, 2L)))
+    if (is.na(aid)) next
+    tidxs <- get(bk, envir = idx0, inherits = FALSE)
+    n <- length(tidxs)
+    out <- integer(0)
+    if (n > 0L) {
+      ids <- integer(n)
+      k <- 0L
+      for (ti in tidxs) {
+        tup <- facts[[ti]]
+        if (length(tup) < 2L) next
+        p <- tup[[2L]]
+        if (!is.null(p) && !is.null(p$tag) && identical(p$tag, "atom")) {
+          k <- k + 1L
+          ids[[k]] <- as.integer(p$id)
+        }
+      }
+      out <- if (k == 0L) integer(0) else if (k == n) ids else ids[seq_len(k)]
+    }
+    if (aid >= 0L && aid < dense_cap) {
+      dense[[aid + 1L]] <- out
+    } else {
+      assign(as.character(aid), out, envir = overflow)
+    }
+  }
+  list(dense = dense, overflow = overflow, dense_cap = dense_cap)
+}
+
+# Thin lookup_ids reader over an id_table (API compat / non-CA callers).
+WamRuntime$make_id_table_lookup_ids <- function(id_table) {
+  if (is.null(id_table)) return(NULL)
+  dense <- id_table$dense
+  dense_cap <- as.integer(id_table$dense_cap)
+  overflow <- id_table$overflow
+  function(atom_id) {
+    aid <- as.integer(atom_id)
+    if (is.na(aid)) return(integer(0))
+    if (aid >= 0L && aid < dense_cap) {
+      hit <- dense[[aid + 1L]]
+      if (is.null(hit)) integer(0) else hit
+    } else {
+      k <- as.character(aid)
+      if (exists(k, envir = overflow, inherits = FALSE))
+        get(k, envir = overflow, inherits = FALSE)
+      else integer(0)
+    }
+  }
+}
+
+# Lazy memo lookup_ids (kept for sources that register without id_table).
 WamRuntime$make_indexed_arg1_parent_lookup_ids <- function(facts, indexes) {
   if (is.null(indexes) || length(indexes) < 1L) return(NULL)
   idx0 <- indexes[[1L]]
@@ -4474,14 +4567,16 @@ WamRuntime$make_indexed_arg1_parent_lookup_ids <- function(facts, indexes) {
   # but a capability caller can supply an arbitrary positive integer; growing
   # a list to that id would turn a cache miss into an unbounded allocation.
   # Rare ids beyond the dense bound use a closure-private hashed overflow.
+  # Intern ids are 0-based; dense slots are 1-based via aid+1.
   dense_limit <- max(4096L, length(facts))
   overflow <- new.env(hash = TRUE, parent = emptyenv())
   function(atom_id) {
     aid <- as.integer(atom_id)
-    if (!is.na(aid) && aid >= 1L) {
-      if (aid <= dense_limit) {
-        if (aid <= length(cache)) {
-          hit <- cache[[aid]]
+    if (!is.na(aid) && aid >= 0L) {
+      if (aid < dense_limit) {
+        slot <- aid + 1L
+        if (slot <= length(cache)) {
+          hit <- cache[[slot]]
           if (!is.null(hit)) return(hit)
         }
       } else {
@@ -4512,10 +4607,11 @@ WamRuntime$make_indexed_arg1_parent_lookup_ids <- function(facts, indexes) {
           out <- if (k == 0L) integer(0) else if (k == n) ids else ids[seq_len(k)]
         }
       }
-      if (aid >= 1L) {
-        if (aid <= dense_limit) {
-          if (aid > length(cache)) length(cache) <<- aid
-          cache[[aid]] <<- out
+      if (aid >= 0L) {
+        if (aid < dense_limit) {
+          slot <- aid + 1L
+          if (slot > length(cache)) length(cache) <<- slot
+          cache[[slot]] <<- out
         } else {
           assign(as.character(aid), out, envir = overflow)
         }
@@ -4528,11 +4624,14 @@ WamRuntime$make_indexed_arg1_parent_lookup_ids <- function(facts, indexes) {
 WamRuntime$normalize_arg1_capability <- function(cap) {
   if (is.null(cap)) return(NULL)
   # Legacy: bare function treated as TermValue-only lookup.
-  if (is.function(cap)) return(list(lookup = cap, lookup_ids = NULL))
+  if (is.function(cap)) {
+    return(list(lookup = cap, lookup_ids = NULL, id_table = NULL))
+  }
   if (!is.list(cap)) return(NULL)
   list(
     lookup = if (!is.null(cap$lookup)) cap$lookup else NULL,
-    lookup_ids = if (!is.null(cap$lookup_ids)) cap$lookup_ids else NULL
+    lookup_ids = if (!is.null(cap$lookup_ids)) cap$lookup_ids else NULL,
+    id_table = if (!is.null(cap$id_table)) cap$id_table else NULL
   )
 }
 
@@ -4552,10 +4651,23 @@ WamRuntime$register_arg1_parent_lookup_fn <- function(program, key, fn,
 
 WamRuntime$register_indexed_arg1_parent_lookup <- function(program, key,
                                                             facts, indexes) {
+  id_table <- WamRuntime$make_indexed_arg1_parent_id_table(facts, indexes)
+  lookup_ids <- if (!is.null(id_table)) {
+    WamRuntime$make_id_table_lookup_ids(id_table)
+  } else {
+    WamRuntime$make_indexed_arg1_parent_lookup_ids(facts, indexes)
+  }
   WamRuntime$register_arg1_capability(program, key, list(
     lookup = WamRuntime$make_indexed_arg1_parent_lookup(facts, indexes),
-    lookup_ids = WamRuntime$make_indexed_arg1_parent_lookup_ids(facts, indexes)
+    lookup_ids = lookup_ids,
+    id_table = id_table
   ))
+}
+
+WamRuntime$get_arg1_parent_id_table <- function(program, key) {
+  cap <- WamRuntime$get_arg1_capability(program, key)
+  if (is.null(cap)) return(NULL)
+  cap$id_table
 }
 
 WamRuntime$register_lmdb_arg1_parent_lookup <- function(program, key, path,

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -4423,9 +4423,9 @@ WamRuntime$build_fact_indexes <- function(facts, arity) {
 # integer-ID DFS; id_table (when present) lets the CA loop read parent
 # vectors by list index without a per-node closure; lookup alone keeps
 # the TermValue path; neither falls back to iterate_goal. Atom-only
-# parents match collect_parents filtering. In-memory indexed sources may
-# pre-materialize id_table (PERF-R-CA-IDTABLE) and keep lookup_ids as a
-# thin reader over it. Lazy/cached LMDB stay on-demand (no id_table).
+# parents match collect_parents filtering. In-memory indexed sources expose
+# a lazy-on-first-CA id_table (PERF-R-CA-IDTABLE); lookup_ids keeps its prior
+# lazy memo API for other callers. Lazy/cached LMDB stay on-demand (no table).
 WamRuntime$arg1_parent_terms_from_tuples <- function(tuples) {
   n <- length(tuples)
   if (n == 0L) return(list())

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -3310,7 +3310,9 @@ WamRuntime$category_ancestor <- function(program, state, key, edge_pred,
   edge_atom_id <- WamRuntime$intern(table, edge_pred)
   cap <- WamRuntime$get_arg1_capability(program, edge_key)
   lookup_ids <- if (!is.null(cap)) cap$lookup_ids else NULL
-  id_table <- if (!is.null(cap)) cap$id_table else NULL
+  id_table <- if (!is.null(cap)) {
+    WamRuntime$resolve_arg1_parent_id_table(cap$id_table)
+  } else NULL
   parent_lookup <- if (!is.null(cap)) cap$lookup else NULL
 
   out_terms <- list()
@@ -4415,7 +4417,7 @@ WamRuntime$build_fact_indexes <- function(facts, arity) {
 # Registry: program$arg1_lookups["pred/arity"] -> capability list:
 #   list(lookup = function(key_term) -> list(atom TermValues) | NULL,
 #        lookup_ids = function(atom_id) -> integer vector of parent ids | NULL,
-#        id_table = list(dense, overflow, dense_cap) | NULL)
+#        id_table = lazy state or list(dense, overflow, dense_cap) | NULL)
 # Installed by codegen after fact tables / FactSources are built — never
 # by guessing pred_*_indexes names from a kernel. lookup_ids enables the
 # integer-ID DFS; id_table (when present) lets the CA loop read parent
@@ -4532,25 +4534,26 @@ WamRuntime$make_indexed_arg1_parent_id_table <- function(facts, indexes) {
   list(dense = dense, overflow = overflow, dense_cap = dense_cap)
 }
 
-# Thin lookup_ids reader over an id_table (API compat / non-CA callers).
-WamRuntime$make_id_table_lookup_ids <- function(id_table) {
-  if (is.null(id_table)) return(NULL)
-  dense <- id_table$dense
-  dense_cap <- as.integer(id_table$dense_cap)
-  overflow <- id_table$overflow
-  function(atom_id) {
-    aid <- as.integer(atom_id)
-    if (is.na(aid)) return(integer(0))
-    if (aid >= 0L && aid < dense_cap) {
-      hit <- dense[[aid + 1L]]
-      if (is.null(hit)) integer(0) else hit
-    } else {
-      k <- as.character(aid)
-      if (exists(k, envir = overflow, inherits = FALSE))
-        get(k, envir = overflow, inherits = FALSE)
-      else integer(0)
+# Defer eager adjacency construction until a CA kernel actually requests it.
+# Registration is emitted for every in-memory FactSource with arity >= 2, so
+# building here would charge unrelated predicates the table's setup/memory.
+WamRuntime$make_lazy_indexed_arg1_parent_id_table <- function(facts, indexes) {
+  state <- new.env(parent = emptyenv())
+  state$ready <- FALSE
+  state$value <- NULL
+  state$get <- function() {
+    if (!state$ready) {
+      state$value <- WamRuntime$make_indexed_arg1_parent_id_table(facts, indexes)
+      state$ready <- TRUE
     }
+    state$value
   }
+  state
+}
+
+WamRuntime$resolve_arg1_parent_id_table <- function(id_table) {
+  if (is.environment(id_table) && is.function(id_table$get)) id_table$get()
+  else id_table
 }
 
 # Lazy memo lookup_ids (kept for sources that register without id_table).
@@ -4651,23 +4654,17 @@ WamRuntime$register_arg1_parent_lookup_fn <- function(program, key, fn,
 
 WamRuntime$register_indexed_arg1_parent_lookup <- function(program, key,
                                                             facts, indexes) {
-  id_table <- WamRuntime$make_indexed_arg1_parent_id_table(facts, indexes)
-  lookup_ids <- if (!is.null(id_table)) {
-    WamRuntime$make_id_table_lookup_ids(id_table)
-  } else {
-    WamRuntime$make_indexed_arg1_parent_lookup_ids(facts, indexes)
-  }
   WamRuntime$register_arg1_capability(program, key, list(
     lookup = WamRuntime$make_indexed_arg1_parent_lookup(facts, indexes),
-    lookup_ids = lookup_ids,
-    id_table = id_table
+    lookup_ids = WamRuntime$make_indexed_arg1_parent_lookup_ids(facts, indexes),
+    id_table = WamRuntime$make_lazy_indexed_arg1_parent_id_table(facts, indexes)
   ))
 }
 
 WamRuntime$get_arg1_parent_id_table <- function(program, key) {
   cap <- WamRuntime$get_arg1_capability(program, key)
   if (is.null(cap)) return(NULL)
-  cap$id_table
+  WamRuntime$resolve_arg1_parent_id_table(cap$id_table)
 }
 
 WamRuntime$register_lmdb_arg1_parent_lookup <- function(program, key, path,

--- a/tests/test_wam_r_ca_direct_lookup.pl
+++ b/tests/test_wam_r_ca_direct_lookup.pl
@@ -57,7 +57,7 @@ test(grouped_by_first_atoms_registers_indexed_lookup, [nondet]) :-
             % IDCACHE: lazy memo helper retained for non-table sources
             assertion(once(sub_string(Rt, _, _, _,
                 'Closure-private memo'))),
-            % IDTABLE: eager dense+overflow adjacency + direct CA read
+            % IDTABLE: lazy-on-first-CA dense+overflow adjacency + direct read
             assertion(once(sub_string(Rt, _, _, _,
                 'id_table'))),
             assertion(once(sub_string(Rt, _, _, _,
@@ -153,11 +153,15 @@ stopifnot(!is.null(shared_program$arg1_lookups))
 stopifnot(exists("cparent/2", envir = shared_program$arg1_lookups, inherits = FALSE))
 cap <- WamRuntime$get_arg1_capability(shared_program, "cparent/2")
 stopifnot(!is.null(cap$lookup), !is.null(cap$lookup_ids), !is.null(cap$id_table))
+# Registration is fleet-wide for arity>=2 in-memory FactSources; the table must
+# remain unbuilt until a CA kernel actually requests it.
+stopifnot(is.environment(cap$id_table), identical(cap$id_table$ready, FALSE))
 lk <- WamRuntime$get_arg1_parent_lookup(shared_program, "cparent/2")
 stopifnot(!is.null(lk))
 lk_ids <- WamRuntime$get_arg1_parent_lookup_ids(shared_program, "cparent/2")
 stopifnot(!is.null(lk_ids))
 id_tab <- WamRuntime$get_arg1_parent_id_table(shared_program, "cparent/2")
+stopifnot(identical(cap$id_table$ready, TRUE))
 stopifnot(!is.null(id_tab), !is.null(id_tab$dense), !is.null(id_tab$overflow))
 stopifnot(as.integer(id_tab$dense_cap) >= 1L)
 stopifnot(as.integer(id_tab$dense_cap) <= 65536L)
@@ -170,15 +174,15 @@ stopifnot(is.null(legacy$lookup_ids), is.null(legacy$id_table), !is.null(legacy$
 # IDTABLE / lookup_ids parity (in-memory indexed)
 # ------------------------------------------------------------------
 aid <- function(nm) as.integer(WamRuntime$intern(intern_table, nm))
-read_table <- function(atom_id) {
+read_table <- function(tab, atom_id) {
   aid0 <- as.integer(atom_id)
-  if (aid0 >= 0L && aid0 < id_tab$dense_cap) {
-    hit <- id_tab$dense[[aid0 + 1L]]
+  if (aid0 >= 0L && aid0 < tab$dense_cap) {
+    hit <- tab$dense[[aid0 + 1L]]
     if (is.null(hit)) integer(0) else hit
   } else {
     k <- as.character(aid0)
-    if (exists(k, envir = id_tab$overflow, inherits = FALSE))
-      get(k, envir = id_tab$overflow, inherits = FALSE)
+    if (exists(k, envir = tab$overflow, inherits = FALSE))
+      get(k, envir = tab$overflow, inherits = FALSE)
     else integer(0)
   }
 }
@@ -187,19 +191,19 @@ p_a1 <- lk_ids(aid("a"))
 p_a2 <- lk_ids(aid("a"))
 stopifnot(identical(p_a1, p_a2))
 stopifnot(identical(p_a1, c(aid("b"), aid("c"), aid("z"), aid("p"))))
-stopifnot(identical(read_table(aid("a")), p_a1))
+stopifnot(identical(read_table(id_tab, aid("a")), p_a1))
 # shared parents across source ids
 p_b <- lk_ids(aid("b"))
 p_c <- lk_ids(aid("c"))
 stopifnot(identical(p_b, aid("d")), identical(p_c, aid("d")))
-stopifnot(identical(read_table(aid("b")), p_b), identical(read_table(aid("c")), p_c))
+stopifnot(identical(read_table(id_tab, aid("b")), p_b), identical(read_table(id_tab, aid("c")), p_c))
 # missing key and empty-after-filter both yield integer(0)
 stopifnot(identical(lk_ids(aid("no_such_node")), integer(0)))
-stopifnot(identical(read_table(aid("no_such_node")), integer(0)))
+stopifnot(identical(read_table(id_tab, aid("no_such_node")), integer(0)))
 # numeric-looking atom names remain atoms (not ints)
 stopifnot(identical(lk_ids(aid("1827")), aid("mid")))
 stopifnot(identical(lk_ids(aid("mid")), aid("9001")))
-stopifnot(identical(read_table(aid("1827")), aid("mid")))
+stopifnot(identical(read_table(id_tab, aid("1827")), aid("mid")))
 # Synthetic facts: mixed atom/non-atom parents + empty bucket + lazy sticky
 syn_facts <- list(
   list(Atom(aid("sx")), Atom(aid("pa"))),
@@ -211,15 +215,14 @@ syn_facts <- list(
 syn_idx <- WamRuntime$build_fact_indexes(syn_facts, 2L)
 syn_ids <- WamRuntime$make_indexed_arg1_parent_lookup_ids(syn_facts, syn_idx)
 syn_tab <- WamRuntime$make_indexed_arg1_parent_id_table(syn_facts, syn_idx)
-syn_tab_ids <- WamRuntime$make_id_table_lookup_ids(syn_tab)
 stopifnot(identical(syn_ids(aid("sx")), c(aid("pa"), aid("pb"))))
-stopifnot(identical(syn_tab_ids(aid("sx")), syn_ids(aid("sx"))))
+stopifnot(identical(read_table(syn_tab, aid("sx")), syn_ids(aid("sx"))))
 stopifnot(identical(syn_ids(aid("sy")), aid("pa")))
-stopifnot(identical(syn_tab_ids(aid("sy")), syn_ids(aid("sy"))))
+stopifnot(identical(read_table(syn_tab, aid("sy")), syn_ids(aid("sy"))))
 stopifnot(identical(syn_ids(aid("sz")), integer(0)))  # non-atom-only bucket
-stopifnot(identical(syn_tab_ids(aid("sz")), integer(0)))
+stopifnot(identical(read_table(syn_tab, aid("sz")), integer(0)))
 stopifnot(identical(syn_ids(aid("missing_syn")), integer(0)))
-stopifnot(identical(syn_tab_ids(aid("missing_syn")), integer(0)))
+stopifnot(identical(read_table(syn_tab, aid("missing_syn")), integer(0)))
 # lazy cache hit retains first result even if underlying facts are mutated
 first_sx <- syn_ids(aid("sx"))
 syn_facts[[1L]][[2L]] <- Atom(aid("mutated"))
@@ -229,7 +232,7 @@ stopifnot(identical(first_sx, c(aid("pa"), aid("pb"))))
 syn_ids2 <- WamRuntime$make_indexed_arg1_parent_lookup_ids(syn_facts, syn_idx)
 syn_tab2 <- WamRuntime$make_indexed_arg1_parent_id_table(syn_facts, syn_idx)
 stopifnot(identical(syn_ids2(aid("sx")), c(aid("mutated"), aid("pb"))))
-stopifnot(identical(WamRuntime$make_id_table_lookup_ids(syn_tab2)(aid("sx")),
+stopifnot(identical(read_table(syn_tab2, aid("sx")),
                     c(aid("mutated"), aid("pb"))))
 # Arbitrary sparse ids must not grow the dense list to the id value.
 high_id <- 1000000000L
@@ -238,12 +241,10 @@ high_idx <- WamRuntime$build_fact_indexes(high_facts, 2L)
 high_ids <- WamRuntime$make_indexed_arg1_parent_lookup_ids(high_facts, high_idx)
 high_tab <- WamRuntime$make_indexed_arg1_parent_id_table(high_facts, high_idx)
 stopifnot(identical(high_ids(high_id), aid("pa")))
-stopifnot(identical(WamRuntime$make_id_table_lookup_ids(high_tab)(high_id),
-                    aid("pa")))
+stopifnot(identical(read_table(high_tab, high_id), aid("pa")))
 stopifnot(as.integer(high_tab$dense_cap) <= 65536L)
 high_facts[[1L]][[2L]] <- Atom(aid("mutated"))
 stopifnot(identical(high_ids(high_id), aid("pa")))  # sparse cache hit
-stopifnot(identical(high_ids(.Machine$integer.max), integer(0)))
 stopifnot(identical(high_ids(.Machine$integer.max), integer(0)))  # cached miss
 
 collect_hops <- function(cat, root, visited_chars, sorted = TRUE) {

--- a/tests/test_wam_r_ca_direct_lookup.pl
+++ b/tests/test_wam_r_ca_direct_lookup.pl
@@ -2,9 +2,10 @@
 % SPDX-License-Identifier: MIT OR Apache-2.0
 % Copyright (c) 2026 John William Creighton (@s243a)
 %
-% PERF-R-CA-DIRECT / IDDFS / IDCACHE / STACK: capability-gated bound-arg1
-% parent lookup for the R category_ancestor/4 kernel, including integer-ID
-% DFS, closure-private parent-id memoization, and iterative frame-stack DFS.
+% PERF-R-CA-DIRECT / IDDFS / IDCACHE / STACK / IDTABLE: capability-gated
+% bound-arg1 parent lookup for the R category_ancestor/4 kernel, including
+% integer-ID DFS, optional in-memory id_table adjacency, and iterative
+% frame-stack DFS.
 %
 % Usage: swipl -g run_tests -t halt tests/test_wam_r_ca_direct_lookup.pl
 
@@ -48,14 +49,19 @@ test(grouped_by_first_atoms_registers_indexed_lookup, [nondet]) :-
             assertion(once(sub_string(Rt, _, _, _,
                 'make_indexed_arg1_parent_lookup_ids'))),
             assertion(once(sub_string(Rt, _, _, _,
+                'make_indexed_arg1_parent_id_table'))),
+            assertion(once(sub_string(Rt, _, _, _,
                 'category_ancestor_hops_ids'))),
             assertion(\+ sub_string(Rt, _, _, _,
                 'category_ancestor_hops_rec_ids')),
-            % IDCACHE: in-memory lookup_ids keeps a closure-private memo
+            % IDCACHE: lazy memo helper retained for non-table sources
             assertion(once(sub_string(Rt, _, _, _,
                 'Closure-private memo'))),
+            % IDTABLE: eager dense+overflow adjacency + direct CA read
             assertion(once(sub_string(Rt, _, _, _,
-                'cache[[aid]] <<- out'))),
+                'id_table'))),
+            assertion(once(sub_string(Rt, _, _, _,
+                'use_table'))),
             % STACK: iterative frame stack (no recursive ID DFS)
             assertion(once(sub_string(Rt, _, _, _,
                 'st_parents'))),
@@ -146,31 +152,55 @@ ca_direct_runtime_proof :-
 stopifnot(!is.null(shared_program$arg1_lookups))
 stopifnot(exists("cparent/2", envir = shared_program$arg1_lookups, inherits = FALSE))
 cap <- WamRuntime$get_arg1_capability(shared_program, "cparent/2")
-stopifnot(!is.null(cap$lookup), !is.null(cap$lookup_ids))
+stopifnot(!is.null(cap$lookup), !is.null(cap$lookup_ids), !is.null(cap$id_table))
 lk <- WamRuntime$get_arg1_parent_lookup(shared_program, "cparent/2")
 stopifnot(!is.null(lk))
 lk_ids <- WamRuntime$get_arg1_parent_lookup_ids(shared_program, "cparent/2")
 stopifnot(!is.null(lk_ids))
+id_tab <- WamRuntime$get_arg1_parent_id_table(shared_program, "cparent/2")
+stopifnot(!is.null(id_tab), !is.null(id_tab$dense), !is.null(id_tab$overflow))
+stopifnot(as.integer(id_tab$dense_cap) >= 1L)
+stopifnot(as.integer(id_tab$dense_cap) <= 65536L)
+
+# Legacy bare-function capability normalizes without id_table
+legacy <- WamRuntime$normalize_arg1_capability(function(x) list())
+stopifnot(is.null(legacy$lookup_ids), is.null(legacy$id_table), !is.null(legacy$lookup))
 
 # ------------------------------------------------------------------
-# IDCACHE: memoized numeric-key parent buckets (in-memory indexed)
+# IDTABLE / lookup_ids parity (in-memory indexed)
 # ------------------------------------------------------------------
 aid <- function(nm) as.integer(WamRuntime$intern(intern_table, nm))
+read_table <- function(atom_id) {
+  aid0 <- as.integer(atom_id)
+  if (aid0 >= 0L && aid0 < id_tab$dense_cap) {
+    hit <- id_tab$dense[[aid0 + 1L]]
+    if (is.null(hit)) integer(0) else hit
+  } else {
+    k <- as.character(aid0)
+    if (exists(k, envir = id_tab$overflow, inherits = FALSE))
+      get(k, envir = id_tab$overflow, inherits = FALSE)
+    else integer(0)
+  }
+}
 # miss then hit: identical ordered parent ids
 p_a1 <- lk_ids(aid("a"))
 p_a2 <- lk_ids(aid("a"))
 stopifnot(identical(p_a1, p_a2))
 stopifnot(identical(p_a1, c(aid("b"), aid("c"), aid("z"), aid("p"))))
+stopifnot(identical(read_table(aid("a")), p_a1))
 # shared parents across source ids
 p_b <- lk_ids(aid("b"))
 p_c <- lk_ids(aid("c"))
 stopifnot(identical(p_b, aid("d")), identical(p_c, aid("d")))
+stopifnot(identical(read_table(aid("b")), p_b), identical(read_table(aid("c")), p_c))
 # missing key and empty-after-filter both yield integer(0)
 stopifnot(identical(lk_ids(aid("no_such_node")), integer(0)))
+stopifnot(identical(read_table(aid("no_such_node")), integer(0)))
 # numeric-looking atom names remain atoms (not ints)
 stopifnot(identical(lk_ids(aid("1827")), aid("mid")))
 stopifnot(identical(lk_ids(aid("mid")), aid("9001")))
-# Synthetic facts: mixed atom/non-atom parents + empty bucket + cache sticky
+stopifnot(identical(read_table(aid("1827")), aid("mid")))
+# Synthetic facts: mixed atom/non-atom parents + empty bucket + lazy sticky
 syn_facts <- list(
   list(Atom(aid("sx")), Atom(aid("pa"))),
   list(Atom(aid("sx")), IntTerm(99L)),
@@ -180,24 +210,37 @@ syn_facts <- list(
 )
 syn_idx <- WamRuntime$build_fact_indexes(syn_facts, 2L)
 syn_ids <- WamRuntime$make_indexed_arg1_parent_lookup_ids(syn_facts, syn_idx)
+syn_tab <- WamRuntime$make_indexed_arg1_parent_id_table(syn_facts, syn_idx)
+syn_tab_ids <- WamRuntime$make_id_table_lookup_ids(syn_tab)
 stopifnot(identical(syn_ids(aid("sx")), c(aid("pa"), aid("pb"))))
+stopifnot(identical(syn_tab_ids(aid("sx")), syn_ids(aid("sx"))))
 stopifnot(identical(syn_ids(aid("sy")), aid("pa")))
+stopifnot(identical(syn_tab_ids(aid("sy")), syn_ids(aid("sy"))))
 stopifnot(identical(syn_ids(aid("sz")), integer(0)))  # non-atom-only bucket
+stopifnot(identical(syn_tab_ids(aid("sz")), integer(0)))
 stopifnot(identical(syn_ids(aid("missing_syn")), integer(0)))
-# cache hit retains first result even if underlying facts are mutated
+stopifnot(identical(syn_tab_ids(aid("missing_syn")), integer(0)))
+# lazy cache hit retains first result even if underlying facts are mutated
 first_sx <- syn_ids(aid("sx"))
 syn_facts[[1L]][[2L]] <- Atom(aid("mutated"))
 stopifnot(identical(syn_ids(aid("sx")), first_sx))
 stopifnot(identical(first_sx, c(aid("pa"), aid("pb"))))
-# fresh uncached builder sees the mutation
+# fresh builders see the mutation
 syn_ids2 <- WamRuntime$make_indexed_arg1_parent_lookup_ids(syn_facts, syn_idx)
+syn_tab2 <- WamRuntime$make_indexed_arg1_parent_id_table(syn_facts, syn_idx)
 stopifnot(identical(syn_ids2(aid("sx")), c(aid("mutated"), aid("pb"))))
+stopifnot(identical(WamRuntime$make_id_table_lookup_ids(syn_tab2)(aid("sx")),
+                    c(aid("mutated"), aid("pb"))))
 # Arbitrary sparse ids must not grow the dense list to the id value.
 high_id <- 1000000000L
 high_facts <- list(list(Atom(high_id), Atom(aid("pa"))))
 high_idx <- WamRuntime$build_fact_indexes(high_facts, 2L)
 high_ids <- WamRuntime$make_indexed_arg1_parent_lookup_ids(high_facts, high_idx)
+high_tab <- WamRuntime$make_indexed_arg1_parent_id_table(high_facts, high_idx)
 stopifnot(identical(high_ids(high_id), aid("pa")))
+stopifnot(identical(WamRuntime$make_id_table_lookup_ids(high_tab)(high_id),
+                    aid("pa")))
+stopifnot(as.integer(high_tab$dense_cap) <= 65536L)
 high_facts[[1L]][[2L]] <- Atom(aid("mutated"))
 stopifnot(identical(high_ids(high_id), aid("pa")))  # sparse cache hit
 stopifnot(identical(high_ids(.Machine$integer.max), integer(0)))


### PR DESCRIPTION
## Summary

Add an optional integer adjacency table to in-memory indexed FactSource capabilities so the R category-ancestor loop reads ordered parent-ID vectors directly instead of invoking `lookup_ids` about 516,000 times per scale-300 query.

The table is materialized **lazily on first CA use**. Registration is emitted for every in-memory FactSource with arity ≥2, so unrelated predicates do not pay the table's setup or memory cost. Lazy/cached LMDB remains on demand and receives no `id_table`. TermValue and generic `iterate_goal` fallbacks are unchanged.

## Profiling

Post-STACK/PATHMARK:

- approximately 516,522 DFS node visits;
- approximately 2,273 distinct IDs;
- approximately 99.56% lookup-cache-hit opportunity;
- cached `lookup_ids` approximately 6.9% self / 19.9% total in Rprof;
- 516k-call microbenchmark: cached closure approximately 0.41 s, direct list reads approximately 0.055 s;
- wrapping the table in a per-node closure remained approximately 0.35 s, confirming closure dispatch as the target.

PATHMARK membership was not revisited.

## Design

- `make_indexed_arg1_parent_id_table`: bounded dense list plus sparse overflow.
- `make_lazy_indexed_arg1_parent_id_table`: one-time materialization state.
- `category_ancestor` resolves the table once per kernel invocation.
- `category_ancestor_hops_ids` uses direct list access on dense hits.
- Existing `lookup` and lazy-memo `lookup_ids` APIs remain available.
- Capability normalization is additive; legacy bare functions receive `id_table = NULL`.
- Dense capacity is derived from fact atom IDs and capped at 65,536, never from a query-time ID.
- Helpers remain inline in `runtime.R.mustache`; no new template partial.

Review follow-up: the original branch built a table eagerly for every registered arity≥2 in-memory FactSource. The corrected implementation leaves the capability unbuilt after registration and materializes it only if CA requests it. The focused test asserts both states.

## Performance

Same-host Cursor cloud agent, R 4.3.3, three repetitions:

| Stage | query median | total median | query samples |
|---|---:|---:|---|
| STACK | 2729 ms | 3255 ms | 3299, 2729, 2661 |
| IDTABLE | 2607 ms | 3186 ms | 3158, 2607, 2601 |

Hosted Ubuntu 24.04, R 4.3.3:

- IDTABLE samples: `4078, 3412, 3268 ms`;
- median query/total: **3412 / 4076 ms**;
- hosted STACK baseline: `3679 / 4344 ms`;
- improvement: **1.08× query**, **1.07× total**;
- 271 rows with canonical six-decimal reference parity;
- about **18.3×** query improvement over the original hosted R result of 62,595 ms.

The table build is approximately 0.03 s and approximately 151–154 KiB at scale 300. Post-change Rprof removes `lookup_ids` from the hot list; `hops_ids` is approximately 25% self / 32% total.

The temporary hosted measurement step was removed after recording the result.

## Compatibility and tests

The existing focused R CA harness covers:

- table/`lookup_ids` parity;
- lazy table materialization;
- duplicates and exact parent order;
- cycles, diamonds, roots, depth boundaries, and mixed/non-atom `Visited`;
- empty buckets and sparse/high IDs;
- legacy capability normalization;
- LMDB laziness markers;
- TermValue and generic fallbacks;
- exact unsorted three-path differential parity.

Validation:

```bash
swipl -g run_tests -t halt tests/test_wam_r_ca_direct_lookup.pl
```

The hosted R lane passes the focused regressions, ISO smoke, effective-distance smoke, direct arg1 suite, benchmark parity, and full classic conformance.

## Change size

- Production runtime: +137 / −28, net +109.
- Focused existing test harness: +55 / −11, net +44.
- Remaining changes are benchmark/status documentation.
