### PR TITLE
PERF-R-CA-LOOPBODY: profile iterative CA loop (negative result)

### DIFF
--- a/docs/WAM_FLEET_GAP_TASKS.md
+++ b/docs/WAM_FLEET_GAP_TASKS.md
@@ -833,7 +833,7 @@ Add each target to the scale-300 effective-distance matrix in
 
 ### BENCH-R: Add R row to effective-distance scale-300 matrix ✅
 - **Lever:** Effective-distance benchmark rows  **Target:** R  **Size:** L  **Depends on:** —
-- **Status:** Done — `examples/benchmark/generate_wam_r_effective_distance_benchmark.pl`, guarded Rscript harness block, scale-300 matrix row + subsection in `WAM_CROSS_TARGET_BENCHMARK_RESULTS.md` (hosted-CI IDTABLE query_ms=3412 median / total_ms=4076, 1.08× / 1.07× vs hosted STACK 3679/4344; prior IDCACHE hosted median was 4812/5610; reference parity match). Initial BENCH-R branch `cursor/bench-r-effective-distance-f421`; optimized by PERF-R-CA-DIRECT, IDDFS, IDCACHE, STACK, and IDTABLE. PATHMARK profiled/declined.
+- **Status:** Done — `examples/benchmark/generate_wam_r_effective_distance_benchmark.pl`, guarded Rscript harness block, scale-300 matrix row + subsection in `WAM_CROSS_TARGET_BENCHMARK_RESULTS.md` (hosted-CI IDTABLE query_ms=3412 median / total_ms=4076, 1.08× / 1.07× vs hosted STACK 3679/4344; prior IDCACHE hosted median was 4812/5610; reference parity match). Initial BENCH-R branch `cursor/bench-r-effective-distance-f421`; optimized by PERF-R-CA-DIRECT, IDDFS, IDCACHE, STACK, and IDTABLE. PATHMARK and LOOPBODY profiled/declined.
 
 ---
 

