### PR TITLE
mu_cosine: add typed vNext PatternAST grounding kernel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,7 @@ jobs:
             prototypes/mu_cosine/test_process_cards.py \
             prototypes/mu_cosine/test_process_expression_p1_protocol.py \
             prototypes/mu_cosine/test_process_expression_vnext_frontend.py \
+            prototypes/mu_cosine/test_process_expression_vnext_patterns.py \
             prototypes/mu_cosine/test_process_expression_tokenizer.py
 
       - name: Run F# WAM target tests (codegen + dotnet smoke + LMDB conformance)

--- a/prototypes/mu_cosine/process_expression_vnext/__init__.py
+++ b/prototypes/mu_cosine/process_expression_vnext/__init__.py
@@ -2,40 +2,69 @@
 """Experimental vNext process-expression frontend kernel.
 
 Proves the parser/elaborator seam described in
-``DESIGN_process_expression_patterns.md``:
+``DESIGN_process_expression_patterns.md``, and one edge of its §1 state machine:
 
 ```text
 functional expression
     -> elaboration-preserving source AST  (functional_parser)
     -> registry-driven elaboration        (elaborator)
-    -> in-memory typed ground term        (ast)
+    -> in-memory typed term               (ast)
+
+PatternAST --ground(bindings)--> GroundAST   (patterns)
 ```
 
 The source tree keeps what elaboration and diagnostics need; it does not
 promise exact source reconstruction.
 
 **This is not vNext activation.** It creates no identity-bearing bytes, no
-canonical ``pe-typed-ast-v1`` serialization, no digests, no receipts, and no
-deployed processes. Registry ``v0.3``, ``pec-v2``, and both sealed golden
-bundles are untouched frozen contracts, not scaffolding this package extends.
+canonical ``pe-typed-ast-v1`` serialization, no digests of any kind including a
+pattern digest, no receipts, and no deployed processes. Registry ``v0.3``,
+``pec-v2``, and both sealed golden bundles are untouched frozen contracts, not
+scaffolding this package extends.
 
-The public seam is deliberately two functions. Hashing, identity, deployment,
-resolution, and verification are *not* exported, because exporting them would
-invite exactly the premature identity-minting the state machine in §1 forbids.
+The public seam is deliberately small. ``interpret``, ``represent`` and
+``verify_factory_receipt`` are the *later* edges of the state machine and are
+absent, as are hashing, identity, deployment, resolution and verification —
+exporting them would invite exactly the premature identity-minting §1 forbids.
 """
 from __future__ import annotations
 
-from .elaborator import ElaborationError, elaborate
+from .elaborator import (
+    ElaborationError,
+    elaborate,
+    elaborate_ground,
+    elaborate_pattern,
+    ground_surface,
+)
 from .functional_parser import NotImplementedInMilestone, ParseError, parse_functional
+from .patterns import (
+    GroundAST,
+    GroundingError,
+    PatternAST,
+    PatternVar,
+    alpha_equivalent,
+    ground,
+    is_ground,
+)
 from .registry import Registry, RegistryError, load_registry
 
 __all__ = [
     "parse_functional",
     "elaborate",
+    "elaborate_ground",
+    "elaborate_pattern",
+    "ground",
+    "ground_surface",
+    "alpha_equivalent",
+    "is_ground",
     "load_registry",
     "Registry",
+    "PatternAST",
+    "PatternVar",
+    "GroundAST",
     "ParseError",
     "NotImplementedInMilestone",
     "ElaborationError",
+    "GroundingError",
     "RegistryError",
 ]

--- a/prototypes/mu_cosine/process_expression_vnext/ast.py
+++ b/prototypes/mu_cosine/process_expression_vnext/ast.py
@@ -27,6 +27,7 @@ noncanonical for that reason.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import itertools
 from typing import Any
 
 from .numerics import Float64Value, NumberLexeme, RealValue
@@ -101,7 +102,13 @@ class SourceAnnotated(SourceNode):
 
 @dataclass(frozen=True)
 class SourceVariable(SourceNode):
-    """Recognized so it can be rejected precisely, not misparsed."""
+    """A functional-surface variable: ``S``, ``Limit``, or ``_``.
+
+    The parser records the *spelling*.  Whether two occurrences denote one
+    logical variable is a scoping question the pattern elaborator answers, not
+    something the source tree may presume — ``_`` is fresh per occurrence while
+    ``S`` is not, and the parser has no scope to decide that in.
+    """
 
     name: str
 
@@ -141,6 +148,18 @@ class SourceReferenceIndex(SourceType):
 
     Kept distinct from :class:`SourceTypeName` so the elaborator can produce a
     :class:`ReferenceIndex` rather than conflating it with a type.
+    """
+
+    name: str
+
+
+@dataclass(frozen=True)
+class SourceVariableIndex(SourceType):
+    """A variable occupying an index position, e.g. the ``C`` in ``substrate[C]``.
+
+    ``TypeOrIndex := Type | Variable | Reference`` (§4), so an index variable is
+    a third thing.  Keeping it distinct from :class:`SourceTypeName` is what
+    stops ``substrate[C]`` from silently meaning "indexed by a type spelled C".
     """
 
     name: str
@@ -239,6 +258,81 @@ class TermIndex(ValueIndex):
         return _index_display(self.term)
 
 
+#: Process-wide monotonic source of variable serials.
+#:
+#: Global rather than per-pattern on purpose.  Per-pattern numbering would let
+#: two independently elaborated patterns mint colliding identities, so a handle
+#: taken from one pattern would silently bind a *different* variable in another.
+#: The cost is that two separately elaborated copies of the same pattern are not
+#: ``==``; :func:`process_expression_vnext.patterns.alpha_equivalent` is the
+#: supported way to compare them.
+_VAR_SERIALS = itertools.count(1)
+
+
+@dataclass(frozen=True, eq=False)
+class VarId:
+    """Opaque identity of one logical pattern variable.
+
+    Identity is the serial alone.  ``display`` is carried for diagnostics and is
+    deliberately *not* part of equality: two variables both spelled ``S`` in
+    different patterns are different variables, and two occurrences of ``_`` in
+    one pattern are different variables despite an identical spelling.
+
+    ``origin`` separates four concepts that §3.4 and the milestone brief require
+    stay distinct, and which are easy to collapse by accident:
+
+    ``named``
+        an author-written variable such as ``S``; bindable by name.
+    ``anonymous``
+        an author-written ``_``; fresh per occurrence, bindable only through the
+        opaque handle this class provides.
+    ``inferred``
+        a constraint variable minted while typing a bare variable against a
+        signature — the "fresh C" in §3.5's *"S is inferred as substrate[C] for a
+        fresh C"*.  It has no author-visible name and is never bindable.
+
+    The fourth concept, a registry signature's own placeholder, is
+    :class:`TypeVar` and is not a :class:`VarId` at all.
+    """
+
+    serial: int
+    origin: str
+    display: str
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, VarId) and self.serial == other.serial
+
+    def __hash__(self) -> int:
+        return hash(self.serial)
+
+    def __str__(self) -> str:
+        return self.display
+
+
+def new_var_id(origin: str, display: str) -> VarId:
+    if origin not in ("named", "anonymous", "inferred"):
+        raise ValueError(f"unknown variable origin: {origin!r}")
+    return VarId(next(_VAR_SERIALS), origin, display)
+
+
+@dataclass(frozen=True)
+class PatternIndex(ValueIndex):
+    """A pattern variable occupying a value-index position.
+
+    ``substrate[C]`` in a *pattern* is indexed by a variable that will later be
+    bound to a corpus reference.  Representing that as :class:`TypeName`,
+    :class:`ReferenceIndex`, or a display string would each be a lie of a
+    different kind: the first makes it a type, the second makes it a registered
+    name that does not exist, and the third loses the identity that decides
+    whether two occurrences are the same variable.
+    """
+
+    var: VarId
+
+    def __str__(self) -> str:
+        return self.var.display
+
+
 def _index_display(term: "TypedTerm") -> str:
     if isinstance(term, Reference):
         return term.name
@@ -301,6 +395,19 @@ class ListTerm(TypedTerm):
     items: tuple[TypedTerm, ...]
 
 
+@dataclass(frozen=True)
+class PatternVariable(TypedTerm):
+    """A variable in term position.  Only a ``PatternAST`` may contain one.
+
+    ``inferred_type`` is the variable's *constraint*, whether the author stated
+    it (``S::substrate[C]``) or it came from the signature slot the variable
+    sits in (``lineage_op(S)``).  A variable with no constraint from either
+    source is underconstrained and never reaches this node.
+    """
+
+    var: VarId
+
+
 def debug_repr(term: TypedTerm) -> dict[str, Any]:
     """NONCANONICAL, NON-IDENTITY-BEARING debug rendering.
 
@@ -332,4 +439,14 @@ def debug_repr(term: TypedTerm) -> dict[str, Any]:
         return {**base, "kind": "float64", "value": term.value.hex16()}
     if isinstance(term, ListTerm):
         return {**base, "kind": "list", "items": [debug_repr(i) for i in term.items]}
+    if isinstance(term, PatternVariable):
+        # The serial is shown because the display name is not identity; two
+        # distinct `_` nodes would otherwise render identically in a diagnostic.
+        return {
+            **base,
+            "kind": "var",
+            "name": term.var.display,
+            "origin": term.var.origin,
+            "serial": term.var.serial,
+        }
     raise TypeError(f"unknown typed term: {type(term).__name__}")

--- a/prototypes/mu_cosine/process_expression_vnext/elaborator.py
+++ b/prototypes/mu_cosine/process_expression_vnext/elaborator.py
@@ -17,6 +17,13 @@ Two rules are easy to get backwards and are therefore stated explicitly:
 * a *successful redundant* annotation leaves no trace, so ``pearltrees`` and
   ``pearltrees::corpus`` are the same typed term.
 
