### PR TITLE
plawk: BEGIN-only programs (and exit in BEGIN)

### DIFF
--- a/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
+++ b/docs/design/PLAWK_AWK_FEATURE_AUDIT.md
@@ -45,7 +45,7 @@ only (runtime pending) · ❌ missing.
 | field assignment (`$2 = expr`) | ✅ | `Pattern { $N = expr; …; print $0 }` splits the record once into an editable field buffer (`%WamFieldBuf` — slices into the record text, no interning), mutates the slot in place (`@wam_fields_set`), and `print $0` joins the fields with OFS once (`@wam_fields_join`). O(record), not O(assignments × record), and zero interning on this path. RHS is a string/integer literal or another field `$M` (read from the current buffer); chained assignments and a pattern guard work; setting a field past the end pads with empties. **v1 scope:** an explicit `FS` (single char **or a multi-char regex** — the buffer splits via `@wam_fields_new_re`), a single rule with no `END`, and the print-the-record idiom. Follow-ons: default (space) `FS`, in-body field reads after assignment, `$0 = expr`, multi-rule/`END` programs, concat/arithmetic RHS. See `PLAWK_FIELD_BUFFER.md` for the field-buffer representation and its scaling note (flat array now; map / hashtable for wide or sparse field spaces) |
 | C-style `for (INIT; COND; UPDATE)` | ◐ | **landed for the three-part form.** A parser normalisation pass (`plawk_normalise_c_for`) desugars `for (INIT; COND; UPDATE) BODY` to `INIT; while (COND) { BODY; UPDATE }`, reusing the while runtime with no codegen changes. INIT/UPDATE are simple statements — an assignment (`i = 0`), an increment (`i++`), or a compound-assign (`i += 3`); COND is the general `while` condition (`i < n`, `&&`/`||`). `break` exits the loop, and loops nest (`for (i…) for (j…)`). Tried after `for (k in arr)` (which commits on `in`); the `;` separators distinguish them. Follow-ons: **`continue`** targeting the for (it would skip the appended UPDATE and infinite-loop, so a for whose own body has a `continue` is left un-desugared and **cleanly rejected** by codegen — a `continue` inside a nested loop in the body is fine); empty parts (`for (;;)`, `for (; c; )`) — v1 requires all three |
 | `delete arr[k]` | ◐ | `delete arr[$k]` removes the entry keyed by a field (parity with `arr[$k]++`), **and `delete arr["lit"]` by a string literal** — the literal is interned to its canonical atom id (via a private c-string global) and handed to the same void backward-shift delete, so it matches the id a `arr["lit"]++` / field key would produce for the same bytes; no missing-key branch is needed (the literal is always present). **An integer-literal key `delete arr[5]`** works too — awk array keys are strings, so the integer is keyed by its decimal text (`"5"`), reusing the string-literal delete. Backward-shift deletion in the runtime (later colliding keys stay reachable), missing key is a no-op (the runtime delete is a no-op for an absent interned key). **Scalar-variable keys landed for both the counter `arr[x]++` and `delete arr[x]`** — in the mixed chain (a program whose END is a plain print, so scalar slots reach the assoc-key site), the group-by-a-copied-field idiom `{ k = $1; freq[k]++ }` and its `delete freq[k]` counterpart work: reading a scalar as an assoc key (inc or delete) is a supported strnum read, so `k` stays a `scalar_strnum` slot whose value already IS the interned atom id `arr[$1]` would produce, and inc/delete use it directly (no field-slice / re-intern). The delete is the same straight-line void `@wam_assoc_i64_delete` on the resolved key id (a missing key is a runtime no-op). **Reading `arr[k]` as a value landed too** (`print arr[k]`) — the walker resolves the read to the array's table index + the key scalar's slot value, then the print emitter fetches the i64 count via `@wam_assoc_i64_get` (absent key → 0) and prints it with `%ld`; it composes in a comma list and in concat (`print "n=" arr[k]`), and the key scalar stays strnum (printable as text and usable as a key in the same record). **A numeric (counter) scalar key works too** for all three ops (`arr[n]++` / `delete arr[n]` / `print arr[n]` where `n` is an i64 counter) — awk array keys are strings, so the counter value is interned via its decimal spelling (`@wam_intern_i64_decimal`, `snprintf` `%lld` → `@wam_intern_atom`) to the same atom id a `"5"` literal / field key would produce. A **double** scalar key is the remaining not-yet (no float→string key path) — it declines cleanly rather than mis-lowering to a garbage `i64 svar(_)` field slice (the field-key inc path is now guarded to integer keys). **The no-`END` group-by also landed in the pure-assoc chain** (a `for (k in arr)` END, which has no scalar SSA slots): a `k = $N` action interns field N into a module global `@plawk_scalar_<name>` (empty string for a field past NF), and `arr[k]++` loads that atom id as the key — so the classic word-count `{ k = $1; freq[k]++ } END { for (w in freq) print w, freq[w] }` works without a literal-key END (v1: a field-copy key; a computed/numeric key in this chain declines cleanly). Reading via `printf` is a separate follow-on (declines cleanly) |
