### PR TITLE
mu_cosine: experimental vNext process-expression frontend kernel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,10 @@ jobs:
         # corpus either way.
         run: |
           python3 -m pytest -q prototypes/mu_cosine/test_process_expression_contract.py \
-            prototypes/mu_cosine/test_process_expression_envelope.py
+            prototypes/mu_cosine/test_process_expression_envelope.py \
+            prototypes/mu_cosine/test_process_cards.py \
+            prototypes/mu_cosine/test_process_expression_p1_protocol.py \
+            prototypes/mu_cosine/test_process_expression_vnext_frontend.py
 
       - name: Run F# WAM target tests (codegen + dotnet smoke + LMDB conformance)
         env:

--- a/prototypes/mu_cosine/process_expression_vnext/__init__.py
+++ b/prototypes/mu_cosine/process_expression_vnext/__init__.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Experimental vNext process-expression frontend kernel.
+
+Proves the parser/elaborator seam described in
+``DESIGN_process_expression_patterns.md``:
+
+```text
+functional expression
+    -> lossless source AST        (functional_parser)
+    -> registry-driven elaboration (elaborator)
+    -> in-memory typed ground term (ast)
+```
+
+**This is not vNext activation.** It creates no identity-bearing bytes, no
+canonical ``pe-typed-ast-v1`` serialization, no digests, no receipts, and no
+deployed processes. Registry ``v0.3``, ``pec-v2``, and both sealed golden
+bundles are untouched frozen contracts, not scaffolding this package extends.
+
+The public seam is deliberately two functions. Hashing, identity, deployment,
+resolution, and verification are *not* exported, because exporting them would
+invite exactly the premature identity-minting the state machine in §1 forbids.
+"""
+from __future__ import annotations
+
+from .elaborator import ElaborationError, elaborate
+from .functional_parser import NotImplementedInMilestone, ParseError, parse_functional
+from .registry import Registry, RegistryError, load_registry
+
+__all__ = [
+    "parse_functional",
+    "elaborate",
+    "load_registry",
+    "Registry",
+    "ParseError",
+    "NotImplementedInMilestone",
+    "ElaborationError",
+    "RegistryError",
+]

--- a/prototypes/mu_cosine/process_expression_vnext/__init__.py
+++ b/prototypes/mu_cosine/process_expression_vnext/__init__.py
@@ -6,10 +6,13 @@ Proves the parser/elaborator seam described in
 
 ```text
 functional expression
-    -> lossless source AST        (functional_parser)
-    -> registry-driven elaboration (elaborator)
-    -> in-memory typed ground term (ast)
+    -> elaboration-preserving source AST  (functional_parser)
+    -> registry-driven elaboration        (elaborator)
+    -> in-memory typed ground term        (ast)
 ```
+
+The source tree keeps what elaboration and diagnostics need; it does not
+promise exact source reconstruction.
 
 **This is not vNext activation.** It creates no identity-bearing bytes, no
 canonical ``pe-typed-ast-v1`` serialization, no digests, no receipts, and no

--- a/prototypes/mu_cosine/process_expression_vnext/ast.py
+++ b/prototypes/mu_cosine/process_expression_vnext/ast.py
@@ -3,14 +3,21 @@
 
 Two distinct trees, deliberately:
 
-* **Source AST** — lossless with respect to the text.  Keeps spans, positional
-  order, *every* named-field occurrence including duplicates, exact numeric
-  lexemes, and unchecked annotations.  Sorting or de-duplicating fields here
-  would hide the duplicate-field error the elaborator must raise, so the parser
-  never does either.
+* **Source AST** — elaboration-preserving.  Keeps spans, positional order,
+  *every* named-field occurrence including duplicates, exact numeric lexemes,
+  and unchecked annotations.  Sorting or de-duplicating fields here would hide
+  the duplicate-field error the elaborator must raise, so the parser never does
+  either.
 * **Typed AST** — immutable semantic nodes with structural equality.  Spans and
   successfully-checked annotations are absent, so ``pearltrees`` and
   ``pearltrees::corpus`` are the same term (§3.5).
+
+The source tree is **elaboration-preserving**, not lossless: it keeps
+everything elaboration and diagnostics need, but it does not promise exact
+source reconstruction.  Grouping parentheses, whitespace and comments
+are not retained, and atom/string nodes hold decoded values rather than original
+spellings.  The narrower claim is deliberate — a "lossless" guarantee this
+implementation cannot satisfy would be worse than an accurate one.
 
 Nothing here is identity-bearing.  ``DESIGN_process_expression_patterns.md``
 §2.1 freezes the canonical wire schema ``pe-typed-ast-v1`` separately, and this
@@ -40,7 +47,7 @@ class Span:
 
 
 # --------------------------------------------------------------------------
-# source AST — lossless, span-carrying, unchecked
+# source AST — elaboration-preserving, span-carrying, unchecked
 # --------------------------------------------------------------------------
 
 
@@ -129,6 +136,17 @@ class SourceFunctionType(SourceType):
 
 
 @dataclass(frozen=True)
+class SourceReferenceIndex(SourceType):
+    """A registered reference occupying an index position, e.g. ``[pearltrees]``.
+
+    Kept distinct from :class:`SourceTypeName` so the elaborator can produce a
+    :class:`ReferenceIndex` rather than conflating it with a type.
+    """
+
+    name: str
+
+
+@dataclass(frozen=True)
 class Type:
     """Semantic type.  Structural equality; no spans."""
 
@@ -171,6 +189,63 @@ class TypeVar(Type):
 
     def __str__(self) -> str:
         return self.name
+
+
+# --------------------------------------------------------------------------
+# value indices — NOT types
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ValueIndex:
+    """An index that is a *value*, not a type.
+
+    §3.2 indexes a substrate by the corpus it views — ``substrate[pearltrees]``
+    — where ``pearltrees`` is a registered corpus *reference*, not a type named
+    ``pearltrees``.  Representing it as :class:`TypeName` would conflate the two
+    namespaces and make ``substrate[pearltrees]`` indistinguishable from an
+    indexed type whose index happens to share a spelling.
+    """
+
+
+@dataclass(frozen=True)
+class ReferenceIndex(ValueIndex):
+    """A registered reference used as an index, e.g. ``substrate[pearltrees]``."""
+
+    name: str
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass(frozen=True)
+class TermIndex(ValueIndex):
+    """EXPERIMENTAL: a whole expression used as an index.
+
+    Needed for ``lineage_op(S, ...) :: abstract_lineage_process[S]`` where ``S``
+    is a substrate *expression* such as ``principal_tree(pearltrees)`` rather
+    than a bare reference.
+
+    The wire representation of an expression-valued index is an **unresolved
+    specification decision** (see the PR's deferred list).  This node is
+    in-memory only and deliberately has no serialization; it exists so the
+    representative signature can be typed honestly instead of being faked as a
+    reference or silently dropped.
+    """
+
+    term: "TypedTerm"
+
+    def __str__(self) -> str:
+        return _index_display(self.term)
+
+
+def _index_display(term: "TypedTerm") -> str:
+    if isinstance(term, Reference):
+        return term.name
+    if isinstance(term, Call):
+        inner = ",".join(_index_display(a) for a in term.args)
+        return f"{term.name}({inner})"
+    return f"<{type(term).__name__.lower()}>"
 
 
 # --------------------------------------------------------------------------

--- a/prototypes/mu_cosine/process_expression_vnext/ast.py
+++ b/prototypes/mu_cosine/process_expression_vnext/ast.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Source AST and typed AST for the vNext frontend.
+
+Two distinct trees, deliberately:
+
+* **Source AST** — lossless with respect to the text.  Keeps spans, positional
+  order, *every* named-field occurrence including duplicates, exact numeric
+  lexemes, and unchecked annotations.  Sorting or de-duplicating fields here
+  would hide the duplicate-field error the elaborator must raise, so the parser
+  never does either.
+* **Typed AST** — immutable semantic nodes with structural equality.  Spans and
+  successfully-checked annotations are absent, so ``pearltrees`` and
+  ``pearltrees::corpus`` are the same term (§3.5).
+
+Nothing here is identity-bearing.  ``DESIGN_process_expression_patterns.md``
+§2.1 freezes the canonical wire schema ``pe-typed-ast-v1`` separately, and this
+milestone deliberately does not implement it: ``debug_repr`` below is labelled
+noncanonical for that reason.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .numerics import Float64Value, NumberLexeme, RealValue
+
+
+# --------------------------------------------------------------------------
+# source spans
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Span:
+    start: int
+    end: int
+
+    def __str__(self) -> str:
+        return f"[{self.start}:{self.end}]"
+
+
+# --------------------------------------------------------------------------
+# source AST — lossless, span-carrying, unchecked
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceNode:
+    span: Span
+
+
+@dataclass(frozen=True)
+class SourceName(SourceNode):
+    """A bare registered name: becomes ``Reference`` or fails."""
+
+    name: str
+
+
+@dataclass(frozen=True)
+class SourceCall(SourceNode):
+    name: str
+    args: tuple["SourceNode", ...]
+    #: Every occurrence, in source order, duplicates included.
+    fields: tuple[tuple[str, "SourceNode", Span], ...]
+
+
+@dataclass(frozen=True)
+class SourceAtom(SourceNode):
+    value: str
+
+
+@dataclass(frozen=True)
+class SourceString(SourceNode):
+    value: str
+
+
+@dataclass(frozen=True)
+class SourceNumber(SourceNode):
+    lexeme: NumberLexeme
+
+
+@dataclass(frozen=True)
+class SourceList(SourceNode):
+    items: tuple["SourceNode", ...]
+
+
+@dataclass(frozen=True)
+class SourceAnnotated(SourceNode):
+    """``Term :: Type`` before the assertion has been checked."""
+
+    term: "SourceNode"
+    asserted: "SourceType"
+
+
+@dataclass(frozen=True)
+class SourceVariable(SourceNode):
+    """Recognized so it can be rejected precisely, not misparsed."""
+
+    name: str
+
+
+# --------------------------------------------------------------------------
+# types
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceType:
+    span: Span
+
+
+@dataclass(frozen=True)
+class SourceTypeName(SourceType):
+    name: str
+
+
+@dataclass(frozen=True)
+class SourceIndexedType(SourceType):
+    name: str
+    indices: tuple[Any, ...]
+
+
+@dataclass(frozen=True)
+class SourceFunctionType(SourceType):
+    """Recognized for a precise rejection; not implemented this milestone."""
+
+    argument_types: tuple[SourceType, ...]
+    result_type: SourceType
+
+
+@dataclass(frozen=True)
+class Type:
+    """Semantic type.  Structural equality; no spans."""
+
+
+@dataclass(frozen=True)
+class TypeName(Type):
+    name: str
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass(frozen=True)
+class IndexedType(Type):
+    name: str
+    indices: tuple[Any, ...]
+
+    def __str__(self) -> str:
+        inner = ",".join(str(i) for i in self.indices)
+        return f"{self.name}[{inner}]"
+
+
+@dataclass(frozen=True)
+class ListType(Type):
+    element: Type
+
+    def __str__(self) -> str:
+        return f"list[{self.element}]"
+
+
+@dataclass(frozen=True)
+class TypeVar(Type):
+    """A registry signature's index placeholder, e.g. the ``C`` in ``substrate[C]``.
+
+    Only ever appears inside a *signature*; a fully elaborated term never
+    retains one, because every index is substituted during elaboration.
+    """
+
+    name: str
+
+    def __str__(self) -> str:
+        return self.name
+
+
+# --------------------------------------------------------------------------
+# typed AST — immutable, structural equality, no spans, no annotations
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TypedTerm:
+    inferred_type: Type
+
+
+@dataclass(frozen=True)
+class Reference(TypedTerm):
+    name: str
+
+
+@dataclass(frozen=True)
+class Call(TypedTerm):
+    name: str
+    args: tuple[TypedTerm, ...]
+    #: Name-keyed and sorted, so field order is not semantic (§2.1 rule 3).
+    fields: tuple[tuple[str, TypedTerm], ...]
+
+
+@dataclass(frozen=True)
+class Atom(TypedTerm):
+    value: str
+
+
+@dataclass(frozen=True)
+class String(TypedTerm):
+    value: str
+
+
+@dataclass(frozen=True)
+class Int(TypedTerm):
+    value: int
+
+
+@dataclass(frozen=True)
+class Real(TypedTerm):
+    value: RealValue
+
+
+@dataclass(frozen=True)
+class Float64(TypedTerm):
+    value: Float64Value
+
+
+@dataclass(frozen=True)
+class ListTerm(TypedTerm):
+    items: tuple[TypedTerm, ...]
+
+
+def debug_repr(term: TypedTerm) -> dict[str, Any]:
+    """NONCANONICAL, NON-IDENTITY-BEARING debug rendering.
+
+    Explicitly *not* ``pe-typed-ast-v1``.  This milestone does not implement the
+    canonical wire schema, and nothing produced here may be hashed, stored as
+    provenance, or joined to a deployed cache.
+    """
+
+    base: dict[str, Any] = {"type": str(term.inferred_type)}
+    if isinstance(term, Reference):
+        return {**base, "kind": "ref", "name": term.name}
+    if isinstance(term, Call):
+        return {
+            **base,
+            "kind": "call",
+            "name": term.name,
+            "args": [debug_repr(a) for a in term.args],
+            "fields": [{"name": n, "value": debug_repr(v)} for n, v in term.fields],
+        }
+    if isinstance(term, Atom):
+        return {**base, "kind": "atom", "value": term.value}
+    if isinstance(term, String):
+        return {**base, "kind": "string", "value": term.value}
+    if isinstance(term, Int):
+        return {**base, "kind": "int", "value": str(term.value)}
+    if isinstance(term, Real):
+        return {**base, "kind": "real", "value": term.value.plain_string()}
+    if isinstance(term, Float64):
+        return {**base, "kind": "float64", "value": term.value.hex16()}
+    if isinstance(term, ListTerm):
+        return {**base, "kind": "list", "items": [debug_repr(i) for i in term.items]}
+    raise TypeError(f"unknown typed term: {type(term).__name__}")

--- a/prototypes/mu_cosine/process_expression_vnext/elaborator.py
+++ b/prototypes/mu_cosine/process_expression_vnext/elaborator.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Registry-driven elaboration: source AST -> typed ground term.
+
+Implements the checking half of ``DESIGN_process_expression_patterns.md`` §3.5:
+
+1. types come from the injected registry;
+2. literal types are inferred from the *expected* type, not the lexeme's shape;
+3. indexed ownership constraints unify (``substrate[C]`` binds ``C``);
+4. every ``::`` assertion is checked;
+5. conflicts and unconsumed fields are rejected before any semantic output; and
+6. normalized inferred types are retained on every node.
+
+Two rules are easy to get backwards and are therefore stated explicitly:
+
+* an annotation **asserts or narrows, never converts** — ``0.85::int`` is an
+  error, not a truncation;
+* a *successful redundant* annotation leaves no trace, so ``pearltrees`` and
+  ``pearltrees::corpus`` are the same typed term.
+
+Nothing here mints identity.  There is no hashing, no serialization to
+``pe-typed-ast-v1``, and no notion of a deployed process.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .ast import (
+    Atom,
+    Call,
+    Float64,
+    IndexedType,
+    Int,
+    ListTerm,
+    ListType,
+    Real,
+    Reference,
+    SourceAnnotated,
+    SourceAtom,
+    SourceCall,
+    SourceIndexedType,
+    SourceList,
+    SourceName,
+    SourceNode,
+    SourceNumber,
+    SourceString,
+    SourceType,
+    SourceTypeName,
+    String,
+    Type,
+    TypeName,
+    TypeVar,
+    TypedTerm,
+)
+from .numerics import NumericError, to_float64, to_int, to_real
+from .registry import Entry, Registry, RegistryError
+
+
+class ElaborationError(ValueError):
+    """A term is well-formed text but ill-typed, or violates the registry."""
+
+    def __init__(self, message: str, span=None):
+        self.span = span
+        super().__init__(message if span is None else f"{message} {span}")
+
+
+def _substitute(declared: Type, bindings: Mapping[str, Any]) -> Type:
+    """Replace signature index variables with their bound values."""
+
+    if isinstance(declared, TypeVar):
+        bound = bindings.get(declared.name)
+        return bound if bound is not None else declared
+    if isinstance(declared, IndexedType):
+        return IndexedType(
+            declared.name,
+            tuple(
+                _substitute(i, bindings) if isinstance(i, Type) else i
+                for i in declared.indices
+            ),
+        )
+    if isinstance(declared, ListType):
+        return ListType(_substitute(declared.element, bindings))
+    return declared
+
+
+def _unify(declared: Type, actual: Type, bindings: dict[str, Any]) -> bool:
+    """Match an actual type against a signature type, binding index variables.
+
+    A variable already bound must match consistently — this is what stops
+    ``cross(principal_tree(pearltrees), principal_tree(simplewiki))``.
+    """
+
+    if isinstance(declared, TypeVar):
+        existing = bindings.get(declared.name)
+        if existing is None:
+            bindings[declared.name] = actual
+            return True
+        return existing == actual
+    if isinstance(declared, TypeName):
+        return isinstance(actual, TypeName) and declared.name == actual.name
+    if isinstance(declared, ListType):
+        return isinstance(actual, ListType) and _unify(
+            declared.element, actual.element, bindings
+        )
+    if isinstance(declared, IndexedType):
+        if not isinstance(actual, IndexedType) or declared.name != actual.name:
+            return False
+        if len(declared.indices) != len(actual.indices):
+            return False
+        return all(
+            _unify(d, a, bindings) if isinstance(d, Type) else d == a
+            for d, a in zip(declared.indices, actual.indices)
+        )
+    return False
+
+
+def _resolve_source_type(node: SourceType) -> Type:
+    if isinstance(node, SourceTypeName):
+        return TypeName(node.name)
+    if isinstance(node, SourceIndexedType):
+        indices = tuple(_resolve_source_type(i) for i in node.indices)
+        if node.name == "list":
+            if len(indices) != 1:
+                raise ElaborationError("list takes exactly one element type", node.span)
+            return ListType(indices[0])
+        return IndexedType(node.name, indices)
+    raise ElaborationError(f"unsupported type form: {type(node).__name__}", node.span)
+
+
+def _literal(node: SourceNode, expected: Type | None) -> TypedTerm:
+    """Type a literal against the *expected* type (§3.6).
+
+    The declared field type wins over the lexeme's surface shape, which is why
+    ``margin(t=1)`` is a ``real`` and not an ``int``.
+    """
+
+    if isinstance(node, SourceNumber):
+        if expected is None:
+            raise ElaborationError(
+                "a numeric literal needs a declared type; the surface spelling "
+                "does not determine whether it is int, real, or float64",
+                node.span,
+            )
+        if not isinstance(expected, TypeName):
+            raise ElaborationError(
+                f"numeric literal cannot satisfy {expected}", node.span
+            )
+        try:
+            if expected.name == "int":
+                return Int(expected, to_int(node.lexeme))
+            if expected.name == "real":
+                return Real(expected, to_real(node.lexeme))
+            if expected.name == "float64":
+                return Float64(expected, to_float64(node.lexeme))
+        except NumericError as exc:
+            raise ElaborationError(str(exc), node.span) from exc
+        raise ElaborationError(
+            f"numeric literal cannot satisfy {expected}", node.span
+        )
+    if isinstance(node, SourceAtom):
+        return Atom(TypeName("atom"), node.value)
+    if isinstance(node, SourceString):
+        return String(TypeName("string"), node.value)
+    raise ElaborationError(  # pragma: no cover - caller dispatches
+        f"not a literal: {type(node).__name__}", node.span
+    )
+
+
+def _elaborate(
+    node: SourceNode, registry: Registry, expected: Type | None
+) -> TypedTerm:
+    if isinstance(node, SourceAnnotated):
+        asserted = _resolve_source_type(node.asserted)
+        # The assertion narrows what the inner term may be, but never converts.
+        inner = _elaborate(node.term, registry, asserted)
+        if inner.inferred_type != asserted:
+            raise ElaborationError(
+                f"annotation {asserted} conflicts with inferred type "
+                f"{inner.inferred_type}; '::' asserts or narrows and never converts",
+                node.span,
+            )
+        if expected is not None and not _unify(expected, asserted, {}):
+            raise ElaborationError(
+                f"expected {expected}, found {asserted}", node.span
+            )
+        # A successful redundant annotation leaves no semantic trace (§3.5).
+        return inner
+
+    if isinstance(node, (SourceNumber, SourceAtom, SourceString)):
+        term = _literal(node, expected)
+        if expected is not None and term.inferred_type != expected:
+            raise ElaborationError(
+                f"expected {expected}, found {term.inferred_type}", node.span
+            )
+        return term
+
+    if isinstance(node, SourceList):
+        if expected is None or not isinstance(expected, ListType):
+            raise ElaborationError(
+                "a list literal needs a declared list type", node.span
+            )
+        items = tuple(
+            _elaborate(item, registry, expected.element) for item in node.items
+        )
+        for item in items:
+            if item.inferred_type != expected.element:
+                raise ElaborationError(
+                    f"list is not homogeneous: expected {expected.element}, "
+                    f"found {item.inferred_type}",
+                    node.span,
+                )
+        return ListTerm(expected, items)
+
+    if isinstance(node, SourceName):
+        try:
+            entry = registry.get(node.name)
+        except RegistryError as exc:
+            raise ElaborationError(str(exc), node.span) from exc
+        if entry.kind != "reference":
+            raise ElaborationError(
+                f"{node.name!r} is a callable and must be applied", node.span
+            )
+        actual = entry.result_type
+        if expected is not None and not _unify(expected, actual, {}):
+            raise ElaborationError(
+                f"expected {expected}, found {actual}", node.span
+            )
+        return Reference(actual, node.name)
+
+    if isinstance(node, SourceCall):
+        return _elaborate_call(node, registry, expected)
+
+    raise ElaborationError(f"unsupported term: {type(node).__name__}", node.span)
+
+
+def _elaborate_call(
+    node: SourceCall, registry: Registry, expected: Type | None
+) -> TypedTerm:
+    try:
+        entry: Entry = registry.get(node.name)
+    except RegistryError as exc:
+        raise ElaborationError(str(exc), node.span) from exc
+    if entry.kind != "call":
+        raise ElaborationError(
+            f"{node.name!r} is a reference and takes no arguments", node.span
+        )
+
+    if len(node.args) != len(entry.arg_types):
+        raise ElaborationError(
+            f"{node.name} expects {len(entry.arg_types)} positional argument(s), "
+            f"got {len(node.args)}",
+            node.span,
+        )
+
+    bindings: dict[str, Any] = {}
+    args: list[TypedTerm] = []
+    for index, (arg, declared) in enumerate(zip(node.args, entry.arg_types)):
+        want = _substitute(declared, bindings)
+        term = _elaborate(arg, registry, want if _is_concrete(want) else None)
+        if not _unify(declared, term.inferred_type, bindings):
+            raise ElaborationError(
+                f"{node.name} argument {index} expects "
+                f"{_substitute(declared, bindings)}, found {term.inferred_type}",
+                arg.span,
+            )
+        args.append(term)
+
+    # Value-indexed ownership: substrate[C] is indexed by the corpus it views,
+    # so C binds to an argument's *reference name* rather than to its type.
+    for var, position in entry.binds:
+        argument = args[position]
+        if not isinstance(argument, Reference):
+            raise ElaborationError(
+                f"{node.name} indexes {var} by argument {position}, which must be a "
+                f"registered reference, not {type(argument).__name__.lower()}",
+                node.args[position].span,
+            )
+        bindings[var] = TypeName(argument.name)
+
+    # Duplicates are detected before any normalization, which is why the parser
+    # keeps every occurrence in source order.
+    seen: dict[str, Any] = {}
+    for field_name, value_node, key_span in node.fields:
+        if field_name in seen:
+            raise ElaborationError(
+                f"duplicate named field {field_name!r} for {node.name}", key_span
+            )
+        seen[field_name] = value_node
+
+    for field_name, key_span in ((n, s) for n, _, s in node.fields):
+        if entry.field(field_name) is None:
+            raise ElaborationError(
+                f"{node.name} does not consume field {field_name!r}", key_span
+            )
+
+    fields: dict[str, TypedTerm] = {}
+    for spec in entry.fields:
+        if spec.name in seen:
+            want = _substitute(spec.type, bindings)
+            term = _elaborate(
+                seen[spec.name], registry, want if _is_concrete(want) else None
+            )
+            if not _unify(spec.type, term.inferred_type, bindings):
+                raise ElaborationError(
+                    f"{node.name} field {spec.name!r} expects "
+                    f"{_substitute(spec.type, bindings)}, found {term.inferred_type}",
+                    node.span,
+                )
+            fields[spec.name] = term
+        elif spec.required:
+            raise ElaborationError(
+                f"{node.name} is missing required field {spec.name!r}", node.span
+            )
+        elif spec.default is not None:
+            fields[spec.name] = _default_term(entry, spec, registry, bindings)
+
+    result = _substitute(entry.result_type, bindings)
+    if isinstance(result, TypeVar) or _contains_typevar(result):
+        raise ElaborationError(
+            f"{node.name} result type {result} is underconstrained", node.span
+        )
+    if expected is not None and not _unify(expected, result, {}):
+        raise ElaborationError(f"expected {expected}, found {result}", node.span)
+
+    return Call(result, node.name, tuple(args), tuple(sorted(fields.items())))
+
+
+def _default_term(entry, spec, registry: Registry, bindings) -> TypedTerm:
+    """Registry defaults are inserted explicitly (§2.1 rule 4).
+
+    A default is written as surface text and elaborated through the same path
+    as an authored value, so an explicit and an elided default cannot diverge.
+    """
+
+    from .functional_parser import parse_functional
+
+    want = _substitute(spec.type, bindings)
+    source = parse_functional(str(spec.default), registry)
+    return _elaborate(source, registry, want if _is_concrete(want) else None)
+
+
+def _is_concrete(declared: Type) -> bool:
+    return not _contains_typevar(declared)
+
+
+def _contains_typevar(declared: Type) -> bool:
+    if isinstance(declared, TypeVar):
+        return True
+    if isinstance(declared, IndexedType):
+        return any(
+            _contains_typevar(i) for i in declared.indices if isinstance(i, Type)
+        )
+    if isinstance(declared, ListType):
+        return _contains_typevar(declared.element)
+    return False
+
+
+def elaborate(source: SourceNode, registry: Registry) -> TypedTerm:
+    """Elaborate a source AST into an in-memory typed ground term.
+
+    The result is *not* identity-bearing and is not serialized to any canonical
+    schema by this milestone.
+    """
+
+    return _elaborate(source, registry, None)

--- a/prototypes/mu_cosine/process_expression_vnext/elaborator.py
+++ b/prototypes/mu_cosine/process_expression_vnext/elaborator.py
@@ -119,17 +119,35 @@ def _unify(declared: Type, actual: Type, bindings: dict[str, Any]) -> bool:
     return False
 
 
-def _resolve_source_type(node: SourceType):
+def _resolve_source_type(node: SourceType, registry: Registry):
     if isinstance(node, SourceReferenceIndex):
+        # An index may name a *reference* value.  A callable is not a value, so
+        # `list[principal_tree]` and `substrate[principal_tree]` must not pass.
+        try:
+            entry = registry.get(node.name)
+        except RegistryError as exc:
+            raise ElaborationError(str(exc), node.span) from exc
+        if entry.kind != "reference":
+            raise ElaborationError(
+                f"{node.name!r} is a callable and cannot be used as a value index",
+                node.span,
+            )
         return ReferenceIndex(node.name)
     if isinstance(node, SourceTypeName):
         return TypeName(node.name)
     if isinstance(node, SourceIndexedType):
-        indices = tuple(_resolve_source_type(i) for i in node.indices)
+        indices = tuple(_resolve_source_type(i, registry) for i in node.indices)
         if node.name == "list":
             if len(indices) != 1:
                 raise ElaborationError("list takes exactly one element type", node.span)
-            return ListType(indices[0])
+            element = indices[0]
+            if not isinstance(element, Type) or isinstance(element, ValueIndex):
+                # A value index is not a type; `list[pearltrees]` is ill-formed.
+                raise ElaborationError(
+                    f"list element type must be a type, not the value {element}",
+                    node.span,
+                )
+            return ListType(element)
         return IndexedType(node.name, indices)
     raise ElaborationError(f"unsupported type form: {type(node).__name__}", node.span)
 
@@ -177,7 +195,7 @@ def _elaborate(
     node: SourceNode, registry: Registry, expected: Type | None
 ) -> TypedTerm:
     if isinstance(node, SourceAnnotated):
-        asserted = _resolve_source_type(node.asserted)
+        asserted = _resolve_source_type(node.asserted, registry)
         # The assertion narrows what the inner term may be, but never converts.
         inner = _elaborate(node.term, registry, asserted)
         if inner.inferred_type != asserted:
@@ -310,6 +328,11 @@ def _elaborate_call(
             )
 
     fields: dict[str, TypedTerm] = {}
+
+    # Pass 1: every authored field.  Doing these first makes the result
+    # independent of the order fields happen to appear in the JSON — otherwise
+    # an authored field declared later could not bind an index that a default
+    # declared earlier needs.
     for spec in entry.fields:
         if spec.name in seen:
             want = _substitute(spec.type, bindings)
@@ -323,7 +346,12 @@ def _elaborate_call(
                     node.span,
                 )
             fields[spec.name] = term
-        elif spec.required:
+
+    # Pass 2: required-but-absent, then defaults, against fully bound indices.
+    for spec in entry.fields:
+        if spec.name in seen:
+            continue
+        if spec.required:
             raise ElaborationError(
                 f"{node.name} is missing required field {spec.name!r}", node.span
             )

--- a/prototypes/mu_cosine/process_expression_vnext/elaborator.py
+++ b/prototypes/mu_cosine/process_expression_vnext/elaborator.py
@@ -27,6 +27,10 @@ from typing import Any, Mapping
 from .ast import (
     Atom,
     Call,
+    ReferenceIndex,
+    SourceReferenceIndex,
+    TermIndex,
+    ValueIndex,
     Float64,
     IndexedType,
     Int,
@@ -77,6 +81,8 @@ def _substitute(declared: Type, bindings: Mapping[str, Any]) -> Type:
                 for i in declared.indices
             ),
         )
+    if isinstance(declared, ValueIndex):
+        return declared
     if isinstance(declared, ListType):
         return ListType(_substitute(declared.element, bindings))
     return declared
@@ -113,7 +119,9 @@ def _unify(declared: Type, actual: Type, bindings: dict[str, Any]) -> bool:
     return False
 
 
-def _resolve_source_type(node: SourceType) -> Type:
+def _resolve_source_type(node: SourceType):
+    if isinstance(node, SourceReferenceIndex):
+        return ReferenceIndex(node.name)
     if isinstance(node, SourceTypeName):
         return TypeName(node.name)
     if isinstance(node, SourceIndexedType):
@@ -265,16 +273,25 @@ def _elaborate_call(
         args.append(term)
 
     # Value-indexed ownership: substrate[C] is indexed by the corpus it views,
-    # so C binds to an argument's *reference name* rather than to its type.
+    # so C binds to an argument's *value*, not to its type.
     for var, position in entry.binds:
         argument = args[position]
-        if not isinstance(argument, Reference):
+        if isinstance(argument, Reference):
+            index: Any = ReferenceIndex(argument.name)
+        else:
+            # EXPERIMENTAL: an expression-valued index.  Its wire form is an
+            # open specification decision; see the module docstring in ast.py.
+            index = TermIndex(argument)
+        existing = bindings.get(var)
+        if existing is not None and existing != index:
+            # A bind must never silently overwrite an ownership constraint that
+            # argument unification already established.
             raise ElaborationError(
-                f"{node.name} indexes {var} by argument {position}, which must be a "
-                f"registered reference, not {type(argument).__name__.lower()}",
+                f"{node.name} would rebind index {var} from {existing} to {index}; "
+                "ownership constraints are established once",
                 node.args[position].span,
             )
-        bindings[var] = TypeName(argument.name)
+        bindings[var] = index
 
     # Duplicates are detected before any normalization, which is why the parser
     # keeps every occurrence in source order.
@@ -311,7 +328,26 @@ def _elaborate_call(
                 f"{node.name} is missing required field {spec.name!r}", node.span
             )
         elif spec.default is not None:
-            fields[spec.name] = _default_term(entry, spec, registry, bindings)
+            want = _substitute(spec.type, bindings)
+            if _contains_typevar(want):
+                # Rather than implement a general dependency solver, refuse a
+                # default whose type is still unresolved.  Accepting it would
+                # make the result depend on JSON field order.
+                raise ElaborationError(
+                    f"{node.name} default for {spec.name!r} has unresolved type "
+                    f"{want}; defaults may not depend on later bindings",
+                    node.span,
+                )
+            term = _default_term(spec, registry, want)
+            # An inserted default goes through the same unification as an
+            # authored value, so an ill-typed default cannot slip in.
+            if not _unify(spec.type, term.inferred_type, bindings):
+                raise ElaborationError(
+                    f"{node.name} default for {spec.name!r} is ill-typed: expected "
+                    f"{want}, found {term.inferred_type}",
+                    node.span,
+                )
+            fields[spec.name] = term
 
     result = _substitute(entry.result_type, bindings)
     if isinstance(result, TypeVar) or _contains_typevar(result):
@@ -324,18 +360,19 @@ def _elaborate_call(
     return Call(result, node.name, tuple(args), tuple(sorted(fields.items())))
 
 
-def _default_term(entry, spec, registry: Registry, bindings) -> TypedTerm:
+def _default_term(spec, registry: Registry, want: Type) -> TypedTerm:
     """Registry defaults are inserted explicitly (§2.1 rule 4).
 
-    A default is written as surface text and elaborated through the same path
-    as an authored value, so an explicit and an elided default cannot diverge.
+    A default is surface *text* elaborated through the same path as an authored
+    value, so an explicit and an elided default cannot diverge.  The registry
+    loader enforces that a default is a JSON string precisely so no numeric
+    rounding can happen before this point.
     """
 
     from .functional_parser import parse_functional
 
-    want = _substitute(spec.type, bindings)
-    source = parse_functional(str(spec.default), registry)
-    return _elaborate(source, registry, want if _is_concrete(want) else None)
+    source = parse_functional(spec.default, registry)
+    return _elaborate(source, registry, want)
 
 
 def _is_concrete(declared: Type) -> bool:
@@ -354,6 +391,28 @@ def _contains_typevar(declared: Type) -> bool:
     return False
 
 
+def _assert_no_type_vars(term: TypedTerm, path: str = "result") -> None:
+    """No ``TypeVar`` may survive into a supposedly ground typed term.
+
+    Checked recursively on the way out rather than trusted per-node: a
+    signature bug, an unbound index, or a reference declaring a variable would
+    otherwise leak an abstract type into a term the caller believes is ground.
+    """
+
+    if _contains_typevar(term.inferred_type):
+        raise ElaborationError(
+            f"{path} retains unresolved type variable(s) in {term.inferred_type}"
+        )
+    if isinstance(term, Call):
+        for index, arg in enumerate(term.args):
+            _assert_no_type_vars(arg, f"{path}.{term.name}[{index}]")
+        for name, value in term.fields:
+            _assert_no_type_vars(value, f"{path}.{term.name}.{name}")
+    elif isinstance(term, ListTerm):
+        for index, item in enumerate(term.items):
+            _assert_no_type_vars(item, f"{path}[{index}]")
+
+
 def elaborate(source: SourceNode, registry: Registry) -> TypedTerm:
     """Elaborate a source AST into an in-memory typed ground term.
 
@@ -361,4 +420,6 @@ def elaborate(source: SourceNode, registry: Registry) -> TypedTerm:
     schema by this milestone.
     """
 
-    return _elaborate(source, registry, None)
+    term = _elaborate(source, registry, None)
+    _assert_no_type_vars(term)
+    return term

--- a/prototypes/mu_cosine/process_expression_vnext/functional_parser.py
+++ b/prototypes/mu_cosine/process_expression_vnext/functional_parser.py
@@ -196,6 +196,9 @@ class _Parser:
             if not match:
                 raise ParseError("malformed atom literal", self.i)
             self.i = match.end()
+            # Atom values are canonically encoded too, so they need the same
+            # Unicode-scalar guard as strings.
+            _reject_lone_surrogates(match.group(1), start)
             return SourceAtom(Span(start, self.i), match.group(1))
 
         if char.isdigit() or (
@@ -344,6 +347,7 @@ class _Parser:
             raise ParseError("expected a type name after '::'", self.i)
         name = word.group(0)
         self.i = word.end()
+        name_end = self.i
         if name == "function":
             raise NotImplementedInMilestone(
                 "function types are recognized but not implemented in this milestone",
@@ -351,7 +355,10 @@ class _Parser:
             )
         self._ws()
         if not self._at("["):
-            return SourceTypeName(Span(start, self.i), name)
+            # Close the span before trivia, then rewind so trailing whitespace
+            # belongs to the caller rather than to the type token.
+            self.i = name_end
+            return SourceTypeName(Span(start, name_end), name)
         self.i += 1
         indices: list[Any] = []
         while True:
@@ -389,10 +396,12 @@ class _Parser:
         name = self._match_registered_name()
         if name is not None:
             after = self.i + len(name)
-            following = self.text[after : after + 1]
-            if following != "(":
+            probe = after
+            while probe < len(self.text) and self.text[probe].isspace():
+                probe += 1
+            if probe >= len(self.text) or self.text[probe] != "(":
                 self.i = after
-                return SourceReferenceIndex(Span(start, self.i), name)
+                return SourceReferenceIndex(Span(start, after), name)
             raise NotImplementedInMilestone(
                 "an expression-valued type index is recognized but not implemented "
                 "in this milestone; its wire representation is an open "
@@ -405,7 +414,10 @@ class _Parser:
 
 
 def parse_functional(text: str, registry) -> SourceNode:
-    """Parse functional-surface text into a lossless source AST.
+    """Parse functional-surface text into an elaboration-preserving source AST.
+
+    The tree keeps what elaboration and diagnostics need; it does not promise
+    exact source reconstruction.
 
     ``registry`` supplies registered names for longest-match lexing only; no
     signature, arity, or type information is consulted here.

--- a/prototypes/mu_cosine/process_expression_vnext/functional_parser.py
+++ b/prototypes/mu_cosine/process_expression_vnext/functional_parser.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Functional-surface parser producing a lossless source AST.
+
+Grammar per ``DESIGN_process_expression_patterns.md`` §4, restricted to the
+ground slice this milestone supports.  The parser resolves *names* against the
+injected registry only for longest-match lexing — it performs no arity,
+type, field, or default checking.  All of that is the elaborator's job, and
+keeping the seam sharp is what lets a parse error and a type error carry
+different diagnostics.
+
+Deliberate non-behaviors:
+
+* named fields are **not** sorted or de-duplicated, so the elaborator can see
+  duplicates and reject them;
+* numeric text is **not** converted, so the declared type can decide later
+  (§3.6);
+* annotations are attached unchecked;
+* variables, modifiers, pins, function types and sum types are *recognized* and
+  rejected with a "not implemented in this milestone" diagnostic rather than
+  being silently misparsed.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from .ast import (
+    SourceAtom,
+    SourceCall,
+    SourceIndexedType,
+    SourceList,
+    SourceName,
+    SourceNode,
+    SourceNumber,
+    SourceString,
+    SourceType,
+    SourceTypeName,
+    SourceVariable,
+    SourceAnnotated,
+    Span,
+)
+from .numerics import NUMBER_RE, NumberLexeme, NumericError
+
+_IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_VARIABLE = re.compile(r"_\Z|[A-Z][A-Za-z0-9_]*\Z")
+_NUMBER_TOKEN = re.compile(r"-?[0-9][0-9A-Za-z_.+-]*")
+_ATOM = re.compile(r"'([^'\\]*)'")
+
+
+class ParseError(ValueError):
+    """Lexing or parsing failed.  Distinct from registry/elaboration errors."""
+
+    def __init__(self, message: str, position: int | None = None):
+        self.position = position
+        super().__init__(
+            message if position is None else f"{message} (at offset {position})"
+        )
+
+
+class NotImplementedInMilestone(ParseError):
+    """A recognized construct deliberately outside this milestone's slice."""
+
+
+class _Parser:
+    def __init__(self, text: str, names: tuple[str, ...]):
+        self.text = text
+        self.i = 0
+        # Longest match first, so `gpt-5.5-low` wins over any shorter prefix.
+        self.names = tuple(sorted(names, key=len, reverse=True))
+
+    # -- lexing helpers ----------------------------------------------------
+
+    def _ws(self) -> None:
+        while self.i < len(self.text) and self.text[self.i].isspace():
+            self.i += 1
+
+    def _at(self, literal: str) -> bool:
+        return self.text.startswith(literal, self.i)
+
+    def _expect(self, literal: str) -> None:
+        if not self._at(literal):
+            got = self.text[self.i : self.i + 12] or "end of input"
+            raise ParseError(f"expected {literal!r}, found {got!r}", self.i)
+        self.i += len(literal)
+
+    def _match_registered_name(self) -> str | None:
+        for name in self.names:
+            end = self.i + len(name)
+            if not self.text.startswith(name, self.i):
+                continue
+            # A registered name must not be a prefix of a longer bare word.
+            if end < len(self.text) and (
+                self.text[end].isalnum() or self.text[end] == "_"
+            ):
+                continue
+            return name
+        return None
+
+    # -- entry -------------------------------------------------------------
+
+    def parse(self) -> SourceNode:
+        node = self.parse_expr()
+        self._ws()
+        if self.i != len(self.text):
+            raise ParseError(
+                f"trailing input: {self.text[self.i : self.i + 16]!r}", self.i
+            )
+        return node
+
+    def parse_expr(self) -> SourceNode:
+        node = self.parse_primary()
+        self._ws()
+        if self._at("."):
+            raise NotImplementedInMilestone(
+                "modifiers are recognized but not implemented in this milestone",
+                self.i,
+            )
+        if self._at("@"):
+            raise NotImplementedInMilestone(
+                "provenance pins are recognized but not implemented in this milestone",
+                self.i,
+            )
+        if self._at("::"):
+            start = self.i
+            self.i += 2
+            asserted = self.parse_type()
+            node = SourceAnnotated(Span(node.span.start, self.i), node, asserted)
+            self._ws()
+            if self._at("."):
+                raise NotImplementedInMilestone(
+                    "modifiers are recognized but not implemented in this milestone",
+                    self.i,
+                )
+        return node
+
+    def parse_primary(self) -> SourceNode:
+        self._ws()
+        if self.i >= len(self.text):
+            raise ParseError("unexpected end of input", self.i)
+        start = self.i
+        char = self.text[self.i]
+
+        if char == "(":
+            self.i += 1
+            inner = self.parse_expr()
+            self._ws()
+            self._expect(")")
+            return inner
+
+        if char == "[":
+            return self.parse_list()
+
+        if char == '"':
+            return self.parse_string()
+
+        if char == "'":
+            match = _ATOM.match(self.text, self.i)
+            if not match:
+                raise ParseError("malformed atom literal", self.i)
+            self.i = match.end()
+            return SourceAtom(Span(start, self.i), match.group(1))
+
+        if char.isdigit() or (
+            char == "-" and self.i + 1 < len(self.text) and self.text[self.i + 1].isdigit()
+        ):
+            return self.parse_number()
+
+        name = self._match_registered_name()
+        if name is not None:
+            self.i += len(name)
+            self._ws()
+            if self._at("("):
+                return self.parse_call(name, start)
+            return SourceName(Span(start, self.i), name)
+
+        word = _IDENT.match(self.text, self.i)
+        if word:
+            token = word.group(0)
+            if _VARIABLE.match(token):
+                self.i = word.end()
+                raise NotImplementedInMilestone(
+                    f"variable {token!r} is recognized but not implemented in this "
+                    "milestone",
+                    start,
+                )
+            raise ParseError(
+                f"unregistered name {token!r}; a bare lowercase word is never "
+                "guessed to be an atom — register it or quote it",
+                start,
+            )
+        raise ParseError(f"unexpected character {char!r}", self.i)
+
+    def parse_call(self, name: str, start: int) -> SourceCall:
+        self._expect("(")
+        args: list[SourceNode] = []
+        fields: list[tuple[str, SourceNode, Span]] = []
+        self._ws()
+        if self._at(")"):
+            self.i += 1
+            return SourceCall(Span(start, self.i), name, (), ())
+        while True:
+            self._ws()
+            if self._at(")"):
+                raise ParseError("trailing comma in argument list", self.i)
+            field_name = self._try_field_name()
+            if field_name is not None:
+                key, key_span = field_name
+                value = self.parse_expr()
+                fields.append((key, value, key_span))
+            else:
+                if fields:
+                    raise ParseError(
+                        "positional argument after a named field", self.i
+                    )
+                args.append(self.parse_expr())
+            self._ws()
+            if self._at(","):
+                self.i += 1
+                continue
+            self._expect(")")
+            break
+        return SourceCall(Span(start, self.i), name, tuple(args), tuple(fields))
+
+    def _try_field_name(self) -> tuple[str, Span] | None:
+        """A field name is `ident =` not followed by `=`."""
+
+        self._ws()
+        save = self.i
+        word = _IDENT.match(self.text, self.i)
+        if not word:
+            return None
+        after = word.end()
+        j = after
+        while j < len(self.text) and self.text[j].isspace():
+            j += 1
+        if j < len(self.text) and self.text[j] == "=" and not self.text.startswith("==", j):
+            self.i = j + 1
+            return word.group(0), Span(save, after)
+        self.i = save
+        return None
+
+    def parse_list(self) -> SourceList:
+        start = self.i
+        self._expect("[")
+        items: list[SourceNode] = []
+        self._ws()
+        if self._at("]"):
+            self.i += 1
+            return SourceList(Span(start, self.i), ())
+        while True:
+            self._ws()
+            if self._at("]"):
+                raise ParseError("trailing comma in list", self.i)
+            items.append(self.parse_expr())
+            self._ws()
+            if self._at(","):
+                self.i += 1
+                continue
+            self._expect("]")
+            break
+        return SourceList(Span(start, self.i), tuple(items))
+
+    def parse_string(self) -> SourceString:
+        start = self.i
+        try:
+            value, offset = json.JSONDecoder().raw_decode(self.text[self.i :])
+        except json.JSONDecodeError as exc:
+            raise ParseError(f"malformed JSON string: {exc}", self.i) from exc
+        if not isinstance(value, str):  # pragma: no cover - '"' guarantees str
+            raise ParseError("expected a string literal", self.i)
+        self.i += offset
+        return SourceString(Span(start, self.i), value)
+
+    def parse_number(self) -> SourceNumber:
+        start = self.i
+        match = _NUMBER_TOKEN.match(self.text, self.i)
+        if not match:  # pragma: no cover - caller checked the first char
+            raise ParseError("expected a number", self.i)
+        token = match.group(0)
+        # Do not let a number run into an adjacent identifier character.
+        if not NUMBER_RE.match(token):
+            raise ParseError(
+                f"malformed numeric literal {token!r} — finite decimals only, "
+                "no NaN, infinity, or malformed exponent",
+                start,
+            )
+        self.i = match.end()
+        try:
+            lexeme = NumberLexeme(token)
+        except NumericError as exc:
+            raise ParseError(str(exc), start) from exc
+        return SourceNumber(Span(start, self.i), lexeme)
+
+    # -- types -------------------------------------------------------------
+
+    def parse_type(self) -> SourceType:
+        self._ws()
+        start = self.i
+        word = _IDENT.match(self.text, self.i)
+        if not word:
+            raise ParseError("expected a type name after '::'", self.i)
+        name = word.group(0)
+        self.i = word.end()
+        if name == "function":
+            raise NotImplementedInMilestone(
+                "function types are recognized but not implemented in this milestone",
+                start,
+            )
+        self._ws()
+        if not self._at("["):
+            return SourceTypeName(Span(start, self.i), name)
+        self.i += 1
+        indices: list[Any] = []
+        while True:
+            self._ws()
+            if self._at("]"):
+                raise ParseError("empty or trailing index in type", self.i)
+            indices.append(self.parse_type_or_index())
+            self._ws()
+            if self._at(","):
+                self.i += 1
+                continue
+            self._expect("]")
+            break
+        return SourceIndexedType(Span(start, self.i), name, tuple(indices))
+
+    def parse_type_or_index(self) -> Any:
+        self._ws()
+        start = self.i
+        word = _IDENT.match(self.text, self.i)
+        if not word:
+            raise ParseError("expected a type or index", self.i)
+        token = word.group(0)
+        if _VARIABLE.match(token):
+            self.i = word.end()
+            raise NotImplementedInMilestone(
+                f"type variable {token!r} is recognized but not implemented in this "
+                "milestone",
+                start,
+            )
+        return self.parse_type()
+
+
+def parse_functional(text: str, registry) -> SourceNode:
+    """Parse functional-surface text into a lossless source AST.
+
+    ``registry`` supplies registered names for longest-match lexing only; no
+    signature, arity, or type information is consulted here.
+    """
+
+    if not isinstance(text, str) or not text.strip():
+        raise ParseError("expression must be a nonempty string")
+    return _Parser(text, registry.names()).parse()

--- a/prototypes/mu_cosine/process_expression_vnext/functional_parser.py
+++ b/prototypes/mu_cosine/process_expression_vnext/functional_parser.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-"""Functional-surface parser producing a lossless source AST.
+"""Functional-surface parser producing an elaboration-preserving source AST.
+
+The tree keeps everything elaboration and diagnostics need — spans, positional
+order, duplicate named fields, exact numeric lexemes, unchecked annotations —
+but it does **not** promise exact source reconstruction: grouping parentheses,
+whitespace and comments are dropped, and atom/string nodes hold decoded values
+rather than original spellings.  The weaker claim is deliberate; promising
+losslessness the implementation cannot deliver would be worse than stating the
+guarantee accurately.
 
 Grammar per ``DESIGN_process_expression_patterns.md`` §4, restricted to the
 ground slice this milestone supports.  The parser resolves *names* against the
@@ -33,6 +41,7 @@ from .ast import (
     SourceName,
     SourceNode,
     SourceNumber,
+    SourceReferenceIndex,
     SourceString,
     SourceType,
     SourceTypeName,
@@ -60,6 +69,32 @@ class ParseError(ValueError):
 
 class NotImplementedInMilestone(ParseError):
     """A recognized construct deliberately outside this milestone's slice."""
+
+
+def _respan(node: SourceNode, span: Span) -> SourceNode:
+    """Return ``node`` with a new span.  Source nodes are frozen dataclasses."""
+
+    import dataclasses
+
+    return dataclasses.replace(node, span=span)
+
+
+def _reject_lone_surrogates(value: str, position: int) -> None:
+    """A lone UTF-16 surrogate cannot be encoded as UTF-8.
+
+    ``json`` happily decodes ``"\\ud800"`` into an unpaired surrogate, which
+    would then blow up at the first encode.  Rejecting it here keeps the
+    invariant that every typed ``String`` is encodable.
+    """
+
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ParseError(
+            "string contains an unpaired UTF-16 surrogate and is not valid "
+            "Unicode text",
+            position,
+        ) from exc
 
 
 class _Parser:
@@ -146,7 +181,9 @@ class _Parser:
             inner = self.parse_expr()
             self._ws()
             self._expect(")")
-            return inner
+            # The span covers the whole parenthesized expression, including the
+            # delimiters, so a diagnostic points at what the author wrote.
+            return _respan(inner, Span(start, self.i))
 
         if char == "[":
             return self.parse_list()
@@ -169,10 +206,14 @@ class _Parser:
         name = self._match_registered_name()
         if name is not None:
             self.i += len(name)
+            # Close the name's span *before* skipping trivia, so trailing
+            # whitespace never becomes part of the token.
+            name_end = self.i
             self._ws()
             if self._at("("):
                 return self.parse_call(name, start)
-            return SourceName(Span(start, self.i), name)
+            self.i = name_end
+            return SourceName(Span(start, name_end), name)
 
         word = _IDENT.match(self.text, self.i)
         if word:
@@ -269,6 +310,7 @@ class _Parser:
             raise ParseError(f"malformed JSON string: {exc}", self.i) from exc
         if not isinstance(value, str):  # pragma: no cover - '"' guarantees str
             raise ParseError("expected a string literal", self.i)
+        _reject_lone_surrogates(value, start)
         self.i += offset
         return SourceString(Span(start, self.i), value)
 
@@ -326,19 +368,39 @@ class _Parser:
         return SourceIndexedType(Span(start, self.i), name, tuple(indices))
 
     def parse_type_or_index(self) -> Any:
+        """An index position may hold a *value reference* or a type.
+
+        A registered reference is matched with the same longest-match rule used
+        for expressions, so a punctuated name such as ``gpt-5.5-low`` lexes as
+        one index rather than failing at ``-5.5-low``.
+        """
+
         self._ws()
         start = self.i
         word = _IDENT.match(self.text, self.i)
-        if not word:
-            raise ParseError("expected a type or index", self.i)
-        token = word.group(0)
-        if _VARIABLE.match(token):
+        if word and _VARIABLE.match(word.group(0)):
             self.i = word.end()
             raise NotImplementedInMilestone(
-                f"type variable {token!r} is recognized but not implemented in this "
-                "milestone",
+                f"type variable {word.group(0)!r} is recognized but not implemented "
+                "in this milestone",
                 start,
             )
+
+        name = self._match_registered_name()
+        if name is not None:
+            after = self.i + len(name)
+            following = self.text[after : after + 1]
+            if following != "(":
+                self.i = after
+                return SourceReferenceIndex(Span(start, self.i), name)
+            raise NotImplementedInMilestone(
+                "an expression-valued type index is recognized but not implemented "
+                "in this milestone; its wire representation is an open "
+                "specification decision",
+                start,
+            )
+        if not word:
+            raise ParseError("expected a type or index", self.i)
         return self.parse_type()
 
 

--- a/prototypes/mu_cosine/process_expression_vnext/numerics.py
+++ b/prototypes/mu_cosine/process_expression_vnext/numerics.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Exact numeric lexemes and registry-directed normalization.
+
+``DESIGN_process_expression_patterns.md`` §3.6: *the declared field type wins
+over the source-language runtime type.*  A numeric literal therefore cannot be
+normalized until elaboration knows what the signature expects, which is why
+parsing produces a :class:`NumberLexeme` and never a Python ``int`` or ``float``.
+
+Going through ``float`` during parsing would silently round a decimal the
+specification requires to survive, and would erase the ``-0`` / ``0``
+distinction that ``float64`` fields must preserve.  Both are tested.
+
+Equality for ``real`` is defined on the normalized ``(sign, digits, exponent)``
+triple rather than on a rendered string.  The canonical *string* form of a
+``real`` is a deferred contract decision (see the PR's deferred-decisions list);
+defining equality structurally lets this milestone stay correct without
+inventing bytes that identity would later depend on.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+import re
+import struct
+
+#: A finite decimal token.  Deliberately excludes ``nan``/``inf`` spellings so
+#: they fail as unregistered names rather than becoming non-finite numbers.
+NUMBER_RE = re.compile(r"\A-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\Z")
+
+
+class NumericError(ValueError):
+    """A numeric lexeme is malformed or cannot satisfy its declared type."""
+
+
+@dataclass(frozen=True)
+class NumberLexeme:
+    """The exact source text of a numeric token, unconverted.
+
+    Held as text on purpose: the same lexeme becomes a different value
+    depending on whether the registry declares the field ``int``, ``real``, or
+    ``float64``.
+    """
+
+    text: str
+
+    def __post_init__(self) -> None:
+        if not NUMBER_RE.match(self.text):
+            raise NumericError(f"malformed numeric literal: {self.text!r}")
+
+    @property
+    def decimal(self) -> Decimal:
+        # Decimal(str) is exact: context precision applies to operations, not
+        # construction, so a value beyond binary64 precision is preserved.
+        try:
+            return Decimal(self.text)
+        except InvalidOperation as exc:  # pragma: no cover - guarded by regex
+            raise NumericError(f"malformed numeric literal: {self.text!r}") from exc
+
+
+def _normalized_triple(value: Decimal) -> tuple[int, tuple[int, ...], int]:
+    """Canonical ``(sign, digits, exponent)`` with trailing zeros stripped.
+
+    Done by hand rather than via ``Decimal.normalize()`` because ``normalize``
+    is an *operation* and would round to the context precision, defeating the
+    exactness this module exists to provide.
+    """
+
+    sign, digits, exponent = value.as_tuple()
+    if not isinstance(exponent, int):  # pragma: no cover - non-finite guarded earlier
+        raise NumericError("non-finite decimal")
+    digits = list(digits)
+    while len(digits) > 1 and digits[-1] == 0:
+        digits.pop()
+        exponent += 1
+    if digits == [0]:
+        # Negative decimal zero normalizes to zero (§3.6).
+        return (0, (0,), 0)
+    return (sign, tuple(digits), exponent)
+
+
+@dataclass(frozen=True)
+class RealValue:
+    """An exact decimal ``real``.  Equality is on the normalized triple."""
+
+    triple: tuple[int, tuple[int, ...], int]
+    source_text: str
+
+    @property
+    def decimal(self) -> Decimal:
+        sign, digits, exponent = self.triple
+        return Decimal((sign, digits, exponent))
+
+    def plain_string(self) -> str:
+        """Non-canonical debug rendering.  See module docstring."""
+
+        return format(self.decimal, "f")
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, RealValue) and self.triple == other.triple
+
+    def __hash__(self) -> int:
+        return hash(self.triple)
+
+
+@dataclass(frozen=True)
+class Float64Value:
+    """An IEEE-754 binary64 value, identified by its exact bits.
+
+    ``+0.0`` and ``-0.0`` are distinct here even though they compare equal as
+    Python floats, because §3.6 requires the bit patterns to stay distinct.
+    """
+
+    bits: int
+
+    @property
+    def as_float(self) -> float:
+        return struct.unpack(">d", self.bits.to_bytes(8, "big"))[0]
+
+    def hex16(self) -> str:
+        return f"{self.bits:016x}"
+
+
+def to_int(lexeme: NumberLexeme) -> int:
+    """``int`` rejects any spelling that is not an exact integer (§3.6)."""
+
+    value = lexeme.decimal
+    sign, digits, exponent = _normalized_triple(value)
+    if exponent < 0:
+        raise NumericError(
+            f"{lexeme.text!r} is not an exact integer and cannot satisfy int"
+        )
+    magnitude = int("".join(str(d) for d in digits)) * (10 ** exponent)
+    return -magnitude if sign else magnitude
+
+
+def to_real(lexeme: NumberLexeme) -> RealValue:
+    """``1``, ``1.0`` and ``1e0`` all normalize to the same ``real``."""
+
+    return RealValue(_normalized_triple(lexeme.decimal), lexeme.text)
+
+
+def to_float64(lexeme: NumberLexeme) -> Float64Value:
+    """Round the exact decimal into binary64 under the default IEEE rule."""
+
+    value = float(lexeme.decimal)
+    if value != value or value in (float("inf"), float("-inf")):
+        raise NumericError(f"{lexeme.text!r} is not finite in float64")
+    # Preserve signed zero: float(Decimal("-0.0")) is -0.0, and struct keeps it.
+    bits = int.from_bytes(struct.pack(">d", value), "big")
+    return Float64Value(bits)

--- a/prototypes/mu_cosine/process_expression_vnext/numerics.py
+++ b/prototypes/mu_cosine/process_expression_vnext/numerics.py
@@ -25,7 +25,21 @@ import struct
 
 #: A finite decimal token.  Deliberately excludes ``nan``/``inf`` spellings so
 #: they fail as unregistered names rather than becoming non-finite numbers.
-NUMBER_RE = re.compile(r"\A-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\Z")
+#:
+#: Leading zeros are **accepted**.  The vNext grammar says only "a finite
+#: decimal numeric token", and v0.3 already accepts ``01`` and canonicalizes it
+#: to ``1``.  Rejecting it here would freeze an unapproved break from v0 inside
+#: an experimental frontend, which is a specification decision rather than an
+#: implementation one.
+NUMBER_RE = re.compile(r"\A-?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\Z")
+
+#: Experimental frontend resource ceiling, not a language contract.
+#:
+#: Exists so a hostile or careless literal fails as a *controlled numeric
+#: error* rather than as an uncaught host ``ValueError`` from CPython's
+#: integer-string conversion limit, or as an attempt to materialize an enormous
+#: integer via ``10 ** exponent``.
+MAX_INT_DIGITS = 4096
 
 
 class NumericError(ValueError):
@@ -51,6 +65,11 @@ class NumberLexeme:
     def decimal(self) -> Decimal:
         # Decimal(str) is exact: context precision applies to operations, not
         # construction, so a value beyond binary64 precision is preserved.
+        if len(self.text) > MAX_INT_DIGITS:
+            raise NumericError(
+                f"numeric literal of {len(self.text)} characters exceeds this "
+                f"experimental frontend's limit of {MAX_INT_DIGITS}"
+            )
         try:
             return Decimal(self.text)
         except InvalidOperation as exc:  # pragma: no cover - guarded by regex
@@ -121,13 +140,24 @@ class Float64Value:
 
 
 def to_int(lexeme: NumberLexeme) -> int:
-    """``int`` rejects any spelling that is not an exact integer (§3.6)."""
+    """``int`` rejects any spelling that is not an exact integer (§3.6).
+
+    The digit ceiling is checked *before* materializing the value, so a short
+    lexeme with a catastrophic exponent such as ``1e1000000000`` is refused
+    without ever allocating the integer it denotes.
+    """
 
     value = lexeme.decimal
     sign, digits, exponent = _normalized_triple(value)
     if exponent < 0:
         raise NumericError(
             f"{lexeme.text!r} is not an exact integer and cannot satisfy int"
+        )
+    total_digits = len(digits) + exponent
+    if total_digits > MAX_INT_DIGITS:
+        raise NumericError(
+            f"integer literal needs {total_digits} digits, above this "
+            f"experimental frontend's limit of {MAX_INT_DIGITS}"
         )
     magnitude = int("".join(str(d) for d in digits)) * (10 ** exponent)
     return -magnitude if sign else magnitude

--- a/prototypes/mu_cosine/process_expression_vnext/numerics.py
+++ b/prototypes/mu_cosine/process_expression_vnext/numerics.py
@@ -41,6 +41,12 @@ NUMBER_RE = re.compile(r"\A-?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\Z")
 #: integer via ``10 ** exponent``.
 MAX_INT_DIGITS = 4096
 
+#: Ceiling on characters produced by the *noncanonical debug* rendering of a
+#: real.  Fixed-point formatting of a short lexeme like ``1e1000000000`` would
+#: otherwise attempt a gigabyte-scale allocation, so the renderer falls back to
+#: a bounded scientific form instead.
+MAX_RENDER_CHARS = 4096
+
 
 class NumericError(ValueError):
     """A numeric lexeme is malformed or cannot satisfy its declared type."""
@@ -110,8 +116,22 @@ class RealValue:
         return Decimal((sign, digits, exponent))
 
     def plain_string(self) -> str:
-        """Non-canonical debug rendering.  See module docstring."""
+        """NONCANONICAL debug rendering, bounded in size.
 
+        Fixed-point output grows with the exponent, so a ~12-character input
+        such as ``1e1000000000`` would demand roughly a gigabyte.  When the
+        plain form would exceed :data:`MAX_RENDER_CHARS` this returns
+        scientific notation instead.  Debug output is never identity-bearing,
+        so the fallback costs nothing but must not be mistaken for a canonical
+        form.
+        """
+
+        sign, digits, exponent = self.triple
+        plain_length = len(digits) + max(exponent, 0) + (1 if sign else 0)
+        if exponent < 0:
+            plain_length = max(len(digits), -exponent + 1) + 2 + (1 if sign else 0)
+        if plain_length > MAX_RENDER_CHARS:
+            return format(self.decimal, "e")
         return format(self.decimal, "f")
 
     def __eq__(self, other: object) -> bool:
@@ -159,7 +179,15 @@ def to_int(lexeme: NumberLexeme) -> int:
             f"integer literal needs {total_digits} digits, above this "
             f"experimental frontend's limit of {MAX_INT_DIGITS}"
         )
-    magnitude = int("".join(str(d) for d in digits)) * (10 ** exponent)
+    try:
+        magnitude = int("".join(str(d) for d in digits)) * (10 ** exponent)
+    except ValueError as exc:
+        # CPython's integer-string conversion limit is configurable and may sit
+        # below this module's ceiling; translate it rather than leaking a raw
+        # host error out of the frontend.
+        raise NumericError(
+            f"integer literal exceeds the host conversion limit: {exc}"
+        ) from exc
     return -magnitude if sign else magnitude
 
 

--- a/prototypes/mu_cosine/process_expression_vnext/registry.py
+++ b/prototypes/mu_cosine/process_expression_vnext/registry.py
@@ -19,7 +19,15 @@ from pathlib import Path
 import re
 from typing import Any, Mapping
 
-from .ast import IndexedType, ListType, Type, TypeName, TypeVar
+from .ast import (
+    IndexedType,
+    ListType,
+    ReferenceIndex,
+    Type,
+    TypeName,
+    TypeVar,
+    ValueIndex,
+)
 
 
 def _contains_type_var(declared: Type) -> bool:
@@ -34,6 +42,9 @@ def _contains_type_var(declared: Type) -> bool:
     return False
 
 _TYPE_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+#: An index position may hold a punctuated registered name such as
+#: ``gpt-5.5-low``, which the plain type-name charset cannot express.
+_INDEX_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_.\-]*")
 _INDEX_VAR = re.compile(r"[A-Z][A-Za-z0-9_]*\Z")
 
 #: Kinds a fixture entry may declare.