+Milestone 2 adds variables to the same code path rather than beside it.  There
+is one ``_elaborate``; a ``scope`` of ``None`` means "ground only" and makes any
+variable an error, so ground expressions elaborate through exactly the checks
+they did before.  Three entry points name the three states:
+:func:`elaborate` (compatibility, ground, bare term), :func:`elaborate_ground`
+(ground, wrapped) and :func:`elaborate_pattern` (may contain variables).
+
 Nothing here mints identity.  There is no hashing, no serialization to
 ``pe-typed-ast-v1``, and no notion of a deployed process.
 """
@@ -27,10 +34,15 @@ from typing import Any, Mapping
 from .ast import (
     Atom,
     Call,
+    PatternIndex,
+    PatternVariable,
     ReferenceIndex,
     SourceReferenceIndex,
+    SourceVariable,
+    SourceVariableIndex,
     TermIndex,
     ValueIndex,
+    VarId,
     Float64,
     IndexedType,
     Int,
@@ -54,8 +66,10 @@ from .ast import (
     TypeName,
     TypeVar,
     TypedTerm,
+    new_var_id,
 )
 from .numerics import NumericError, to_float64, to_int, to_real
+from .patterns import GroundAST, PatternAST, PatternVar, ground, make_ground
 from .registry import Entry, Registry, RegistryError
 
 
@@ -65,6 +79,102 @@ class ElaborationError(ValueError):
     def __init__(self, message: str, span=None):
         self.span = span
         super().__init__(message if span is None else f"{message} {span}")
+
+
+class _Scope:
+    """Variable scope for one pattern elaboration.
+
+    Its whole job is to answer "is this the same variable as that one?", which
+    is why the parser cannot do it: two ``S`` tokens are one variable and two
+    ``_`` tokens are two, and only something that spans the whole expression
+    knows which.
+    """
+
+    def __init__(self) -> None:
+        self._named: dict[str, VarId] = {}
+        self.constraints: dict[VarId, Type | None] = {}
+        self.term_positions: set[VarId] = set()
+        #: Author-visible variables in first-occurrence order.  Inferred
+        #: constraint variables are deliberately excluded: they have no name, no
+        #: author intent behind them, and admitting them to the binding table
+        #: would let a caller bind an artifact of type inference.
+        self.order: list[VarId] = []
+
+    def _register(self, var: VarId) -> VarId:
+        if var not in self.constraints:
+            self.constraints[var] = None
+            self.order.append(var)
+        return var
+
+    def named(self, name: str) -> VarId:
+        var = self._named.get(name)
+        if var is None:
+            var = new_var_id("named", name)
+            self._named[name] = var
+            self._register(var)
+        return var
+
+    def anonymous(self) -> VarId:
+        return self._register(new_var_id("anonymous", "_"))
+
+    def inferred(self, hint: str) -> VarId:
+        # Not registered: an inferred variable is resolved by unification, never
+        # by a caller.
+        return new_var_id("inferred", hint)
+
+    def variable_for(self, name: str) -> VarId:
+        return self.anonymous() if name == "_" else self.named(name)
+
+    def table(self) -> tuple[PatternVar, ...]:
+        return tuple(
+            PatternVar(
+                var=var,
+                constraint=self.constraints[var],
+                in_term_position=var in self.term_positions,
+            )
+            for var in self.order
+        )
+
+
+def _freshen(declared: Any, scope: _Scope) -> Any:
+    """Replace a signature's own index placeholders with fresh pattern indices.
+
+    §3.5: ``lineage_op(S)`` infers ``S :: substrate[C]`` *for a fresh C*.  The
+    registry's ``C`` is a :class:`TypeVar` shared by every use of the signature,
+    so reusing it as the variable's constraint would make two unrelated
+    expressions appear to share an ownership constraint.
+    """
+
+    if isinstance(declared, TypeVar):
+        return PatternIndex(scope.inferred(declared.name))
+    if isinstance(declared, IndexedType):
+        return IndexedType(
+            declared.name,
+            tuple(
+                _freshen(i, scope) if isinstance(i, Type) else i
+                for i in declared.indices
+            ),
+        )
+    if isinstance(declared, ListType):
+        return ListType(_freshen(declared.element, scope))
+    return declared
+
+
+def _expectation(node: SourceNode, want: Type) -> Type | None:
+    """What to hand down as the expected type.
+
+    Ground elaboration keeps its pre-existing rule — an expectation that still
+    carries signature variables is dropped, because a literal cannot satisfy one
+    and the diagnostic would be confusing.  A *variable* is the exception: the
+    slot's declared type is precisely what constrains it, so dropping it there
+    would make every ``lineage_op(S)`` underconstrained.
+    """
+
+    if _is_concrete(want):
+        return want
+    if isinstance(node, (SourceVariable, SourceAnnotated)):
+        return want
+    return None
 
 
 def _substitute(declared: Type, bindings: Mapping[str, Any]) -> Type:
@@ -119,7 +229,15 @@ def _unify(declared: Type, actual: Type, bindings: dict[str, Any]) -> bool:
     return False
 
 
-def _resolve_source_type(node: SourceType, registry: Registry):
+def _resolve_source_type(node: SourceType, registry: Registry, scope: _Scope | None):
+    if isinstance(node, SourceVariableIndex):
+        if scope is None:
+            raise ElaborationError(
+                f"index variable {node.name!r} appears in a ground expression; "
+                "use elaborate_pattern() for expressions containing variables",
+                node.span,
+            )
+        return PatternIndex(scope.variable_for(node.name))
     if isinstance(node, SourceReferenceIndex):
         # An index may name a *reference* value.  A callable is not a value, so
         # `list[principal_tree]` and `substrate[principal_tree]` must not pass.
@@ -136,7 +254,7 @@ def _resolve_source_type(node: SourceType, registry: Registry):
     if isinstance(node, SourceTypeName):
         return TypeName(node.name)
     if isinstance(node, SourceIndexedType):
-        indices = tuple(_resolve_source_type(i, registry) for i in node.indices)
+        indices = tuple(_resolve_source_type(i, registry, scope) for i in node.indices)
         if node.name == "list":
             if len(indices) != 1:
                 raise ElaborationError("list takes exactly one element type", node.span)
@@ -192,12 +310,15 @@ def _literal(node: SourceNode, expected: Type | None) -> TypedTerm:
 
 
 def _elaborate(
-    node: SourceNode, registry: Registry, expected: Type | None
+    node: SourceNode, registry: Registry, expected: Type | None, scope: _Scope | None
 ) -> TypedTerm:
+    if isinstance(node, SourceVariable):
+        return _elaborate_variable(node, expected, scope)
+
     if isinstance(node, SourceAnnotated):
-        asserted = _resolve_source_type(node.asserted, registry)
+        asserted = _resolve_source_type(node.asserted, registry, scope)
         # The assertion narrows what the inner term may be, but never converts.
-        inner = _elaborate(node.term, registry, asserted)
+        inner = _elaborate(node.term, registry, asserted, scope)
         if inner.inferred_type != asserted:
             raise ElaborationError(
                 f"annotation {asserted} conflicts with inferred type "
@@ -225,7 +346,7 @@ def _elaborate(
                 "a list literal needs a declared list type", node.span
             )
         items = tuple(
-            _elaborate(item, registry, expected.element) for item in node.items
+            _elaborate(item, registry, expected.element, scope) for item in node.items
         )
         for item in items:
             if item.inferred_type != expected.element:
@@ -253,13 +374,51 @@ def _elaborate(
         return Reference(actual, node.name)
 
     if isinstance(node, SourceCall):
-        return _elaborate_call(node, registry, expected)
+        return _elaborate_call(node, registry, expected, scope)
 
     raise ElaborationError(f"unsupported term: {type(node).__name__}", node.span)
 
 
+def _elaborate_variable(
+    node: SourceVariable, expected: Type | None, scope: _Scope | None
+) -> TypedTerm:
+    if scope is None:
+        raise ElaborationError(
+            f"variable {node.name!r} appears in a ground expression; use "
+            "elaborate_pattern() for expressions containing variables",
+            node.span,
+        )
+    if expected is None:
+        raise ElaborationError(
+            f"variable {node.name!r} is underconstrained: it carries no '::' "
+            "annotation and the position it occupies declares no type",
+            node.span,
+        )
+    constraint = _freshen(expected, scope)
+    if not isinstance(constraint, Type):  # pragma: no cover - registry forbids it
+        raise ElaborationError(
+            f"variable {node.name!r} cannot be constrained by the value index "
+            f"{constraint}",
+            node.span,
+        )
+    var = scope.variable_for(node.name)
+    previous = scope.constraints.get(var)
+    if previous is not None and previous != constraint:
+        # Two occurrences of one named variable are one variable, so two
+        # constraints must agree; silently keeping either would make the pattern
+        # mean something the author did not write.
+        raise ElaborationError(
+            f"variable {node.name!r} is constrained as both {previous} and "
+            f"{constraint}",
+            node.span,
+        )
+    scope.constraints[var] = constraint
+    scope.term_positions.add(var)
+    return PatternVariable(constraint, var)
+
+
 def _elaborate_call(
-    node: SourceCall, registry: Registry, expected: Type | None
+    node: SourceCall, registry: Registry, expected: Type | None, scope: _Scope | None
 ) -> TypedTerm:
     try:
         entry: Entry = registry.get(node.name)
@@ -281,7 +440,7 @@ def _elaborate_call(
     args: list[TypedTerm] = []
     for index, (arg, declared) in enumerate(zip(node.args, entry.arg_types)):
         want = _substitute(declared, bindings)
-        term = _elaborate(arg, registry, want if _is_concrete(want) else None)
+        term = _elaborate(arg, registry, _expectation(arg, want), scope)
         if not _unify(declared, term.inferred_type, bindings):
             raise ElaborationError(
                 f"{node.name} argument {index} expects "
@@ -296,6 +455,13 @@ def _elaborate_call(
         argument = args[position]
         if isinstance(argument, Reference):
             index: Any = ReferenceIndex(argument.name)
+        elif isinstance(argument, PatternVariable):
+            # The ownership index *is* the author's variable, so it must stay a
+            # pattern index rather than becoming a TermIndex wrapping a variable
+            # — otherwise grounding would have to reach inside an index to
+            # substitute, and `binds` would produce a shape that direct ground
+            # elaboration never produces.
+            index = PatternIndex(argument.var)
         else:
             # EXPERIMENTAL: an expression-valued index.  Its wire form is an
             # open specification decision; see the module docstring in ast.py.
@@ -336,8 +502,9 @@ def _elaborate_call(
     for spec in entry.fields:
         if spec.name in seen:
             want = _substitute(spec.type, bindings)
+            value_node = seen[spec.name]
             term = _elaborate(
-                seen[spec.name], registry, want if _is_concrete(want) else None
+                value_node, registry, _expectation(value_node, want), scope
             )
             if not _unify(spec.type, term.inferred_type, bindings):
                 raise ElaborationError(
@@ -400,7 +567,10 @@ def _default_term(spec, registry: Registry, want: Type) -> TypedTerm:
     from .functional_parser import parse_functional
 
     source = parse_functional(spec.default, registry)
-    return _elaborate(source, registry, want)
+    # Scope is None even inside a pattern: a registry default is fixed text, and
+    # a default that introduced a variable would add a binding obligation the
+    # author never wrote.
+    return _elaborate(source, registry, want, None)
 
 
 def _is_concrete(declared: Type) -> bool:
@@ -444,10 +614,102 @@ def _assert_no_type_vars(term: TypedTerm, path: str = "result") -> None:
 def elaborate(source: SourceNode, registry: Registry) -> TypedTerm:
     """Elaborate a source AST into an in-memory typed ground term.
 
