### PR TITLE
mu_cosine: reject incomplete SM-FS ranking candidate v2 before amendment

### DIFF
--- a/prototypes/mu_cosine/REPORT_sm_fs_filing.md
+++ b/prototypes/mu_cosine/REPORT_sm_fs_filing.md
@@ -183,3 +183,11 @@ reproducible but remains a disabled preflight scaffold. The independent
 the complete fit/evaluate/decide transaction, held-outcome capability boundary, candidate/final
 verifier, and complete execution bindings must land before a fresh candidate is generated and
 reviewed.
+
+Replacement candidate v2 at commit `64ee948ed`, SHA-256 `a490cff99178ca01…`, is also rejected
+before step 4 by `REVIEW_sm_fs_ranking_candidate_v2_lock.md`. Its static hashes and honest fold-0
+projection check out, but its fitter cannot instantiate the countersigned checkpoints, no fresh
+v2 plan or candidate-derived final-lock receipt exists, held access and downstream receipts remain
+self-authenticated, and its NumPy/interpolated bootstrap differs from the exact SHA-256/nearest-rank
+procedure frozen by the first candidate review. Both preregistrations, fitting, held scoring,
+reserve access, and checkpoint release therefore remain blocked.

--- a/prototypes/mu_cosine/REVIEW_sm_fs_ranking_candidate_v2_lock.md
+++ b/prototypes/mu_cosine/REVIEW_sm_fs_ranking_candidate_v2_lock.md
@@ -1,0 +1,214 @@
+# Independent review: SM-FS ranking candidate v2
+
+**Verdict:** authentic static artifact; **request changes before sequence step 4**.
+Candidate v2 does not authorize fitting, and this review does not amend either the ranking or
+retention/transfer preregistration.
+
+This review was completed before any ranking optimizer step, held-fold score, reserve access, or
+step-4 amendment. It binds:
+
+- candidate lock
+  `~/mu_data/sm_fs_ranking_run_v2/candidate_lock_v2.json`, SHA-256
+  `a490cff99178ca0187c1e11a880c6618e00594bc4b9e7e8757171440159440e3`;
+- landed commit `64ee948ed94d502038e5c46421eab5844c9dd899`; and
+- the prior rejection review
+  `68e036c59c210002c50eafcbf6333cdb43393383fe916cd1449942f9fcc584f1`.
+
+The scientific parents remain ranking preregistration
+`0235521270c565a413d69feaa01a6e101fb533261942451a43ddf963e409aca2`
+(protocol SHA-256 `25bac71a67b317700f6a5123af238f01e9b57225bf4deaf71a6470486bd194f3`)
+and still-blocked retention/transfer preregistration
+`f3e1d123e6f81191489689d7f7e0fd121e25ff891ada330fe668b8b3238497c1`
+(protocol SHA-256 `5cbe305ed3eb0c2ecbb78b6f032e326c5c0c72bf415d218c538bbe3abdacd3d8`).
+
+The accompanying JSON is the machine-checkable authority. The local candidate path is provenance,
+not publication permission.
+
+## 1. What passed
+
+The candidate file is the artifact Fable reported, rather than a fabricated replacement:
+
+- its SHA-256 and landed commit match the handoff;
+- every recorded code hash, the ranking-manifest hash, title-table hash, and all three initialized
+  checkpoint hashes match disk;
+- the manifest's `pairs.jsonl` and `fold_assignment.tsv` output hashes match disk;
+- the source bundle contains 361 queries, 359 candidates, 129,599 pairs, 82 lineage blocks, and
+  fold populations `73/72/72/72/72`;
+- the actual fold-0 projection is mode `0600`, hash-consistent, contains 103,392 rows, and excludes
+  all 73 fold-0 queries; and
+- the live ranking and retention preregistrations remain blocked, so the first optimizer step is
+  not currently reachable.
+
+For complete finite inputs, the evaluator's exact-destination rank, ascending catalog-column tie
+rule, arm direction, three-seed within-query averaging, query-weighted block aggregation,
+`+0.010` point floor, and strict lower-CI `> 0` gate are directionally correct.
+
+These facts authenticate useful pieces of the replacement. They do not make the candidate an
+executable or independently countersigned training transaction.
+
+## 2. Blocking findings
+
+### CAND2-1 — the complete fitter cannot load the countersigned checkpoints
+
+Both `cmd_fit` and `cmd_evaluate` construct `MuAttention(**blob["cfg"])`. Every countersigned
+initialization stores the established legacy config:
+
+```text
+{"d_model": 384, "heads": 4, "layers": 3, "judge_name": true,
+ "ridge": 0.1, "op_name": true, "corpus_name": true}
+```
+
+`MuAttention.__init__` accepts `n_heads` and `n_layers`, not `heads` and `layers`, and does not
+accept the remaining legacy flags. Independent reproduction raises
+`TypeError: MuAttention.__init__() got an unexpected keyword argument 'heads'` before optimizer
+construction. The established compatible loading path is `load_expanded`; the new transaction
+does not use or reproduce it.
+
+Thus CAND-1 is not closed: source text for a loop exists, but no registered fit can execute.
+
+### CAND2-2 — the preregistration ID cycle remains and no fresh plan exists
+
+Candidate-bound `sm_fs_protocols.py` still hard-codes both current preregistration IDs. Step 4 must
+derive new ranking and retention IDs, which forces a change to candidate-bound code or makes the
+validators reject the amended documents. Either outcome invalidates this reviewed candidate.
+
+The v2 namespace has no training plan. It contains a candidate, title table, and one fold-0
+projection. The only `training_plan.json` is the obsolete v1 plan bound to the rejected scaffold.
+Candidate v2 consequently binds no exact 30-job matrix, per-fold projection identities, schedule
+population, or plan hash. The prior review explicitly required an ID-free sampler/validator seam
+and a fresh plan plus candidate; neither was delivered.
+
+### CAND2-3 — the final lock and “independent” receipt are not candidate-bound
+
+`sm_fs_ranking_lock_verify.py` emits only a candidate. It has no final-lock emitter, no
+verification-receipt emitter, and no verifier for the provenance or authority of a receipt.
+
+After the live preregistration becomes true, `fitting_allowed` accepts a receipt containing the
+right schema, final-lock hash, preregistration ID, and any nonempty string other than `"self"` in
+the `verifier` field. A caller can write both JSON objects. The final lock contains no reviewed
+candidate SHA or review ID, and its common verification is recomputed against whatever code and
+data happen to exist after step 4. Post-review changes can therefore be presented as a wholly new
+accepted final lock.
+
+A valid finalization must derive from this exact candidate, bind an independently generated
+review receipt and review ID, and prove that the only intervening changes are the narrowly
+authorized preregistration amendments. A name string is not independent verification.
+
+### CAND2-4 — train/evaluate/decide capabilities trust self-authored receipts
+
+The honest fold-0 projection is clean, but the fitter does not authenticate its origin. It trusts
+`projection_sha256` from the adjacent caller-controlled metadata and does not verify metadata
+schema, requested fold, source-manifest hash, held-query exclusion, or a final-lock-bound
+projection identity. A projection containing a held association plus a matching self-authored
+metadata file passes its checks.
+
+The evaluator likewise checks a checkpoint only against a SHA supplied by the same fit receipt.
+It does not validate receipt schema, fold, arm, seed, initialization, projection, final-lock chain,
+commit, environment, or trainable contract. Worse, it opens the complete pair bundle—including
+held outcomes—before attempting to deserialize the checkpoint. Arbitrary bytes plus a
+self-consistent receipt therefore cross the held-outcome capability boundary.
+
+The decision worker trusts evaluation rows without validating their schema, job identity,
+checkpoint, catalog, tie rule, finiteness, query uniqueness, exact fold membership, or complete
+361-query population. Self-authored reciprocal ranks can consequently be attributed to registered
+arms and seeds.
+
+The sealed outputs are also insufficient to reproduce the registered report. Evaluation stores
+only destination rank and reciprocal rank, not the per-candidate scores needed to recompute exact
+ranking or the registered nDCG, AUC, MSE/MAE, relation, and hardness diagnostics. Decision output
+omits the required bootstrap mean/attempts, held-query count, unique-destination count, and
+seed-specific results. Those omissions leave decision-bearing reporting choices after scoring.
+
+### CAND2-5 — several claimed bindings are fields but not enforced bindings
+
+The supplied verifier omits `environment`, `tokenizer_structure`, `frozen_reference`,
+`augmentation`, `early_stopping`, and `cleanliness_scope` from `_verify_common`. Mutating all of
+those fields is accepted. Unsandboxed WSL host execution sees the recorded GTX 1660 SUPER and
+re-emits the candidate exactly; sandboxed verification sees no CUDA device and emits different
+environment bytes, yet the supplied verifier still reports success. That cross-context acceptance
+is direct evidence that the environment lock is descriptive rather than enforced.
+
+The verifier copies initialization hashes from source constants without reading the checkpoint
+files, and it verifies only the ranking manifest bytes—not the manifest-bound pair and fold files.
+The candidate records only the number of trainable tensors and total parameters, not the required
+exact 18 names and shapes. The fitter reopens title, projection, and checkpoint paths after lock
+verification; the exact verified descriptors/bytes are not carried into execution.
+
+### CAND2-6 — the frozen inference algorithm is not implemented
+
+The prior review froze a versioned SHA-256 rejection sampler with exactly 82 block draws per
+replicate and nearest-rank sorted endpoints at zero-based indices 249 and 9749. `cmd_decide`
+instead uses NumPy `default_rng` and linearly interpolated `np.percentile` endpoints. Candidate
+v2 binds only the seed, resample count, confidence, and minimum block count, omitting the sampler
+schema, sampler ID, key fields, rejection rule, draw count, and endpoint rule.
+
+The evaluator also does not reject nonfinite predictions. If the destination score is NaN, every
+greater-than and equality comparison is false and the destination is silently assigned rank 1;
+NaN competitor scores are silently ignored. This is a direct false-positive path and violates the
+frozen fail-closed requirement.
+
+### CAND2-7 — the private transaction still has incomplete rollback and directory guarantees
+
+`install_private` correctly stages mode-`0600` data, fsyncs it, hard-links without replacement,
+and checks the resulting target. It does not remove the installed target when parent fsync or
+post-install verification fails, despite claiming rollback. It fsyncs the directory before
+unlinking the staging name but not after cleanup, so the final one-link namespace state is not the
+state made durable. Existing parent directories are not checked for mode, ownership, or symlink
+substitution, and `read_bound` does not require private input mode.
+
+These are fail-closed perimeter gaps, but they matter because the candidate claims the stronger
+transaction as an authorization premise.
+
+### CAND2-8 — decision-bearing paths have no executable tests
+
+The new suite adds four unit tests. It never loads a real countersigned checkpoint, constructs the
+optimizer, executes even one fit step, scores a candidate list, validates a fit/evaluation
+receipt, exercises final-lock/receipt acceptance, checks the bootstrap known-answer sequence, or
+tests the primary decision. This is why the incompatible loader, receipt substitutions, NaN rank,
+and wrong bootstrap survived.
+
+## 3. Required replacement candidate
+
+Keep both preregistrations blocked while the engineering lane:
+
+1. extracts the sampler into an ID-free stable module and removes hard-coded preregistration IDs
+   from every candidate-bound validator;
+2. fixes checkpoint construction and tests all three exact initialized bytes through model load,
+   exact allowlist resolution, optimizer construction, and a deterministic one-step smoke;
+3. freezes all five train-only projections before candidate generation and independently verifies
+   their schema, fold, source manifest, row population, and zero held-query overlap;
+4. emits a fresh training plan binding the exact 30 jobs, projections, code, artifacts,
+   environment, exact trainable names/shapes, and complete inference contract;
+5. implements a candidate-derived final-lock emitter and an independent review-receipt verifier
+   that bind the candidate SHA, review ID, and a whitelist of permitted preregistration changes;
+6. chains and verifies every fit and evaluation receipt before held access or decision use, with
+   exact job/population checks and finite predictions;
+7. implements the frozen SHA-256 block sampler and nearest-rank endpoints exactly;
+8. completes rollback, second directory fsync, directory privacy, and descriptor/byte handoff
+   guarantees;
+9. adds known-answer and adversarial tests over the actual load/fit/evaluate/decide paths; and
+10. emits a fresh plan and candidate in a new no-replace namespace from the clean landed commit.
+
+That candidate then receives another independent review. Do not amend or “repair” candidate v2 in
+place.
+
+## 4. Conditions preserved for the later amendment
+
+The frozen estimand remains exploratory and catalog-transductive: 361 queries, 359 candidates,
+five folds, 82 unsplit lineage blocks, two paired arms, three seeds, exact-destination MRR,
+`graded-negative-minus-positive-only`, `+0.010` minimum point gain, strict lower CI greater than
+zero, ascending frozen catalog-column tie rule, and no secondary rescue. A pass authorizes only a
+new reserve preregistration; it never authorizes opening the 1,481-row reserve.
+
+The bootstrap remains the exact algorithm frozen in the prior review: average seeds within query,
+form the paired contrast, draw 82 UTF-8-sorted blocks with replacement using the versioned
+SHA-256 rejection sampler and identical multiplicities for both arms, retain the query-weighted
+mean, use 9,999 replicates at seed `3997999`, and take nearest-rank endpoints 249 and 9749.
+
+The later retention cascade remains narrow and still blocked. Only the source ranking protocol
+hash/ID and verified negative-bundle status/hash may change. Track T must independently regrow its
+pre-Pearltrees base under seeds `3998101`--`3998103`; ranking initializations and fitted
+checkpoints remain forbidden there.
+
+Until a replacement candidate passes review, step 4, the retention cascade, model fitting,
+held-fold scoring, reserve access, and checkpoint release all remain unauthorized.