@@ -71,8 +82,19 @@ def _parse_type(text: str, i: int) -> tuple[Type, int]:
                 indices.append(TypeVar(inner_match.group(0)))
                 i = inner_match.end()
             else:
-                inner, i = _parse_type(text, i)
-                indices.append(inner)
+                punctuated = _INDEX_NAME.match(text, i)
+                if punctuated and (
+                    punctuated.end() >= len(text)
+                    or text[punctuated.end()] in ",]"
+                ):
+                    # A bare concrete index token.  Whether it denotes a type or
+                    # a registered value reference cannot be known until every
+                    # entry is loaded, so it is resolved in a second pass below.
+                    indices.append(TypeName(punctuated.group(0)))
+                    i = punctuated.end()
+                else:
+                    inner, i = _parse_type(text, i)
+                    indices.append(inner)
             if i < len(text) and text[i] == ",":
                 i += 1
                 continue
@@ -304,8 +326,14 @@ def load_registry(path: str | Path) -> Registry:
                     )
                 )
             fields = tuple(collected)
-        elif spec.get("args") or spec.get("fields"):
-            raise RegistryError(f"reference {name!r} cannot declare args or fields")
+        else:
+            # Check *presence*, not truthiness: `{"args": [], "binds": "junk"}`
+            # would otherwise load with all three declarations silently dropped.
+            present = sorted(set(spec) & {"args", "fields", "binds"})
+            if present:
+                raise RegistryError(
+                    f"reference {name!r} cannot declare call-only key(s): {present}"
+                )
 
         entries[name] = Entry(
             name=name,
@@ -315,4 +343,57 @@ def load_registry(path: str | Path) -> Registry:
             fields=fields,
             binds=binds,
         )