--- a/docs/WAM_R_STATUS.md
+++ b/docs/WAM_R_STATUS.md
@@ -64,7 +64,9 @@ default 4096), and explicit `auto` (codegen resolves via shared
   parity match — see `docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md`.
   Further optimized by PERF-R-CA-DIRECT / IDDFS / IDCACHE / STACK / IDTABLE.
   Hosted-CI IDTABLE median query_ms=3412 / total_ms=4076, 1.08× / 1.07×
-  vs hosted STACK 3679/4344.
+  vs hosted STACK 3679/4344. PERF-R-CA-LOOPBODY profiled the remaining
+  `hops_ids` loop body and declined micro-opts (within noise; ~62% of
+  query is outside CA).
 
 ## Path forward
 
@@ -73,6 +75,6 @@ default 4096), and explicit `auto` (codegen resolves via shared
 
 ## Document status
 
-Fleet-aligned snapshot updated for PERF-R-CA-IDTABLE (2026-07-26): optional
-lazy-on-first-CA `id_table` adjacency on indexed FactSources; hosted remeasure
-3412/4076 with 271-row parity. PATHMARK remains declined.
+Fleet-aligned snapshot updated for PERF-R-CA-LOOPBODY (2026-07-26):
+post-IDTABLE loop-body trials were neutral/slower; no production change.
+Hosted IDTABLE 3412/4076 retained. PATHMARK remains declined.

--- a/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
+++ b/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
@@ -438,6 +438,24 @@ parity. This is about 18.3× faster than the original hosted R query result of
 62595 ms. Residual cost is the iterative DFS body and lowered WAM
 `step`/orchestration.
 
+PERF-R-CA-LOOPBODY line-profiled the post-IDTABLE iterative
+`category_ancestor_hops_ids` body on a Cursor cloud agent (R 4.3.3; no
+per-loop `proc.time`). Call-level phase walls on scale-300 attribute
+~38% of query time to `hops_ids`, ~0% to CA result packing beyond that,
+and ~62% to lowered WAM `step` / effective-distance orchestration outside
+CA. Counters: ~369k node enters, growth-branch hits = 0, max frame sp = 9
+with `cap = max_depth + 2` (max_depth = 10), so the capacity-growth path
+is idle but removing it alone is not a measurable win. Specialized
+single-change trials (no growth branch; skip redundant `as.integer`; skip
+frame-slot clear; O(1) root-on-path count via frame save/restore) all
+preserved 271-row parity and stayed within run-to-run noise or were
+slightly slower (7-rep interleaved medians ≈ 2553 ms base vs 2558 / 2581
+ms). Official same-host 5-rep IDTABLE baseline: query samples
+3106, 2542, 2488, 2528, 2507 (median 2528 / total 3049). No production
+change retained. Hosted IDTABLE reference remains 3412 / 4076 (samples
+4078, 3412, 3268) vs STACK 3679 / 4344. Next end-to-end leverage is
+outside the CA DFS loop.
+
 #### Reproduction
 
 ```bash

--- a/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
+++ b/docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md
@@ -22,7 +22,7 @@ All primary measurements at **scale 300** (6004 `category_parent` facts,
 | **F# WAM + FFI (functions mode)** | **11** | **159** | **1** | **Yes** | Lowered predicates; .NET 8 Release build |
 | **F# LMDB cached (two-level L1/L2)** | **2** | -- | **1** | **Yes** | Fact-access only (no WAM overhead); see below |
 | Python WAM | 215 | 689 | 1 | Yes | CPython 3.12; WAM interpreter, FFI for `category_parent/2` |
-| R WAM (functions, kernels_on) | 3679 | 4344 | 1 | Yes | Hosted Ubuntu 24.04 CI, R 4.3.3; + iterative integer-ID DFS frames (STACK); 3-rep median query |
+| R WAM (functions, kernels_on) | 3412 | 4076 | 1 | Yes | Hosted Ubuntu 24.04 CI, R 4.3.3; + IDTABLE (lazy in-memory adjacency); 3-rep median query |
 | Go WAM | -- | -- | -- | Yes | Build OK; benchmark driver in progress |
 
 **Key takeaway:** Atom interning (replacing `HashMap<String, Vec<String>>` with


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Negative result.** Post-IDTABLE line/phase profiling of `category_ancestor_hops_ids` does not justify retaining a loop-body production change. No runtime/template code is modified.

## Phase attribution (same-host, R 4.3.3)

Call-level wrappers only (no per-loop `proc.time`):

| Phase | Fraction of query |
|-------|-------------------|
| `hops_ids` iterative DFS | ~38% |
| CA result packing beyond hops | ~0% |
| Outside CA (lowered WAM `step` + ED orchestration) | ~62% |

Counters on full scale-300 query (`max_depth=10`): ~369k enters, **growth-branch hits = 0**, `max_sp=9`, `max_vlen=10`, `cap=max_depth+2=12`. Capacity invariant holds (`max_sp ≤ max_depth - vlen0 ≤ max_depth`); the growth path is idle but removing it alone is not a measurable win.

Line profile (sourced instrumented hops): hottest lines are `root_seen` / root-in-parents `any(...)`, dense table read, redundant `as.integer`, path `any(visited==pid)`, and frame-slot clear. PATHMARK path membership was **not** revisited (~1.3% self historically).

## Trials (specialized single-change, interleaved, 271-row parity)

Official same-host IDTABLE baseline (5-rep):

* samples: `3106, 2542, 2488, 2528, 2507`
* median query/total: **2528 / 3049 ms**
* rows: 271

| Candidate | Result vs base |
|-----------|----------------|
| Remove growth branch | ~0.998–1.018× (within noise; sd ≈ 24–38 ms) |
| Skip redundant `as.integer` | ~1.013× |
| Skip `st_parents` clear on pop | ~1.018× |
| O(1) root-on-path via frame save/restore | parity OK, **~0.95–0.99× (slower)** |

7-rep confirm: base median 2553 (sd 23.9) vs no_growth 2558 / root_frame 2581.

## Hosted reference (unchanged; no production delta to remeasure)

* IDTABLE: **3412 / 4076** (samples `4078, 3412, 3268`)
* STACK: **3679 / 4344**

## Decision

Do not retain a production loop-body change. Residual end-to-end leverage is outside the CA DFS loop (lowered WAM / orchestration). IDTABLE stays lazy-on-first-CA.

## Docs

* `docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md` — LOOPBODY subsection + executive-summary R row aligned to hosted IDTABLE 3412/4076
* `docs/WAM_R_STATUS.md`
* `docs/WAM_FLEET_GAP_TASKS.md`

## Reproduction

From the UnifyWeaver repository root:

```bash
swipl -q -s examples/benchmark/generate_wam_r_effective_distance_benchmark.pl -- \
  data/benchmark/300/facts.pl /tmp/wam-bench/r-ed-300 kernels_on functions
( cd /tmp/wam-bench/r-ed-300/R && Rscript run_effective_distance.R \
    /path/to/UnifyWeaver/data/benchmark/300 5 )
```

CA contract tests (unchanged; no production delta):

```bash
swipl -g run_tests -t halt tests/test_wam_r_ca_direct_lookup.pl
```

Artifacts were retained in the agent workspace under `/opt/cursor/artifacts/perf-r-ca-loopbody/` (`SUMMARY.txt`, profiles, trial logs).

Do not merge until review.
<!-- CURSOR_AGENT_PR_BODY_END -->