--- a/prototypes/mu_cosine/SM_FS_LINEAGE_RANKING_CANDIDATE_V2_REVIEW.json
+++ b/prototypes/mu_cosine/SM_FS_LINEAGE_RANKING_CANDIDATE_V2_REVIEW.json
@@ -1,0 +1,182 @@
+{
+  "schema": "unifyweaver.sm-fs-ranking-candidate-review.v2",
+  "review_document": "REVIEW_sm_fs_ranking_candidate_v2_lock.md",
+  "review_document_sha256": "0881dcaa24077a1cfbd3de5b4dd21b69b2bcfd32f8eba21248734bf83c3c8a70",
+  "review_status": "authentic-static-artifact-request-changes-before-step-4",
+  "reviewed_before": [
+    "ranking-optimizer-step",
+    "held-fold-score",
+    "reserve-access",
+    "step-4-prereg-amendment"
+  ],
+  "parent_contracts": {
+    "prior_candidate_review_id": "68e036c59c210002c50eafcbf6333cdb43393383fe916cd1449942f9fcc584f1",
+    "ranking_prereg_id": "0235521270c565a413d69feaa01a6e101fb533261942451a43ddf963e409aca2",
+    "ranking_protocol_sha256": "25bac71a67b317700f6a5123af238f01e9b57225bf4deaf71a6470486bd194f3",
+    "retention_prereg_id": "f3e1d123e6f81191489689d7f7e0fd121e25ff891ada330fe668b8b3238497c1",
+    "retention_protocol_sha256": "5cbe305ed3eb0c2ecbb78b6f032e326c5c0c72bf415d218c538bbe3abdacd3d8"
+  },
+  "candidate": {
+    "path": "~/mu_data/sm_fs_ranking_run_v2/candidate_lock_v2.json",
+    "schema": "unifyweaver.sm-fs-ranking-execution-lock.candidate.v2",
+    "sha256": "a490cff99178ca0187c1e11a880c6618e00594bc4b9e7e8757171440159440e3",
+    "git_commit": "64ee948ed94d502038e5c46421eab5844c9dd899",
+    "ranking_bundle_manifest_sha256": "e01e1e48b5464bd315cff3c982e035f390cab8ba2b4c3ee60322dac65bf35894",
+    "title_table_sha256": "78182f1559123bbbb8ac05a47bb2a32f9651225bee2c574688718a32acf8ba20",
+    "training_plan_sha256": null,
+    "initialized_checkpoints": {
+      "3997001": "a3bf4c0588cc3e4cf1ad335b66440c113e7ee11fd116bd7307a3cee57447098e",
+      "3997002": "fb353e693951819683793641464155e144caad73c553039fc64f1c6e253ad796",
+      "3997003": "f42bdea0071a64dca0dad5312178127906b96215ba6890f6a37ad19d87ffdd5a"
+    },
+    "code_sha256": {
+      "fine_tune_channel_heads.py": "4e156eebb6675d950a6b5b41bdeaa87e2d2df2780b6fd5706f5c0eb54d15395c",
+      "judge_cards.py": "71c8733a8dcdf782dc4620a65c99846e2575e2400032336fca599aaa1537844d",
+      "mu_attention.py": "778664fa6e2b95100bff526bab5751b3907887a2e77ea412897dcffffb788443",
+      "sm_fs_protocols.py": "a007663a9339ab371ec7093dfbaacafbd75c779c2149d6e63a26730814a903e4",
+      "sm_fs_ranking_construct.py": "40ed4212f218817166df305b78280966a6af9561d5e3a12440d40af9a2ff67bc",
+      "sm_fs_ranking_lock_verify.py": "1170f39707f4d6343b68628bb5f7934199f2e942679009387a091e89853031b1",
+      "sm_fs_ranking_pipeline.py": "8f81059cdbbb9300d97e8a0bb64bcc79a79a454391917a415e7634eb3850b36a"
+    },
+    "fitting_authorized": false,
+    "static_hashes_match": true,
+    "supplied_verifier_accepts": true,
+    "complete_state_reproduction_enforced": false
+  },
+  "grounding": {
+    "queries": 361,
+    "candidates": 359,
+    "pairs": 129599,
+    "lineage_blocks": 82,
+    "fold_query_counts": [
+      73,
+      72,
+      72,
+      72,
+      72
+    ],
+    "fold_assignment_sha256": "b5439b1acdfb5020ecb7fb4fad437fd183242408d09056e1ed7ec90d33335f37",
+    "fold0_projection_rows": 103392,
+    "fold0_held_queries_excluded": 73,
+    "fold0_projection_held_query_overlap": 0,
+    "fold0_projection_meta_sha256": "18a418d0abb1ab23c8199e1d6c89227acebdc798e3467e5cb7e31adebeca8695",
+    "fold0_projection_sha256": "3bd7feb3742895d72866d5ba5dc90427db34ad973ec95fa43fe5f878f664b539",
+    "countersigned_checkpoint_loads_in_pipeline": false,
+    "optimizer_reachable": false,
+    "fresh_training_plan_present": false,
+    "final_lock_emitter_present": false,
+    "verification_receipt_emitter_present": false,
+    "frozen_bootstrap_implemented": false,
+    "nonfinite_scores_fail_closed": false
+  },
+  "blocking_findings": [
+    "countersigned-checkpoint-config-incompatible-with-fit-and-evaluate",
+    "preregistration-id-cycle-remains-and-fresh-v2-plan-absent",
+    "final-lock-and-independent-receipt-not-candidate-bound",
+    "projection-fit-evaluation-and-decision-receipts-self-authenticate",
+    "claimed-environment-tokenizer-reference-augmentation-and-trainable-bindings-not-enforced",
+    "frozen-bootstrap-and-nonfinite-ranking-fail-closed-contract-not-implemented",
+    "transaction-rollback-directory-durability-and-private-mode-contract-incomplete",
+    "decision-bearing-fit-evaluate-finalize-and-bootstrap-tests-absent"
+  ],
+  "authorization": {
+    "step_4_prereg_amendment_authorized": false,
+    "retention_cascade_authorized": false,
+    "model_fitting_authorized": false,
+    "held_fold_scoring_authorized": false,
+    "reserve_access_authorized": false,
+    "checkpoint_release_authorized": false
+  },
+  "replacement_sequence": [
+    "extract-id-free-sampler-and-remove-hard-coded-prereg-ids-from-candidate-bound-code",
+    "fix-checkpoint-construction-and-smoke-all-three-initializations-through-optimizer",
+    "freeze-and-independently-verify-all-five-train-only-projections-before-candidate",
+    "emit-fresh-plan-binding-30-jobs-projections-code-exact-trainables-and-inference",
+    "implement-candidate-derived-final-lock-and-independent-review-receipt-verifier",
+    "chain-and-verify-fit-evaluation-and-decision-receipts-before-held-access",
+    "implement-frozen-sha256-bootstrap-nearest-rank-endpoints-and-finite-score-gates",
+    "complete-private-transaction-rollback-directory-fsync-mode-and-byte-handoff",
+    "add-real-load-one-step-evaluate-decide-known-answer-and-adversarial-tests",
+    "generate-fresh-plan-and-candidate-in-new-no-replace-namespace",
+    "independently-review-fresh-candidate",
+    "only-then-amend-ranking-prereg-and-cascade-retention-still-blocked"
+  ],
+  "frozen_later_amendment_requirements": {
+    "ranking_estimand_unchanged": true,
+    "queries": 361,
+    "candidates": 359,
+    "folds": 5,
+    "lineage_blocks": 82,
+    "fold_assignment_sha256": "b5439b1acdfb5020ecb7fb4fad437fd183242408d09056e1ed7ec90d33335f37",
+    "evidence_scope": "map-near-lineage-blocked-catalog-transductive",
+    "primary": {
+      "metric": "exact-destination-mrr",
+      "contrast": "graded-negative-minus-positive-only",
+      "minimum_point_gain": 0.01,
+      "interval_lower_strictly_greater_than": 0.0,
+      "tie_rule": "ascending-frozen-catalog-column",
+      "secondary_rescue_authorized": false,
+      "passing_authorizes": "new-reserve-preregistration-only"
+    },
+    "reserve_rows_untouched": 1481,
+    "ranking_seeds": [
+      3997001,
+      3997002,
+      3997003
+    ],
+    "track_t_independent_regrowth": true,
+    "track_t_seeds": [
+      3998101,
+      3998102,
+      3998103
+    ],
+    "bootstrap": {
+      "seed_average_within_query_before_contrast": true,
+      "unit": "frozen-adaptive-lineage-block",
+      "observed_eligible_blocks": 82,
+      "draws_per_replicate": 82,
+      "resamples": 9999,
+      "seed": 3997999,
+      "same_multiplicities_both_arms": true,
+      "query_weighted_mean_preserved": true,
+      "replicate_formula": "sum_b(m_b*sum_q_in_b(d_q))/sum_b(m_b*n_b)",
+      "sampler_schema": "unifyweaver.sm-fs-ranking-bootstrap-key.v1",
+      "sampler_id": "sm-fs-ranking-bootstrap-v1",
+      "sampler_serialization": "canonical-json-sorted-keys-compact-utf8-terminal-lf",
+      "sampler_key_fields": [
+        "draw",
+        "replicate",
+        "retry",
+        "sampler_id",
+        "schema",
+        "seed"
+      ],
+      "sampler_index": "sha256-unsigned-big-endian-rejection-then-modulo-82",
+      "lower_order_zero_based": 249,
+      "upper_order_zero_based": 9749,
+      "order_rule": "nearest-rank-ceil-p-times-resamples-one-based",
+      "minimum_observed_blocks": 20,
+      "minimum_unique_blocks_per_replicate": null
+    }
+  },
+  "retention_cascade": {
+    "only_allowed_source_changes": [
+      "ranking_protocol_sha256",
+      "ranking_prereg_id",
+      "negative_bundle_status",
+      "negative_bundle_sha256"
+    ],
+    "execution_authorized": false,
+    "null_ledger_status": "blocked-until-frozen-and-verified",
+    "null_ledger_sha256": null,
+    "behavior_panel_sha256": null,
+    "fresh_target_cohort_stays_blocked": true,
+    "reserve_rows_authorized": false,
+    "quarantined_rows_authorized": false,
+    "track_r_contract_unchanged": true,
+    "track_t_contract_unchanged": true,
+    "inference_and_bonferroni_unchanged": true,
+    "privacy_and_checkpoint_release_gates_unchanged": true
+  },
+  "review_id": "916cad2f7b3a9d99fa4b8549cd4423b4849c3f205075cd0734e3672a9044aa2d"
+}