-    return Registry(entries, label=document.get("label", str(path)))
+
+    # Second pass: a concrete index token naming a registered *reference* is a
+    # value index, not a type.  Only now is the full name set known, so this
+    # cannot be decided while individual signatures are parsed.  Without it the
+    # registry and the surface parser would build different nodes for the same
+    # spelling, and `fixed()::substrate[pearltrees]` would fail with the
+    # contradictory message "expected substrate[pearltrees], found
+    # substrate[pearltrees]".
+    references = {n for n, e in entries.items() if e.kind == KIND_REFERENCE}
+    resolved = {
+        name: Entry(
+            name=entry.name,
+            kind=entry.kind,
+            result_type=_resolve_value_indices(entry.result_type, references),
+            arg_types=tuple(
+                _resolve_value_indices(t, references) for t in entry.arg_types
+            ),
+            fields=tuple(
+                FieldSpec(
+                    name=f.name,
+                    type=_resolve_value_indices(f.type, references),
+                    required=f.required,
+                    default=f.default,
+                )
+                for f in entry.fields
+            ),
+            binds=entry.binds,
+        )
+        for name, entry in entries.items()
+    }
+    return Registry(resolved, label=document.get("label", str(path)))
+
+
+def _resolve_value_indices(declared: Type, references: set[str]) -> Type:
+    """Rewrite index-position type names that actually name a reference."""
+
+    if isinstance(declared, IndexedType):
+        indices = []
+        for index in declared.indices:
+            if isinstance(index, TypeName) and index.name in references:
+                indices.append(ReferenceIndex(index.name))
+            elif isinstance(index, Type):
+                indices.append(_resolve_value_indices(index, references))
+            else:
+                indices.append(index)
+        return IndexedType(declared.name, tuple(indices))
+    if isinstance(declared, ListType):
+        element = _resolve_value_indices(declared.element, references)
+        if isinstance(element, ValueIndex):
+            raise RegistryError(
+                f"list element type may not be a value reference: {element}"
+            )
+        return ListType(element)
+    return declared