-| `exit [n]` | ✅ | stops the record loop, runs END, returns N (default 0); `exit` in a rule body, an `if`/`else` branch, or a loop (propagates past the loop) — scalar state at the exit point flows into END. **Also in an `END` block** (`END { print n; exit 1 }`): the store plus truncation of the rest of the block, and it overrides a rule-level `exit`. `exit` in a `BEGIN` block is still a parse error (it would have to skip the record loop yet still run END — see gap 4) |
+| `exit [n]` | ✅ | stops the record loop, runs END, returns N (default 0); `exit` in a rule body, an `if`/`else` branch, or a loop (propagates past the loop) — scalar state at the exit point flows into END. **Also in an `END` block** (`END { print n; exit 1 }`): the store plus truncation of the rest of the block, and it overrides a rule-level `exit`. **And in a BEGIN-ONLY program** (`BEGIN { print 1+1; exit 3 }`), where there is no loop to skip. `exit` in a BEGIN block of a program that HAS rules declines — it would have to skip the loop yet still run END (see gap 4) |
 | `delete arr[k]` | ❌ | |
 | `getline` | ◐ | **Main-input, redirected, and command-pipe scalar/record getline landed.** Plain `getline` reads the next record from the primary driver stream into `$0`, re-splits `$1…$NF` with the active FS, updates `NF`, and advances `NR`/`FNR`; `getline var` advances the same stream and counters but preserves `$0`/fields. Both honor the active RS (including regex RS) and RT because they share the driver's reader state. Redirected `getline var < "file"` and `getline < "file"` use filename-keyed handles; redirected record getline does **not** advance NR/FNR and remains physical-newline-only in v1, but now **updates `RT`** to the separator it matched (a physical newline, or empty at a trailing unterminated record / EOF), matching gawk (which sets `RT` on every getline); it restores the caller's `RS` afterward. Literal-command `"cmd" | getline` and `"cmd" | getline var` use a command-keyed `popen(cmd, "r")` registry shared by both target forms: the record target replaces `$0` and re-splits fields, the scalar target preserves `$0`/fields, and each successful pipe record advances `NR` (therefore also `FNR`, which is intentionally an alias of `NR` in plawk's single-input model). Pipe reads are physical-newline-only in v1 but now **update `RT`** to the matched separator (`"\n"` for a newline-terminated pipe record, empty for a final record with no trailing newline), for both the record and scalar pipe forms, matching gawk. All three families support bare statements, status capture, and canonical while-drain forms, returning 1 on a record, 0 at clean EOF (including a child that merely exits nonzero), or -1 on an actual pipe/open/read/close/allocation failure; EOF/error preserve the target. `cmd | getline` necessarily executes the shell command supplied by the awk program. Cleanly rejected follow-ons: dynamic filenames or commands, and getline in BEGIN/END. The multi-pass / `over` readers still cover the bulk-scan use |
 
@@ -206,17 +206,29 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    `tests/test_plawk_end_exit.pl`. *Still open (follow-on):* `exit` in the
    ASSOC / for-in END chains (they have their own emitters -- all decline
    cleanly), `exit` inside an END `if` branch (that surface takes prints only),
-   non-constant exit codes (`exit code_var`), and `exit` in a **`BEGIN`**
-   block. That last one is NOT a grammar gap like the others: awk's
-   `BEGIN { exit }` skips the record loop but still runs END, and the driver
-   template emits the BEGIN body inside `entry` ahead of that block's own
-   terminator, so there is nowhere to branch from. It needs either a template
-   change (a load+branch in `entry` for EVERY program, losing byte-identity
-   everywhere) or a dedicated loop-free driver clause that emits END with the
-   slots at their zero values. Its most useful form -- a BEGIN-only program
-   (`awk 'BEGIN { print 1+1; exit }'`) -- is additionally blocked by a separate
-   gap: `rules//1` requires at least one rule, so a zero-rule program does not
-   parse at all, and POSIX says a BEGIN-only program reads no input.
+   and non-constant exit codes (`exit code_var`).
+   **BEGIN-ONLY programs landed** -- `awk 'BEGIN { print 1 + 1 }'`, the
+   calculator idiom, and with it `exit` in BEGIN. Two gaps had to close
+   together: `rules//1` required at least one rule (so a zero-rule program did
+   not PARSE), and the shared driver template always opens a stream and runs a
+   record loop. POSIX says a BEGIN-only program exits WITHOUT reading its
+   input, so this gets a loop-free driver that opens no stream -- it ignores a
+   file argument, does not consume stdin, and cannot block; `main` takes no
+   argv. Constant arithmetic is evaluated in BEGIN print fields and printf
+   arguments (`print 1 + 1`, `print 7 / 2` -> 3.5 since awk division is IEEE,
+   `printf "%.2f\n", 22 / 7`), every leaf being a literal because BEGIN has
+   neither a record nor a scalar slot -- a field or variable leaf declines.
+   With no loop to skip, `exit [N]` in BEGIN is the same store-and-truncate as
+   in END. Tests: `tests/test_plawk_begin_only.pl`.
+   *Still open (follow-on):* a zero-rule program WITH an `END`
+   (`BEGIN {…} END {…}`, or `END {…}` alone) -- awk DOES read input in that
+   case (its END sees `NR`), so the loop-free driver must not claim it and no
+   driver yet runs a record loop with no rules; it declines cleanly. `exit` in
+   a BEGIN block of a program that HAS rules also declines: it would have to
+   skip the record loop yet still run END, and the shared template emits the
+   BEGIN body inside `entry` ahead of that block's own terminator, so there is
+   nowhere to branch from -- expressing it would mean a load+branch in `entry`
+   for EVERY program, losing byte-identity everywhere.
 5. **Ternary `?:` — LANDED (print / printf, numeric).** `COND ? A : B` in a
    print field or printf argument: the condition is a numeric comparison
    `L <op> R` and both branches are numeric (fields, `NR`/`NF`, integer
@@ -263,6 +275,11 @@ guards · generator blocks (`gen { emit … } as name`, input iterators) ·
    `delete arr[k]`), and `delete` in the scalar/mixed sequence-walker path.
 7. **`split` / `sub` / `gsub` / `match` / `sprintf`** — the string-builtin
    family; larger, lower priority for the DSL's data-pipeline focus.
+
+**Program structure:** a program needs at least one clause, and `rules//1` no
+longer requires a rule — a BEGIN-only program parses and compiles to a loop-free
+driver that reads no input (POSIX). A zero-rule program with an `END` parses but
+declines, since awk reads input in that case.
 
 Deferred by design (the DSL's model diverges here): multi-file `FILENAME`/`FNR`
 (`ARGV[N]`/`ARGC` themselves are landed for rule

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -170,6 +170,45 @@ plawk_program_native_driver_ir(Program, _InputPath, _DriverIR) :-
     !,
     fail.
 
+%% A BEGIN-ONLY program: BEGIN clauses, no rules, no END.
+%
+%  POSIX: "If an awk program consists of only actions with the pattern BEGIN,
+%  awk shall exit without reading its input." So this driver opens NO stream and
+%  emits NO record loop -- `awk 'BEGIN { print 1 + 1 }'` must not block on stdin,
+%  and it must ignore a file argument rather than reading it. The presence of an
+%  END changes that (input IS read), which is why this clause requires `[]` for
+%  both rules and END; a zero-rule program WITH an END has no driver yet and
+%  declines cleanly.
+%
+%  Because there is no loop, `exit [N]` in BEGIN needs no branch: the block runs
+%  straight into `ret`, so it is the same store-and-truncate as `exit` in END.
+%  That is what makes BEGIN's exit tractable here while it stays out of reach for
+%  a program with rules -- there, BEGIN would have to skip the loop yet still run
+%  END, and the shared driver template emits the BEGIN body inside `entry` ahead
+%  of that block's own terminator.
+plawk_program_native_driver_ir(
+    program(BeginClauses, [], []),
+    _InputPath,
+    DriverIR
+) :-
+    BeginClauses \== [],
+    !,
+    plawk_output_separator(BeginClauses, OutputSeparator),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_only_body_ir(BeginClauses, OutputSeparator, BeginIR),
+    plawk_i64_end_print_globals(BeginClauses, BeginGlobalIR, RuntimeGlobals),
+    format(atom(DriverIR),
+'~w
+
+define i32 @main() {
+entry:
+~w
+  %plawk_exit_ec = load i32, i32* @plawk_exit_code
+  ret i32 %plawk_exit_ec
+}
+',
+        [RuntimeGlobals, BeginIR]).
+
 plawk_program_native_driver_ir(
     program(BeginClauses, [rule(Pattern, [Action0])], []),
     InputPath,
@@ -12564,6 +12603,33 @@ plawk_begin_output_statements(Actions, Statements) :-
 
 plawk_begin_output_statement(print(_Fields)).
 plawk_begin_output_statement(printf(string(_Format), _Args)).
+% `exit [N]` is collected as an output statement so it keeps its position in the
+% sequence -- the emitter truncates there, making later statements dead. It is
+% collected in EVERY context, including the record-loop one that cannot lower it,
+% so that context fails explicitly rather than silently dropping the exit.
+plawk_begin_output_statement(exit(int(Code))) :-
+    integer(Code).
+
+%% plawk_begin_has_exit(+Actions) is semidet.
+%  The BEGIN block contains an `exit`. Only the BEGIN-ONLY driver can lower one.
+plawk_begin_has_exit(Actions) :-
+    member(exit(int(Code)), Actions),
+    integer(Code),
+    !.
+
+%% plawk_begin_only_body_ir(+BeginClauses, +OutputSeparator, -IR) is semidet.
+%  The BEGIN body for the loop-free driver: the startup stores, then every output
+%  statement -- `exit` included, since with no record loop it is just the store
+%  plus truncation of what follows. Mirrors plawk_begin_print_ir/3 minus the
+%  exit rejection that only a following record loop requires.
+plawk_begin_only_body_ir([begin(Actions)], OutputSeparator, IR) :-
+    plawk_begin_clause_outputs_ir([begin(Actions)], OutputSeparator, _GlobalIR,
+        OutputIR),
+    plawk_rs_store_lines([begin(Actions)], RsStoreLines),
+    plawk_subsep_store_lines([begin(Actions)], SubsepStoreLines),
+    plawk_fs_regex_store_lines([begin(Actions)], StoreLines),
+    append([RsStoreLines, SubsepStoreLines, StoreLines, [OutputIR]], Lines),
+    plawk_join_nonempty_ir(Lines, IR).
 
 %% plawk_begin_outputs_ir(+Statements, -GlobalIR, -BodyIR) is semidet.
 %  Emit every BEGIN output statement in order. Statement 0 is byte-identical to
@@ -12578,6 +12644,15 @@ plawk_begin_outputs_ir(Statements, OutputSeparator, GlobalIR, BodyIR) :-
     plawk_join_nonempty_ir(Bodies, BodyIR).
 
 plawk_begin_outputs_ir_([], _Index, _OutputSeparator, [], []).
+% `exit [N]` in BEGIN. Reachable only from the BEGIN-ONLY driver, where there is
+% no record loop to skip: the block runs straight into `ret`, so setting the
+% status is the store alone and the statements after it are dead. Same
+% store-and-truncate as `exit` in an END block.
+plawk_begin_outputs_ir_([exit(int(Code)) | _Rest], _Index, _OutputSeparator,
+        [''], [Body]) :-
+    integer(Code),
+    !,
+    format(atom(Body), '  store i32 ~w, i32* @plawk_exit_code', [Code]).
 plawk_begin_outputs_ir_([Statement | Rest], Index, OutputSeparator,
         [Global | Globals], [Body | Bodies]) :-
     plawk_begin_output_ir(Statement, OutputSeparator, RawGlobal, RawBody),
@@ -12646,20 +12721,19 @@ plawk_begin_printf_arg(string(Value), Prefix, Index, [GlobalIR], [PtrLine],
     format(atom(PtrLine),
         '  ~w = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0',
         [PtrIR, BytesLen, BytesLen, GlobalName]).
-plawk_begin_printf_arg(int(Value), Prefix, Index, [], SetupParts, [i64(ValueIR)]) :-
-    integer(Value),
+% An integer / float literal, or constant arithmetic over them
+% (`BEGIN { printf "%d\n", 1 + 1 }`). Folded by the ordinary expression
+% emitters; a division makes the tree double-typed, as awk's division is IEEE.
+plawk_begin_printf_arg(Expr, Prefix, Index, [], SetupParts, [CallArg]) :-
+    plawk_begin_const_expr(Expr),
     !,
     format(atom(Base), '~w_arg~w', [Prefix, Index]),
-    plawk_i64_expr_ir(int(Value), 0, Base, Base, ValueIR, [], SetupParts).
-plawk_begin_printf_arg(float_const(Mantissa, Denominator), Prefix, Index, [],
-        SetupParts, [f64(ValueIR)]) :-
-    integer(Mantissa),
-    integer(Denominator),
-    Denominator > 0,
-    !,
-    format(atom(Base), '~w_arg~w', [Prefix, Index]),
-    plawk_f64_expr_ir(float_const(Mantissa, Denominator), 0, Base, Base, ValueIR,
-        [], SetupParts).
+    (   plawk_expr_is_double(Expr)
+    ->  plawk_f64_expr_ir(Expr, 32, Base, Base, ValueIR, [], SetupParts),
+        CallArg = f64(ValueIR)
+    ;   plawk_i64_expr_ir(Expr, 32, Base, Base, ValueIR, [], SetupParts),
+        CallArg = i64(ValueIR)
+    ).
 
 %% plawk_fs_regex_global_lines(+BeginClauses, -Lines)
 %
@@ -12703,6 +12777,15 @@ plawk_begin_print_ir([begin(Actions)], OutputSeparator, IR) :-
     plawk_begin_output_statements(Actions, Statements),
     Statements \== [],
     !,
+    % A BEGIN `exit` is only expressible when there is no record loop to skip
+    % (the BEGIN-ONLY driver). Here a loop follows, and awk's `BEGIN { exit }`
+    % must skip it yet still run END -- which this template cannot express, the
+    % BEGIN body being emitted inside `entry` ahead of that block's own
+    % terminator. Fail AFTER the cut so the program declines: falling through to
+    % the stores-only clause below would silently drop the exit, and merely
+    % storing the code would run the loop anyway (wrong output AND, on driver
+    % paths that do not declare @plawk_exit_code, invalid IR).
+    \+ plawk_begin_has_exit(Actions),
     plawk_begin_clause_outputs_ir([begin(Actions)], OutputSeparator, _GlobalIR,
         OutputIR),
     plawk_rs_store_lines([begin(Actions)], RsStoreLines),
@@ -12828,6 +12911,54 @@ plawk_subsep_global_lines(BeginClauses, [Line]) :-
 plawk_subsep_global_lines(_BeginClauses, []).
 
 plawk_begin_print_field(string(_)).
+% Constant arithmetic (`BEGIN { print 1 + 1 }` -- the calculator idiom).
+plawk_begin_print_field(Expr) :-
+    plawk_begin_const_expr(Expr).
+
+%% plawk_begin_const_expr(+Expr) is semidet.
+%  An expression BEGIN can evaluate. BEGIN runs before the record loop, so there
+%  is no current record and no scalar slot: every leaf must be a literal, and the
+%  whole tree folds through the ordinary i64 / f64 expression emitters. This is
+%  what makes `awk 'BEGIN { print 1 + 1 }'` work; a field or variable leaf fails
+%  here, so such a program declines rather than reading state that does not exist.
+plawk_begin_const_expr(int(Value)) :-
+    integer(Value).
+plawk_begin_const_expr(float_const(Mantissa, Denominator)) :-
+    integer(Mantissa),
+    integer(Denominator),
+    Denominator > 0.
+plawk_begin_const_expr(Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, Right),
+    plawk_begin_const_expr(Left),
+    plawk_begin_const_expr(Right).
+
+%% plawk_begin_const_expr_lines(+Expr, +Index)//
+%  Evaluate and print a constant BEGIN expression. Names are
+%  `plawk_begin_expr_<Index>`-based -- they contain `begin_`, so the
+%  per-statement suffix rename uniquifies them like every other BEGIN name.
+%  A double-typed tree (a float leaf, or a division, which is IEEE in awk)
+%  prints as %g; otherwise i64 as %ld.
+plawk_begin_const_expr_lines(Expr, Index) -->
+    { format(atom(Base), 'plawk_begin_expr_~w', [Index]),
+      (   plawk_expr_is_double(Expr)
+      ->  plawk_f64_expr_ir(Expr, 32, Base, Base, ValueIR, [], SetupParts),
+          format(atom(FmtPtr),
+              '  %~w_fmt = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_f64, i32 0, i32 0',
+              [Base]),
+          format(atom(PrintCall),
+              '  %~w_pr = call i32 (i8*, ...) @printf(i8* %~w_fmt, double ~w)',
+              [Base, Base, ValueIR])
+      ;   plawk_i64_expr_ir(Expr, 32, Base, Base, ValueIR, [], SetupParts),
+          format(atom(FmtPtr),
+              '  %~w_fmt = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_i64, i32 0, i32 0',
+              [Base]),
+          format(atom(PrintCall),
+              '  %~w_pr = call i32 (i8*, ...) @printf(i8* %~w_fmt, i64 ~w)',
+              [Base, Base, ValueIR])
+      ),
+      append(SetupParts, [FmtPtr, PrintCall], Lines)
+    },
+    Lines.
 
 plawk_begin_print_lines([], _OutputSeparator, _) -->
     { plawk_ors_terminator_ir(begin_newline_fmt, begin_ors_ptr, printed_begin_newline,
@@ -12837,6 +12968,12 @@ plawk_begin_print_lines([], _OutputSeparator, _) -->
 plawk_begin_print_lines([string(Value) | Rest], OutputSeparator, Index) -->
     plawk_begin_separator_lines(Index, OutputSeparator),
     plawk_begin_string_print_lines(Value, Index),
+    { NextIndex is Index + 1 },
+    plawk_begin_print_lines(Rest, OutputSeparator, NextIndex).
+plawk_begin_print_lines([Expr | Rest], OutputSeparator, Index) -->
+    { plawk_begin_const_expr(Expr) },
+    plawk_begin_separator_lines(Index, OutputSeparator),
+    plawk_begin_const_expr_lines(Expr, Index),
     { NextIndex is Index + 1 },
     plawk_begin_print_lines(Rest, OutputSeparator, NextIndex).
 

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -822,7 +822,17 @@ program_rules(case_blocks(Blocks)) -->
     case_blocks_rest(Blocks0),
     { Blocks = [Block | Blocks0] }.
 program_rules(Rules) -->
-    rules(Rules).
+    rules(Rules),
+    !.
+% NO rules at all -- a BEGIN-only program (`awk 'BEGIN { print 1 + 1 }'`, the
+% calculator idiom) or a BEGIN/END pair with no per-record work. rules//1
+% requires at least one rule, so this clause supplies the empty case; it is last,
+% so a program that does have rules is unaffected. Consumes only whitespace,
+% leaving any `END { … }` for end_clauses//1. Whether such a program reads input
+% is a CODEGEN question, not a parsing one: POSIX says a BEGIN-only program exits
+% without reading input, while the presence of an END means input is read.
+program_rules([]) -->
+    ws.
 
 case_blocks_rest([Block | Blocks]) -->
     ws,
@@ -1862,6 +1872,13 @@ begin_action(Action) -->
 % state; codegen decides which argument shapes it can lower.
 begin_action(Action) -->
     printf_action(Action),
+    !.
+% `BEGIN { … exit [N] }` -- set the program's exit status. In a BEGIN-only
+% program there is no record loop to skip, so this is the same store-and-truncate
+% as in END. With rules present it would have to skip the loop yet still run END,
+% which the shared driver template cannot express; codegen declines that shape.
+begin_action(Action) -->
+    exit_action(Action),
     !.
 begin_action(Action) -->
     print_action(Action),

--- a/tests/test_plawk_begin_only.pl
+++ b/tests/test_plawk_begin_only.pl
@@ -1,0 +1,312 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% plawk: BEGIN-ONLY programs -- `awk 'BEGIN { print 1 + 1 }'`, the calculator
+% idiom, plus `exit` in BEGIN.
+%
+% Two gaps had to close together. `rules//1` required at least one rule, so a
+% zero-rule program did not PARSE at all; and even parsed, the shared driver
+% template opens a stream and runs a record loop.
+%
+% POSIX: "If an awk program consists of only actions with the pattern BEGIN, awk
+% shall exit without reading its input." Verified against gawk 5.2: a BEGIN-only
+% program IGNORES a file argument and does not consume stdin, while adding an END
+% makes input read again (`BEGIN {…} END { print NR }` prints 0 with no stdin, 2
+% with a two-line file). So the loop-free driver requires `[]` for BOTH rules and
+% END; a zero-rule program WITH an END would have to read input with no rules to
+% run, and declines cleanly.
+%
+% Because there is no record loop, `exit [N]` in BEGIN needs no branch -- the
+% block runs straight into `ret`, so it is the same store-and-truncate as `exit`
+% in an END block. That is exactly why BEGIN's exit is tractable HERE and not in
+% a program with rules: there it would have to skip the loop yet still run END,
+% and the template emits the BEGIN body inside `entry` ahead of that block's own
+% terminator.
+%
+% gawk 5.2 is the oracle for every expectation here, exit STATUS included.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_begin_only).
+
+% --- parsing: zero rules ---------------------------------------------------
+
+test(begin_only_parses_with_no_rules) :-
+    plawk_parse_string("BEGIN { print \"x\" }\n",
+        program([begin([print([string("x")])])], [], [])),
+    !.
+
+test(begin_only_with_exit_parses) :-
+    plawk_parse_string("BEGIN { print \"x\"; exit 3 }\n",
+        program([begin([print([string("x")]), exit(int(3))])], [], [])),
+    !.
+
+% A zero-rule BEGIN/END pair parses too (codegen declines it -- see below).
+test(begin_and_end_without_rules_parses) :-
+    plawk_parse_string("BEGIN { print \"b\" }\nEND { print \"e\" }\n",
+        program([begin([print([string("b")])])], [],
+            [end([print([string("e")])])])),
+    !.
+
+% Programs that DO have rules are unaffected by the empty-rules clause.
+test(rules_still_required_to_be_parsed_when_present) :-
+    plawk_parse_string("BEGIN { print \"x\" }\n{ print $1 }\n",
+        program([begin([print([string("x")])])],
+            [rule(always, [print([field(1)])])], [])),
+    !.
+
+% The empty-rules clause must not turn malformed input into a zero-rule program:
+% `eos` still has to be reached, so junk after the clauses is still an error.
+test(malformed_programs_still_rejected) :-
+    forall(member(Src, ["foo\n",
+                        "{ print $1\n",
+                        "BEGIN { print \"x\" }\n%%%\n",
+                        "}\n",
+                        "{ print $1 }\nzzz\n"]),
+        ( plawk_parse_string(Src, P)
+        -> format(user_error, "~nunexpectedly parsed: ~w -> ~q~n", [Src, P]), fail
+        ;  true
+        )),
+    !.
+
+% --- POSIX: no input is read ----------------------------------------------
+
+% A file argument is IGNORED, not read -- the program prints only its own output.
+test(begin_only_ignores_file_argument, [condition(clang_available)]) :-
+    run_with_input("BEGIN { print \"x\" }\n", "a 1\nb 2\n", "x\n", 0),
+    !.
+
+% Nor is stdin consumed. Piping data in changes nothing.
+test(begin_only_does_not_consume_stdin, [condition(clang_available)]) :-
+    build_only("BEGIN { print \"x\" }\n", Bin),
+    run_stdin(Bin, "a\nb\n", Out, Status),
+    assertion(Out == "x\n"),
+    assertion(Status == exit(0)),
+    !.
+
+% And with no stdin at all it must not block. run_stdin/4 with "" closes stdin
+% immediately; a program that waited on input would hang the suite instead.
+test(begin_only_does_not_block_without_stdin, [condition(clang_available)]) :-
+    build_only("BEGIN { print \"x\" }\n", Bin),
+    run_stdin(Bin, "", Out, Status),
+    assertion(Out == "x\n"),
+    assertion(Status == exit(0)),
+    !.
+
+% The IR proves it structurally: no stream is opened and no record loop exists.
+test(begin_only_ir_has_no_stream_or_loop) :-
+    plawk_parse_string("BEGIN { print \"x\" }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'wam_stream_open_value')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'wam_stream_read_line')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'loop:')),
+    % main takes no argv, since there is no input path to consult
+    assertion(once(sub_atom(DriverIR, _, _, _, 'define i32 @main() {'))),
+    !.
+
+% --- output ---------------------------------------------------------------
+
+test(begin_only_print, [condition(clang_available)]) :-
+    run("BEGIN { print \"x\" }\n", "x\n", 0),
+    !.
+
+test(begin_only_two_prints, [condition(clang_available)]) :-
+    run("BEGIN { print \"a\"; print \"b\" }\n", "a\nb\n", 0),
+    !.
+
+test(begin_only_printf, [condition(clang_available)]) :-
+    run("BEGIN { printf \"%d\\n\", 42 }\n", "42\n", 0),
+    !.
+
+% --- the calculator idiom -------------------------------------------------
+
+test(begin_only_integer_arithmetic, [condition(clang_available)]) :-
+    run("BEGIN { print 1 + 1 }\n", "2\n", 0),
+    !.
+
+test(begin_only_precedence, [condition(clang_available)]) :-
+    run("BEGIN { print 2 * 3 + 4 }\n", "10\n", 0),
+    !.
+
+test(begin_only_modulo, [condition(clang_available)]) :-
+    run("BEGIN { print 10 % 3 }\n", "1\n", 0),
+    !.
+
+% awk division is IEEE, so the tree is double-typed and prints as %g.
+test(begin_only_division_is_float, [condition(clang_available)]) :-
+    run("BEGIN { print 7 / 2 }\n", "3.5\n", 0),
+    !.
+
+test(begin_only_float_literal, [condition(clang_available)]) :-
+    run("BEGIN { print 3.5 + 1 }\n", "4.5\n", 0),
+    !.
+
+% A label beside a computed value: OFS separates them, as in any print.
+test(begin_only_label_and_value, [condition(clang_available)]) :-
+    run("BEGIN { print \"sum:\", 1 + 2 }\n", "sum: 3\n", 0),
+    !.
+
+test(begin_only_printf_arithmetic, [condition(clang_available)]) :-
+    run("BEGIN { printf \"%d\\n\", 1 + 1 }\n", "2\n", 0),
+    !.
+
+test(begin_only_printf_division_precision, [condition(clang_available)]) :-
+    run("BEGIN { printf \"%.2f\\n\", 22 / 7 }\n", "3.14\n", 0),
+    !.
+
+% --- exit in BEGIN --------------------------------------------------------
+
+test(begin_only_exit_sets_status, [condition(clang_available)]) :-
+    run("BEGIN { print \"x\"; exit 3 }\n", "x\n", 3),
+    !.
+
+test(begin_only_bare_exit_is_zero, [condition(clang_available)]) :-
+    run("BEGIN { exit }\n", "", 0),
+    !.
+
+% Statements after the exit are dead, as in END.
+test(begin_only_exit_truncates, [condition(clang_available)]) :-
+    run("BEGIN { print \"a\"; exit 1; print \"b\" }\n", "a\n", 1),
+    !.
+
+test(begin_only_calc_then_exit, [condition(clang_available)]) :-
+    run("BEGIN { print 6 * 7; exit 0 }\n", "42\n", 0),
+    !.
+
+% --- clean declines -------------------------------------------------------
+
+% A zero-rule program WITH an END: awk reads input in this case (END sees NR), so
+% the loop-free driver must not claim it. No driver handles zero rules plus a
+% record loop yet, so it declines -- a follow-on, not a silent wrong answer.
+test(begin_and_end_without_rules_declines) :-
+    build_status("BEGIN { print \"b\" }\nEND { print \"e\" }\n", 3),
+    !.
+
+test(end_only_without_rules_declines) :-
+    build_status("END { print \"e\" }\n", 3),
+    !.
+
+% BEGIN has no record and no scalar slots, so a field or variable read declines
+% rather than reading state that does not exist. (gawk prints empty for both --
+% the same uninitialised-value gap tracked elsewhere.)
+test(begin_only_field_read_declines) :-
+    build_status("BEGIN { print $1 }\n", 3),
+    !.
+
+test(begin_only_variable_read_declines) :-
+    build_status("BEGIN { print n }\n", 3),
+    !.
+
+% `exit` in a BEGIN block of a program that HAS rules: it would have to skip the
+% record loop yet still run END, which the shared driver template cannot express.
+% Declines rather than silently ignoring the exit.
+test(begin_exit_with_rules_declines) :-
+    build_status("BEGIN { exit 1 }\n{ print $1 }\n", 3),
+    !.
+
+% --- structure ------------------------------------------------------------
+
+% Only literal-leaf expressions are BEGIN-evaluable; a field or variable leaf
+% fails, which is what makes the declines above declines rather than bad IR.
+test(begin_const_expr_accepts_only_literal_leaves) :-
+    assertion(plawk_native_codegen:plawk_begin_const_expr(int(1))),
+    assertion(plawk_native_codegen:plawk_begin_const_expr(float_const(7, 2))),
+    assertion(plawk_native_codegen:plawk_begin_const_expr(
+        add_i64(int(1), int(2)))),
+    assertion(\+ plawk_native_codegen:plawk_begin_const_expr(field(1))),
+    assertion(\+ plawk_native_codegen:plawk_begin_const_expr(var(n))),
+    assertion(\+ plawk_native_codegen:plawk_begin_const_expr(
+        add_i64(int(1), field(1)))),
+    !.
+
+% `exit` is collected as a BEGIN output statement so it keeps its position in the
+% sequence -- that is what lets the emitter truncate at the right point.
+test(begin_exit_is_an_output_statement) :-
+    plawk_native_codegen:plawk_begin_output_statements(
+        [set(var('FS'), string(",")), print([string("a")]), exit(int(1)),
+         print([string("b")])],
+        Statements),
+    assertion(Statements == [print([string("a")]), exit(int(1)),
+                             print([string("b")])]),
+    !.
+
+:- end_tests(plawk_begin_only).
+
+% --- helpers ---------------------------------------------------------------
+
+odir(Dir) :-
+    current_prolog_flag(tmp_dir, Tmp),
+    directory_file_path(Tmp, 'uw_plawk_begin_only', Dir),
+    ( exists_directory(Dir) -> true ; make_directory_path(Dir) ).
+
+build_only(Src, Bin) :-
+    odir(Dir),
+    directory_file_path(Dir, 'bo_bin', Bin),
+    % A build that unexpectedly declines must not silently run a stale binary.
+    ( exists_file(Bin) -> delete_file(Bin) ; true ),
+    directory_file_path(Dir, 'bo', Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    cli([build, Prog, '-o', Bin], 0).
+
+% Run with NO arguments at all and stdin closed.
+run(Src, Expected, ExpectedStatus) :-
+    build_only(Src, Bin),
+    run_stdin(Bin, "", Out, Status),
+    assertion(Out == Expected),
+    assertion(Status == exit(ExpectedStatus)).
+
+% Run WITH a file argument, to prove the file is ignored rather than read.
+run_with_input(Src, Input, Expected, ExpectedStatus) :-
+    odir(Dir),
+    build_only(Src, Bin),
+    directory_file_path(Dir, 'bo_in.txt', In),
+    setup_call_cleanup(open(In, write, SI, [encoding(utf8)]),
+        write(SI, Input), close(SI)),
+    process_create(Bin, [In], [stdout(pipe(PS)), stderr(std), process(Pid)]),
+    read_string(PS, _, Out),
+    close(PS),
+    process_wait(Pid, Status),
+    assertion(Out == Expected),
+    assertion(Status == exit(ExpectedStatus)).
+
+% Run with no arguments, writing StdinText then closing stdin. Closing it is what
+% makes "did it block on input?" observable: a reader would see EOF and finish,
+% but the point is that our output must not depend on the data at all.
+run_stdin(Bin, StdinText, Out, Status) :-
+    process_create(Bin, [],
+        [stdin(pipe(PIn)), stdout(pipe(POut)), stderr(std), process(Pid)]),
+    write(PIn, StdinText),
+    close(PIn),
+    read_string(POut, _, Out),
+    close(POut),
+    process_wait(Pid, Status).
+
+% Build only, asserting the CLI status (3 = parses but outside the compilable
+% surface -- a clean decline, distinct from 2 = parse error).
+build_status(Src, ExpectedStatus) :-
+    odir(Dir),
+    directory_file_path(Dir, 'bo_decline', Prog0),
+    atom_concat(Prog0, '.plawk', Prog),
+    setup_call_cleanup(open(Prog, write, S, [encoding(utf8)]),
+        write(S, Src), close(S)),
+    atom_concat(Prog0, '_bin', Bin),
+    cli([build, Prog, '-o', Bin], ExpectedStatus).
+
+cli(Args, ExpectedStatus) :-
+    process_create(path(swipl), ['examples/plawk/bin/plawk' | Args],
+        [stdout(pipe(S)), stderr(std), process(Pid)]),
+    read_string(S, _, _), close(S),
+    process_wait(Pid, exit(Status)),
+    assertion(Status == ExpectedStatus).


### PR DESCRIPTION
`awk 'BEGIN { print 1 + 1 }'` — the calculator idiom — didn't work at all, and neither did `exit` in BEGIN. Two gaps had to close together, which is why this is one change rather than two.

## 1. Grammar: zero rules

`rules//1` required at least one rule, so a zero-rule program didn't parse. `program_rules//1` now has an empty-rules clause, placed **last** so a program that does have rules is unaffected. It consumes only whitespace, leaving any `END { … }` for `end_clauses//1`.

`eos` still has to be reached, so malformed input isn't silently reinterpreted as a zero-rule program — there's a test over five malformed programs (`foo`, `{ print $1`, `BEGIN {…} %%%`, `}`, `{ print $1 } zzz`) pinning that they all still reject.

## 2. Driver: no input is read

POSIX: *"If an awk program consists of only actions with the pattern BEGIN, awk shall exit without reading its input."* Confirmed against gawk 5.2 — and the boundary matters:

| program | no stdin | with a 2-line file |
|---|---|---|
| `BEGIN { print "x" }` | `x` | `x` (file **ignored**) |
| `BEGIN {…} END { print NR }` | `b` / `0` | `b` / `2` (input **read**) |

So a BEGIN-only program gets a **loop-free driver** that opens no stream and emits no record loop: it ignores a file argument, doesn't consume stdin, can't block, and `main` takes no argv. The clause requires `[]` for **both** rules and END for exactly that reason — a zero-rule program *with* an END must read input, so it declines instead (follow-on).

Three separate tests prove the no-input property behaviourally (file argument ignored, stdin not consumed, no block with stdin closed), plus an IR-shape assertion that no `wam_stream_open_value`, no `wam_stream_read_line`, and no `loop:` appear.

## The calculator idiom

Constant arithmetic now evaluates in BEGIN print fields and printf arguments:

```awk
BEGIN { print 1 + 1 }              → 2
BEGIN { print 2 * 3 + 4 }          → 10
BEGIN { print 10 % 3 }             → 1
BEGIN { print 7 / 2 }              → 3.5      (awk division is IEEE)
BEGIN { print 3.5 + 1 }            → 4.5
BEGIN { print "sum:", 1 + 2 }      → sum: 3
BEGIN { printf "%.2f\n", 22 / 7 }  → 3.14
```

`plawk_begin_const_expr/1` requires every leaf to be a literal, because BEGIN has neither a record nor a scalar slot — a field or variable leaf fails, so those programs decline rather than reading state that doesn't exist.

## `exit` in BEGIN

With no record loop to skip, it's the same store-and-truncate as `exit` in an END block: `BEGIN { print "a"; exit 1; print "b" }` prints `a` and exits 1.

**A bug my own test caught, worth calling out.** Collecting `exit` as a BEGIN output statement initially made `BEGIN { exit 1 } { print $1 }` **miscompile** — clang error `use of undefined value '@plawk_exit_code'` on a driver path that doesn't declare it — and where it did compile, it stored the code and then ran the loop anyway, i.e. wrong output.

A BEGIN exit is only expressible when there's no loop to skip, so the shared record-loop emitter now rejects it explicitly, failing **after** its cut so the program declines. Failing *before* the cut would have fallen through to the stores-only clause and silently **dropped** the exit — the same silent-drop shape fixed in #4008. `exit` is still collected in every context precisely so the context that cannot lower it fails loudly rather than quietly.

## No regressions

Every existing shape — BEGIN+rule, rule only, rule+END, BEGIN+rule+END, BEGIN `FS`/`OFS` assignments, BEGIN printf, for-in END, END exit — emits **byte-identical IR**, verified by golden dump diff against the merge base, and re-checked after the exit-rejection restructure.

`tests/test_plawk_begin_only.pl` — 31 tests, gawk 5.2 as oracle for output **and** exit status: zero-rule parsing, the malformed-input guard, the three no-input proofs plus the IR-shape assertion, the calculator cases, exit with truncation, and six clean declines (zero-rule-with-END, END-only, BEGIN field read, BEGIN variable read, BEGIN exit with rules, and the structural `plawk_begin_const_expr` boundary).

Suites green: `begin_only`, `begin_printf`, `end_printf`, `end_exit`, `exit`, `ofs`, `ors`, `printf`, `multi_print_end`, `end_if`, `expr_pattern`, `scalar_pattern`, `multipass`, `passes`, `over_table`, `multipass_cache`, `rs_regex`, `subsep`, `split`, `strscalar`, `nested_string_scalar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJci66LfkyrStXJPxmMksn)_