--- a/prototypes/mu_cosine/sm_fs_ranking_candidate_v2_review.py
+++ b/prototypes/mu_cosine/sm_fs_ranking_candidate_v2_review.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""Verify the independent fail-closed review of SM-FS ranking candidate v2.
+
+This verifier authenticates the exact static candidate and the review decision.  It deliberately
+cannot authorize a preregistration amendment, fitting, held scoring, or reserve access.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+from pathlib import Path
+from typing import Any, Mapping
+
+from routed_policy import canonical_json_bytes, strict_json_loads
+from sm_fs_protocols import ProtocolError, ROOT, _full_sha, _require
+from sm_fs_ranking_candidate_review import (
+    EXPECTED_BOOTSTRAP,
+    EXPECTED_PRIMARY,
+    EXPECTED_RETENTION_CASCADE,
+    EXPECTED_REVIEW_ID as PRIOR_REVIEW_ID,
+    load_and_verify_candidate_review,
+)
+
+
+REVIEW_PATH = ROOT / "SM_FS_LINEAGE_RANKING_CANDIDATE_V2_REVIEW.json"
+REVIEW_DOCUMENT_NAME = "REVIEW_sm_fs_ranking_candidate_v2_lock.md"
+REVIEW_SCHEMA = "unifyweaver.sm-fs-ranking-candidate-review.v2"
+CANDIDATE_SCHEMA = "unifyweaver.sm-fs-ranking-execution-lock.candidate.v2"
+EXPECTED_REVIEW_ID = "916cad2f7b3a9d99fa4b8549cd4423b4849c3f205075cd0734e3672a9044aa2d"
+
+RANK_DIR = Path("~/mu_data/sm_fs_ranking_v1").expanduser()
+RUN_DIR = Path("~/mu_data/sm_fs_ranking_run_v2").expanduser()
+
+EXPECTED_PARENT_CONTRACTS = {
+    "prior_candidate_review_id": PRIOR_REVIEW_ID,
+    "ranking_prereg_id": (
+        "0235521270c565a413d69feaa01a6e101fb533261942451a43ddf963e409aca2"
+    ),
+    "ranking_protocol_sha256": (
+        "25bac71a67b317700f6a5123af238f01e9b57225bf4deaf71a6470486bd194f3"
+    ),
+    "retention_prereg_id": (
+        "f3e1d123e6f81191489689d7f7e0fd121e25ff891ada330fe668b8b3238497c1"
+    ),
+    "retention_protocol_sha256": (
+        "5cbe305ed3eb0c2ecbb78b6f032e326c5c0c72bf415d218c538bbe3abdacd3d8"
+    ),
+}
+
+EXPECTED_CANDIDATE = {
+    "sha256": "a490cff99178ca0187c1e11a880c6618e00594bc4b9e7e8757171440159440e3",
+    "git_commit": "64ee948ed94d502038e5c46421eab5844c9dd899",
+    "ranking_bundle_manifest_sha256": (
+        "e01e1e48b5464bd315cff3c982e035f390cab8ba2b4c3ee60322dac65bf35894"
+    ),
+    "title_table_sha256": (
+        "78182f1559123bbbb8ac05a47bb2a32f9651225bee2c574688718a32acf8ba20"
+    ),
+}
+
+EXPECTED_INITIALIZED = {
+    "3997001": "a3bf4c0588cc3e4cf1ad335b66440c113e7ee11fd116bd7307a3cee57447098e",
+    "3997002": "fb353e693951819683793641464155e144caad73c553039fc64f1c6e253ad796",
+    "3997003": "f42bdea0071a64dca0dad5312178127906b96215ba6890f6a37ad19d87ffdd5a",
+}
+
+EXPECTED_CODE = {
+    "fine_tune_channel_heads.py": (
+        "4e156eebb6675d950a6b5b41bdeaa87e2d2df2780b6fd5706f5c0eb54d15395c"
+    ),
+    "judge_cards.py": "71c8733a8dcdf782dc4620a65c99846e2575e2400032336fca599aaa1537844d",
+    "mu_attention.py": "778664fa6e2b95100bff526bab5751b3907887a2e77ea412897dcffffb788443",
+    "sm_fs_protocols.py": (
+        "a007663a9339ab371ec7093dfbaacafbd75c779c2149d6e63a26730814a903e4"
+    ),
+    "sm_fs_ranking_construct.py": (
+        "40ed4212f218817166df305b78280966a6af9561d5e3a12440d40af9a2ff67bc"
+    ),
+    "sm_fs_ranking_lock_verify.py": (
+        "1170f39707f4d6343b68628bb5f7934199f2e942679009387a091e89853031b1"
+    ),
+    "sm_fs_ranking_pipeline.py": (
+        "8f81059cdbbb9300d97e8a0bb64bcc79a79a454391917a415e7634eb3850b36a"
+    ),
+}
+
+EXPECTED_BLOCKERS = {
+    "countersigned-checkpoint-config-incompatible-with-fit-and-evaluate",
+    "preregistration-id-cycle-remains-and-fresh-v2-plan-absent",
+    "final-lock-and-independent-receipt-not-candidate-bound",
+    "projection-fit-evaluation-and-decision-receipts-self-authenticate",
+    "claimed-environment-tokenizer-reference-augmentation-and-trainable-bindings-not-enforced",
+    "frozen-bootstrap-and-nonfinite-ranking-fail-closed-contract-not-implemented",
+    "transaction-rollback-directory-durability-and-private-mode-contract-incomplete",
+    "decision-bearing-fit-evaluate-finalize-and-bootstrap-tests-absent",
+}
+
+EXPECTED_REPLACEMENT_SEQUENCE = [
+    "extract-id-free-sampler-and-remove-hard-coded-prereg-ids-from-candidate-bound-code",
+    "fix-checkpoint-construction-and-smoke-all-three-initializations-through-optimizer",
+    "freeze-and-independently-verify-all-five-train-only-projections-before-candidate",
+    "emit-fresh-plan-binding-30-jobs-projections-code-exact-trainables-and-inference",
+    "implement-candidate-derived-final-lock-and-independent-review-receipt-verifier",
+    "chain-and-verify-fit-evaluation-and-decision-receipts-before-held-access",
+    "implement-frozen-sha256-bootstrap-nearest-rank-endpoints-and-finite-score-gates",
+    "complete-private-transaction-rollback-directory-fsync-mode-and-byte-handoff",
+    "add-real-load-one-step-evaluate-decide-known-answer-and-adversarial-tests",
+    "generate-fresh-plan-and-candidate-in-new-no-replace-namespace",
+    "independently-review-fresh-candidate",
+    "only-then-amend-ranking-prereg-and-cascade-retention-still-blocked",
+]
+
+EXPECTED_GROUNDING = {
+    "queries": 361,
+    "candidates": 359,
+    "pairs": 129599,
+    "lineage_blocks": 82,
+    "fold_query_counts": [73, 72, 72, 72, 72],
+    "fold_assignment_sha256": (
+        "b5439b1acdfb5020ecb7fb4fad437fd183242408d09056e1ed7ec90d33335f37"
+    ),
+    "fold0_projection_rows": 103392,
+    "fold0_held_queries_excluded": 73,
+    "fold0_projection_held_query_overlap": 0,
+    "fold0_projection_meta_sha256": (
+        "18a418d0abb1ab23c8199e1d6c89227acebdc798e3467e5cb7e31adebeca8695"
+    ),
+    "fold0_projection_sha256": (
+        "3bd7feb3742895d72866d5ba5dc90427db34ad973ec95fa43fe5f878f664b539"
+    ),
+    "countersigned_checkpoint_loads_in_pipeline": False,
+    "optimizer_reachable": False,
+    "fresh_training_plan_present": False,
+    "final_lock_emitter_present": False,
+    "verification_receipt_emitter_present": False,
+    "frozen_bootstrap_implemented": False,
+    "nonfinite_scores_fail_closed": False,
+}
+
+FULL_GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _review_id(document: Mapping[str, Any]) -> str:
+    core = dict(document)
+    core.pop("review_id", None)
+    return hashlib.sha256(canonical_json_bytes(core)).hexdigest()
+
+
+def _read_regular(path: Path, description: str, *, private: bool = False) -> bytes:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise ProtocolError(f"cannot open {description}: {exc}") from exc
+    try:
+        metadata = os.fstat(fd)
+        _require(stat.S_ISREG(metadata.st_mode), f"{description} must be a regular file")
+        _require(metadata.st_nlink == 1, f"{description} must have exactly one hard link")
+        if private:
+            _require(
+                stat.S_IMODE(metadata.st_mode) == 0o600,
+                f"{description} mode must be 0600",
+            )
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(fd, 1 << 20)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks)
+    finally:
+        os.close(fd)
+
+
+def _load_json(path: Path, description: str, *, private: bool = False) -> dict[str, Any]:
+    payload = _read_regular(path, description, private=private)
+    try:
+        document = strict_json_loads(payload, source=str(path))
+    except ValueError as exc:
+        raise ProtocolError(f"cannot parse {description}: {exc}") from exc
+    _require(isinstance(document, dict), f"{description} must be a JSON object")
+    return document
+
+
+def _sha(path: Path, description: str, *, private: bool = False) -> str:
+    return hashlib.sha256(_read_regular(path, description, private=private)).hexdigest()
+
+
+def load_and_verify_candidate_v2_review(
+    path: str | Path = REVIEW_PATH,
+) -> dict[str, Any]:
+    path = Path(path)
+    _require(path.name == REVIEW_PATH.name, "unexpected candidate-v2-review filename")
+    document = _load_json(path, "candidate v2 review")
+    _require(document.get("schema") == REVIEW_SCHEMA, "unsupported candidate-v2-review schema")
+    _require(
+        document.get("review_document") == REVIEW_DOCUMENT_NAME,
+        "candidate-v2-review document path drifted",
+    )
+    review_document = path.with_name(REVIEW_DOCUMENT_NAME)
+    observed_document_sha = _sha(review_document, "candidate v2 review document")
+    _require(
+        document.get("review_document_sha256") == observed_document_sha,
+        "candidate-v2-review document hash differs",
+    )
+    _require(document.get("review_id") == _review_id(document), "candidate-v2-review ID mismatch")
+    _require(
+        document.get("review_status")
+        == "authentic-static-artifact-request-changes-before-step-4",
+        "candidate-v2-review status drifted",
+    )
+    _require(
+        document.get("reviewed_before")
+        == [
+            "ranking-optimizer-step",
+            "held-fold-score",
+            "reserve-access",
+            "step-4-prereg-amendment",
+        ],
+        "candidate-v2-review timing boundary drifted",
+    )
+
+    prior = load_and_verify_candidate_review()
+    _require(prior.get("review_id") == PRIOR_REVIEW_ID, "prior candidate review drifted")
+    _require(
+        document.get("parent_contracts") == EXPECTED_PARENT_CONTRACTS,
+        "candidate-v2-review parent contracts drifted",
+    )
+
+    candidate = document.get("candidate", {})
+    _require(candidate.get("schema") == CANDIDATE_SCHEMA, "candidate v2 schema drifted")
+    for field, expected in EXPECTED_CANDIDATE.items():
+        if field == "git_commit":
+            _require(
+                isinstance(candidate.get(field), str)
+                and FULL_GIT_SHA_RE.fullmatch(candidate[field]) is not None,
+                "candidate v2 git commit must be a full lowercase SHA",
+            )
+        else:
+            _full_sha(candidate.get(field), f"candidate v2 {field}")
+        _require(candidate.get(field) == expected, f"candidate v2 {field} drifted")
+    _require(candidate.get("training_plan_sha256") is None, "candidate v2 acquired a plan")
+    _require(
+        candidate.get("initialized_checkpoints") == EXPECTED_INITIALIZED,
+        "candidate v2 initialized checkpoints drifted",
+    )
+    _require(candidate.get("code_sha256") == EXPECTED_CODE, "candidate v2 code drifted")
+    _require(candidate.get("fitting_authorized") is False, "candidate v2 authorized fitting")
+    _require(candidate.get("static_hashes_match") is True, "candidate v2 grounding disappeared")
+    _require(
+        candidate.get("supplied_verifier_accepts") is True
+        and candidate.get("complete_state_reproduction_enforced") is False,
+        "candidate v2 verifier characterization drifted",
+    )
+
+    _require(document.get("grounding") == EXPECTED_GROUNDING, "candidate v2 grounding drifted")
+    _require(
+        set(document.get("blocking_findings", [])) == EXPECTED_BLOCKERS,
+        "candidate v2 blockers drifted",
+    )
+    authorization = document.get("authorization", {})
+    expected_false = {
+        "step_4_prereg_amendment_authorized",
+        "retention_cascade_authorized",
+        "model_fitting_authorized",
+        "held_fold_scoring_authorized",
+        "reserve_access_authorized",
+        "checkpoint_release_authorized",
+    }
+    _require(set(authorization) == expected_false, "candidate v2 authorization fields drifted")
+    for field in expected_false:
+        _require(authorization.get(field) is False, f"{field} became authorized")
+    _require(
+        document.get("replacement_sequence") == EXPECTED_REPLACEMENT_SEQUENCE,
+        "candidate v2 replacement sequence drifted",
+    )
+
+    later = document.get("frozen_later_amendment_requirements", {})
+    _require(later.get("ranking_estimand_unchanged") is True, "ranking estimand became mutable")
+    _require(
+        (
+            later.get("queries"),
+            later.get("candidates"),
+            later.get("folds"),
+            later.get("lineage_blocks"),
+        )
+        == (361, 359, 5, 82),
+        "later ranking population drifted",
+    )
+    _require(later.get("primary") == EXPECTED_PRIMARY, "later primary decision drifted")
+    _require(later.get("bootstrap") == EXPECTED_BOOTSTRAP, "later bootstrap contract drifted")
+    _require(later.get("reserve_rows_untouched") == 1481, "reserve population drifted")
+    _require(
+        later.get("track_t_independent_regrowth") is True
+        and later.get("track_t_seeds") == [3998101, 3998102, 3998103],
+        "Track T independence drifted",
+    )
+    _require(
+        document.get("retention_cascade") == EXPECTED_RETENTION_CASCADE,
+        "later retention cascade drifted",
+    )
+    _require(
+        document.get("review_id") == EXPECTED_REVIEW_ID,
+        "frozen candidate-v2-review ID drifted",
+    )
+    return document
+
+
+def verify_reviewed_candidate_v2(
+    candidate_path: str | Path,
+    review: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Authenticate the exact rejected candidate and its currently present static inputs."""
+
+    review = dict(review or load_and_verify_candidate_v2_review())
+    candidate_path = Path(candidate_path)
+    payload = _read_regular(candidate_path, "reviewed candidate v2", private=True)
+    _require(
+        hashlib.sha256(payload).hexdigest() == review["candidate"]["sha256"],
+        "reviewed candidate v2 hash differs",
+    )
+    try:
+        candidate = strict_json_loads(payload, source=str(candidate_path))
+    except ValueError as exc:
+        raise ProtocolError(f"reviewed candidate v2 JSON is invalid: {exc}") from exc
+    _require(isinstance(candidate, dict), "reviewed candidate v2 must be an object")
+    _require(candidate.get("schema") == CANDIDATE_SCHEMA, "reviewed candidate v2 schema drifted")
+    _require(
+        candidate.get("git_commit") == review["candidate"]["git_commit"],
+        "reviewed candidate v2 commit drifted",
+    )
+    _require(
+        candidate.get("ranking_bundle_manifest_sha256")
+        == review["candidate"]["ranking_bundle_manifest_sha256"],
+        "reviewed candidate v2 bundle drifted",
+    )
+    _require(
+        candidate.get("title_table_sha256") == review["candidate"]["title_table_sha256"],
+        "reviewed candidate v2 title table drifted",
+    )
+    _require(
+        candidate.get("initialized_checkpoints") == EXPECTED_INITIALIZED,
+        "reviewed candidate v2 initialization bindings drifted",
+    )
+    _require(candidate.get("code_sha256") == EXPECTED_CODE, "reviewed candidate v2 code drifted")
+    _require(candidate.get("fitting_authorized") is False, "reviewed candidate v2 authorized fitting")
+
+    for filename, expected in EXPECTED_CODE.items():
+        _require(
+            _sha(ROOT / filename, f"candidate-bound code {filename}") == expected,
+            f"candidate-bound code {filename} differs",
+        )
+    _require(
+        _sha(RANK_DIR / "manifest.json", "ranking manifest", private=True)
+        == EXPECTED_CANDIDATE["ranking_bundle_manifest_sha256"],
+        "ranking manifest differs",
+    )
+    manifest = _load_json(RANK_DIR / "manifest.json", "ranking manifest", private=True)
+    _require(
+        manifest.get("counts", {}).get("queries") == 361
+        and manifest.get("counts", {}).get("candidates") == 359
+        and manifest.get("counts", {}).get("pairs") == 129599,
+        "ranking manifest population differs",
+    )
+    _require(
+        manifest.get("fold", {}).get("blocks") == 82
+        and manifest.get("fold", {}).get("fold_map_counts") == [73, 72, 72, 72, 72]
+        and manifest.get("fold", {}).get("assignment_sha256")
+        == EXPECTED_GROUNDING["fold_assignment_sha256"],
+        "ranking manifest fold contract differs",
+    )
+    output_payloads: dict[str, bytes] = {}
+    for filename, expected in manifest.get("outputs", {}).items():
+        payload = _read_regular(
+            RANK_DIR / filename,
+            f"ranking output {filename}",
+            private=True,
+        )
+        _require(
+            hashlib.sha256(payload).hexdigest() == expected,
+            f"ranking output {filename} differs",
+        )
+        output_payloads[filename] = payload
+    _require(
+        _sha(RUN_DIR / "titles.json", "title table", private=True)
+        == EXPECTED_CANDIDATE["title_table_sha256"],
+        "title table differs",
+    )
+    for seed, expected in EXPECTED_INITIALIZED.items():
+        _require(
+            _sha(RANK_DIR / f"init_seed{seed}.pt", f"initialized checkpoint {seed}", private=True)
+            == expected,
+            f"initialized checkpoint {seed} differs",
+        )
+    projection_meta_path = RUN_DIR / "fold0" / "train_projection.meta.json"
+    _require(
+        _sha(projection_meta_path, "fold-0 projection metadata", private=True)
+        == EXPECTED_GROUNDING["fold0_projection_meta_sha256"],
+        "fold-0 projection metadata hash differs",
+    )
+    projection_meta = _load_json(
+        projection_meta_path,
+        "fold-0 projection metadata",
+        private=True,
+    )
+    _require(
+        projection_meta.get("schema") == "unifyweaver.sm-fs-ranking-train-projection.v1"
+        and projection_meta.get("fold") == 0
+        and projection_meta.get("rows") == EXPECTED_GROUNDING["fold0_projection_rows"]
+        and projection_meta.get("held_queries_excluded")
+        == EXPECTED_GROUNDING["fold0_held_queries_excluded"]
+        and projection_meta.get("source_manifest_sha256")
+        == EXPECTED_CANDIDATE["ranking_bundle_manifest_sha256"],
+        "fold-0 projection metadata differs",
+    )
+    projection_payload = _read_regular(
+        RUN_DIR / "fold0" / "train_projection.jsonl",
+        "fold-0 projection",
+        private=True,
+    )
+    _require(
+        hashlib.sha256(projection_payload).hexdigest()
+        == projection_meta.get("projection_sha256")
+        == EXPECTED_GROUNDING["fold0_projection_sha256"],
+        "fold-0 projection hash differs",
+    )
+    pairs = [
+        json.loads(line)
+        for line in output_payloads["pairs.jsonl"].decode("utf-8").splitlines()
+    ]
+    held_queries = {row["query"] for row in pairs if row["fold"] == 0}
+    projection_rows = [
+        json.loads(line) for line in projection_payload.decode("utf-8").splitlines()
+    ]
+    _require(
+        len(projection_rows) == EXPECTED_GROUNDING["fold0_projection_rows"],
+        "fold-0 projection row count differs",
+    )
+    _require(
+        not ({row["query"] for row in projection_rows} & held_queries),
+        "fold-0 projection contains held queries",
+    )
+    _require(not (RUN_DIR / "training_plan.json").exists(), "rejected v2 namespace was modified")
+    return {
+        "candidate_sha256": EXPECTED_CANDIDATE["sha256"],
+        "candidate_authentic": True,
+        "step_4_prereg_amendment_authorized": False,
+        "model_fitting_authorized": False,
+    }
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--candidate")
+    args = parser.parse_args(argv)
+    review = load_and_verify_candidate_v2_review()
+    print(f"ranking-candidate-v2-review\t{review['review_id']}")
+    print("review-record\tauthenticated")
+    print("step-4-amendment\tblocked")
+    print("model-fitting\tblocked")
+    if args.candidate:
+        verify_reviewed_candidate_v2(args.candidate, review)
+        print("local-candidate\tstatic-artifact-authentic-verified-rejected")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/mu_cosine/test_sm_fs_ranking_candidate_v2_review.py
+++ b/prototypes/mu_cosine/test_sm_fs_ranking_candidate_v2_review.py
@@ -1,0 +1,231 @@
+"""Enforcement and adversarial tests for the rejected SM-FS candidate v2."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import sm_fs_ranking_lock_verify as supplied
+import sm_fs_ranking_pipeline as pipeline
+from mu_attention import MuAttention
+from routed_policy import canonical_json_bytes
+from sm_fs_protocols import ProtocolError
+from sm_fs_ranking_candidate_review import EXPECTED_BOOTSTRAP
+from sm_fs_ranking_candidate_v2_review import (
+    EXPECTED_BLOCKERS,
+    EXPECTED_REPLACEMENT_SEQUENCE,
+    REVIEW_PATH,
+    _review_id,
+    load_and_verify_candidate_v2_review,
+)
+
+
+def _review() -> dict:
+    return json.loads(REVIEW_PATH.read_text(encoding="utf-8"))
+
+
+def _write_review_fixture(tmp_path: Path, document: dict) -> Path:
+    source = REVIEW_PATH.with_name(document["review_document"])
+    copied = tmp_path / document["review_document"]
+    copied.write_bytes(source.read_bytes())
+    document["review_document_sha256"] = hashlib.sha256(copied.read_bytes()).hexdigest()
+    document["review_id"] = _review_id(document)
+    path = tmp_path / REVIEW_PATH.name
+    path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def test_committed_v2_review_blocks_every_authorization():
+    review = load_and_verify_candidate_v2_review()
+    assert set(review["blocking_findings"]) == EXPECTED_BLOCKERS
+    assert review["replacement_sequence"] == EXPECTED_REPLACEMENT_SEQUENCE
+    assert not any(review["authorization"].values())
+    assert review["candidate"]["training_plan_sha256"] is None
+    assert review["grounding"]["countersigned_checkpoint_loads_in_pipeline"] is False
+
+
+@pytest.mark.parametrize(
+    "mutation,message",
+    [
+        (
+            lambda d: d["authorization"].update(step_4_prereg_amendment_authorized=True),
+            "step_4_prereg_amendment_authorized",
+        ),
+        (
+            lambda d: d["authorization"].update(model_fitting_authorized=True),
+            "model_fitting_authorized",
+        ),
+        (
+            lambda d: d.update(blocking_findings=d["blocking_findings"][:-1]),
+            "candidate v2 blockers",
+        ),
+        (
+            lambda d: d["grounding"].update(countersigned_checkpoint_loads_in_pipeline=True),
+            "candidate v2 grounding",
+        ),
+        (
+            lambda d: d["grounding"].update(frozen_bootstrap_implemented=True),
+            "candidate v2 grounding",
+        ),
+        (
+            lambda d: d["candidate"].update(training_plan_sha256="0" * 64),
+            "acquired a plan",
+        ),
+        (
+            lambda d: d.update(replacement_sequence=d["replacement_sequence"][:-1]),
+            "replacement sequence",
+        ),
+        (
+            lambda d: d["frozen_later_amendment_requirements"]["primary"].update(
+                minimum_point_gain=0.0
+            ),
+            "primary decision",
+        ),
+        (
+            lambda d: d["frozen_later_amendment_requirements"]["bootstrap"].update(
+                sampler_id="changed"
+            ),
+            "bootstrap contract",
+        ),
+        (
+            lambda d: d["retention_cascade"].update(execution_authorized=True),
+            "retention cascade",
+        ),
+    ],
+)
+def test_resealed_v2_review_mutations_fail(tmp_path, mutation, message):
+    document = _review()
+    mutation(document)
+    path = _write_review_fixture(tmp_path, document)
+    with pytest.raises(ProtocolError, match=message):
+        load_and_verify_candidate_v2_review(path)
+
+
+def test_review_document_tamper_fails(tmp_path):
+    path = _write_review_fixture(tmp_path, _review())
+    document_path = path.with_name(_review()["review_document"])
+    document_path.write_bytes(document_path.read_bytes() + b"\nchanged\n")
+    with pytest.raises(ProtocolError, match="document hash"):
+        load_and_verify_candidate_v2_review(path)
+
+
+def test_hard_bound_review_id_rejects_unenumerated_reseal(tmp_path):
+    document = _review()
+    document["unreviewed_note"] = True
+    path = _write_review_fixture(tmp_path, document)
+    with pytest.raises(ProtocolError, match="frozen candidate-v2-review ID"):
+        load_and_verify_candidate_v2_review(path)
+
+
+def test_pipeline_constructor_is_incompatible_with_countersigned_cfg():
+    params = inspect.signature(MuAttention.__init__).parameters
+    assert "heads" not in params and "layers" not in params
+    assert "n_heads" in params and "n_layers" in params
+    source = inspect.getsource(pipeline.cmd_fit)
+    assert 'MuAttention(**blob["cfg"])' in source
+    legacy_cfg = {
+        "d_model": 384,
+        "heads": 4,
+        "layers": 3,
+        "judge_name": True,
+        "ridge": 0.1,
+        "op_name": True,
+        "corpus_name": True,
+    }
+    with pytest.raises(TypeError, match="unexpected keyword argument 'heads'"):
+        MuAttention(**legacy_cfg)
+
+
+def test_supplied_verifier_accepts_tampered_claimed_bindings(monkeypatch):
+    baseline = {
+        "git_commit": "a" * 40,
+        "ranking_bundle_manifest_sha256": "b" * 64,
+        "initialized_checkpoints": {"3997001": "c" * 64},
+        "title_table_sha256": "d" * 64,
+        "e5_revision": "e" * 40,
+        "code_sha256": {"x": "f" * 64},
+        "adam": {"lr": 0.1},
+        "steps": 1,
+        "batch_size": 2,
+        "query_draws": 1,
+        "anchor_weight": 1.0,
+        "grad_clip": 1.0,
+        "trainable_contract": {"tensor_count": 18, "param_count": 1195782},
+        "tie_rule": "ascending-frozen-catalog-column",
+        "bootstrap": {"seed": 3997999},
+        "schemas": ["x"],
+        "environment": {"cuda_available": True},
+        "tokenizer_structure": "expected",
+        "frozen_reference": "expected",
+        "augmentation": {"anchor_rows_augmented": False},
+        "early_stopping": False,
+        "cleanliness_scope": "expected",
+    }
+    monkeypatch.setattr(supplied, "_bindings", lambda: dict(baseline))
+    lock = dict(baseline)
+    lock.update(schema=supplied.CAND_SCHEMA, fitting_authorized=False)
+    lock["environment"] = {"cuda_available": False}
+    lock["tokenizer_structure"] = "forged"
+    lock["frozen_reference"] = "forged"
+    lock["augmentation"] = {"anchor_rows_augmented": True}
+    lock["early_stopping"] = True
+    lock["cleanliness_scope"] = "forged"
+    assert supplied.verify_candidate_lock(lock) is True
+
+
+def test_no_final_lock_or_independent_receipt_emitter_exists():
+    assert not hasattr(supplied, "emit_final")
+    assert not hasattr(supplied, "emit_verification_receipt")
+    source = inspect.getsource(pipeline.fitting_allowed)
+    assert 'receipt.get("verifier") not in (None, "", "self")' in source
+
+
+def test_current_decision_uses_wrong_sampler_and_percentile():
+    source = inspect.getsource(pipeline.cmd_decide)
+    assert "np.random.default_rng" in source
+    assert "np.percentile" in source
+    assert EXPECTED_BOOTSTRAP["sampler_id"] not in source
+
+
+def test_nan_destination_score_is_silently_ranked_first_by_current_expression():
+    scores = np.array([0.8, np.nan, 0.7])
+    destination_index = 1
+    rank = 1 + int(np.sum(scores > scores[destination_index])) + int(
+        np.sum(
+            (scores == scores[destination_index])
+            & (np.arange(len(scores)) < destination_index)
+        )
+    )
+    assert rank == 1
+    assert not np.isfinite(scores).all()
+
+
+def test_install_failure_after_link_leaves_permanent_target(tmp_path, monkeypatch):
+    target = tmp_path / "receipt.json"
+    real_fsync = pipeline.os.fsync
+    calls = 0
+
+    def fail_directory_fsync(fd):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("injected directory fsync failure")
+        return real_fsync(fd)
+
+    monkeypatch.setattr(pipeline.os, "fsync", fail_directory_fsync)
+    with pytest.raises(OSError, match="injected directory fsync failure"):
+        pipeline.install_private(str(target), b"payload\n")
+    assert target.exists()
+    assert not list(tmp_path.glob(".stage-*"))
+
+
+def test_review_id_uses_canonical_json():
+    document = _review()
+    expected = document.pop("review_id")
+    assert hashlib.sha256(canonical_json_bytes(document)).hexdigest() == expected


### PR DESCRIPTION
## Summary

Independently audits the replacement SM-FS ranking execution candidate at landed commit `64ee948ed94d502038e5c46421eab5844c9dd899` and candidate SHA-256 `a490cff99178ca0187c1e11a880c6618e00594bc4b9e7e8757171440159440e3`.

The candidate's static provenance is authentic: recorded code, manifest, title table, initialized checkpoints, pair/fold outputs, and the existing fold-0 projection all reproduce. The execution transaction is nevertheless **rejected before step 4**. This PR leaves both preregistrations, fitting, held-fold scoring, reserve access, and checkpoint release blocked.

## Why the candidate remains blocked

The independent review reproduced these decision-bearing problems:

- `fit` and `evaluate` instantiate `MuAttention` with the legacy serialized config, raising on `heads` before optimizer construction; the established compatible loader is not used.
- Candidate-bound code still hard-codes the current ranking and retention preregistration IDs, so the required step-4 amendment invalidates the reviewed code binding; no fresh v2 training plan or complete projection matrix is frozen.
- There is no candidate-derived final-lock emitter or independently authenticated review-receipt chain. The current gate accepts caller-authored final-lock/receipt JSON after the live prereg flag changes.
- Projection, fit, evaluation, and decision receipts are self-authenticated and incompletely bound. The evaluator opens held outcomes before authenticating a loadable registered checkpoint.
- Several claimed execution bindings are descriptive fields omitted from verification, including environment, tokenizer structure, frozen-reference rule, augmentation, early stopping, and cleanliness scope.
- The decision worker uses NumPy RNG plus interpolated percentiles instead of the previously frozen SHA-256 rejection sampler and nearest-rank endpoints. Nonfinite predictions can silently receive rank 1.
- Evaluation does not seal candidate scores needed to reproduce the ranking and registered diagnostics; decision output omits required population and bootstrap provenance.
- The private install transaction can leave a permanent target after directory-fsync failure, despite the rollback claim.
- The added implementation tests do not execute a real checkpoint load, optimizer construction/step, held evaluation, final-lock receipt path, frozen bootstrap known answer, or primary decision.

## What this PR adds

- A detailed independent review with a precise replacement sequence.
- A canonical machine-readable review authority whose review ID is bound to the prose hash and parent protocols.
- A fail-closed verifier that authenticates both the review record and the real local candidate's static artifacts before reporting the rejection.
- Re-derivation of source counts/folds and the fold-0 train-only projection, including zero held-query overlap.
- Twenty adversarial tests covering review tampering, legacy checkpoint incompatibility, omitted lock bindings, missing emitters, wrong bootstrap, NaN rank inflation, and incomplete rollback.
- A report update recording that candidate v2 does not unlock the amendment or first optimizer step.

## Frozen outcome

Review ID: `916cad2f7b3a9d99fa4b8549cd4423b4849c3f205075cd0734e3672a9044aa2d`

The candidate must be replaced in a new no-replace namespace after the loader, ID cycle, plan/projection bindings, authenticated receipt chain, exact bootstrap, finite/output checks, transaction guarantees, and decision-bearing integration tests are fixed. It must not be amended or repaired in place.

## Validation

- `226 passed` across the related SM-FS protocol, freeze, filing, privacy, execution-review, training, candidate-review, pipeline, and new candidate-v2 review suites.
- Python compilation succeeds.
- `git diff --check` is clean.
- The verifier authenticates the actual local candidate and reports:
  - `review-record authenticated`
  - `step-4-amendment blocked`
  - `model-fitting blocked`
  - `local-candidate static-artifact-authentic-verified-rejected`