--- a/prototypes/mu_cosine/process_expression_vnext/registry.py
+++ b/prototypes/mu_cosine/process_expression_vnext/registry.py
@@ -21,6 +21,18 @@ from typing import Any, Mapping
 
 from .ast import IndexedType, ListType, Type, TypeName, TypeVar
 
+
+def _contains_type_var(declared: Type) -> bool:
+    if isinstance(declared, TypeVar):
+        return True
+    if isinstance(declared, IndexedType):
+        return any(
+            _contains_type_var(i) for i in declared.indices if isinstance(i, Type)
+        )
+    if isinstance(declared, ListType):
+        return _contains_type_var(declared.element)
+    return False
+
 _TYPE_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 _INDEX_VAR = re.compile(r"[A-Z][A-Za-z0-9_]*\Z")
 
@@ -127,10 +139,45 @@ class Registry:
         return name in self._entries
 
 
+TOP_LEVEL_KEYS = frozenset({"label", "status", "production", "note", "entries"})
+ENTRY_KEYS = frozenset({"kind", "type", "args", "fields", "binds", "note"})
+FIELD_KEYS = frozenset({"type", "required", "default", "note"})
+
+_ENTRY_NAME = re.compile(r"\A[A-Za-z_][A-Za-z0-9_.\-]*\Z")
+_FIELD_NAME = re.compile(r"\A[a-z_][a-z0-9_]*\Z")
+
+
+def _strict_pairs(pairs):
+    """Reject duplicate keys at every object level.
+
+    ``json.loads`` silently keeps the last of a duplicated key, which would let
+    a fixture declare one thing and mean another.
+    """
+
+    seen: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in seen:
+            raise RegistryError(f"duplicate key in registry fixture: {key!r}")
+        seen[key] = value
+    return seen
+
+
+def _reject_unknown(obj: Mapping[str, Any], allowed: frozenset[str], where: str):
+    unknown = sorted(set(obj) - allowed)
+    if unknown:
+        raise RegistryError(f"unknown key(s) in {where}: {unknown}")
+
+
 def load_registry(path: str | Path) -> Registry:
-    document = json.loads(Path(path).read_text(encoding="utf-8"))
+    try:
+        document = json.loads(
+            Path(path).read_text(encoding="utf-8"), object_pairs_hook=_strict_pairs
+        )
+    except json.JSONDecodeError as exc:
+        raise RegistryError(f"malformed registry fixture: {exc}") from exc
     if not isinstance(document, dict):
         raise RegistryError("registry fixture must be a JSON object")
+    _reject_unknown(document, TOP_LEVEL_KEYS, "registry fixture")
 
     status = document.get("status")
     if status != "experimental-test-fixture":
@@ -152,20 +199,41 @@ def load_registry(path: str | Path) -> Registry:
 
     entries: dict[str, Entry] = {}
     for name, spec in raw_entries.items():
+        if not _ENTRY_NAME.match(name):
+            raise RegistryError(f"malformed entry name: {name!r}")
         if not isinstance(spec, dict):
             raise RegistryError(f"entry {name!r} must be an object")
+        _reject_unknown(spec, ENTRY_KEYS, f"entry {name!r}")
         kind = spec.get("kind")
         if kind not in (KIND_REFERENCE, KIND_CALL):
             raise RegistryError(f"entry {name!r} has unsupported kind {kind!r}")
         if "type" not in spec:
             raise RegistryError(f"entry {name!r} has no type")
+        if not isinstance(spec["type"], str):
+            raise RegistryError(f"entry {name!r} type must be a string")
         result_type = parse_type(spec["type"])
+        if kind == KIND_REFERENCE and _contains_type_var(result_type):
+            # A reference has no arguments, so nothing can ever bind its
+            # variables; accepting it would let a TypeVar escape into a
+            # supposedly ground elaboration result.
+            raise RegistryError(
+                f"reference {name!r} declares unresolved type variable(s) in "
+                f"{spec['type']!r}; a reference has no arguments to bind them"
+            )
 
         arg_types: tuple[Type, ...] = ()
         fields: tuple[FieldSpec, ...] = ()
         binds: tuple[tuple[str, int], ...] = ()
         if kind == KIND_CALL:
-            arg_types = tuple(parse_type(t) for t in spec.get("args", []))
+            raw_args = spec.get("args", [])
+            if not isinstance(raw_args, list):
+                raise RegistryError(f"entry {name!r} args must be a list")
+            for declared in raw_args:
+                if not isinstance(declared, str):
+                    raise RegistryError(
+                        f"entry {name!r} argument types must be strings"
+                    )
+            arg_types = tuple(parse_type(t) for t in raw_args)
             raw_binds = spec.get("binds", {})
             if not isinstance(raw_binds, dict):
                 raise RegistryError(f"entry {name!r} binds must be an object")
@@ -191,12 +259,37 @@ def load_registry(path: str | Path) -> Registry:
                 raise RegistryError(f"entry {name!r} fields must be an object")
             collected = []
             for field_name, field_spec in raw_fields.items():
+                if not _FIELD_NAME.match(field_name):
+                    raise RegistryError(
+                        f"entry {name!r} has malformed field name {field_name!r}"
+                    )
                 if not isinstance(field_spec, dict) or "type" not in field_spec:
                     raise RegistryError(
                         f"entry {name!r} field {field_name!r} needs a type"
                     )
-                required = bool(field_spec.get("required", False))
+                _reject_unknown(
+                    field_spec, FIELD_KEYS, f"entry {name!r} field {field_name!r}"
+                )
+                if not isinstance(field_spec["type"], str):
+                    raise RegistryError(
+                        f"entry {name!r} field {field_name!r} type must be a string"
+                    )
+                required = field_spec.get("required", False)
+                if not isinstance(required, bool):
+                    raise RegistryError(
+                        f"entry {name!r} field {field_name!r} required must be a "
+                        f"JSON boolean, got {required!r}"
+                    )
                 default = field_spec.get("default")
+                if default is not None and not isinstance(default, str):
+                    # Defaults are *surface text*.  Accepting a JSON number and
+                    # later calling str() on the resulting Python float would
+                    # round the value before elaboration ever sees it.
+                    raise RegistryError(
+                        f"entry {name!r} field {field_name!r} default must be a "
+                        "JSON string of surface text or null; a JSON number would "
+                        "round before elaboration"
+                    )
                 if required and default is not None:
                     raise RegistryError(
                         f"entry {name!r} field {field_name!r} is required and "

--- a/prototypes/mu_cosine/process_expression_vnext/registry.py
+++ b/prototypes/mu_cosine/process_expression_vnext/registry.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Injected experimental registry for the vNext frontend milestone.
+
+There is **no approved production vNext registry**.  This loader therefore
+accepts only an explicitly-supplied fixture and never falls back to the frozen
+v0.3 registry in ``process_cards.py`` — silently borrowing v0.3 signatures would
+make the frontend look more validated than it is, and would smuggle the
+retired ``source`` catch-all type into a language that deliberately drops it
+(§3.2).
+
+Signature types are written in the functional surface's type syntax and parsed
+here, so a fixture cannot express a type the language cannot.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+from typing import Any, Mapping
+
+from .ast import IndexedType, ListType, Type, TypeName, TypeVar
+
+_TYPE_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_INDEX_VAR = re.compile(r"[A-Z][A-Za-z0-9_]*\Z")
+
+#: Kinds a fixture entry may declare.
+KIND_REFERENCE = "reference"
+KIND_CALL = "call"
+
+
+class RegistryError(ValueError):
+    """The registry fixture is malformed, or a name is not registered."""
+
+
+def parse_type(text: str) -> Type:
+    """Parse a signature type such as ``substrate[C]`` or ``list[real]``."""
+
+    parsed, rest = _parse_type(text.strip(), 0)
+    if rest != len(text.strip()):
+        raise RegistryError(f"trailing input in type: {text!r}")
+    return parsed
+
+
+def _parse_type(text: str, i: int) -> tuple[Type, int]:
+    match = _TYPE_NAME.match(text, i)
+    if not match:
+        raise RegistryError(f"expected a type name in {text!r} at {i}")
+    name = match.group(0)
+    i = match.end()
+    if i < len(text) and text[i] == "[":
+        i += 1
+        indices: list[Any] = []
+        while True:
+            if i < len(text) and text[i] == "]":
+                raise RegistryError(f"empty index list in {text!r}")
+            inner_match = _TYPE_NAME.match(text, i)
+            if inner_match and _INDEX_VAR.match(inner_match.group(0)):
+                indices.append(TypeVar(inner_match.group(0)))
+                i = inner_match.end()
+            else:
+                inner, i = _parse_type(text, i)
+                indices.append(inner)
+            if i < len(text) and text[i] == ",":
+                i += 1
+                continue
+            if i >= len(text) or text[i] != "]":
+                raise RegistryError(f"unterminated index list in {text!r}")
+            i += 1
+            break
+        if name == "list":
+            if len(indices) != 1:
+                raise RegistryError("list takes exactly one element type")
+            element = indices[0]
+            if isinstance(element, TypeVar):
+                raise RegistryError("list element type may not be an index variable")
+            return ListType(element), i
+        return IndexedType(name, tuple(indices)), i
+    return TypeName(name), i
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    name: str
+    type: Type
+    required: bool
+    default: Any | None  # source text for a literal default, or None
+
+
+@dataclass(frozen=True)
+class Entry:
+    name: str
+    kind: str
+    result_type: Type
+    arg_types: tuple[Type, ...] = ()
+    fields: tuple[FieldSpec, ...] = ()
+    #: Index variables bound from a positional argument's *value*, e.g.
+    #: ``principal_tree(pearltrees) :: substrate[pearltrees]`` binds ``C`` to
+    #: argument 0.  §3.2 indexes substrates by the corpus they view, so the
+    #: index is a value reference rather than a type.
+    binds: tuple[tuple[str, int], ...] = ()
+
+    def field(self, name: str) -> FieldSpec | None:
+        for spec in self.fields:
+            if spec.name == name:
+                return spec
+        return None
+
+
+class Registry:
+    """A validated, injected registry.  Never falls back to v0.3."""
+
+    def __init__(self, entries: Mapping[str, Entry], *, label: str):
+        self._entries = dict(entries)
+        self.label = label
+
+    def names(self) -> tuple[str, ...]:
+        return tuple(self._entries)
+
+    def get(self, name: str) -> Entry:
+        try:
+            return self._entries[name]
+        except KeyError as exc:
+            raise RegistryError(f"unregistered name: {name}") from exc
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._entries
+
+
+def load_registry(path: str | Path) -> Registry:
+    document = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise RegistryError("registry fixture must be a JSON object")
+
+    status = document.get("status")
+    if status != "experimental-test-fixture":
+        raise RegistryError(
+            "registry fixture must declare status 'experimental-test-fixture'; "
+            "this loader refuses anything that looks like a release registry"
+        )
+    if document.get("production") is not False:
+        raise RegistryError("registry fixture must declare production=false")
+    if "registry_version" in document:
+        raise RegistryError(
+            "a test fixture must not claim a registry_version; versions belong to "
+            "sealed release registries only"
+        )
+
+    raw_entries = document.get("entries")
+    if not isinstance(raw_entries, dict) or not raw_entries:
+        raise RegistryError("registry fixture has no entries")
+
+    entries: dict[str, Entry] = {}
+    for name, spec in raw_entries.items():
+        if not isinstance(spec, dict):
+            raise RegistryError(f"entry {name!r} must be an object")
+        kind = spec.get("kind")
+        if kind not in (KIND_REFERENCE, KIND_CALL):
+            raise RegistryError(f"entry {name!r} has unsupported kind {kind!r}")
+        if "type" not in spec:
+            raise RegistryError(f"entry {name!r} has no type")
+        result_type = parse_type(spec["type"])
+
+        arg_types: tuple[Type, ...] = ()
+        fields: tuple[FieldSpec, ...] = ()
+        binds: tuple[tuple[str, int], ...] = ()
+        if kind == KIND_CALL:
+            arg_types = tuple(parse_type(t) for t in spec.get("args", []))
+            raw_binds = spec.get("binds", {})
+            if not isinstance(raw_binds, dict):
+                raise RegistryError(f"entry {name!r} binds must be an object")
+            collected_binds = []
+            for var, position in raw_binds.items():
+                if not _INDEX_VAR.match(var):
+                    raise RegistryError(
+                        f"entry {name!r} binds a non-variable index {var!r}"
+                    )
+                if not isinstance(position, int) or isinstance(position, bool):
+                    raise RegistryError(
+                        f"entry {name!r} binds {var!r} to a non-integer position"
+                    )
+                if not 0 <= position < len(arg_types):
+                    raise RegistryError(
+                        f"entry {name!r} binds {var!r} to out-of-range position "
+                        f"{position}"
+                    )
+                collected_binds.append((var, position))
+            binds = tuple(sorted(collected_binds))
+            raw_fields = spec.get("fields", {})
+            if not isinstance(raw_fields, dict):
+                raise RegistryError(f"entry {name!r} fields must be an object")
+            collected = []
+            for field_name, field_spec in raw_fields.items():
+                if not isinstance(field_spec, dict) or "type" not in field_spec:
+                    raise RegistryError(
+                        f"entry {name!r} field {field_name!r} needs a type"
+                    )
+                required = bool(field_spec.get("required", False))
+                default = field_spec.get("default")
+                if required and default is not None:
+                    raise RegistryError(
+                        f"entry {name!r} field {field_name!r} is required and "
+                        "cannot also declare a default"
+                    )
+                collected.append(
+                    FieldSpec(
+                        name=field_name,
+                        type=parse_type(field_spec["type"]),
+                        required=required,
+                        default=default,
+                    )
+                )
+            fields = tuple(collected)
+        elif spec.get("args") or spec.get("fields"):
+            raise RegistryError(f"reference {name!r} cannot declare args or fields")
+
+        entries[name] = Entry(
+            name=name,
+            kind=kind,
+            result_type=result_type,
+            arg_types=arg_types,
+            fields=fields,
+            binds=binds,
+        )
+    return Registry(entries, label=document.get("label", str(path)))

--- a/prototypes/mu_cosine/process_expression_vnext/testdata/frontend_registry_fixture.json
+++ b/prototypes/mu_cosine/process_expression_vnext/testdata/frontend_registry_fixture.json
@@ -31,10 +31,14 @@
       "binds": {"C": 0}
     },
 