+    Compatibility convenience, retained from milestone 1 and **ground-only**: a
+    variable anywhere in ``source`` is an :class:`ElaborationError`, never a
+    silently accepted free variable.  It returns the bare
+    :class:`~.ast.TypedTerm`; :func:`elaborate_ground` returns the same term
+    wrapped in the :class:`~.patterns.GroundAST` state type, and
+    ``elaborate_ground(s, r).term == elaborate(s, r)`` always holds.  Prefer
+    :func:`elaborate_ground` in new code, because a bare ``TypedTerm`` does not
+    say which state-machine state it is in.
+
     The result is *not* identity-bearing and is not serialized to any canonical
     schema by this milestone.
     """
 
-    term = _elaborate(source, registry, None)
+    term = _elaborate(source, registry, None, None)
     _assert_no_type_vars(term)
     return term
+
+
+def elaborate_ground(source: SourceNode, registry: Registry) -> GroundAST:
+    """Elaborate a variable-free source AST into a ``GroundAST``.
+
+    The groundness proof runs on the way out, so the state type is earned rather
+    than asserted.
+    """
+
+    return make_ground(elaborate(source, registry), what="ground elaboration")
+
+
+def elaborate_pattern(source: SourceNode, registry: Registry) -> PatternAST:
+    """Elaborate a source AST that may contain variables into a ``PatternAST``.
+
+    Type checking is the same checking ground elaboration does — signatures,
+    ownership indices, annotations, field consumption — with variables treated
+    as terms of their constrained type.  A pattern that cannot type-check is
+    rejected here rather than at grounding, which is why
+    ``cross_substrate(S::substrate[C], T::substrate[OtherC])`` fails before any
+    binding is supplied.
+    """
+
+    scope = _Scope()
+    term = _elaborate(source, registry, None, scope)
+    _assert_no_type_vars(term)
+    return PatternAST(
+        term=term, variables=scope.table(), registry_label=registry.label
+    )
+
+
+def ground_surface(
+    pattern: PatternAST, registry: Registry, bindings: Mapping[Any, str]
+) -> GroundAST:
+    """Convenience: parse surface-text bindings, then :func:`~.patterns.ground`.
+
+    Kept separate from :func:`~.patterns.ground` on purpose.  Grounding takes
+    elaborated values so that a malformed binding *string* raises a parse or
+    elaboration error from this function, and a genuinely unsatisfiable binding
+    raises a ``GroundingError`` from that one — collapsing the two would make
+    "your text is malformed" and "your bindings do not ground this pattern"
+    indistinguishable.
+
+    Each binding is elaborated against its variable's constraint, which is what
+    lets ``D = "0.85"`` become a ``real`` rather than needing ``0.85::real``.
+    """
+
+    from .functional_parser import parse_functional
+
+    prepared: dict[Any, TypedTerm] = {}
+    for key, text in bindings.items():
+        if isinstance(key, VarId):
+            matches = [v for v in pattern.variables if v.var == key]
+        else:
+            matches = [v for v in pattern.named_variables if v.name == key]
+        if not matches:
+            # Let ground() own the "unknown binding" diagnostic; passing the
+            # value through unchanged keeps one message for one failure.
+            prepared[key] = text  # type: ignore[assignment]
+            continue
+        spec = matches[0]
+        source = parse_functional(text, registry)
+        # A constraint that still mentions a pattern index cannot serve as an
+        # *expected* type here: `substrate[C]` would reject the very value that
+        # determines C.  Those constraints are checked by ground(), whose
+        # unification can bind index variables; only fully determined
+        # constraints are pushed down, and those are what a bare numeric literal
+        # needs in order to be a real rather than an error.
+        expected = spec.constraint
+        if expected is not None and _contains_pattern_index(expected):
+            expected = None
+        prepared[key] = _elaborate(source, registry, expected, None)
+    return ground(pattern, prepared)
+
+
+def _contains_pattern_index(declared: Any) -> bool:
+    if isinstance(declared, PatternIndex):
+        return True
+    if isinstance(declared, IndexedType):
+        return any(_contains_pattern_index(i) for i in declared.indices)
+    if isinstance(declared, ListType):
+        return _contains_pattern_index(declared.element)
+    return False

--- a/prototypes/mu_cosine/process_expression_vnext/functional_parser.py
+++ b/prototypes/mu_cosine/process_expression_vnext/functional_parser.py
@@ -23,9 +23,14 @@ Deliberate non-behaviors:
 * numeric text is **not** converted, so the declared type can decide later
   (§3.6);
 * annotations are attached unchecked;
-* variables, modifiers, pins, function types and sum types are *recognized* and
-  rejected with a "not implemented in this milestone" diagnostic rather than
-  being silently misparsed.
+* variables are parsed into :class:`SourceVariable` / :class:`SourceVariableIndex`
+  carrying only their *spelling*.  Whether two occurrences denote one logical
+  variable is a scoping decision, and the parser has no scope; the ground
+  elaboration path rejects any variable it finds, so the ground surface is
+  unchanged;
+* modifiers, pins, function types, sum types and expression-valued type indices
+  are *recognized* and rejected with a "not implemented in this milestone"
+  diagnostic rather than being silently misparsed.
 """
 from __future__ import annotations
 
@@ -46,6 +51,7 @@ from .ast import (
     SourceType,
     SourceTypeName,
     SourceVariable,
+    SourceVariableIndex,
     SourceAnnotated,
     Span,
 )
@@ -223,11 +229,9 @@ class _Parser:
             token = word.group(0)
             if _VARIABLE.match(token):
                 self.i = word.end()