+    "lineage_at": {"kind": "reference", "type": "relation_family"},
+
     "lineage_op": {
       "kind": "call",
-      "type": "relation_family",
+      "type": "abstract_lineage_process[S]",
       "args": ["substrate[C]"],
+      "binds": {"S": 0},
+      "note": "Per the specification lineage_at is the relation_family reference and lineage_op is the coarse operator with type abstract_lineage_process[S]. S is an expression-valued index, carried in memory as the experimental TermIndex node.",
       "fields": {
         "estimand": {"type": "atom"},
         "decay": {"type": "real", "default": "0.85"},
@@ -45,8 +49,9 @@
 
     "hop_decay_targets": {
       "kind": "call",
-      "type": "target_factory",
+      "type": "target_factory[S,hop_decay]",
       "args": ["substrate[C]"],
+      "binds": {"S": 0},
       "fields": {
         "decay": {"type": "real", "required": true},
         "weights": {"type": "list[real]"}
@@ -65,8 +70,24 @@
 
     "cross_substrate": {
       "kind": "call",
-      "type": "relation_family",
+      "type": "cross_view",
       "args": ["substrate[C]", "substrate[C]"]
+    },
+
+    "judge_view": {
+      "kind": "call",
+      "type": "judge_scope[J]",
+      "args": ["judge"],
+      "binds": {"J": 0},
+      "note": "Exercises a punctuated registered name in an index position."
+    },
+
+    "rebinding_probe": {
+      "kind": "call",
+      "type": "cross_view",
+      "args": ["substrate[C]", "corpus"],
+      "binds": {"C": 1},
+      "note": "TEST-ONLY. Argument unification binds C from argument 0; the binds declaration then tries to rebind it from argument 1. A mismatch must fail rather than silently overwrite the ownership constraint."
     }
   }
 }

--- a/prototypes/mu_cosine/process_expression_vnext/testdata/frontend_registry_fixture.json
+++ b/prototypes/mu_cosine/process_expression_vnext/testdata/frontend_registry_fixture.json
@@ -38,11 +38,15 @@
       "type": "abstract_lineage_process[S]",
       "args": ["substrate[C]"],
       "binds": {"S": 0},
-      "note": "Per the specification lineage_at is the relation_family reference and lineage_op is the coarse operator with type abstract_lineage_process[S]. S is an expression-valued index, carried in memory as the experimental TermIndex node.",
+      "note": "Per the specification lineage_at is the relation_family reference and lineage_op is the coarse operator with type abstract_lineage_process[S]. S is an expression-valued index, carried in memory as the experimental TermIndex node. Fields mirror the §4.1/§13 examples; the coarse form deliberately inserts NO defaults, because lineage_op(S) is 'ground but underconstrained' and hop-decay-shaped defaults would silently answer the interpretation question.",
       "fields": {
+        "family_spec": {"type": "atom"},
         "estimand": {"type": "atom"},
-        "decay": {"type": "real", "default": "0.85"},
-        "depth": {"type": "depth_limit", "default": "unbounded_depth"},
+        "impl": {"type": "atom"},
+        "decay": {"type": "real"},
+        "hop_origin": {"type": "int"},
+        "direction": {"type": "atom"},
+        "depth": {"type": "depth_limit"},
         "note": {"type": "string"}
       }
     },
@@ -54,7 +58,39 @@
       "binds": {"S": 0},
       "fields": {
         "decay": {"type": "real", "required": true},
-        "weights": {"type": "list[real]"}
+        "hop_origin": {"type": "int"},
+        "direction": {"type": "atom"},
+        "depth": {"type": "depth_limit"}
+      }
+    },
+
+    "default_probe": {
+      "kind": "call",
+      "type": "cross_view",
+      "args": [],
+      "note": "TEST-ONLY probe for default insertion. Deliberately not a lineage entry, so default mechanics cannot be mistaken for lineage semantics.",
+      "fields": {
+        "decay": {"type": "real", "default": "0.85"},
+        "depth": {"type": "depth_limit", "default": "unbounded_depth"}
+      }
+    },
+
+    "list_probe": {
+      "kind": "call",
+      "type": "cross_view",
+      "args": [],
+      "note": "TEST-ONLY probe for homogeneous list elements.",
+      "fields": {"weights": {"type": "list[real]"}}
+    },
+
+    "order_probe": {
+      "kind": "call",
+      "type": "cross_view",
+      "args": [],
+      "note": "TEST-ONLY probe proving default resolution does not depend on JSON field order: the authored field s binds S, and the default for x needs that binding even though x is declared first.",
+      "fields": {
+        "x": {"type": "substrate[S]", "default": "principal_tree(pearltrees)"},
+        "s": {"type": "substrate[S]", "required": true}
       }
     },
 

--- a/prototypes/mu_cosine/process_expression_vnext/testdata/frontend_registry_fixture.json
+++ b/prototypes/mu_cosine/process_expression_vnext/testdata/frontend_registry_fixture.json
@@ -1,0 +1,72 @@
+{
+  "label": "vnext-frontend-milestone-fixture",
+  "status": "experimental-test-fixture",
+  "production": false,
+  "note": "TEST-ONLY, NON-RELEASE. Not a production registry and deliberately carries no registry_version: versions belong to sealed release registries. Entries cover only the representative examples in DESIGN_process_expression_patterns.md needed to exercise the parser/elaborator seam. Signatures here are NOT language contracts.",
+  "entries": {
+    "pearltrees": {"kind": "reference", "type": "corpus"},
+    "simplewiki": {"kind": "reference", "type": "corpus"},
+    "haiku": {"kind": "reference", "type": "judge"},
+    "haiku.fast": {"kind": "reference", "type": "judge"},
+    "gpt-5.5-low": {"kind": "reference", "type": "judge"},
+    "gpt-5.5": {"kind": "reference", "type": "judge"},
+
+    "unbounded_depth": {"kind": "reference", "type": "depth_limit"},
+    "bounded_depth": {
+      "kind": "call",
+      "type": "depth_limit",
+      "args": ["int"]
+    },
+
+    "principal_tree": {
+      "kind": "call",
+      "type": "substrate[C]",
+      "args": ["corpus"],
+      "binds": {"C": 0}
+    },
+    "full_dag": {
+      "kind": "call",
+      "type": "substrate[C]",
+      "args": ["corpus"],
+      "binds": {"C": 0}
+    },
+
+    "lineage_op": {
+      "kind": "call",
+      "type": "relation_family",
+      "args": ["substrate[C]"],
+      "fields": {
+        "estimand": {"type": "atom"},
+        "decay": {"type": "real", "default": "0.85"},
+        "depth": {"type": "depth_limit", "default": "unbounded_depth"},
+        "note": {"type": "string"}
+      }
+    },
+
+    "hop_decay_targets": {
+      "kind": "call",
+      "type": "target_factory",
+      "args": ["substrate[C]"],
+      "fields": {
+        "decay": {"type": "real", "required": true},
+        "weights": {"type": "list[real]"}
+      }
+    },
+
+    "margin": {
+      "kind": "call",
+      "type": "score_descriptor",
+      "args": [],
+      "fields": {
+        "t": {"type": "real", "required": true},
+        "epsilon": {"type": "float64"}
+      }
+    },
+
+    "cross_substrate": {
+      "kind": "call",
+      "type": "relation_family",
+      "args": ["substrate[C]", "substrate[C]"]
+    }
+  }
+}

--- a/prototypes/mu_cosine/test_process_expression_vnext_frontend.py
+++ b/prototypes/mu_cosine/test_process_expression_vnext_frontend.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Frontend-kernel tests for the experimental vNext process-expression package.
+
+Covers the numbered semantics required of this milestone: the parse/elaborate
+seam, registry-driven typing, indexed ownership, exact numerics, and
+phase-appropriate diagnostics.
+
+Two boundaries are asserted rather than assumed:
+
+* nothing in the package exports hashing, identity, resolution, or deployment;
+* registry v0.3, ``pec-v2``, and both sealed golden bundles are untouched.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from process_expression_vnext import (
+    ElaborationError,
+    NotImplementedInMilestone,
+    ParseError,
+    RegistryError,
+    elaborate,
+    load_registry,
+    parse_functional,
+)
+from process_expression_vnext.ast import (
+    Atom,
+    Call,
+    Float64,
+    IndexedType,
+    Int,
+    ListTerm,
+    ListType,
+    Real,
+    Reference,
+    String,
+    TypeName,
+)
+from process_expression_vnext.numerics import NumberLexeme, NumericError, to_float64
+
+FIXTURE = ROOT / "process_expression_vnext" / "testdata" / "frontend_registry_fixture.json"
+
+SEALED = {
+    "PROCESS_EXPRESSION_GOLDEN_v1.json":
+        "b053351a2a419ac58b7ab644afe15c60543846ce8b9d5a3d9bcbc332ca24db29",
+    "PROCESS_EXPRESSION_GOLDEN_v2.json":
+        "85e6421f5a1347fca5937d1243dc01500a9aa5b7221571b4918248e57ece6344",
+}
+
+
+@pytest.fixture(scope="module")
+def reg():
+    return load_registry(FIXTURE)
+
+
+def ela(text, reg):
+    return elaborate(parse_functional(text, reg), reg)
+
+
+# --------------------------------------------------------------------------
+# 1-4  surface forms, collisions, lexing, order
+# --------------------------------------------------------------------------
+
+
+def test_reference_and_call_are_distinct_node_kinds(reg):
+    assert isinstance(ela("pearltrees", reg), Reference)
+    assert isinstance(ela("principal_tree(pearltrees)", reg), Call)
+
+
+def test_reference_atom_and_string_cannot_collide(reg):
+    ref = ela("haiku", reg)
+    atom = ela("'haiku'", reg)
+    text = ela('"haiku"', reg)
+    assert isinstance(ref, Reference) and ref.inferred_type == TypeName("judge")
+    assert isinstance(atom, Atom) and atom.inferred_type == TypeName("atom")
+    assert isinstance(text, String) and text.inferred_type == TypeName("string")
+    assert atom.value == text.value == "haiku"
+    assert atom != text  # same characters, different semantic nodes
+
+
+def test_dotted_and_hyphenated_names_use_longest_match(reg):
+    """`gpt-5.5-low` must lex as one token, not as arithmetic on `gpt`."""
+
+    assert ela("gpt-5.5-low", reg).name == "gpt-5.5-low"
+    assert ela("gpt-5.5", reg).name == "gpt-5.5"
+    assert ela("haiku.fast", reg).name == "haiku.fast"
+    assert ela("haiku", reg).name == "haiku"
+
+
+def test_positional_argument_order_is_preserved(reg):
+    term = ela(
+        "cross_substrate(principal_tree(pearltrees),full_dag(pearltrees))", reg
+    )
+    assert [a.name for a in term.args] == ["principal_tree", "full_dag"]
+
+
+# --------------------------------------------------------------------------
+# 5-8  named fields
+# --------------------------------------------------------------------------
+
+
+def test_reordered_named_fields_are_structurally_equal(reg):
+    a = ela("lineage_op(principal_tree(pearltrees),estimand='hop_decay',decay=0.5)", reg)
+    b = ela("lineage_op(principal_tree(pearltrees),decay=0.5,estimand='hop_decay')", reg)
+    assert a == b
+
+
+def test_duplicate_named_fields_fail_before_normalization(reg):
+    with pytest.raises(ElaborationError, match="duplicate named field 'decay'"):
+        ela("lineage_op(principal_tree(pearltrees),decay=0.5,decay=0.5)", reg)
+
+
+def test_unknown_missing_and_ignored_fields_fail_closed(reg):
+    with pytest.raises(ElaborationError, match="does not consume field 'nope'"):
+        ela("lineage_op(principal_tree(pearltrees),nope=1)", reg)
+    with pytest.raises(ElaborationError, match="missing required field 't'"):
+        ela("margin()", reg)
+    # `margin` does not consume `decay`; a plausible-looking field is still ignored.
+    with pytest.raises(ElaborationError, match="does not consume field 'decay'"):
+        ela("margin(t=0.01,decay=0.85)", reg)
+
+
+def test_explicit_and_elided_defaults_elaborate_identically(reg):
+    elided = ela("lineage_op(principal_tree(pearltrees))", reg)
+    explicit = ela(
+        "lineage_op(principal_tree(pearltrees),decay=0.85,depth=unbounded_depth)", reg
+    )
+    assert elided == explicit
+    assert dict(elided.fields)["decay"] == Real(
+        TypeName("real"), ela("margin(t=0.85)", reg).fields[0][1].value
+    )
+
+
+# --------------------------------------------------------------------------
+# 9-11  annotations assert, never convert
+# --------------------------------------------------------------------------
+
+
+def test_redundant_annotation_leaves_no_semantic_trace(reg):
+    assert ela("pearltrees", reg) == ela("pearltrees::corpus", reg)
+
+
+def test_conflicting_annotation_fails_before_semantic_output(reg):
+    with pytest.raises(ElaborationError, match="expected judge, found corpus"):
+        ela("pearltrees::judge", reg)
+
+
+def test_a_judge_is_not_a_substrate(reg):
+    with pytest.raises(ElaborationError, match="expects substrate"):
+        ela("lineage_op(haiku)", reg)
+
+
+# --------------------------------------------------------------------------
+# 12-14  nesting and indexed ownership
+# --------------------------------------------------------------------------
+
+
+def test_nested_calls_and_expression_valued_fields(reg):
+    term = ela(
+        "lineage_op(principal_tree(pearltrees),depth=bounded_depth(4))", reg
+    )
+    assert isinstance(term.args[0], Call)
+    depth = dict(term.fields)["depth"]
+    assert isinstance(depth, Call) and depth.name == "bounded_depth"
+    assert depth.args[0] == Int(TypeName("int"), 4)
+
+
+def test_indexed_type_substitution(reg):
+    assert ela("principal_tree(pearltrees)", reg).inferred_type == IndexedType(
+        "substrate", (TypeName("pearltrees"),)
+    )
+    assert ela("full_dag(simplewiki)", reg).inferred_type == IndexedType(
+        "substrate", (TypeName("simplewiki"),)
+    )
+    # The annotation in the specification's own example type-checks.
+    ela("principal_tree(pearltrees)::substrate[pearltrees]", reg)
+
+
+def test_incompatible_indexed_use_fails(reg):
+    """Both substrates must view the same corpus; `C` binds once."""
+
+    ela("cross_substrate(principal_tree(pearltrees),full_dag(pearltrees))", reg)
+    with pytest.raises(ElaborationError, match="expected substrate\\[pearltrees\\]"):
+        ela(
+            "cross_substrate(principal_tree(pearltrees),principal_tree(simplewiki))",
+            reg,
+        )
+
+
+# --------------------------------------------------------------------------
+# 15  lists
+# --------------------------------------------------------------------------
+
+
+def test_lists_are_homogeneous_per_declared_element_type(reg):
+    term = ela(
+        "hop_decay_targets(principal_tree(pearltrees),decay=0.85,weights=[0.4,0.6])",
+        reg,
+    )
+    weights = dict(term.fields)["weights"]
+    assert isinstance(weights, ListTerm)
+    assert weights.inferred_type == ListType(TypeName("real"))
+    assert all(isinstance(i, Real) for i in weights.items)
+
+    with pytest.raises(ElaborationError):
+        ela(
+            "hop_decay_targets(principal_tree(pearltrees),decay=0.85,"
+            "weights=[0.4,'six'])",
+            reg,
+        )
+
+
+# --------------------------------------------------------------------------
+# 16-20  numerics
+# --------------------------------------------------------------------------
+
+
+def test_integral_lexeme_in_a_real_field_becomes_real(reg):
+    """The declared type wins over the surface spelling (§3.6)."""
+
+    term = ela("margin(t=1)", reg)
+    value = dict(term.fields)["t"]
+    assert isinstance(value, Real) and not isinstance(value, Int)
+    assert value.inferred_type == TypeName("real")
+
+
+def test_equivalent_real_spellings_normalize_identically(reg):
+    one = ela("margin(t=1)", reg)
+    assert one == ela("margin(t=1.0)", reg) == ela("margin(t=1e0)", reg)
+
+
+def test_decimal_beyond_binary64_precision_survives(reg):
+    precise = "0.1234567890123456789012345"
+    term = ela(f"margin(t={precise})", reg)
+    value = dict(term.fields)["t"]
+    assert value.value.plain_string() == precise
+    # Going through float would have rounded it; prove the rounded form differs.
+    assert str(float(precise)) != precise
+    assert ela(f"margin(t={precise})", reg) != ela("margin(t=0.1234567890123457)", reg)
+
+
+def test_real_negative_zero_normalizes_to_zero(reg):
+    assert ela("margin(t=-0.0)", reg) == ela("margin(t=0.0)", reg)
+    assert ela("margin(t=-0.0)", reg) == ela("margin(t=0)", reg)
+
+
+def test_float64_preserves_signed_zero_as_distinct_bits(reg):
+    negative = ela("margin(t=1,epsilon=-0.0)", reg)
+    positive = ela("margin(t=1,epsilon=0.0)", reg)
+    neg_bits = dict(negative.fields)["epsilon"]
+    pos_bits = dict(positive.fields)["epsilon"]
+    assert isinstance(neg_bits, Float64) and isinstance(pos_bits, Float64)
+    assert neg_bits.value.hex16() == "8000000000000000"
+    assert pos_bits.value.hex16() == "0000000000000000"
+    assert negative != positive  # distinct, unlike Python float equality
+    assert neg_bits.value.as_float == pos_bits.value.as_float == 0.0
+
+
+# --------------------------------------------------------------------------
+# 21  phase-appropriate diagnostics
+# --------------------------------------------------------------------------
+
+
+def test_fractional_value_cannot_satisfy_int(reg):
+    with pytest.raises(ElaborationError, match="not an exact integer"):
+        ela("bounded_depth(3.5)", reg)
+    with pytest.raises(ElaborationError, match="not an exact integer"):
+        ela("0.85::int", reg)
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["margin(t=1e)", "margin(t=1e+)", "margin(t=1.)", "margin(t=01)"],
+)
+def test_malformed_numeric_lexemes_fail_at_parse(text, reg):
+    with pytest.raises(ParseError):
+        parse_functional(text, reg)
+
+
+@pytest.mark.parametrize("text", ["nan", "inf", "-inf", "margin(t=nan)"])
+def test_nan_and_infinity_are_not_numbers(text, reg):
+    """No spelling of a non-finite value reaches a numeric type.
+
+    They fail at *parse*, as unregistered names or stray characters, because
+    the numeric grammar admits finite decimals only — so `float('inf')` is
+    never constructed anywhere on the path.
+    """
+
+    with pytest.raises(ParseError, match="unregistered name|malformed|unexpected"):
+        parse_functional(text, reg)
+
+
+def test_trailing_input_and_trailing_commas_fail_at_parse(reg):
+    with pytest.raises(ParseError, match="trailing input"):
+        parse_functional("pearltrees pearltrees", reg)
+    with pytest.raises(ParseError, match="trailing comma"):
+        parse_functional("bounded_depth(4,)", reg)
+    with pytest.raises(ParseError, match="trailing comma"):
+        parse_functional("hop_decay_targets(principal_tree(pearltrees),)", reg)
+
+
+def test_unregistered_name_is_not_guessed_to_be_an_atom(reg):
+    with pytest.raises(ParseError, match="unregistered name"):
+        parse_functional("attention", reg)
+    assert ela("'attention'", reg).value == "attention"
+
+
+def test_deferred_constructs_are_rejected_precisely_not_misparsed(reg):
+    for text in ["lineage_op(S)", "haiku.D", "haiku@rev/abc", "X"]:
+        with pytest.raises((NotImplementedInMilestone, ParseError)) as excinfo:
+            parse_functional(text, reg)
+        assert "not implemented in this milestone" in str(excinfo.value) or (
+            "unregistered" in str(excinfo.value)
+        )
+
+
+def test_arity_errors_name_the_call(reg):
+    with pytest.raises(ElaborationError, match="expects 1 positional"):
+        ela("principal_tree(pearltrees,simplewiki)", reg)
+    with pytest.raises(ElaborationError, match="takes no arguments"):
+        ela("pearltrees(simplewiki)", reg)
+    with pytest.raises(ElaborationError, match="must be applied"):
+        ela("principal_tree", reg)
+
+
+def test_errors_carry_a_source_location_where_applicable(reg):
+    with pytest.raises(ParseError) as excinfo:
+        parse_functional("pearltrees pearltrees", reg)
+    assert excinfo.value.position is not None
+
+
+# --------------------------------------------------------------------------
+# 22  determinism
+# --------------------------------------------------------------------------
+
+
+def test_parsing_and_elaboration_are_deterministic(reg):
+    text = (
+        "lineage_op(principal_tree(pearltrees),estimand='hop_decay',"
+        "decay=0.85,depth=bounded_depth(4),note=\"n\")"
+    )
+    results = [ela(text, reg) for _ in range(5)]
+    assert all(r == results[0] for r in results)
+    assert len({repr(r) for r in results}) == 1
+
+
+# --------------------------------------------------------------------------
+# registry isolation
+# --------------------------------------------------------------------------
+
+
+def test_registry_is_injected_and_never_falls_back_to_v0_3(reg):
+    """v0.3 names must not resolve through the vNext fixture."""
+
+    import process_cards as pc
+
+    assert "luna" in pc.REGISTRY and "luna" not in reg
+    with pytest.raises(ParseError, match="unregistered name"):
+        parse_functional("luna", reg)
+    # And the fixture's own names are not in v0.3.
+    assert "pearltrees" not in pc.REGISTRY
+
+
+def test_fixture_declares_itself_experimental_and_non_release():
+    document = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert document["status"] == "experimental-test-fixture"
+    assert document["production"] is False
+    assert "registry_version" not in document
+
+
+def test_loader_rejects_anything_resembling_a_release_registry(tmp_path):
+    document = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    for mutation in (
+        {"status": "release"},
+        {"production": True},
+        {"registry_version": "v0.4"},
+    ):
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps({**document, **mutation}), encoding="utf-8")
+        with pytest.raises(RegistryError):
+            load_registry(path)
+
+
+# --------------------------------------------------------------------------
+# 23  the frozen contracts are untouched
+# --------------------------------------------------------------------------
+
+
+def test_sealed_golden_bundles_are_byte_identical():
+    for name, digest in SEALED.items():
+        actual = hashlib.sha256((ROOT / name).read_bytes()).hexdigest()
+        assert actual == digest, f"{name} changed"
+
+
+def test_v0_3_behavior_is_unchanged():
+    import process_cards as pc
+
+    assert pc.REGISTRY_VERSION == "v0.3"
+    node = pc.parse("lineage(graph,decay=0.85)")
+    assert pc.canonical(node) == "lineage(graph,decay=0.85)"
+    assert len(pc.ast_sha(node)) == 16
+
+
+def test_package_exports_no_identity_or_deployment_surface():
+    import process_expression_vnext as vnext
+
+    forbidden = (
+        "digest", "hash", "sha", "identity", "deploy", "resolve", "verify",
+        "receipt", "canonical_bytes", "pe_typed_ast",
+    )
+    for name in dir(vnext):
+        if name.startswith("_"):
+            continue
+        assert not any(f in name.lower() for f in forbidden), name
+
+
+def test_debug_repr_is_labelled_noncanonical(reg):
+    from process_expression_vnext.ast import debug_repr
+
+    assert "NONCANONICAL" in debug_repr.__doc__
+    payload = debug_repr(ela("margin(t=1)", reg))
+    assert payload["fields"][0]["value"]["kind"] == "real"
+    assert "schema" not in payload  # never claims pe-typed-ast-v1

--- a/prototypes/mu_cosine/test_process_expression_vnext_frontend.py
+++ b/prototypes/mu_cosine/test_process_expression_vnext_frontend.py
@@ -35,6 +35,8 @@ from process_expression_vnext import (
 from process_expression_vnext.ast import (
     Atom,
     Call,
+    ReferenceIndex,
+    TermIndex,
     Float64,
     IndexedType,
     Int,
@@ -135,9 +137,10 @@ def test_explicit_and_elided_defaults_elaborate_identically(reg):
         "lineage_op(principal_tree(pearltrees),decay=0.85,depth=unbounded_depth)", reg
     )
     assert elided == explicit
-    assert dict(elided.fields)["decay"] == Real(
-        TypeName("real"), ela("margin(t=0.85)", reg).fields[0][1].value
-    )
+    fields = dict(elided.fields)
+    assert isinstance(fields["decay"], Real)
+    assert fields["decay"].inferred_type == TypeName("real")
+    assert isinstance(fields["depth"], Reference)
 
 
 # --------------------------------------------------------------------------
@@ -176,10 +179,10 @@ def test_nested_calls_and_expression_valued_fields(reg):
 
 def test_indexed_type_substitution(reg):
     assert ela("principal_tree(pearltrees)", reg).inferred_type == IndexedType(
-        "substrate", (TypeName("pearltrees"),)
+        "substrate", (ReferenceIndex("pearltrees"),)
     )
     assert ela("full_dag(simplewiki)", reg).inferred_type == IndexedType(
-        "substrate", (TypeName("simplewiki"),)
+        "substrate", (ReferenceIndex("simplewiki"),)
     )
     # The annotation in the specification's own example type-checks.
     ela("principal_tree(pearltrees)::substrate[pearltrees]", reg)
@@ -194,6 +197,131 @@ def test_incompatible_indexed_use_fails(reg):
             "cross_substrate(principal_tree(pearltrees),principal_tree(simplewiki))",
             reg,
         )
+
+
+def test_value_indices_are_not_types(reg):
+    """`substrate[pearltrees]` indexes by a corpus *reference*, not a type.
+
+    Representing the index as ``TypeName("pearltrees")`` would conflate the
+    value and type namespaces.
+    """
+
+    substrate = ela("principal_tree(pearltrees)", reg).inferred_type
+    assert isinstance(substrate, IndexedType)
+    (index,) = substrate.indices
+    assert isinstance(index, ReferenceIndex)
+    assert not isinstance(index, TypeName)
+    assert index.name == "pearltrees"
+
+
+def test_punctuated_reference_parses_inside_a_type_index(reg):
+    """`judge_scope[gpt-5.5-low]` must lex the index as one registered name."""
+
+    typed = ela("judge_view(gpt-5.5-low)::judge_scope[gpt-5.5-low]", reg)
+    (index,) = typed.inferred_type.indices
+    assert isinstance(index, ReferenceIndex) and index.name == "gpt-5.5-low"
+
+
+def test_expression_valued_index_is_tagged_experimental(reg):
+    """`lineage_op(S,...) :: abstract_lineage_process[S]` where S is a call.
+
+    The wire form of an expression-valued index is an open specification
+    decision, so it is carried by an explicitly experimental in-memory node
+    rather than faked as a reference.
+    """
+
+    typed = ela("lineage_op(principal_tree(pearltrees))", reg)
+    assert typed.inferred_type.name == "abstract_lineage_process"
+    (index,) = typed.inferred_type.indices
+    assert isinstance(index, TermIndex)
+    assert "unresolved" in TermIndex.__doc__ and "specification decision" in (
+        " ".join(TermIndex.__doc__.split())
+    )
+    # It cannot be written in an annotation; that would presume the wire form.
+    with pytest.raises(NotImplementedInMilestone, match="open .*specification"):
+        parse_functional(
+            "lineage_op(principal_tree(pearltrees))"
+            "::abstract_lineage_process[principal_tree(pearltrees)]",
+            reg,
+        )
+
+
+def test_fixture_does_not_conflate_lineage_at_with_lineage_op(reg):
+    """The specification separates the family reference from the operator."""
+
+    assert ela("lineage_at", reg).inferred_type == TypeName("relation_family")
+    op = ela("lineage_op(principal_tree(pearltrees))", reg)
+    assert op.inferred_type != TypeName("relation_family")
+    assert op.inferred_type.name == "abstract_lineage_process"
+
+
+def test_a_bind_cannot_overwrite_an_established_ownership_constraint(reg):
+    """Argument unification binds `C` first; `binds` may not silently change it."""
+
+    ela("rebinding_probe(principal_tree(pearltrees),pearltrees)", reg)
+    with pytest.raises(ElaborationError, match="would rebind index C"):
+        ela("rebinding_probe(principal_tree(pearltrees),simplewiki)", reg)
+
+
+def test_defaults_are_type_checked_like_authored_values(tmp_path, reg):
+    document = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    document["entries"]["bad_default"] = {
+        "kind": "call",
+        "type": "cross_view",
+        "args": [],
+        "fields": {"n": {"type": "int", "default": "'not_an_int'"}},
+    }
+    path = tmp_path / "bad_default.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    bad = load_registry(path)
+    with pytest.raises(ElaborationError, match="ill-typed|expected int"):
+        elaborate(parse_functional("bad_default()", bad), bad)
+
+
+def test_a_default_with_an_unresolved_type_cannot_enter_the_typed_ast(tmp_path):
+    """Rather than a dependency solver, refuse order-dependent defaults."""
+
+    document = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    document["entries"]["unresolved_default"] = {
+        "kind": "call",
+        "type": "cross_view",
+        "args": [],
+        "fields": {"e": {"type": "entity[S]", "default": "pearltrees"}},
+    }
+    path = tmp_path / "unresolved_default.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    registry = load_registry(path)
+    with pytest.raises(ElaborationError, match="unresolved type"):
+        elaborate(parse_functional("unresolved_default()", registry), registry)
+
+
+def test_a_reference_may_not_declare_an_unresolvable_type_variable(tmp_path):
+    """A reference has no arguments, so nothing could ever bind `S`."""
+
+    document = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    document["entries"]["dangling_entity"] = {"kind": "reference", "type": "entity[S]"}
+    path = tmp_path / "dangling.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    with pytest.raises(RegistryError, match="unresolved type variable"):
+        load_registry(path)
+
+
+def test_no_type_variable_survives_into_an_elaborated_result(reg):
+    def walk(term):
+        yield term
+        if isinstance(term, Call):
+            for a in term.args:
+                yield from walk(a)
+            for _, v in term.fields:
+                yield from walk(v)
+
+    for text in [
+        "principal_tree(pearltrees)",
+        "lineage_op(principal_tree(pearltrees))",
+        "hop_decay_targets(principal_tree(pearltrees),decay=0.85)",
+    ]:
+        for term in walk(ela(text, reg)):
+            assert "TypeVar" not in repr(term.inferred_type)
 
 
 # --------------------------------------------------------------------------
@@ -277,13 +405,25 @@ def test_fractional_value_cannot_satisfy_int(reg):
         ela("0.85::int", reg)
 
 
-@pytest.mark.parametrize(
-    "text",
-    ["margin(t=1e)", "margin(t=1e+)", "margin(t=1.)", "margin(t=01)"],
-)
+@pytest.mark.parametrize("text", ["margin(t=1e)", "margin(t=1e+)", "margin(t=1.)"])
 def test_malformed_numeric_lexemes_fail_at_parse(text, reg):
     with pytest.raises(ParseError):
         parse_functional(text, reg)
+
+
+def test_leading_zeros_are_accepted_as_in_v0(reg):
+    """`01` is valid; rejecting it would be an unapproved break from v0.
+
+    The vNext grammar says only "a finite decimal numeric token", and v0.3
+    accepts `01` and canonicalizes it to `1`.  Whether to forbid it is a
+    specification decision, not something an experimental frontend should
+    freeze.
+    """
+
+    import process_cards as pc
+
+    assert pc.canonical(pc.parse("margin(t=01)")) == "margin(t=1)"
+    assert ela("margin(t=01)", reg) == ela("margin(t=1)", reg)
 
 
 @pytest.mark.parametrize("text", ["nan", "inf", "-inf", "margin(t=nan)"])
@@ -338,6 +478,61 @@ def test_errors_carry_a_source_location_where_applicable(reg):
     assert excinfo.value.position is not None
 
 
+def test_lone_surrogates_are_rejected_but_valid_pairs_survive(reg):
+    """A typed String must always be UTF-8 encodable."""
+
+    paired = parse_functional('"\\ud83d\\ude00"', reg)   # a valid surrogate pair
+    assert paired.value == "\U0001f600"
+    paired.value.encode("utf-8")
+
+    for lone in ['"\\ud800"', '"\\udc00"', '"a\\ud800b"']:
+        with pytest.raises(ParseError, match="surrogate"):
+            parse_functional(lone, reg)
+
+
+def test_oversized_integers_fail_as_controlled_numeric_errors(reg):
+    """Neither CPython's digit limit nor a huge exponent may escape raw."""
+
+    from process_expression_vnext.numerics import MAX_INT_DIGITS
+
+    long_literal = "9" * (MAX_INT_DIGITS + 10)
+    with pytest.raises((ElaborationError, ParseError)) as excinfo:
+        ela(f"bounded_depth({long_literal})", reg)
+    assert "limit" in str(excinfo.value)
+
+    # Short lexeme, catastrophic exponent: rejected without allocating it.
+    with pytest.raises(ElaborationError, match="limit"):
+        ela("bounded_depth(1e1000000000)", reg)
+
+
+def test_spans_cover_the_expression_and_exclude_trailing_trivia(reg):
+    bare = parse_functional("pearltrees", reg)
+    assert (bare.span.start, bare.span.end) == (0, len("pearltrees"))
+
+    grouped = parse_functional("(pearltrees)", reg)
+    assert (grouped.span.start, grouped.span.end) == (0, len("(pearltrees)"))
+
+    annotated = parse_functional("(pearltrees)::corpus", reg)
+    assert annotated.span.start == 0
+    assert annotated.span.end == len("(pearltrees)::corpus")
+
+    padded = parse_functional("  pearltrees  ", reg)
+    assert padded.span.end == len("  pearltrees")  # trailing trivia excluded
+
+
+def test_source_tree_is_documented_as_elaboration_preserving_not_lossless():
+    """The public claim must match what the implementation delivers."""
+
+    from process_expression_vnext import ast as ast_module
+    from process_expression_vnext import functional_parser as parser_module
+
+    for doc in (ast_module.__doc__, parser_module.__doc__):
+        flat = " ".join(doc.split())
+        assert "elaboration-preserving" in flat
+        assert "exact source reconstruction" in flat
+        assert "lossless source AST" not in flat
+
+
 # --------------------------------------------------------------------------
 # 22  determinism
 # --------------------------------------------------------------------------
@@ -388,6 +583,58 @@ def test_loader_rejects_anything_resembling_a_release_registry(tmp_path):
         path.write_text(json.dumps({**document, **mutation}), encoding="utf-8")
         with pytest.raises(RegistryError):
             load_registry(path)
+
+
+def test_loader_rejects_duplicate_keys_at_every_level(tmp_path):
+    """`json.loads` keeps the last duplicate, so a fixture could lie."""
+
+    path = tmp_path / "dupe.json"
+    path.write_text(
+        '{"status":"experimental-test-fixture","production":false,'
+        '"entries":{"a":{"kind":"reference","type":"corpus"},'
+        '"a":{"kind":"reference","type":"judge"}}}',
+        encoding="utf-8",
+    )
+    with pytest.raises(RegistryError, match="duplicate key"):
+        load_registry(path)
+
+
+@pytest.mark.parametrize(
+    "path_keys,mutation,pattern",
+    [
+        ([], {"surprise": 1}, "unknown key"),
+        (["entries", "pearltrees"], {"surprise": 1}, "unknown key"),
+        (["entries", "margin", "fields", "t"], {"surprise": 1}, "unknown key"),
+        (["entries", "margin", "fields", "t"], {"required": "false"}, "must be a JSON boolean"),
+        (["entries", "pearltrees"], {"type": 7}, "must be a string"),
+        (["entries", "margin"], {"args": "nope"}, "must be a list"),
+    ],
+)
+def test_loader_fails_closed_on_malformed_declarations(
+    tmp_path, path_keys, mutation, pattern
+):
+    document = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    target = document
+    for key in path_keys:
+        target = target[key]
+    target.update(mutation)
+    path = tmp_path / "malformed.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    with pytest.raises(RegistryError, match=pattern):
+        load_registry(path)
+
+
+def test_a_numeric_json_default_is_rejected_before_it_can_round(tmp_path):
+    """A JSON number would be parsed as a float and rounded by `str()`."""
+
+    document = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    document["entries"]["lineage_op"]["fields"]["decay"]["default"] = (
+        0.1234567890123456789012345
+    )
+    path = tmp_path / "numeric_default.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    with pytest.raises(RegistryError, match="must be a JSON string"):
+        load_registry(path)
 
 
 # --------------------------------------------------------------------------