-                raise NotImplementedInMilestone(
-                    f"variable {token!r} is recognized but not implemented in this "
-                    "milestone",
-                    start,
-                )
+                # Scoping — whether two occurrences are one variable — belongs to
+                # the pattern elaborator, so the parser records only the spelling.
+                return SourceVariable(Span(start, self.i), token)
             raise ParseError(
                 f"unregistered name {token!r}; a bare lowercase word is never "
                 "guessed to be an atom — register it or quote it",
@@ -387,11 +391,7 @@ class _Parser:
         word = _IDENT.match(self.text, self.i)
         if word and _VARIABLE.match(word.group(0)):
             self.i = word.end()
-            raise NotImplementedInMilestone(
-                f"type variable {word.group(0)!r} is recognized but not implemented "
-                "in this milestone",
-                start,
-            )
+            return SourceVariableIndex(Span(start, self.i), word.group(0))
 
         name = self._match_registered_name()
         if name is not None:

--- a/prototypes/mu_cosine/process_expression_vnext/patterns.py
+++ b/prototypes/mu_cosine/process_expression_vnext/patterns.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Pattern state, grounding, and alpha-equivalence for the vNext frontend.
+
+Implements one edge of the state machine in
+``DESIGN_process_expression_patterns.md`` §1::
+
+    PatternAST --ground(bindings)--> GroundAST
+
+and nothing beyond it.  ``interpret``, ``represent``, and
+``verify_factory_receipt`` are later edges and are deliberately absent, so a
+caller cannot mistake a ``GroundAST`` for something deployable.
+
+The two states are real types with checked invariants, not documentation:
+
+``PatternAST``
+    may contain :class:`~.ast.PatternVariable` nodes and :class:`~.ast.PatternIndex`
+    value indices.
+
+``GroundAST``
+    is *proved* on construction to contain neither, and no registry-signature
+    :class:`~.ast.TypeVar` either.  The proof is recursive and covers arguments,
+    fields, list items, every inferred type, and the interior of a
+    :class:`~.ast.TermIndex` — a variable hiding inside an expression-valued
+    index is exactly the leak a per-node check would miss.
+
+A ``GroundAST`` may still be semantically coarse.  ``lineage_op(principal_tree(
+pearltrees))`` is ground and remains interpretation-underconstrained (§4.1), so
+grounding performs no interpretation, no representation selection, and no
+factory verification.
+
+Nothing here mints identity.  There is no pattern digest, no canonical pattern
+bytes, no alpha-normalized serialization, and no ``pe-typed-ast-v1``.  A digest
+would have to commit to the wire form of an expression-valued ``TermIndex``,
+which is an open specification decision; :func:`alpha_equivalent` answers the
+comparison question structurally and in memory instead.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Mapping
+
+from .ast import (
+    Call,
+    IndexedType,
+    ListTerm,
+    ListType,
+    PatternIndex,
+    PatternVariable,
+    Reference,
+    ReferenceIndex,
+    TermIndex,
+    Type,
+    TypeName,
+    TypeVar,
+    TypedTerm,
+    ValueIndex,
+    VarId,
+)
+
+
+class GroundingError(ValueError):
+    """A binding set does not ground a pattern.
+
+    Distinct from ``ParseError`` (malformed text) and ``ElaborationError``
+    (well-formed text, ill-typed or registry-violating) so a caller can tell
+    which of the three stages rejected the input.
+    """
+
+
+# --------------------------------------------------------------------------
+# state types
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GroundAST:
+    """A typed term proved free of variables and signature type variables.
+
+    Construct through :func:`make_ground`, which runs the proof.  Building the
+    dataclass directly is possible in Python and is not defended against — the
+    guarantee is that every path in this package goes through the proof, not
+    that the type is unforgeable.
+    """
+
+    term: TypedTerm
+
+    def __str__(self) -> str:
+        return f"GroundAST({type(self.term).__name__})"
+
+
+@dataclass(frozen=True)
+class PatternVar:
+    """One logical variable of a pattern, with what elaboration learned about it."""
+
+    var: VarId
+    #: The variable's constraint, or ``None`` for a variable that occurs only in
+    #: index position (``substrate[C]`` declares no type for ``C``).
+    constraint: Type | None
+    #: True when the variable occurs in term position and therefore needs a
+    #: binding.  An index-only variable is satisfied by inference instead.
+    in_term_position: bool
+
+    @property
+    def name(self) -> str:
+        return self.var.display
+
+    @property
+    def label(self) -> str:
+        """Diagnostic label that stays unambiguous for anonymous variables.
+
+        Two ``_`` occurrences share a display name, so a message that used the
+        name alone could not say *which* one failed.
+        """
+
+        if self.var.origin == "named":
+            return repr(self.name)
+        return f"_#{self.var.serial}"
+
+
+@dataclass(frozen=True)
+class PatternAST:
+    """A typed term that may contain variables, plus its variable table.
+
+    Immutable: :func:`ground` never mutates a pattern, and grounding the same
+    pattern twice with different bindings is well defined.
+    """
+
+    term: TypedTerm
+    variables: tuple[PatternVar, ...]
+    registry_label: str
+
+    @property
+    def named_variables(self) -> tuple[PatternVar, ...]:
+        return tuple(v for v in self.variables if v.var.origin == "named")
+
+    @property
+    def anonymous_variables(self) -> tuple[PatternVar, ...]:
+        """Handles for ``_`` occurrences.
+
+        Exposed because an anonymous variable has no name to bind by, and a
+        pattern whose ``_`` occurrences could not be bound at all would be
+        unusable rather than merely anonymous.
+        """
+
+        return tuple(v for v in self.variables if v.var.origin == "anonymous")
+
+    @property
+    def required_variables(self) -> tuple[PatternVar, ...]:
+        return tuple(v for v in self.variables if v.in_term_position)
+
+    def variable(self, name: str) -> PatternVar:
+        matches = [v for v in self.named_variables if v.name == name]
+        if not matches:
+            raise GroundingError(f"pattern has no variable named {name!r}")
+        # The scope keys named variables by name, so this cannot be ambiguous.
+        return matches[0]
+
+
+# --------------------------------------------------------------------------
+# ground proof
+# --------------------------------------------------------------------------
+
+
+def _type_defects(declared: Any, path: str) -> list[str]:
+    """Every reason ``declared`` is not ground, rather than the first."""
+
+    found: list[str] = []
+    if isinstance(declared, TypeVar):
+        found.append(f"{path}: unresolved signature type variable {declared.name}")
+    elif isinstance(declared, PatternIndex):
+        found.append(f"{path}: unbound pattern index {declared.var.display}")
+    elif isinstance(declared, TermIndex):
+        found.extend(_term_defects(declared.term, f"{path}<index>"))
+    elif isinstance(declared, IndexedType):
+        for position, index in enumerate(declared.indices):
+            found.extend(_type_defects(index, f"{path}[{position}]"))
+    elif isinstance(declared, ListType):
+        found.extend(_type_defects(declared.element, f"{path}.element"))
+    return found
+
+
+def _term_defects(term: TypedTerm, path: str) -> list[str]:
+    found: list[str] = []
+    if isinstance(term, PatternVariable):
+        found.append(f"{path}: unbound variable {term.var.display}")
+    found.extend(_type_defects(term.inferred_type, f"{path}:type"))
+    if isinstance(term, Call):
+        for position, arg in enumerate(term.args):
+            found.extend(_term_defects(arg, f"{path}.{term.name}[{position}]"))
+        for name, value in term.fields:
+            found.extend(_term_defects(value, f"{path}.{term.name}.{name}"))
+    elif isinstance(term, ListTerm):
+        for position, item in enumerate(term.items):
+            found.extend(_term_defects(item, f"{path}[{position}]"))
+    return found
+
+
+def is_ground(term: TypedTerm) -> bool:
+    return not _term_defects(term, "term")
+
+
+def make_ground(term: TypedTerm, *, what: str = "term") -> GroundAST:
+    """Prove ``term`` ground and wrap it.  The only supported constructor."""
+
+    defects = _term_defects(term, what)
+    if defects:
+        raise GroundingError(
+            f"{what} is not ground: " + "; ".join(defects[:8])
+            + ("; …" if len(defects) > 8 else "")
+        )
+    return GroundAST(term)
+
+
+# --------------------------------------------------------------------------
+# binding
+# --------------------------------------------------------------------------
+
+
+def index_of(term: TypedTerm) -> ValueIndex:
+    """The value-index form of a term (§3.2).
+
+    A bare registered reference indexes as itself; anything else is an
+    expression-valued index.  This is the same rule the elaborator applies when
+    a signature's ``binds`` names an argument, which is what makes an inferred
+    index and an explicitly supplied one comparable.
+    """
+
+    if isinstance(term, Reference):
+        return ReferenceIndex(term.name)
+    return TermIndex(term)
+
+
+def _substitute_type(
+    declared: Any, index_values: Mapping[VarId, ValueIndex]
+) -> Any:
+    if isinstance(declared, PatternIndex):
+        bound = index_values.get(declared.var)
+        return declared if bound is None else bound
+    if isinstance(declared, TermIndex):
+        return TermIndex(_substitute_term(declared.term, {}, index_values))
+    if isinstance(declared, IndexedType):
+        return IndexedType(
+            declared.name,
+            tuple(_substitute_type(i, index_values) for i in declared.indices),
+        )
+    if isinstance(declared, ListType):
+        return ListType(_substitute_type(declared.element, index_values))
+    return declared
+
+
+def _substitute_term(
+    term: TypedTerm,
+    term_values: Mapping[VarId, TypedTerm],
+    index_values: Mapping[VarId, ValueIndex],
+) -> TypedTerm:
+    if isinstance(term, PatternVariable):
+        bound = term_values.get(term.var)
+        if bound is None:
+            return term
+        return bound
+    inferred = _substitute_type(term.inferred_type, index_values)
+    if isinstance(term, Call):
+        return Call(
+            inferred,
+            term.name,
+            tuple(_substitute_term(a, term_values, index_values) for a in term.args),
+            tuple(
+                (n, _substitute_term(v, term_values, index_values))
+                for n, v in term.fields
+            ),
+        )
+    if isinstance(term, ListTerm):
+        return ListTerm(
+            inferred,
+            tuple(_substitute_term(i, term_values, index_values) for i in term.items),
+        )
+    if inferred == term.inferred_type:
+        return term
+    return replace(term, inferred_type=inferred)
+
+
+def _unify_constraint(
+    declared: Any, actual: Any, index_values: dict[VarId, ValueIndex]
+) -> bool:
+    """Match a pattern constraint against a ground type, binding index variables.
+
+    Only :class:`PatternIndex` binds.  A :class:`TypeVar` reaching here means a
+    signature placeholder escaped elaboration, so it deliberately does not
+    unify — grounding must not paper over that.
+    """
+
+    if isinstance(declared, PatternIndex):
+        existing = index_values.get(declared.var)
+        if existing is None:
+            if not isinstance(actual, ValueIndex):
+                return False
+            index_values[declared.var] = actual
+            return True
+        return existing == actual
+    if isinstance(declared, TypeVar):
+        return False
+    if isinstance(declared, TypeName):
+        return isinstance(actual, TypeName) and declared.name == actual.name
+    if isinstance(declared, ListType):
+        return isinstance(actual, ListType) and _unify_constraint(
+            declared.element, actual.element, index_values
+        )
+    if isinstance(declared, IndexedType):
+        if not isinstance(actual, IndexedType) or declared.name != actual.name:
+            return False
+        if len(declared.indices) != len(actual.indices):
+            return False
+        return all(
+            _unify_constraint(d, a, index_values)
+            for d, a in zip(declared.indices, actual.indices)
+        )
+    if isinstance(declared, ValueIndex):
+        return declared == actual
+    return False  # pragma: no cover - every Type subclass is covered above
+
+
+def _binding_term(value: Any, label: str) -> TypedTerm:
+    """Accept a typed ground value or a :class:`GroundAST`; reject the rest."""
+
+    if isinstance(value, GroundAST):
+        return value.term
+    if isinstance(value, PatternAST):
+        raise GroundingError(
+            f"binding for {label} is a PatternAST; a variable binds to a ground "
+            "value, and nesting a pattern would reintroduce the variables "
+            "grounding exists to remove"
+        )
+    if isinstance(value, str):
+        raise GroundingError(
+            f"binding for {label} is a string; ground() takes elaborated terms so "
+            "that a parse error cannot masquerade as a binding error — use "
+            "ground_surface() if you want surface text parsed"
+        )
+    if not isinstance(value, TypedTerm):
+        raise GroundingError(
+            f"binding for {label} is {type(value).__name__}, not a typed term"
+        )
+    defects = _term_defects(value, f"binding for {label}")
+    if defects:
+        raise GroundingError(
+            "binding is not ground: " + "; ".join(defects[:4])
+        )
+    return value
+
+
+def ground(
+    pattern: PatternAST, bindings: Mapping[Any, Any] | None = None
+) -> GroundAST:
+    """Substitute ``bindings`` into ``pattern`` and prove the result ground.
+
+    Keys are variable names (``"S"``) or opaque :class:`VarId` handles, the
+    latter being the only way to bind an anonymous ``_``.  Values are typed
+    ground terms or :class:`GroundAST`.
+
+    The pattern is not mutated, the result does not depend on mapping order, and
+    an index variable that another binding already determines need not be
+    supplied — but if it is, it must agree.
+    """
+
+    if not isinstance(pattern, PatternAST):
+        raise GroundingError(
+            f"ground() takes a PatternAST, not {type(pattern).__name__}"
+        )
+    supplied = dict(bindings or {})
+    by_id = {v.var: v for v in pattern.variables}
+    by_name = {v.name: v for v in pattern.named_variables}
+
+    # 1. Resolve keys.  Sorting by serial makes the diagnostic for a pattern with
+    #    several problems deterministic rather than dict-order dependent.
+    resolved: dict[VarId, TypedTerm] = {}
+    for key, value in supplied.items():
+        if isinstance(key, VarId):
+            spec = by_id.get(key)
+            if spec is None:
+                raise GroundingError(
+                    f"binding handle {key.display!r} (serial {key.serial}) does not "
+                    "belong to this pattern"
+                )
+        elif isinstance(key, str):
+            spec = by_name.get(key)
+            if spec is None:
+                known = ", ".join(sorted(v.name for v in pattern.named_variables))
+                raise GroundingError(
+                    f"unknown binding {key!r}; this pattern binds "
+                    f"[{known}]" + (" plus anonymous handles"
+                                    if pattern.anonymous_variables else "")
+                )
+        else:
+            raise GroundingError(
+                f"binding key must be a variable name or a VarId handle, got "
+                f"{type(key).__name__}"
+            )
+        if spec.var in resolved:
+            raise GroundingError(
+                f"variable {spec.label} is bound twice, once by name and once by "
+                "handle"
+            )
+        resolved[spec.var] = _binding_term(value, spec.label)
+
+    # 2. Seed index values from every binding, then check each constraint.  Both
+    #    loops run in serial order so acceptance and the message are independent
+    #    of the caller's mapping order.
+    order = sorted(resolved, key=lambda v: v.serial)
+    index_values: dict[VarId, ValueIndex] = {}
+    for var in order:
+        index_values[var] = index_of(resolved[var])
+
+    for var in order:
+        spec = by_id[var]
+        if spec.constraint is None:
+            continue
+        value = resolved[var]
+        if not _unify_constraint(spec.constraint, value.inferred_type, index_values):
+            raise GroundingError(
+                f"binding for {spec.label} has type {value.inferred_type}, which "
+                f"does not satisfy {_substitute_type(spec.constraint, index_values)}"
+            )
+
+    # 3. Every variable in term position needs a value; an index-only variable is
+    #    allowed to be inferred (§3.5's "fresh C").
+    missing = [
+        spec.label
+        for spec in pattern.required_variables
+        if spec.var not in resolved
+    ]
+    if missing:
+        raise GroundingError(
+            "missing binding(s) for " + ", ".join(sorted(missing))
+        )
+
+    result = _substitute_term(pattern.term, resolved, index_values)
+    return make_ground(result, what="grounded term")
+
+
+# --------------------------------------------------------------------------
+# alpha equivalence
+# --------------------------------------------------------------------------
+
+
+def alpha_equivalent(left: PatternAST, right: PatternAST) -> bool:
+    """True when two patterns differ only by a consistent renaming.
+
+    Implemented as a paired walk carrying a bijection, not by normalizing either
+    side.  A normal form would be a byte-level commitment this milestone is not
+    allowed to make: the canonical encoding of an expression-valued
+    ``TermIndex`` is unresolved, so any normalized rendering would either fix
+    that decision or quietly drop it.
+    """
+
+    if not isinstance(left, PatternAST) or not isinstance(right, PatternAST):
+        raise TypeError("alpha_equivalent compares two PatternAST values")
+    forward: dict[VarId, VarId] = {}
+    backward: dict[VarId, VarId] = {}
+    return _alpha_term(left.term, right.term, forward, backward)
+
+
+def _alpha_var(a: VarId, b: VarId, fwd, bwd) -> bool:
+    # Origin is part of the comparison: `_` and `S` are different kinds of
+    # binding occurrence, so a pattern that repeats `S` is not a renaming of one
+    # that writes `_` twice even when both have two occurrences.
+    if a.origin != b.origin:
+        return False
+    if a in fwd or b in bwd:
+        return fwd.get(a) == b and bwd.get(b) == a
+    fwd[a] = b
+    bwd[b] = a
+    return True
+
+
+def _alpha_type(a: Any, b: Any, fwd, bwd) -> bool:
+    if isinstance(a, PatternIndex) or isinstance(b, PatternIndex):
+        return (
+            isinstance(a, PatternIndex)
+            and isinstance(b, PatternIndex)
+            and _alpha_var(a.var, b.var, fwd, bwd)
+        )
+    if isinstance(a, TermIndex) or isinstance(b, TermIndex):
+        return (
+            isinstance(a, TermIndex)
+            and isinstance(b, TermIndex)
+            and _alpha_term(a.term, b.term, fwd, bwd)
+        )
+    if isinstance(a, IndexedType) or isinstance(b, IndexedType):
+        return (
+            isinstance(a, IndexedType)
+            and isinstance(b, IndexedType)
+            and a.name == b.name
+            and len(a.indices) == len(b.indices)
+            and all(
+                _alpha_type(x, y, fwd, bwd) for x, y in zip(a.indices, b.indices)
+            )
+        )
+    if isinstance(a, ListType) or isinstance(b, ListType):
+        return (
+            isinstance(a, ListType)
+            and isinstance(b, ListType)
+            and _alpha_type(a.element, b.element, fwd, bwd)
+        )
+    return a == b
+
+
+def _alpha_term(a: TypedTerm, b: TypedTerm, fwd, bwd) -> bool:
+    if type(a) is not type(b):
+        return False
+    if not _alpha_type(a.inferred_type, b.inferred_type, fwd, bwd):
+        return False
+    if isinstance(a, PatternVariable):
+        return _alpha_var(a.var, b.var, fwd, bwd)
+    if isinstance(a, Call):
+        return (
+            a.name == b.name
+            and len(a.args) == len(b.args)
+            and len(a.fields) == len(b.fields)
+            and all(_alpha_term(x, y, fwd, bwd) for x, y in zip(a.args, b.args))
+            and all(
+                xn == yn and _alpha_term(xv, yv, fwd, bwd)
+                for (xn, xv), (yn, yv) in zip(a.fields, b.fields)
+            )
+        )
+    if isinstance(a, ListTerm):
+        return len(a.items) == len(b.items) and all(
+            _alpha_term(x, y, fwd, bwd) for x, y in zip(a.items, b.items)
+        )
+    if isinstance(a, Reference):
+        return a.name == b.name
+    return a == b

--- a/prototypes/mu_cosine/test_process_expression_vnext_frontend.py
+++ b/prototypes/mu_cosine/test_process_expression_vnext_frontend.py
@@ -538,12 +538,34 @@ def test_unregistered_name_is_not_guessed_to_be_an_atom(reg):
 
 
 def test_deferred_constructs_are_rejected_precisely_not_misparsed(reg):
-    for text in ["lineage_op(S)", "haiku.D", "haiku@rev/abc", "X"]:
+    deferred = [
+        "haiku.D",                                              # modifier
+        "haiku@rev/abc",                                        # provenance pin
+        "pearltrees::substrate[principal_tree(pearltrees)]",    # expression index
+        "pearltrees::function([corpus],corpus)",                # function type
+        "attention",                                            # unregistered word
+    ]
+    for text in deferred:
         with pytest.raises((NotImplementedInMilestone, ParseError)) as excinfo:
             parse_functional(text, reg)
         assert "not implemented in this milestone" in str(excinfo.value) or (
             "unregistered" in str(excinfo.value)
         )
+
+
+def test_variables_parse_but_the_ground_path_still_refuses_them(reg):
+    """Milestone 2 moved the variable rejection from parsing to elaboration.
+
+    Variables now parse — scoping is not something the parser can decide — but
+    ``elaborate()`` stays ground-only, so the ground surface is unchanged: every
+    expression that failed before still fails, with a type-stage diagnostic
+    instead of a parse-stage one.
+    """
+
+    for text in ["lineage_op(S)", "X", "lineage_op(S::substrate[C])"]:
+        parse_functional(text, reg)  # no longer a parse error
+        with pytest.raises(ElaborationError, match="ground expression"):
+            ela(text, reg)
 
 
 def test_arity_errors_name_the_call(reg):

--- a/prototypes/mu_cosine/test_process_expression_vnext_patterns.py
+++ b/prototypes/mu_cosine/test_process_expression_vnext_patterns.py
@@ -1,0 +1,927 @@
+#!/usr/bin/env python3
+"""Milestone-2 tests: typed variables, ``PatternAST``, and checked grounding.
+
+Covers the one state-machine edge this milestone implements
+(``DESIGN_process_expression_patterns.md`` §1)::
+
+    PatternAST --ground(bindings)--> GroundAST
+
+and the acceptance criteria that edge is responsible for: §16.3 (``_`` fresh per
+occurrence, repeated named variables unify) and the *equality-structure* half of
+§16.4 (alpha-equivalent patterns preserve equality structure).  The other half of
+§16.4 — a shared pattern *digest* — is deliberately not implemented and not
+tested, because a digest would have to fix the wire form of an expression-valued
+``TermIndex``, which is an unresolved specification decision.
+
+Two boundaries are asserted rather than assumed:
+
+* grounding produces no identity, no digest, and no canonical bytes;
+* the ground surface from milestone 1 is unchanged.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from process_expression_vnext import (
+    ElaborationError,
+    GroundAST,
+    GroundingError,
+    ParseError,
+    PatternAST,
+    alpha_equivalent,
+    elaborate,
+    elaborate_ground,
+    elaborate_pattern,
+    ground,
+    ground_surface,
+    is_ground,
+    load_registry,
+    parse_functional,
+)
+from process_expression_vnext.ast import (
+    Call,
+    IndexedType,
+    ListTerm,
+    ListType,
+    PatternIndex,
+    PatternVariable,
+    Reference,
+    ReferenceIndex,
+    TermIndex,
+    TypeName,
+    TypeVar,
+    TypedTerm,
+    debug_repr,
+)
+from process_expression_vnext.numerics import NumberLexeme, to_real
+from process_expression_vnext.patterns import index_of, make_ground
+
+FIXTURE = ROOT / "process_expression_vnext" / "testdata" / "frontend_registry_fixture.json"
+
+SEALED = {
+    "PROCESS_EXPRESSION_GOLDEN_v1.json":
+        "b053351a2a419ac58b7ab644afe15c60543846ce8b9d5a3d9bcbc332ca24db29",
+    "PROCESS_EXPRESSION_GOLDEN_v2.json":
+        "85e6421f5a1347fca5937d1243dc01500a9aa5b7221571b4918248e57ece6344",
+}
+
+#: The §13.1 worked example, used by several tests.
+HOP_DECAY_PATTERN = """hop_decay_targets(
+  S::substrate[C],
+  decay=D::real,
+  hop_origin=H::int,
+  direction='ancestor',
+  depth=Limit::depth_limit
+)"""
+
+HOP_DECAY_GROUND = (
+    "hop_decay_targets(principal_tree(pearltrees),decay=0.85,hop_origin=1,"
+    "direction='ancestor',depth=bounded_depth(4))"
+)
+
+HOP_DECAY_BINDINGS = {
+    "S": "principal_tree(pearltrees)",
+    "C": "pearltrees",
+    "D": "0.85",
+    "H": "1",
+    "Limit": "bounded_depth(4)",
+}
+
+
+@pytest.fixture(scope="module")
+def reg():
+    return load_registry(FIXTURE)
+
+
+def pat(text, registry) -> PatternAST:
+    return elaborate_pattern(parse_functional(text, registry), registry)
+
+
+def gnd(text, registry) -> GroundAST:
+    return elaborate_ground(parse_functional(text, registry), registry)
+
+
+# --------------------------------------------------------------------------
+# the §13.1 worked example
+# --------------------------------------------------------------------------
+
+
+def test_typed_pattern_grounds_to_the_expected_term(reg):
+    pattern = pat(HOP_DECAY_PATTERN, reg)
+    result = ground_surface(pattern, reg, HOP_DECAY_BINDINGS)
+    assert isinstance(result, GroundAST)
+    assert result.term == gnd(HOP_DECAY_GROUND, reg).term
+
+
+def test_grounded_and_directly_elaborated_terms_are_structurally_identical(reg):
+    """The two routes to the same process must not diverge in any node.
+
+    Structural equality of the roots is the headline claim, but it would also
+    hold if both sides were equally wrong, so the inferred types are compared
+    node by node as well.
+    """
+
+    grounded = ground_surface(pat(HOP_DECAY_PATTERN, reg), reg, HOP_DECAY_BINDINGS).term
+    direct = gnd(HOP_DECAY_GROUND, reg).term
+    assert grounded == direct
+    assert debug_repr(grounded) == debug_repr(direct)
+    assert grounded.inferred_type == direct.inferred_type
+    assert str(grounded.inferred_type) == "target_factory[principal_tree(pearltrees),hop_decay]"
+    assert [n for n, _ in grounded.fields] == [
+        "decay", "depth", "direction", "hop_origin"
+    ]
+
+
+def test_inferring_an_index_does_not_require_supplying_it(reg):
+    """`C` is determined by `S`, so binding it is optional — but must agree."""
+
+    pattern = pat(HOP_DECAY_PATTERN, reg)
+    without_c = {k: v for k, v in HOP_DECAY_BINDINGS.items() if k != "C"}
+    assert ground_surface(pattern, reg, without_c).term == gnd(HOP_DECAY_GROUND, reg).term
+
+    conflicting = {**HOP_DECAY_BINDINGS, "C": "simplewiki"}
+    with pytest.raises(GroundingError, match="does not satisfy"):
+        ground_surface(pattern, reg, conflicting)
+
+
+def test_an_index_only_variable_is_not_a_required_binding(reg):
+    pattern = pat(HOP_DECAY_PATTERN, reg)
+    assert pattern.variable("C").in_term_position is False
+    assert pattern.variable("C").constraint is None
+    assert "C" not in {v.name for v in pattern.required_variables}
+    assert {v.name for v in pattern.required_variables} == {"S", "D", "H", "Limit"}
+
+
+# --------------------------------------------------------------------------
+# repeated ownership constraints
+# --------------------------------------------------------------------------
+
+
+CROSS = "cross_substrate(S::substrate[C], T::substrate[C])"
+
+
+def test_repeated_ownership_accepts_one_corpus(reg):
+    result = ground_surface(
+        pat(CROSS, reg),
+        reg,
+        {"S": "principal_tree(pearltrees)", "T": "full_dag(pearltrees)"},
+    )
+    assert result.term == gnd(
+        "cross_substrate(principal_tree(pearltrees),full_dag(pearltrees))", reg
+    ).term
+
+
+def test_repeated_ownership_rejects_two_corpora(reg):
+    with pytest.raises(GroundingError, match="does not satisfy"):
+        ground_surface(
+            pat(CROSS, reg),
+            reg,
+            {"S": "principal_tree(pearltrees)", "T": "full_dag(simplewiki)"},
+        )
+
+
+def test_binding_order_cannot_change_the_result(reg):
+    """Both acceptance and rejection must be order-independent.
+
+    Dict order is the caller's, not the pattern's, so a solver that consumed
+    bindings in insertion order could accept one spelling of a binding set and
+    reject the other.
+    """
+
+    pattern = pat(CROSS, reg)
+    forward = {"S": "principal_tree(pearltrees)", "T": "full_dag(pearltrees)"}
+    reverse = {"T": "full_dag(pearltrees)", "S": "principal_tree(pearltrees)"}
+    assert ground_surface(pattern, reg, forward).term == (
+        ground_surface(pattern, reg, reverse).term
+    )
+
+    bad_forward = {"S": "principal_tree(pearltrees)", "T": "full_dag(simplewiki)"}
+    bad_reverse = {"T": "full_dag(simplewiki)", "S": "principal_tree(pearltrees)"}
+    messages = []
+    for bindings in (bad_forward, bad_reverse):
+        with pytest.raises(GroundingError) as excinfo:
+            ground_surface(pattern, reg, bindings)
+        messages.append(str(excinfo.value))
+    assert messages[0] == messages[1]
+
+
+def test_the_full_hop_decay_pattern_is_also_order_independent(reg):
+    pattern = pat(HOP_DECAY_PATTERN, reg)
+    reversed_bindings = dict(reversed(list(HOP_DECAY_BINDINGS.items())))
+    assert ground_surface(pattern, reg, HOP_DECAY_BINDINGS).term == (
+        ground_surface(pattern, reg, reversed_bindings).term
+    )
+
+
+# --------------------------------------------------------------------------
+# repeated named term variables
+# --------------------------------------------------------------------------
+
+
+def test_one_binding_substitutes_every_occurrence_of_a_named_variable(reg):
+    pattern = pat("cross_substrate(S, S)", reg)
+    assert len(pattern.variables) == 1
+    result = ground_surface(pattern, reg, {"S": "principal_tree(pearltrees)"})
+    assert result.term == gnd(
+        "cross_substrate(principal_tree(pearltrees),principal_tree(pearltrees))", reg
+    ).term
+
+
+def test_repeated_occurrences_retain_equality_structure_in_the_pattern(reg):
+    """The two occurrences must be *the same* variable, not two equal ones."""
+
+    pattern = pat("cross_substrate(S, S)", reg)
+    first, second = pattern.term.args
+    assert isinstance(first, PatternVariable) and isinstance(second, PatternVariable)
+    assert first.var == second.var
+    assert first.var.serial == second.var.serial
+    assert first == second
+
+    distinct = pat("cross_substrate(S::substrate[C], T::substrate[C])", reg)
+    left, right = distinct.term.args
+    assert left.var != right.var
+
+
+def test_a_named_variable_cannot_carry_two_different_constraints(reg):
+    with pytest.raises(ElaborationError, match="constrained as both"):
+        pat("cross_substrate(S::substrate[C], S::substrate[OtherC])", reg)
+
+
+# --------------------------------------------------------------------------
+# anonymous variables
+# --------------------------------------------------------------------------
+
+
+ANON = "cross_substrate(_::substrate[C], _::substrate[C])"
+
+
+def test_each_underscore_is_a_distinct_variable(reg):
+    pattern = pat(ANON, reg)
+    handles = pattern.anonymous_variables
+    assert len(handles) == 2
+    assert handles[0].var != handles[1].var
+    assert handles[0].var.serial != handles[1].var.serial
+    # Same spelling, different identity — which is exactly why the display name
+    # must not be the identity.
+    assert handles[0].name == handles[1].name == "_"
+    assert pattern.term.args[0] != pattern.term.args[1]
+
+
+def test_a_string_binding_named_underscore_binds_nothing(reg):
+    pattern = pat(ANON, reg)
+    with pytest.raises(GroundingError, match="unknown binding '_'"):
+        ground_surface(pattern, reg, {"_": "principal_tree(pearltrees)"})
+
+
+def test_anonymous_variables_are_bindable_through_their_handles(reg):
+    pattern = pat(ANON, reg)
+    left, right = pattern.anonymous_variables
+    result = ground_surface(
+        pattern,
+        reg,
+        {left.var: "principal_tree(pearltrees)", right.var: "full_dag(pearltrees)"},
+    )
+    assert result.term == gnd(
+        "cross_substrate(principal_tree(pearltrees),full_dag(pearltrees))", reg
+    ).term
+
+
+def test_anonymous_occurrences_still_share_a_named_ownership_index(reg):
+    """`_` is fresh, but the `C` they both mention is not."""
+
+    pattern = pat(ANON, reg)
+    left, right = pattern.anonymous_variables
+    with pytest.raises(GroundingError, match="does not satisfy"):
+        ground_surface(
+            pattern,
+            reg,
+            {left.var: "principal_tree(pearltrees)", right.var: "full_dag(simplewiki)"},
+        )
+
+
+def test_anonymous_diagnostics_identify_which_occurrence_failed(reg):
+    pattern = pat(ANON, reg)
+    left, _right = pattern.anonymous_variables
+    with pytest.raises(GroundingError) as excinfo:
+        ground_surface(pattern, reg, {left.var: "principal_tree(pearltrees)"})
+    # Not just "_": two occurrences share that spelling.
+    assert "_#" in str(excinfo.value)
+
+
+def test_a_handle_from_another_pattern_is_refused(reg):
+    """Variable identity is global, so a foreign handle cannot silently bind."""
+
+    first = pat(ANON, reg)
+    second = pat(ANON, reg)
+    foreign = second.anonymous_variables[0].var
+    with pytest.raises(GroundingError, match="does not belong to this pattern"):
+        ground_surface(
+            first,
+            reg,
+            {
+                first.anonymous_variables[0].var: "principal_tree(pearltrees)",
+                foreign: "full_dag(pearltrees)",
+            },
+        )
+
+
+# --------------------------------------------------------------------------
+# term variables and value-index variables share one binding
+# --------------------------------------------------------------------------
+
+
+#: `C` is a term here (the corpus `principal_tree` views) *and* an index there
+#: (the ownership index of `S`).  One spelling, and it must be one variable.
+OWNERSHIP = "cross_substrate(principal_tree(C), S::substrate[C])"
+
+
+def test_a_variable_in_term_and_index_position_is_one_logical_binding(reg):
+    pattern = pat(OWNERSHIP, reg)
+    corpus_var = pattern.variable("C")
+    assert corpus_var.in_term_position is True
+    assert corpus_var.constraint == TypeName("corpus")
+
+    # The same VarId appears as a term node and inside argument 1's type.
+    term_node = pattern.term.args[0].args[0]
+    assert isinstance(term_node, PatternVariable)
+    index = pattern.term.args[1].inferred_type.indices[0]
+    assert isinstance(index, PatternIndex)
+    assert index.var == term_node.var
+
+    result = ground_surface(
+        pattern, reg, {"C": "pearltrees", "S": "full_dag(pearltrees)"}
+    )
+    assert result.term == gnd(
+        "cross_substrate(principal_tree(pearltrees),full_dag(pearltrees))", reg
+    ).term
+
+
+def test_an_explicit_corpus_must_agree_with_the_one_inferred_from_the_substrate(reg):
+    with pytest.raises(GroundingError, match="does not satisfy"):
+        ground_surface(
+            pat(OWNERSHIP, reg),
+            reg,
+            {"C": "simplewiki", "S": "full_dag(pearltrees)"},
+        )
+
+
+def test_index_of_matches_what_elaboration_records_for_an_argument(reg):
+    """An inferred index and a supplied one are only comparable if built alike."""
+
+    reference = gnd("pearltrees", reg).term
+    assert index_of(reference) == ReferenceIndex("pearltrees")
+    call = gnd("principal_tree(pearltrees)", reg).term
+    assert index_of(call) == TermIndex(call)
+    # And that is the shape elaboration itself puts in the result type.
+    assert gnd(HOP_DECAY_GROUND, reg).term.inferred_type.indices[0] == TermIndex(call)
+
+
+# --------------------------------------------------------------------------
+# inference of a fresh constraint variable
+# --------------------------------------------------------------------------
+
+
+def test_a_bare_variable_takes_its_constraint_from_the_slot(reg):
+    """§3.5: `lineage_op(S)` infers `S::substrate[C]` for a *fresh* C."""
+
+    pattern = pat("lineage_op(S)", reg)
+    constraint = pattern.variable("S").constraint
+    assert isinstance(constraint, IndexedType)
+    assert constraint.name == "substrate"
+    index = constraint.indices[0]
+    assert isinstance(index, PatternIndex)
+    assert index.var.origin == "inferred"
+
+    result = ground_surface(pattern, reg, {"S": "principal_tree(pearltrees)"})
+    assert result.term == gnd("lineage_op(principal_tree(pearltrees))", reg).term
+
+
+def test_an_inferred_constraint_variable_is_not_bindable(reg):
+    """It is an artifact of inference, not something the author wrote."""
+
+    pattern = pat("lineage_op(S)", reg)
+    inferred = pattern.variable("S").constraint.indices[0].var
+    assert inferred not in {v.var for v in pattern.variables}
+    with pytest.raises(GroundingError, match="does not belong to this pattern"):
+        ground_surface(
+            pattern, reg, {"S": "principal_tree(pearltrees)", inferred: "pearltrees"}
+        )
+
+
+def test_two_bare_variables_get_separate_fresh_constraints(reg):
+    """A fresh C per *occurrence*, so unrelated patterns cannot appear to share one."""
+
+    first = pat("lineage_op(S)", reg).variable("S").constraint.indices[0].var
+    second = pat("lineage_op(S)", reg).variable("S").constraint.indices[0].var
+    assert first != second
+
+
+def test_the_signature_placeholder_never_becomes_a_user_variable(reg):
+    """Registry `TypeVar` and pattern variables are different namespaces.
+
+    The fixture's `lineage_op` declares `substrate[C]` and the pattern below
+    writes its own `C`.  If the two were conflated, the author's `C` would
+    silently pick up whatever the signature meant by it.
+    """
+
+    pattern = pat("lineage_op(S::substrate[C])", reg)
+    index = pattern.variable("S").constraint.indices[0]
+    assert isinstance(index, PatternIndex)
+    assert not isinstance(index, TypeVar)
+    assert index.var.origin == "named"
+    assert index.var == pattern.variable("C").var
+    # And no signature placeholder survives anywhere in the pattern.
+    assert _typevars_in(pattern.term) == []
+
+
+# --------------------------------------------------------------------------
+# type conflicts
+# --------------------------------------------------------------------------
+
+
+def test_a_judge_cannot_satisfy_a_substrate_slot(reg):
+    with pytest.raises(ElaborationError, match="expected substrate"):
+        pat("lineage_op(J::judge)", reg)
+
+
+def test_mismatched_ownership_variables_fail_before_any_binding(reg):
+    """The signature says both arguments share one corpus; the pattern does not."""
+
+    with pytest.raises(ElaborationError, match="expected substrate"):
+        pat("cross_substrate(S::substrate[C], T::substrate[OtherC])", reg)
+
+
+def test_a_top_level_unannotated_variable_is_underconstrained(reg):
+    with pytest.raises(ElaborationError, match="underconstrained"):
+        pat("X", reg)
+
+
+def test_a_bare_list_literal_is_still_rejected_before_its_elements(reg):
+    """A list with no declared type fails as a list, not as a variable.
+
+    Worth pinning: the element diagnostic would be the misleading one, since the
+    variable is underconstrained only as a consequence of the list being so.
+    """
+
+    with pytest.raises(ElaborationError, match="declared list type"):
+        pat("[W]", reg)
+
+
+def test_a_variable_may_not_index_a_list_element_type(reg):
+    with pytest.raises(ElaborationError, match="must be a type"):
+        pat("list_probe(weights=W::list[C])", reg)
+
+
+# --------------------------------------------------------------------------
+# binding-set errors
+# --------------------------------------------------------------------------
+
+
+def test_missing_bindings_are_named(reg):
+    with pytest.raises(GroundingError, match="missing binding"):
+        ground_surface(pat(CROSS, reg), reg, {"S": "principal_tree(pearltrees)"})
+
+
+def test_an_unknown_binding_name_is_rejected(reg):
+    with pytest.raises(GroundingError, match="unknown binding 'Nope'"):
+        ground_surface(
+            pat(CROSS, reg),
+            reg,
+            {
+                "S": "principal_tree(pearltrees)",
+                "T": "full_dag(pearltrees)",
+                "Nope": "pearltrees",
+            },
+        )
+
+
+def test_a_binding_for_a_variable_the_pattern_does_not_use_is_rejected(reg):
+    """An extra binding is an error, not a no-op.
+
+    Silently ignoring it would let a caller believe a constraint was applied
+    when the pattern never mentioned the variable.
+    """
+
+    with pytest.raises(GroundingError, match="unknown binding 'D'"):
+        ground_surface(
+            pat(CROSS, reg),
+            reg,
+            {
+                "S": "principal_tree(pearltrees)",
+                "T": "full_dag(pearltrees)",
+                "D": "0.85",
+            },
+        )
+
+
+def test_binding_a_variable_to_a_pattern_is_rejected(reg):
+    pattern = pat(CROSS, reg)
+    inner = pat("cross_substrate(S, S)", reg)
+    with pytest.raises(GroundingError, match="is a PatternAST"):
+        ground(
+            pattern,
+            {
+                "S": inner,
+                "T": gnd("full_dag(pearltrees)", reg),
+            },
+        )
+
+
+def test_binding_a_variable_to_a_nonground_term_is_rejected(reg):
+    """A term carrying a variable is not a value, whatever its type says."""
+
+    donor = pat("cross_substrate(S, S)", reg)
+    with pytest.raises(GroundingError, match="not ground"):
+        ground(
+            pat(CROSS, reg),
+            {"S": donor.term.args[0], "T": gnd("full_dag(pearltrees)", reg)},
+        )
+
+
+def test_ground_refuses_raw_surface_strings(reg):
+    """Parse failures must not be able to masquerade as binding failures."""
+
+    with pytest.raises(GroundingError, match="ground_surface"):
+        ground(pat(CROSS, reg), {"S": "principal_tree(pearltrees)"})
+
+
+def test_ground_refuses_a_non_term_binding_value(reg):
+    with pytest.raises(GroundingError, match="not a typed term"):
+        ground(pat(CROSS, reg), {"S": 42})
+
+
+def test_a_binding_key_must_be_a_name_or_a_handle(reg):
+    with pytest.raises(GroundingError, match="binding key"):
+        ground(pat(CROSS, reg), {7: gnd("full_dag(pearltrees)", reg)})
+
+
+def test_binding_one_variable_by_both_name_and_handle_is_rejected(reg):
+    pattern = pat(CROSS, reg)
+    handle = pattern.variable("S").var
+    with pytest.raises(GroundingError, match="bound twice"):
+        ground_surface(
+            pattern,
+            reg,
+            {
+                "S": "principal_tree(pearltrees)",
+                handle: "full_dag(pearltrees)",
+                "T": "full_dag(pearltrees)",
+            },
+        )
+
+
+def test_ground_requires_a_pattern(reg):
+    with pytest.raises(GroundingError, match="takes a PatternAST"):
+        ground(gnd("pearltrees", reg), {})
+
+
+def test_a_malformed_binding_string_raises_a_parse_error_not_a_grounding_error(reg):
+    """Three stages, three error types — the seam the brief asks for."""
+
+    with pytest.raises(ParseError):
+        ground_surface(pat(CROSS, reg), reg, {"S": "principal_tree(", "T": "x"})
+    with pytest.raises(ElaborationError):
+        # Well-formed text, ill-typed: principal_tree views a corpus, not a judge.
+        ground_surface(
+            pat(CROSS, reg),
+            reg,
+            {"S": "principal_tree(haiku)", "T": "full_dag(pearltrees)"},
+        )
+    with pytest.raises(GroundingError):
+        ground_surface(pat(CROSS, reg), reg, {"S": "principal_tree(pearltrees)"})
+
+
+# --------------------------------------------------------------------------
+# groundness proof
+# --------------------------------------------------------------------------
+
+
+def _typevars_in(term: TypedTerm) -> list[str]:
+    found: list[str] = []
+
+    def walk_type(declared):
+        if isinstance(declared, TypeVar):
+            found.append(declared.name)
+        elif isinstance(declared, TermIndex):
+            walk_term(declared.term)
+        elif isinstance(declared, IndexedType):
+            for index in declared.indices:
+                walk_type(index)
+        elif isinstance(declared, ListType):
+            walk_type(declared.element)
+
+    def walk_term(node):
+        walk_type(node.inferred_type)
+        if isinstance(node, Call):
+            for arg in node.args:
+                walk_term(arg)
+            for _name, value in node.fields:
+                walk_term(value)
+        elif isinstance(node, ListTerm):
+            for item in node.items:
+                walk_term(item)
+
+    walk_term(term)
+    return found
+
+
+def _variables_in(term: TypedTerm) -> list[object]:
+    found: list[object] = []
+
+    def walk_type(declared):
+        if isinstance(declared, PatternIndex):
+            found.append(declared.var)
+        elif isinstance(declared, TermIndex):
+            walk_term(declared.term)
+        elif isinstance(declared, IndexedType):
+            for index in declared.indices:
+                walk_type(index)
+        elif isinstance(declared, ListType):
+            walk_type(declared.element)
+
+    def walk_term(node):
+        if isinstance(node, PatternVariable):
+            found.append(node.var)
+        walk_type(node.inferred_type)
+        if isinstance(node, Call):
+            for arg in node.args:
+                walk_term(arg)
+            for _name, value in node.fields:
+                walk_term(value)
+        elif isinstance(node, ListTerm):
+            for item in node.items:
+                walk_term(item)
+
+    walk_term(term)
+    return found
+
+
+def test_nothing_variable_survives_anywhere_in_a_ground_result(reg):
+    """Calls, fields, list items, inferred types, and nested indices."""
+
+    pattern = pat(
+        "list_probe(weights=[W1::real, W2::real])", reg
+    )
+    listy = ground_surface(pattern, reg, {"W1": "0.4", "W2": "0.6"}).term
+    assert _variables_in(listy) == []
+    assert _typevars_in(listy) == []
+    assert isinstance(listy.fields[0][1], ListTerm)
+    assert [i.value for i in listy.fields[0][1].items] == [
+        to_real(NumberLexeme("0.4")), to_real(NumberLexeme("0.6"))
+    ]
+
+    nested = ground_surface(pat(HOP_DECAY_PATTERN, reg), reg, HOP_DECAY_BINDINGS).term
+    assert _variables_in(nested) == []
+    assert _typevars_in(nested) == []
+    # The result type carries a TermIndex; the check must have looked inside it.
+    assert isinstance(nested.inferred_type.indices[0], TermIndex)
+    assert is_ground(nested)
+
+
+def test_the_proof_looks_inside_an_expression_valued_index(reg):
+    """A variable hiding in a `TermIndex` must not pass as ground.
+
+    Constructed by hand: elaboration never builds this shape, because a
+    variable argument becomes a `PatternIndex` rather than a `TermIndex`.  That
+    is the point — the proof has to be sound against shapes the current
+    elaborator does not produce, since a later milestone may.
+    """
+
+    donor = pat("cross_substrate(S, S)", reg)
+    hidden = donor.term.args[0]
+    smuggled = Call(
+        IndexedType("target_factory", (TermIndex(hidden), TypeName("hop_decay"))),
+        "hop_decay_targets",
+        (),
+        (),
+    )
+    assert is_ground(smuggled) is False
+    with pytest.raises(GroundingError, match="unbound variable"):
+        make_ground(smuggled)
+
+
+def test_the_proof_rejects_a_surviving_signature_placeholder(reg):
+    smuggled = Reference(IndexedType("substrate", (TypeVar("C"),)), "pearltrees")
+    with pytest.raises(GroundingError, match="unresolved signature type variable"):
+        make_ground(smuggled)
+
+
+def test_a_pattern_is_not_a_ground_ast(reg):
+    pattern = pat(CROSS, reg)
+    assert is_ground(pattern.term) is False
+    with pytest.raises(GroundingError, match="not ground"):
+        make_ground(pattern.term)
+
+
+# --------------------------------------------------------------------------
+# immutability
+# --------------------------------------------------------------------------
+
+
+def test_grounding_leaves_the_pattern_untouched(reg):
+    pattern = pat(HOP_DECAY_PATTERN, reg)
+    before = copy.deepcopy(pattern)
+    ground_surface(pattern, reg, HOP_DECAY_BINDINGS)
+    assert pattern == before
+    assert _variables_in(pattern.term)  # still a pattern, not consumed
+
+
+def test_one_pattern_grounds_more_than_once_with_different_bindings(reg):
+    pattern = pat(CROSS, reg)
+    first = ground_surface(
+        pattern, reg, {"S": "principal_tree(pearltrees)", "T": "full_dag(pearltrees)"}
+    )
+    second = ground_surface(
+        pattern, reg, {"S": "principal_tree(simplewiki)", "T": "full_dag(simplewiki)"}
+    )
+    assert first.term != second.term
+    assert first.term == gnd(
+        "cross_substrate(principal_tree(pearltrees),full_dag(pearltrees))", reg
+    ).term
+
+
+# --------------------------------------------------------------------------
+# alpha equivalence
+# --------------------------------------------------------------------------
+
+
+def test_renaming_every_variable_preserves_alpha_equivalence(reg):
+    assert alpha_equivalent(
+        pat("lineage_op(S::substrate[C])", reg),
+        pat("lineage_op(X::substrate[Y])", reg),
+    )
+
+
+def test_different_repeated_variable_structure_is_not_alpha_equivalent(reg):
+    assert not alpha_equivalent(
+        pat("cross_substrate(S, S)", reg),
+        pat("cross_substrate(S::substrate[C], T::substrate[C])", reg),
+    )
+
+
+def test_anonymous_and_named_variables_are_not_interchangeable(reg):
+    """`_` twice and `S,T` twice both have two variables, but differ in kind."""
+
+    assert not alpha_equivalent(
+        pat(ANON, reg),
+        pat("cross_substrate(S::substrate[C], T::substrate[C])", reg),
+    )
+
+
+def test_alpha_equivalence_is_reflexive_and_symmetric(reg):
+    left = pat(HOP_DECAY_PATTERN, reg)
+    right = pat(HOP_DECAY_PATTERN.replace("S::", "Sub::").replace("D::", "Dec::"), reg)
+    assert alpha_equivalent(left, left)
+    assert alpha_equivalent(left, right)
+    assert alpha_equivalent(right, left)
+
+
+def test_alpha_equivalence_still_compares_the_ground_parts(reg):
+    assert not alpha_equivalent(
+        pat("cross_substrate(S::substrate[C], T::substrate[C])", reg),
+        pat(OWNERSHIP, reg),
+    )
+
+
+def test_a_pattern_and_its_renaming_are_not_equal_as_data(reg):
+    """Alpha-equivalence is needed precisely because `==` is stricter."""
+
+    left = pat("lineage_op(S::substrate[C])", reg)
+    right = pat("lineage_op(X::substrate[Y])", reg)
+    assert left.term != right.term
+    assert alpha_equivalent(left, right)
+
+
+def test_alpha_equivalent_requires_two_patterns(reg):
+    with pytest.raises(TypeError):
+        alpha_equivalent(pat(CROSS, reg), gnd("pearltrees", reg))
+
+
+# --------------------------------------------------------------------------
+# state boundary and non-goals
+# --------------------------------------------------------------------------
+
+
+def test_the_compatibility_api_stays_ground_only(reg):
+    """`elaborate()` must never silently accept a free variable."""
+
+    for text in ["lineage_op(S)", "cross_substrate(S, S)", "lineage_op(S::substrate[C])"]:
+        with pytest.raises(ElaborationError, match="ground expression"):
+            elaborate(parse_functional(text, reg), reg)
+
+
+#: A cross-section of the ground surface: references, annotations, every numeric
+#: type, defaults, lists, punctuated names, ownership indices, and the coarse and
+#: precise lineage forms of §4.1.
+GROUND_SURFACE = [
+    "pearltrees",
+    "pearltrees::corpus",
+    "haiku::judge",
+    "lineage_at",
+    "unbounded_depth",
+    "bounded_depth(4)",
+    "principal_tree(pearltrees)",
+    "principal_tree(pearltrees)::substrate[pearltrees]",
+    "full_dag(simplewiki)",
+    "margin(t=1)",
+    "margin(t=0.03)",
+    "margin(t=1,epsilon=-0.0)",
+    "default_probe()",
+    "list_probe(weights=[0.4,0.6])",
+    "list_probe(weights=[])",
+    "judge_view(gpt-5.5-low)",
+    "judge_view(haiku.fast)",
+    "order_probe(s=principal_tree(pearltrees))",
+    "cross_substrate(principal_tree(pearltrees),full_dag(pearltrees))",
+    "lineage_op(principal_tree(pearltrees))",
+    "lineage_op(principal_tree(pearltrees),estimand='hop_decay')",
+    HOP_DECAY_GROUND,
+]
+
+
+@pytest.mark.parametrize("text", GROUND_SURFACE)
+def test_elaborate_ground_wraps_exactly_what_elaborate_returns(reg, text):
+    source = parse_functional(text, reg)
+    assert elaborate_ground(source, reg).term == elaborate(source, reg)
+
+
+@pytest.mark.parametrize("text", GROUND_SURFACE)
+def test_the_pattern_path_agrees_with_the_ground_path(reg, text):
+    """Adding variables must not have moved the variable-free surface.
+
+    Both entry points share one ``_elaborate``, so this is the test that would
+    catch the scope parameter changing a decision it has no business changing —
+    an expectation pushed down differently, or a default resolved in another
+    order.
+    """
+
+    source = parse_functional(text, reg)
+    direct = elaborate(source, reg)
+    pattern = elaborate_pattern(source, reg)
+    assert pattern.variables == ()
+    assert pattern.term == direct
+    assert debug_repr(pattern.term) == debug_repr(direct)
+    # A variable-free pattern grounds under the empty binding set.
+    assert ground(pattern, {}).term == direct
+    assert ground(pattern, None).term == direct
+
+
+def test_a_ground_ast_may_still_be_semantically_coarse(reg):
+    """Grounding is not interpretation (§4.1).
+
+    `lineage_op(S)` grounded is ground *and* still underconstrained about which
+    lineage estimand it names, and nothing here resolves that.
+    """
+
+    result = ground_surface(
+        pat("lineage_op(S)", reg), reg, {"S": "principal_tree(pearltrees)"}
+    )
+    assert isinstance(result, GroundAST)
+    assert result.term.fields == ()          # no estimand, no impl, no defaults
+    assert str(result.term.inferred_type).startswith("abstract_lineage_process[")
+
+
+def test_the_package_exports_no_identity_or_digest_surface():
+    import process_expression_vnext as package
+
+    exported = set(package.__all__)
+    forbidden = {
+        "digest", "sha256", "canonical_bytes", "pattern_digest", "identity",
+        "serialize", "encode", "deploy", "resolve", "interpret", "represent",
+        "verify", "verify_factory_receipt", "receipt",
+    }
+    assert exported & forbidden == set()
+    for name in exported:
+        assert hasattr(package, name)
+
+
+def test_no_module_in_the_package_can_compute_a_digest():
+    """A digest is not merely unexported — nothing here can produce one.
+
+    Checked at the import level rather than the export level: an unexported
+    helper that hashed a typed term would still be a pattern digest, and a
+    pattern digest is what this milestone is forbidden to mint.
+    """
+
+    package_dir = ROOT / "process_expression_vnext"
+    modules = sorted(package_dir.glob("*.py"))
+    assert modules, "package has no modules to check"
+    for module in modules:
+        text = module.read_text(encoding="utf-8")
+        for banned in ("hashlib", "sha256", "blake2"):
+            assert banned not in text, f"{module.name} reaches for {banned}"
+
+
+def test_sealed_bundles_are_untouched():
+    for name, expected in SEALED.items():
+        actual = hashlib.sha256((ROOT / name).read_bytes()).hexdigest()
+        assert actual == expected, f"{name} changed"


### PR DESCRIPTION
vNext milestone 2: typed variables, a real `PatternAST`, and explicit type-checked grounding.

Branched from `main` at **`41a9fc29499062fbea84868b03b3ff7b5fed09dd`** (after #4019 at `f961675` and #4012 at `186f405`).

## What this implements

One edge of the `DESIGN_process_expression_patterns.md` §1 state machine:

```
PatternAST --ground(bindings)--> GroundAST
```

and nothing beyond it. `interpret`, `represent` and `verify_factory_receipt` are later edges and are absent, so a caller cannot mistake a `GroundAST` for something deployable.

## Public state and API boundary

| Function | In | Out |
|---|---|---|
| `parse_functional(text, registry)` | text | source AST (may contain variables) |
| `elaborate_pattern(source, registry)` | source AST | `PatternAST` |
| `ground(pattern, bindings)` | `PatternAST` + typed values | `GroundAST` |
| `ground_surface(pattern, registry, bindings)` | `PatternAST` + surface text | `GroundAST` |
| `elaborate_ground(source, registry)` | source AST | `GroundAST` |
| `elaborate(source, registry)` | source AST | bare `TypedTerm` (compatibility) |
| `alpha_equivalent(p, q)` | two `PatternAST` | `bool` |

The states are types with checked invariants, not documentation:

- **`PatternAST`** may contain `PatternVariable` nodes and `PatternIndex` value indices, and carries its variable table.
- **`GroundAST`** is *proved* on construction to contain neither, and no registry-signature `TypeVar` either. The proof is recursive across arguments, fields, list items, every inferred type, and **the interior of a `TermIndex`** — a variable hiding inside an expression-valued index is exactly the leak a per-node check misses.

A `GroundAST` may still be semantically coarse. `lineage_op(principal_tree(pearltrees))` grounds and stays interpretation-underconstrained (§4.1); grounding performs no interpretation, no representation selection, and no factory verification.

`elaborate()` is retained as a compatibility convenience and stays **ground-only** — a variable anywhere is an `ElaborationError`, never a silently accepted free variable. `elaborate_ground(s, r).term == elaborate(s, r)` always holds, and that identity is parametrized over 22 ground expressions.

Three error types for three stages: `ParseError` (malformed text) → `ElaborationError` (well-formed, ill-typed) → `GroundingError` (well-typed pattern, bad binding set). `ground()` refuses raw strings precisely so a parse failure cannot masquerade as a binding failure; `ground_surface()` is the separate helper that parses.

## How variables are represented

`VarId` is an opaque process-wide serial. **The display name is deliberately not part of equality** — two variables spelled `S` in different patterns are different variables, and two `_` in one pattern are different variables despite an identical spelling.

Four concepts stay separate, per the brief:

| Concept | Node | Bindable |
|---|---|---|
| named variable `S` | `VarId(origin="named")` | by name or handle |
| anonymous `_` | `VarId(origin="anonymous")`, fresh per occurrence | by handle only |
| inferred constraint variable | `VarId(origin="inferred")` | never — not in the variable table |
| registry signature placeholder | `TypeVar` — not a `VarId` at all | n/a |

The inferred kind is §3.5's *"S is inferred as `substrate[C]` for a fresh C"*. Reusing the registry's own `C` there would make two unrelated expressions appear to share an ownership constraint, so each occurrence mints its own.

In value-index position a variable becomes `PatternIndex(var)`, a `ValueIndex` subclass. Encoding it as `TypeName` would make it a type, as `ReferenceIndex` would make it a registered name that does not exist, and as a display string would lose the identity that decides whether two occurrences are the same variable.

## Term variables and index variables share one binding

`cross_substrate(principal_tree(C), S::substrate[C])` — `C` is a term (argument to `principal_tree`) *and* an index (the ownership index of `S`). Both resolve to one `VarId`, so binding `C = simplewiki` while `S = full_dag(pearltrees)` fails. Conversely `C` need not be supplied at all when another binding determines it, but if supplied it must agree.

## Grounding

Substitutes every occurrence of a named variable consistently, treats each anonymous occurrence independently, solves ownership/index constraints induced by bindings, type-checks each binding against its variable's constraint, and rejects missing / unknown / extra / non-ground / incompatible / doubly-bound values. Both acceptance **and the error message** are order-independent, verified by grounding the same pattern from reversed dicts. The pattern is never mutated and grounds repeatedly with different bindings.

## Acceptance-test matrix

| Requirement | Tests |
|---|---|
| §13.1 pattern → ground term | equals direct ground elaboration, node-by-node incl. inferred types |
| Repeated ownership `substrate[C]` twice | one corpus passes; two corpora fail; order-independent, same message |
| Repeated named term variable | `cross_substrate(S,S)` — one binding, both occurrences, same `VarId` |
| Anonymous variables | two `_` distinct; `"_"` binds nothing; handles exposed and bindable; still share a named `C`; diagnostics say `_#serial` |
| Foreign handle | a handle from another pattern is refused |
| Inferred fresh `C` | `lineage_op(S)` infers `substrate[C]`; fresh per occurrence; not bindable |
| Type conflicts | `lineage_op(J::judge)`, `cross_substrate(S::substrate[C], T::substrate[OtherC])`, one name with two constraints, top-level `X`, `list[C]` |
| Binding-set errors | missing, unknown, extra, `PatternAST` value, non-ground value, raw string, non-term value, bad key type, name+handle collision |
| Ground proof | variables absent from calls, list items, fields, inferred types, nested indices; hand-built `TermIndex` leak rejected; surviving `TypeVar` rejected |
| Alpha equivalence | renaming preserved; different repeat structure not; `_` vs named not; reflexive/symmetric; ground parts still compared; `==` is strictly stronger |
| Immutability | deep-copy equality after grounding; regrounding with different bindings |
| Ground surface unchanged | 22 expressions: `elaborate` ≡ `elaborate_ground` ≡ `elaborate_pattern` |
| Non-goals | no digest surface exported; **no module imports `hashlib`/`sha256`/`blake2`** |

## Ground-surface preservation

The riskiest claim, so it was measured rather than argued. Both packages were loaded side by side (`main` extracted via `git archive`) and 161 expressions elaborated through each:

- **45 / 45** expressions that elaborated on `main` produce **byte-identical** `debug_repr`;
- **116 / 116** rejections are still rejections;
- **0** changes in acceptance status.

The only behavioral difference is *which stage* rejects a variable. `lineage_op(S)` was a `NotImplementedInMilestone` from the parser; it is now an `ElaborationError` from the ground path. That seam move is required — the parser has no scope and therefore cannot decide whether two occurrences are one variable — and the milestone-1 test that asserted the old behavior was updated to assert the new one plus the unchanged rejection.

## Fixture

`frontend_registry_fixture.json` is **unchanged**. An `ownership_probe` entry was added while developing the term/index sharing test and then removed: `cross_substrate(principal_tree(C), S::substrate[C])` exercises the same mechanism using entries that already existed, and fewer test-only entries is better.

## Deferred decisions

- **Pattern digest** (acceptance criterion §16.4's first half). Not implemented. It would have to fix the wire form of an expression-valued `TermIndex`, which is unresolved. `alpha_equivalent()` answers the comparison question structurally and in memory instead, so the *equality-structure* half of §16.4 is covered.
- **Canonical pattern bytes / alpha-normalized serialization / `pe-typed-ast-v1`.** Same reason.
- **`TermIndex` wire form.** Still open, still in-memory only.
- **The canonical string form of a `real`.** Carried over from milestone 1; equality remains structural on the normalized triple.
- **Annotating an index variable.** The §4 grammar has `TypeOrIndex := Type | Variable | Reference` with no annotation slot, so an index-only variable carries no constraint and is checked by index agreement alone.
- **Prolog adapter, function and sum types, modifiers, pins.** Out of scope; still recognized and rejected precisely.

## Not authorized by this PR

This is **not vNext activation**. It creates no identity-bearing bytes, no digests of any kind, no receipts, and no deployed processes. It authorizes no corpus enumeration, no generator Part 2, no model training, and no decoder or filing work.

Registry v0.3, `process_cards.py`, `pec-v2`, the merged `tok-v1` tokenizer, and both sealed golden bundles are untouched frozen contracts.

**Issue #4013 enumeration remains paused.** Nothing here decides whether hop-decay filing targets are semantic μ — `hop_decay_targets` is used only as the §13.1 worked example, and the fixture's `lineage_op` still inserts no hop-decay-shaped defaults for exactly that reason.

## Validation

- **330 passed** — the brief's required suite list (contract, envelope, process_cards, p1_protocol, vnext_frontend, vnext_patterns, tokenizer)
- **519 passed** — combined with the filing suites (filing_path_decision, filing_privacy, pearltrees_filing_v1, sm_fs_filing, sm_fs_protocols, sm_fs_privacy)
- `python3 -m compileall -q prototypes/mu_cosine/process_expression_vnext` — clean
- `git diff --check` — clean
- Sealed bundles verified byte-identical:
  - `PROCESS_EXPRESSION_GOLDEN_v1.json` — `b053351a2a419ac58b7ab644afe15c60543846ce8b9d5a3d9bcbc332ca24db29`
  - `PROCESS_EXPRESSION_GOLDEN_v2.json` — `85e6421f5a1347fca5937d1243dc01500a9aa5b7221571b4918248e57ece6344`

The new suite is appended to the existing process-expression CI step; no current suite was dropped.

---
_Generated by [Claude Code](https://claude.ai/code/session_017xCXhV5sHDsMiDyU5q7Hqg)_