--- a/prototypes/mu_cosine/test_process_expression_vnext_frontend.py
+++ b/prototypes/mu_cosine/test_process_expression_vnext_frontend.py
@@ -132,10 +132,8 @@ def test_unknown_missing_and_ignored_fields_fail_closed(reg):
 
 
 def test_explicit_and_elided_defaults_elaborate_identically(reg):
-    elided = ela("lineage_op(principal_tree(pearltrees))", reg)
-    explicit = ela(
-        "lineage_op(principal_tree(pearltrees),decay=0.85,depth=unbounded_depth)", reg
-    )
+    elided = ela("default_probe()", reg)
+    explicit = ela("default_probe(decay=0.85,depth=unbounded_depth)", reg)
     assert elided == explicit
     fields = dict(elided.fields)
     assert isinstance(fields["decay"], Real)
@@ -319,9 +317,101 @@ def test_no_type_variable_survives_into_an_elaborated_result(reg):
         "principal_tree(pearltrees)",
         "lineage_op(principal_tree(pearltrees))",
         "hop_decay_targets(principal_tree(pearltrees),decay=0.85)",
+        "order_probe(s=principal_tree(pearltrees))",
     ]:
         for term in walk(ela(text, reg)):
             assert "TypeVar" not in repr(term.inferred_type)
+
+
+def test_registry_and_surface_agree_on_a_concrete_value_index(tmp_path):
+    """The same spelling must build the same node in both parsers.
+
+    Otherwise a fixed-result entry loads but cannot be annotated, producing the
+    contradictory diagnostic "expected substrate[pearltrees], found
+    substrate[pearltrees]".
+    """
+
+    from process_expression_vnext.registry import parse_type
+
+    document = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    document["entries"]["fixed_tree"] = {
+        "kind": "call",
+        "type": "substrate[pearltrees]",
+        "args": [],
+    }
+    path = tmp_path / "fixed.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    registry = load_registry(path)
+
+    call = elaborate(parse_functional("fixed_tree()", registry), registry)
+    assert call.inferred_type == IndexedType("substrate", (ReferenceIndex("pearltrees"),))
+    # ...and the annotation of the identical spelling now agrees.
+    annotated = elaborate(
+        parse_functional("fixed_tree()::substrate[pearltrees]", registry), registry
+    )
+    assert annotated == call
+
+    # A punctuated reference is expressible in a registry signature too.
+    assert parse_type("judge_scope[gpt-5.5-low]") is not None
+
+
+def test_a_value_index_cannot_become_a_list_element_type(reg):
+    """`list[T]` requires a genuine type; a value is not one."""
+
+    with pytest.raises(ElaborationError, match="must be a type, not the value"):
+        ela("[]::list[pearltrees]", reg)
+
+
+def test_a_callable_cannot_be_used_as_a_value_index(reg):
+    with pytest.raises(ElaborationError, match="callable and cannot be used"):
+        ela("[]::list[principal_tree]", reg)
+    with pytest.raises(ElaborationError, match="callable and cannot be used"):
+        ela("principal_tree(pearltrees)::substrate[principal_tree]", reg)
+
+
+def test_default_resolution_does_not_depend_on_json_field_order(reg, tmp_path):
+    """`order_probe` declares the defaulted field *before* the field that binds it."""
+
+    document = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert list(document["entries"]["order_probe"]["fields"]) == ["x", "s"]
+    forward = ela("order_probe(s=principal_tree(pearltrees))", reg)
+
+    # Swapping the JSON member order must not change the outcome.
+    swapped = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    probe = swapped["entries"]["order_probe"]["fields"]
+    swapped["entries"]["order_probe"]["fields"] = {"s": probe["s"], "x": probe["x"]}
+    path = tmp_path / "swapped.json"
+    path.write_text(json.dumps(swapped), encoding="utf-8")
+    other = load_registry(path)
+    reversed_result = elaborate(
+        parse_functional("order_probe(s=principal_tree(pearltrees))", other), other
+    )
+    assert forward == reversed_result
+
+
+def test_the_specifications_own_lineage_examples_are_executable(reg):
+    """§4.1's coarse-to-precise ladder must not fail as unknown fields."""
+
+    for text in [
+        "lineage_op(principal_tree(pearltrees))",
+        "lineage_op(principal_tree(pearltrees),"
+        "family_spec='lineage_interpretations_v1')",
+        "lineage_op(principal_tree(pearltrees),estimand='hop_decay')",
+        "lineage_op(principal_tree(pearltrees),estimand='hop_decay',"
+        "impl='graph_walk',decay=0.85,hop_origin=1,direction='ancestor',"
+        "depth=unbounded_depth)",
+    ]:
+        ela(text, reg)
+
+
+def test_the_coarse_lineage_form_inserts_no_defaults(reg):
+    """`lineage_op(S)` is "ground but underconstrained" per §4.1.
+
+    Inserting hop-decay-shaped defaults would silently answer the very
+    interpretation question the coarse form leaves open.
+    """
+
+    assert ela("lineage_op(principal_tree(pearltrees))", reg).fields == ()
 
 
 # --------------------------------------------------------------------------
@@ -330,21 +420,14 @@ def test_no_type_variable_survives_into_an_elaborated_result(reg):
 
 
 def test_lists_are_homogeneous_per_declared_element_type(reg):
-    term = ela(
-        "hop_decay_targets(principal_tree(pearltrees),decay=0.85,weights=[0.4,0.6])",
-        reg,
-    )
+    term = ela("list_probe(weights=[0.4,0.6])", reg)
     weights = dict(term.fields)["weights"]
     assert isinstance(weights, ListTerm)
     assert weights.inferred_type == ListType(TypeName("real"))
     assert all(isinstance(i, Real) for i in weights.items)
 
     with pytest.raises(ElaborationError):
-        ela(
-            "hop_decay_targets(principal_tree(pearltrees),decay=0.85,"
-            "weights=[0.4,'six'])",
-            reg,
-        )
+        ela("list_probe(weights=[0.4,'six'])", reg)
 
 
 # --------------------------------------------------------------------------
@@ -520,13 +603,99 @@ def test_spans_cover_the_expression_and_exclude_trailing_trivia(reg):
     assert padded.span.end == len("  pearltrees")  # trailing trivia excluded
 
 
+def test_debug_rendering_of_a_real_is_bounded(reg):
+    """A ~12-character lexeme must not demand a gigabyte of output.
+
+    Fixed-point rendering scales with the exponent, so the noncanonical debug
+    form falls back to scientific notation past a ceiling.
+    """
+
+    from process_expression_vnext.numerics import (
+        MAX_RENDER_CHARS,
+        NumberLexeme,
+        to_real,
+    )
+
+    for text in ("1e1000000000", "1e100000", "1e-100000"):
+        rendered = to_real(NumberLexeme(text)).plain_string()
+        assert len(rendered) <= MAX_RENDER_CHARS, text
+    # Ordinary precision still renders plainly, so exactness stays visible.
+    precise = "0.1234567890123456789012345"
+    assert to_real(NumberLexeme(precise)).plain_string() == precise
+
+
+def test_host_integer_conversion_limit_is_translated(reg):
+    """CPython's limit is configurable and may sit below the frontend ceiling."""
+
+    from process_expression_vnext.numerics import NumberLexeme, NumericError, to_int
+
+    original = sys.get_int_max_str_digits()
+    try:
+        sys.set_int_max_str_digits(640)
+        with pytest.raises(NumericError):
+            to_int(NumberLexeme("9" * 700))
+    finally:
+        sys.set_int_max_str_digits(original)
+
+
+def test_lone_surrogates_are_rejected_in_atoms_too(reg):
+    """Canonical encoding covers atom values, so they need the same guard."""
+
+    with pytest.raises(ParseError, match="surrogate"):
+        parse_functional("'" + chr(0xD800) + "'", reg)
+    assert ela("'ok'", reg).value == "ok"
+
+
+def test_a_simple_type_span_excludes_trailing_trivia(reg):
+    node = parse_functional("pearltrees::corpus  ", reg)
+    assert node.span.end == len("pearltrees::corpus")
+
+
+def test_expression_index_diagnostic_survives_trivia(reg):
+    """Whitespace must not downgrade the deferral into a generic parse error."""
+
+    for text in [
+        "lineage_op(principal_tree(pearltrees))"
+        "::abstract_lineage_process[principal_tree(pearltrees)]",
+        "lineage_op(principal_tree(pearltrees))"
+        "::abstract_lineage_process[principal_tree (pearltrees)]",
+    ]:
+        with pytest.raises(NotImplementedInMilestone, match="specification decision"):
+            parse_functional(text, reg)
+
+
+def test_a_reference_cannot_carry_silently_discarded_declarations(tmp_path):
+    """Presence, not truthiness: `{"args": [], "binds": "junk"}` must fail."""
+
+    document = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    document["entries"]["pearltrees"] = {
+        "kind": "reference",
+        "type": "corpus",
+        "args": [],
+        "fields": {},
+        "binds": "garbage",
+    }
+    path = tmp_path / "ref_extras.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    with pytest.raises(RegistryError, match="call-only key"):
+        load_registry(path)
+
+
 def test_source_tree_is_documented_as_elaboration_preserving_not_lossless():
     """The public claim must match what the implementation delivers."""
 
     from process_expression_vnext import ast as ast_module
     from process_expression_vnext import functional_parser as parser_module
 
-    for doc in (ast_module.__doc__, parser_module.__doc__):
+    import process_expression_vnext as package
+
+    docs = (
+        ast_module.__doc__,
+        parser_module.__doc__,
+        package.__doc__,
+        parse_functional.__doc__,
+    )
+    for doc in docs:
         flat = " ".join(doc.split())
         assert "elaboration-preserving" in flat
         assert "exact source reconstruction" in flat


### PR DESCRIPTION
## Summary

First executable milestone of [`DESIGN_process_expression_patterns.md`](../blob/main/prototypes/mu_cosine/DESIGN_process_expression_patterns.md):

```text
functional expression
    -> elaboration-preserving source AST  (functional_parser)
    -> registry-driven elaboration        (elaborator)
    -> in-memory typed ground term        (ast)
```

**This is an experimental frontend kernel, not vNext activation.** It mints no identity, emits no canonical bytes, implements no `pe-typed-ast-v1` serialization, and exposes no resolution, verification, or deployment surface. Registry `v0.3`, `pec-v2`, and both sealed golden bundles are frozen legacy contracts — verified byte-identical.

The Prolog adapter is deliberately **not** implemented here; cross-surface equivalence should follow once frontend semantics and the wire schema are stable.

## Architecture and state boundary

The parse/elaborate seam is the point of the milestone, so the halves are kept strictly apart:

- **`functional_parser.py`** — an **elaboration-preserving** source AST: spans, positional order, *every* named-field occurrence in source order including duplicates, exact numeric lexemes, unchecked annotations. It does **not** promise exact source reconstruction — grouping, trivia and original literal spellings are not retained — and says so, because a guarantee the implementation cannot meet is worse than an accurate one. It sorts and de-duplicates nothing, since either would hide the duplicate-field error elaboration must raise.
- **`elaborator.py`** — resolves against an injected registry; validates arity and named fields; rejects duplicate, unknown, missing and ignored fields; inserts defaults; unifies indexed ownership; checks `::` as an assertion, never a conversion.
- **`ast.py`** — two distinct trees. Typed nodes are immutable with structural equality; spans and successfully-checked annotations are absent, so `pearltrees` and `pearltrees::corpus` are the same term. Value indices (`ReferenceIndex`, experimental `TermIndex`) are a **separate hierarchy from types**, so `substrate[pearltrees]` is not a type named `pearltrees`. `debug_repr` is labelled noncanonical and non-identity-bearing.
- **`numerics.py`** — lexemes stay text until the declared type decides (§3.6). Converting through `float` during parsing would round a decimal the specification requires to survive *and* erase the signed-zero distinction `float64` must preserve.
- **`registry.py`** — loads only an injected fixture, never falling back to v0.3. Borrowing v0.3 signatures would make this frontend look more validated than it is and would smuggle back the retired `source` catch-all that §3.2 drops.

Public seam:

```python
surface = parse_functional(text, registry)
typed   = elaborate(surface, registry)
```

A test asserts the package exports nothing whose name contains `digest`, `hash`, `identity`, `deploy`, `resolve`, `verify`, or `receipt`.

## Changed files

Seven new package/test paths, plus one modification:

```
A  process_expression_vnext/{__init__,ast,functional_parser,registry,numerics,elaborator}.py
A  process_expression_vnext/testdata/frontend_registry_fixture.json
A  test_process_expression_vnext_frontend.py
M  .github/workflows/test.yml          # runs the frontend + lightweight legacy suites
```

## Registry fixture

`status: experimental-test-fixture`, `production: false`, and **no** `registry_version` — versions belong to sealed release registries, and the loader actively rejects anything resembling one.

Signatures follow the specification rather than convenience: `lineage_at` is the `relation_family` reference, `lineage_op(S,…)` is `abstract_lineage_process[S]`, and `hop_decay_targets` is `target_factory[S,hop_decay]`. All four of §4.1's coarse-to-precise examples are executable, and the coarse form inserts **no** defaults, because hop-decay-shaped defaults would silently answer the interpretation question `lineage_op(S)` exists to leave open. Synthetic test mechanics live in explicitly named `default_probe` / `list_probe` / `order_probe` / `rebinding_probe` entries so they cannot be mistaken for lineage semantics.

## Tests and sealed hashes

```
python3 -m pytest -q \
  test_process_expression_vnext_frontend.py \
  test_process_cards.py \
  test_process_expression_contract.py \
  test_process_expression_envelope.py \
  test_process_expression_p1_protocol.py
-> 184 passed        (75 frontend)
```

`git diff --check` and `compileall` clean.

| file | sha256 | |
|---|---|---|
| `PROCESS_EXPRESSION_GOLDEN_v1.json` | `b053351a2a419ac58b7ab644afe15c60543846ce8b9d5a3d9bcbc332ca24db29` | ✅ |
| `PROCESS_EXPRESSION_GOLDEN_v2.json` | `85e6421f5a1347fca5937d1243dc01500a9aa5b7221571b4918248e57ece6344` | ✅ |

Behaviors worth singling out:

- `margin(t=1)` elaborates to **`real`**, not `int` — the declared type wins over the spelling;
- `0.1234567890123456789012345` survives exactly, and the test proves the `float`-rounded form differs;
- `-0.0` normalizes to zero as a `real` but keeps `8000000000000000` as a `float64`, distinct from `0000000000000000`;
- `01` is **accepted** and normalizes to `1`, matching v0.3 — forbidding it would be a specification decision;
- `cross_substrate(principal_tree(pearltrees), principal_tree(simplewiki))` fails because `C` binds once, and a `binds` declaration cannot overwrite a constraint unification already established;
- resource ceilings are controlled errors: `1e1000000000` is refused without allocating it, the host integer-conversion limit is translated rather than leaked, and debug rendering of a real is bounded;
- variables, modifiers, pins and function types are rejected with *"not implemented in this milestone"* rather than misparsed.

## Deferred contract decisions

Recorded rather than silently resolved. Each would change type meaning, numeric normalization, source-to-semantic mapping, or future canonical bytes.

**1. Wire form of an expression-valued index.** `abstract_lineage_process[S]` needs `S` to be a substrate *expression*. `TermIndex` carries it in memory so the correct signature is expressible, but it has no serialization and cannot be written in an annotation — that would presume the very decision this milestone must not make. *Smallest example:* `lineage_op(principal_tree(pearltrees))`.

**2. Canonical `real` string form.** §2.1 rule 8 requires "canonical exact-decimal strings" without defining one. Equality here is on the normalized `(sign, digits, exponent)` triple; rendering is explicitly noncanonical and bounded. *Recommendation:* plain decimal with trailing zeros stripped, plus an exponent threshold. *Smallest example:* `1e0`, `1`, `1.0`.

**3. How an index binds to an argument.** The specification shows the result type, not the mechanism. Resolved here by an explicit fixture field `binds: {"C": 0}`. *Open:* whether a nested `Call` may serve as an index — currently yes, via the experimental `TermIndex`.

**4. May a positional argument follow a named field?** The EBNF permits interleaving; this rejects it. *Smallest example:* `lineage_op(decay=0.5, principal_tree(pearltrees))`.

**5. Are registry defaults surface text or pre-typed values?** Text here, elaborated through the same path as authored values, so explicit and elided provably cannot diverge — and so a JSON number cannot round before elaboration sees it.

**6. Is `list` a reserved constructor?** Reserved here. *Smallest example:* a registry entry named `list`.

## Non-goals honored

No changes to `process_cards.py` or v0.3; no variables, `PatternAST`, grounding, or alpha-normalization; no Prolog parsing or execution; no `pe-typed-ast-v1`, AST hashes, or identity; no interpretation/representation rules; no candidate collection, selectors, or aggregation; no resolution or verification receipts; no factory realization; no migration manifests; no `pec-v3` or v3 golden bundle; no encoders, decoders, training, or deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xCXhV5sHDsMiDyU5q7Hqg