### PR TITLE
mu_cosine: ranking pipeline v3 — CAND2-1..8 replacement; fitting double-locked

### DIFF
--- a/prototypes/mu_cosine/sm_fs_bootstrap.py
+++ b/prototypes/mu_cosine/sm_fs_bootstrap.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Frozen decision bootstrap (CAND2-6): SHA-256 rejection sampler, query-weighted block mean,
+nearest-rank endpoints.
+
+Implements REVIEW_sm_fs_ranking_candidate_lock.md §3 steps 3-7 exactly:
+- each replicate draws exactly 82 block indices with replacement from the canonical UTF-8-sorted
+  82-block list, identical multiplicities for both arms (the statistic consumes the paired
+  per-query differences, so pairing is structural);
+- replicate statistic = Σ_b m_b·Σ_{q∈b} d(q) / Σ_b m_b·n_b (query-weighted mean under block
+  multiplicities);
+- versioned SHA-256 rejection sampler; canonical-JSON key with exactly
+  {schema, sampler_id, seed, replicate, draw, retry}; digest as unsigned big-endian 256-bit int,
+  reject at floor(2^256/82)*82 before modulo;
+- 9,999 resamples, seed 3997999; nearest-rank central endpoints = zero-based sorted replicate
+  indices 249 and 9749;
+- fail closed on nonfinite inputs or fewer than 20 eligible blocks in the OBSERVED population
+  (a replicate may contain fewer than 20 unique blocks).
+
+Versioned strings chosen by this candidate (bound fields, reviewed at step 3):
+  KEY_SCHEMA = unifyweaver.sm-fs-ranking-bootstrap-key.v1
+  SAMPLER_ID = sm-fs-ranking-bootstrap-v1
+"""
+import hashlib
+import math
+
+from sm_fs_sampler import canonical_json_bytes
+
+KEY_SCHEMA = "unifyweaver.sm-fs-ranking-bootstrap-key.v1"
+SAMPLER_ID = "sm-fs-ranking-bootstrap-v1"
+RESAMPLES, SEED, N_BLOCKS = 9999, 3997999, 82
+LO_INDEX, HI_INDEX = 249, 9749
+MIN_OBSERVED_BLOCKS = 20
+
+
+class BootstrapError(ValueError):
+    pass
+
+
+def _need(c, m):
+    if not c:
+        raise BootstrapError(m)
+
+
+def block_draw(seed, replicate, draw):
+    """One rejection-sampled block index in [0, 82)."""
+    limit = ((1 << 256) // N_BLOCKS) * N_BLOCKS
+    retry = 0
+    while True:
+        key = canonical_json_bytes({
+            "draw": draw, "replicate": replicate, "retry": retry,
+            "sampler_id": SAMPLER_ID, "schema": KEY_SCHEMA, "seed": seed,
+        })
+        value = int.from_bytes(hashlib.sha256(key).digest(), "big", signed=False)
+        if value < limit:
+            return value % N_BLOCKS, retry
+        retry += 1
+
+
+def decide(block_values):
+    """block_values: {block_name: [d(q), ...]} over the canonical observed blocks.
+
+    Returns the decision record: point estimate (query-weighted over observed blocks),
+    nearest-rank CI, replicate stats, and gate booleans. Fails closed on nonfinite inputs
+    or an observed population under 20 blocks."""
+    blocks = sorted(block_values)                     # canonical UTF-8 sort
+    _need(len(blocks) == N_BLOCKS,
+          f"observed block list has {len(blocks)} entries, frozen spec requires {N_BLOCKS}")
+    eligible = [b for b in blocks if block_values[b]]
+    _need(len(eligible) >= MIN_OBSERVED_BLOCKS,
+          f"only {len(eligible)} nonempty observed blocks (<{MIN_OBSERVED_BLOCKS})")
+    for b in blocks:
+        for v in block_values[b]:
+            _need(isinstance(v, float) and math.isfinite(v), f"nonfinite d(q) in block {b}")
+    total = sum(v for b in blocks for v in block_values[b])
+    count = sum(len(block_values[b]) for b in blocks)
+    _need(count > 0, "no paired differences")
+    point = total / count
+    sums = {b: sum(block_values[b]) for b in blocks}
+    lens = {b: len(block_values[b]) for b in blocks}
+    stats, attempts = [], 0
+    for rep in range(RESAMPLES):
+        num = den = 0.0
+        for draw in range(N_BLOCKS):
+            i, retry = block_draw(SEED, rep, draw)
+            attempts += 1 + retry
+            b = blocks[i]
+            num += sums[b]
+            den += lens[b]
+        _need(den > 0, f"replicate {rep} drew only empty blocks")
+        stats.append(num / den)
+    stats.sort()
+    return {
+        "delta_mrr": point, "ci95": [stats[LO_INDEX], stats[HI_INDEX]],
+        "resamples": RESAMPLES, "seed": SEED, "draws_per_replicate": N_BLOCKS,
+        "endpoint_rule": "nearest-rank-zero-based-249-9749",
+        "sampler": {"schema": KEY_SCHEMA, "sampler_id": SAMPLER_ID,
+                    "rejection_limit": "floor(2^256/82)*82"},
+        "bootstrap_mean": sum(stats) / len(stats), "sampler_attempts": attempts,
+        "observed_blocks": len(blocks), "nonempty_blocks": len(eligible),
+        "query_count": count,
+        "passed_exploratory_gate": bool(point >= 0.010 and stats[LO_INDEX] > 0.0),
+    }

--- a/prototypes/mu_cosine/sm_fs_ranking_lock_verify.py
+++ b/prototypes/mu_cosine/sm_fs_ranking_lock_verify.py
@@ -1,65 +1,103 @@
 #!/usr/bin/env python3
-"""Candidate/final execution-lock emitter + independent verifier (CAND-4/5 replacement).
+"""Candidate/final lock emitter + verifier v3 (CAND2-3/5 replacement).
 
-One authority for the lock schemas: `emit_candidate()` writes the v2-namespace candidate with
-every §4 binding as an enforced FIELD; `verify_candidate_lock`/`verify_final_lock` recompute
-every bound hash from disk and reject tampering. The final verifier is what the pipeline's
-fitting gate calls — locks never self-assert (CAND-2).
+Finalization chain (CAND2-3): a final lock is valid only when
+  1. the LIVE preregistration authorizes fitting;
+  2. the lock binds the exact reviewed CANDIDATE bytes (candidate_sha256) and the rigor lane's
+     REVIEW ID, and the named review artifact — a file COMMITTED by the rigor lane's own PR —
+     records verdict "accepted" for that exact candidate SHA and review ID. Caller-authored
+     JSON cannot substitute for the committed review artifact;
+  3. every hash the candidate bound still recomputes from disk (the only permitted intervening
+     changes are the preregistration amendments the review authorizes).
 
-  python3 sm_fs_ranking_lock_verify.py emit      # fresh candidate in the v2 namespace
+All-fields verification (CAND2-5): _verify_common enforces EVERY bound field — code hashes
+(ID-free set; sm_fs_protocols is deliberately excluded per CAND2-2), ranking manifest AND the
+manifest-bound pairs/fold bytes, titles, plan, initialized checkpoints BY READING THE BYTES,
+the exact 18 trainable names+shapes (obtained by really loading a countersigned checkpoint
+through the established loader), environment INVARIANT fields (versions/flags — enforced), with
+runtime fields (CUDA device/driver) recorded separately as descriptive so sandboxed
+verification neither falsely passes nor falsely fails.
+
+  python3 sm_fs_ranking_lock_verify.py emit
   python3 sm_fs_ranking_lock_verify.py verify --lock PATH
 """
 import argparse
-import hashlib
 import json
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from sm_fs_ranking_pipeline import (ADAM, ANCHOR_W, ARMS, BOOT, BS, CLIP, DRAWS, INIT_SHA,
+from sm_fs_ranking_pipeline import (ADAM, ANCHOR_W, ARMS, BS, CLIP, DRAWS, INIT_SHA,
                                     RANK_DIR, ROOT, RUN_DIR, SEEDS, STEPS, PipelineError,
-                                    canon, enforce_environment, git_head, install_private,
-                                    lane_clean, need, read_bound, sha_bytes)
+                                    canon, enforce_environment, git_head,
+                                    install_private, lane_clean, load_checkpoint_bytes,
+                                    need, read_bound, resolve_allowlist, sha_bytes)
 
 CODE_FILES = ("sm_fs_ranking_pipeline.py", "sm_fs_ranking_lock_verify.py",
-              "sm_fs_ranking_construct.py", "sm_fs_protocols.py",
+              "sm_fs_sampler.py", "sm_fs_bootstrap.py", "sm_fs_ranking_construct.py",
               "fine_tune_channel_heads.py", "mu_attention.py", "judge_cards.py")
-CAND_SCHEMA = "unifyweaver.sm-fs-ranking-execution-lock.candidate.v2"
-FINAL_SCHEMA = "unifyweaver.sm-fs-ranking-execution-lock.final.v1"
+CAND_SCHEMA = "unifyweaver.sm-fs-ranking-execution-lock.candidate.v3"
+FINAL_SCHEMA = "unifyweaver.sm-fs-ranking-execution-lock.final.v2"
+RECEIPT_SCHEMA = "unifyweaver.sm-fs-ranking-final-verification-receipt.v2"
+
+
+def _trainable_inventory():
+    """Load a real countersigned checkpoint (cpu) and resolve the exact 18 names+shapes."""
+    ckpt_bytes = read_bound(os.path.join(RANK_DIR, f"init_seed{SEEDS[0]}.pt"),
+                            expect_sha=INIT_SHA[SEEDS[0]], private=True,
+                            description="initialized checkpoint")
+    model, _ = load_checkpoint_bytes(ckpt_bytes, "cpu")
+    names, shapes, tensors = resolve_allowlist(model)
+    return shapes
 
 
 def _bindings():
     need(lane_clean(), "tracked prototypes/mu_cosine files dirty — land the commit first "
-                       "(scope: tracked lane files only; untracked and other paths excluded)")
-    man_sha = sha_bytes(read_bound(os.path.join(RANK_DIR, "manifest.json")))
-    titles_path = os.path.join(RUN_DIR, "titles.json")
+                       "(scope: tracked lane files only)")
+    man_bytes = read_bound(os.path.join(RANK_DIR, "manifest.json"))
+    man = json.loads(man_bytes)
+    # manifest-bound data files verified by bytes, not presence (CAND2-5)
+    read_bound(os.path.join(RANK_DIR, "pairs.jsonl"),
+               expect_sha=man["outputs"]["pairs.jsonl"], description="pairs")
+    read_bound(os.path.join(RANK_DIR, "fold_assignment.tsv"),
+               expect_sha=man["outputs"]["fold_assignment.tsv"], description="folds")
+    for s in SEEDS:                                     # init bytes actually read (CAND2-5)
+        read_bound(os.path.join(RANK_DIR, f"init_seed{s}.pt"), expect_sha=INIT_SHA[s],
+                   private=True, description=f"init seed {s}")
+    env = enforce_environment()
     return {
         "git_commit": git_head(),
         "cleanliness_scope": "tracked prototypes/mu_cosine files only",
-        "ranking_bundle_manifest_sha256": man_sha,
+        "ranking_bundle_manifest_sha256": sha_bytes(man_bytes),
         "initialized_checkpoints": {str(s): INIT_SHA[s] for s in SEEDS},
-        "title_table_sha256": sha_bytes(read_bound(titles_path, description="title table")),
+        "title_table_sha256": sha_bytes(read_bound(
+            os.path.join(RUN_DIR, "titles.json"), private=True, description="title table")),
+        "training_plan_sha256": sha_bytes(read_bound(
+            os.path.join(RUN_DIR, "training_plan.json"), private=True,
+            description="training plan")),
         "e5_revision": __import__("mu_attention").E5_REVISION,
         "tokenizer_structure": "mu_attention.Tokenizer(qtbl, ptbl, idx, {}, {}); "
                                "e5 query/passage prefixes; titles-only text",
         "code_sha256": {n: sha_bytes(read_bound(os.path.join(ROOT, n))) for n in CODE_FILES},
         "adam": ADAM, "steps": STEPS, "batch_size": BS, "query_draws": DRAWS,
         "anchor_weight": ANCHOR_W, "grad_clip": CLIP, "early_stopping": False,
-        "trainable_contract": {"tensor_count": 18, "param_count": 1195782,
-                               "assertion": "resolve_allowlist before optimizer construction"},
+        "trainable_names_shapes": _trainable_inventory(),
         "frozen_reference": "copy.deepcopy of exact loaded init, eval, grads off, "
                             "before optimizer creation",
         "augmentation": {"train_rng": "numpy default_rng(seed+1), consumed in row order",
                          "anchor_rows_augmented": False},
         "tie_rule": "ascending-frozen-catalog-column",
-        "bootstrap": BOOT,
-        "schemas": ["unifyweaver.sm-fs-ranking-train-projection.v1",
-                    "unifyweaver.sm-fs-ranking-fit-receipt.v1",
-                    "unifyweaver.sm-fs-ranking-eval-receipt.v1",
-                    "unifyweaver.sm-fs-ranking-decision.v1"],
-        "environment": enforce_environment(),
+        "environment_invariant": env["invariant"],
     }
+
+
+BOUND_KEYS = ("cleanliness_scope", "ranking_bundle_manifest_sha256",
+              "initialized_checkpoints", "title_table_sha256", "training_plan_sha256",
+              "e5_revision", "tokenizer_structure", "code_sha256", "adam", "steps",
+              "batch_size", "query_draws", "anchor_weight", "grad_clip", "early_stopping",
+              "trainable_names_shapes", "frozen_reference", "augmentation", "tie_rule",
+              "environment_invariant")
 
 
 def emit_candidate():
@@ -67,38 +105,71 @@ def emit_candidate():
     lock["schema"] = CAND_SCHEMA
     lock["status"] = "CANDIDATE for independent review; fitting stays blocked"
     lock["fitting_authorized"] = False
+    lock["environment_runtime_descriptive"] = enforce_environment()["runtime"]
     data = canon(lock)
-    out = os.path.join(RUN_DIR, "candidate_lock_v2.json")
+    out = os.path.join(RUN_DIR, "candidate_lock_v3.json")
     install_private(out, data)
-    print(f"candidate v2 -> {out} (sha {sha_bytes(data)[:16]}, "
+    print(f"candidate v3 -> {out} (sha {sha_bytes(data)[:16]}, "
           f"commit {lock['git_commit'][:12]})")
     return out
 
 
 def _verify_common(lock):
     live = _bindings()
-    for key in ("ranking_bundle_manifest_sha256", "initialized_checkpoints",
-                "title_table_sha256", "e5_revision", "code_sha256", "adam", "steps",
-                "batch_size", "query_draws", "anchor_weight", "grad_clip",
-                "trainable_contract", "tie_rule", "bootstrap", "schemas"):
+    for key in BOUND_KEYS:
         need(lock.get(key) == live[key],
              f"lock binding {key!r} does not match recomputed state")
-    need(lock.get("git_commit") == live["git_commit"],
-         "lock was generated from a different commit than the current tree")
 
 
-def verify_candidate_lock(lock, **_):
-    need(lock.get("schema") == CAND_SCHEMA, "not a v2 candidate lock")
+def verify_candidate_lock(lock):
+    need(lock.get("schema") == CAND_SCHEMA, "not a v3 candidate lock")
     need(lock.get("fitting_authorized") is False, "candidate must not authorize fitting")
     _verify_common(lock)
+    need(lock.get("git_commit") == git_head(),
+         "candidate was generated from a different commit than the current tree")
     return True
 
 
-def verify_final_lock(lock, **_):
-    need(lock.get("schema") == FINAL_SCHEMA, "not a final lock")
+def verify_final_lock(lock):
+    need(lock.get("schema") == FINAL_SCHEMA, "not a final.v2 lock")
     need(lock.get("fitting_authorized") is True, "final lock must authorize fitting")
-    _verify_common(lock)
+    cand_path = os.path.join(RUN_DIR, "candidate_lock_v3.json")
+    cand_bytes = read_bound(cand_path, private=True, description="reviewed candidate")
+    need(lock.get("candidate_sha256") == sha_bytes(cand_bytes),
+         "final lock does not bind the reviewed candidate bytes")
+    review_name = lock.get("review_artifact")
+    need(isinstance(review_name, str) and review_name.startswith("SM_FS_")
+         and "/" not in review_name, "final lock must name a committed review artifact")
+    review = json.loads(read_bound(os.path.join(ROOT, review_name),
+                                   description="committed review artifact"))
+    need(review.get("verdict") == "accepted", "committed review verdict is not 'accepted'")
+    need(review.get("candidate_sha256") == lock.get("candidate_sha256"),
+         "committed review does not accept this candidate")
+    need(review.get("review_id") == lock.get("review_id"),
+         "review id mismatch between lock and committed review")
+    _verify_common(lock)                      # only prereg amendments may have intervened
     return True
+
+
+def fitting_allowed(final_lock_path, receipt_path):
+    doc = json.loads(read_bound(os.path.join(ROOT, "SM_FS_LINEAGE_RANKING_PREREG.json"),
+                                description="live preregistration"))
+    need(doc.get("model_fitting_authorized") is True,
+         "live preregistration does not authorize model fitting")
+    lock_bytes = read_bound(final_lock_path, description="final lock")
+    lock = json.loads(lock_bytes)
+    receipt = json.loads(read_bound(receipt_path, description="verification receipt"))
+    need(receipt.get("schema") == RECEIPT_SCHEMA, "receipt schema mismatch")
+    need(receipt.get("final_lock_sha256") == sha_bytes(lock_bytes),
+         "receipt does not bind these exact final-lock bytes")
+    need(receipt.get("review_id") == lock.get("review_id"),
+         "receipt review id mismatch")
+    derived = sha_bytes(canon({k: v for k, v in doc.items() if k != "prereg_id"}))
+    need(lock.get("prereg_id") == doc.get("prereg_id") == receipt.get("prereg_id"),
+         "prereg id mismatch across lock/receipt/live document")
+    need(lock.get("prereg_id_derived") == derived, "lock's derived prereg id is stale")
+    verify_final_lock(lock)
+    return lock, receipt
 
 
 def main(argv=None):

--- a/prototypes/mu_cosine/sm_fs_ranking_pipeline.py
+++ b/prototypes/mu_cosine/sm_fs_ranking_pipeline.py
@@ -1,67 +1,75 @@
 #!/usr/bin/env python3
-"""SM-FS ranking pipeline v2 — complete fit/evaluate/decide, fitting double-locked.
+"""SM-FS ranking pipeline v3 — CAND2-1..8 replacement; fitting double-locked.
 
-Replacement for the rejected candidate 6c4801cf… (REVIEW_sm_fs_ranking_candidate_lock.md).
-Every blocking finding is addressed structurally, not textually:
+Changes from the rejected v2 candidate (REVIEW_sm_fs_ranking_candidate_v2_lock.md):
 
-CAND-1  The full transaction is HERE: project (train-only capability separation), fit (complete
-        optimizer loop), evaluate (held-fold 359-candidate scorer), decide (paired lineage-block
-        bootstrap), each with sealed receipts — landed BEFORE candidate generation.
-CAND-2  `fitting_allowed` is cycle-free and never trusts caller JSON: the LIVE preregistration
-        must say model_fitting_authorized=true, AND an independently emitted verification
-        receipt must bind the exact final-lock SHA, AND every hash the lock binds (plan, code,
-        bundle, initialized bytes) is recomputed from disk. A hand-written lock cannot pass.
-CAND-3  The fitter NEVER receives held associations: `project` (the trusted coordinator) writes
-        a per-fold train-only projection through a private transaction; `fit` refuses any input
-        other than a verified projection; `evaluate` opens held rows only after verifying the
-        sealed fit receipt binds the checkpoint bytes.
-CAND-4  All §4 bindings are enforced fields (title-table/E5/tokenizer hashes, complete Adam
-        options, the exact 18-name allowlist asserted before optimizer construction, frozen-ref
-        rule, augmentation + RNG reset/consumption order, dtype + full runtime provenance,
-        tie rule, schemas, per-job init reuse checks).
-CAND-5  sm_fs_ranking_lock_verify.py provides the candidate/final-lock verifier with tamper
-        rejection; this module calls it, never reimplements it.
-CAND-6  install_private(): same-directory 0600 staging, data fsync, hard-link no-replace
-        install, parent-directory fsync, rollback on failure, post-install mode/nlink/symlink/
-        content verification. read_bound(): descriptor-bound verified bytes (no reopen).
-CAND-7  No `assert` on any critical path (explicit raises survive python -O); subprocess return
-        codes checked; cleanliness scope stated honestly; environment provenance includes
-        python/numpy/torch/CUDA/device/driver/dtype/threads and the RNG reset order.
+CAND2-1  Checkpoints load through the ESTABLISHED path: verified descriptor-bound bytes are
+         staged to a 0600 tempfile and loaded with fine_tune_channel_heads.load_expanded, which
+         accepts the countersigned legacy cfg ({heads, layers, judge_name, ridge, ...}).
+         An executable test loads a real countersigned checkpoint, constructs the optimizer,
+         and runs one fit step.
+CAND2-2  The sampler seam is ID-free (sm_fs_sampler.py); this pipeline imports no module that
+         hard-codes a preregistration ID. `plan` emits the fresh v3 plan: the exact 30-job
+         matrix, ALL FIVE per-fold projection identities, schedule populations, and its own hash.
+CAND2-3  Finalization chain lives in sm_fs_ranking_lock_verify: the final lock must bind the
+         reviewed candidate SHA and the independent review ID from the rigor lane's COMMITTED
+         review artifact — caller-authored JSON cannot substitute.
+CAND2-4  Nothing trusts adjacent self-authored metadata: `fit` authenticates its projection
+         against the PLAN-bound hash; `evaluate` fully validates the fit receipt (schema, job
+         identity, countersigned init hash, plan-bound projection, lock chain, trainable names,
+         environment) and verifies the checkpoint bytes BEFORE any held outcome is opened;
+         `decide` validates every eval receipt (schema, job identity, checkpoint chain, catalog
+         hash, tie rule, finiteness, query uniqueness, exact fold membership, complete
+         361-query population). Eval receipts store the FULL per-candidate score vector plus
+         registered diagnostics (nDCG, AUC, MSE/MAE, per-relation and per-hardness) so no
+         reporting choice survives scoring.
+CAND2-6  Decision inference = sm_fs_bootstrap (frozen SHA-256 rejection sampler, 82 draws per
+         replicate, query-weighted block mean, nearest-rank endpoints 249/9749). Nonfinite
+         scores fail closed at scoring time — a NaN can never rank.
+CAND2-7  install_private: parent-directory mode/owner/symlink checks, unlink-target rollback on
+         post-verify failure, directory fsync after staging cleanup; read_bound(private=True)
+         requires mode 0600.
+CAND2-8  test_sm_fs_ranking_pipeline.py exercises the real loader+optimizer+one-step fit,
+         scoring with NaN rejection, receipt acceptance/rejection, bootstrap known answers, and
+         the decision path.
 
-  python3 sm_fs_ranking_pipeline.py project --fold 0
-  python3 sm_fs_ranking_pipeline.py fit --fold 0 --arm graded_negative --seed 3997001 \
-      --final-lock L --verification-receipt R      # double-locked until reseal steps 4-6
-  python3 sm_fs_ranking_pipeline.py evaluate --fold 0 --arm graded_negative --seed 3997001
-  python3 sm_fs_ranking_pipeline.py decide
+Fitting remains blocked: cmd_fit calls sm_fs_ranking_lock_verify.fitting_allowed, which requires
+the live prereg to authorize fitting AND a final lock bound to the reviewed candidate SHA and
+review ID. No such artifacts exist yet.
 """
 import argparse
 import hashlib
 import json
+import math
 import os
 import platform
 import stat
 import subprocess
 import sys
+import tempfile
 from collections import defaultdict
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 RANK_DIR = os.path.expanduser("~/mu_data/sm_fs_ranking_v1")
-RUN_DIR = os.path.expanduser("~/mu_data/sm_fs_ranking_run_v2")     # NEW namespace (CAND-8)
+RUN_DIR = os.path.expanduser("~/mu_data/sm_fs_ranking_run_v3")     # fresh namespace
 SEEDS = (3997001, 3997002, 3997003)
 ARMS = ("positive_only", "graded_negative")
 STEPS, BS, DRAWS, LR, ANCHOR_W, CLIP = 800, 48, 24, 5e-4, 1.0, 1.0
 ADAM = {"class": "torch.optim.Adam", "lr": LR, "betas": [0.9, 0.999], "eps": 1e-08,
         "weight_decay": 0, "amsgrad": False}
 BUCKET_SLOTS = [("hard", 3), ("medium", 2), ("easy", 1)]
-BOOT = {"resamples": 9999, "seed": 3997999, "confidence": 0.95, "min_blocks": 20}
 INIT_SHA = {
     3997001: "a3bf4c0588cc3e4cf1ad335b66440c113e7ee11fd116bd7307a3cee57447098e",
     3997002: "fb353e693951819683793641464155e144caad73c553039fc64f1c6e253ad796",
     3997003: "f42bdea0071a64dca0dad5312178127906b96215ba6890f6a37ad19d87ffdd5a",
 }
-TRAINABLE_18 = None   # resolved at load: exact ordered (name, shape) list, then frozen
+PLAN_SCHEMA = "unifyweaver.sm-fs-ranking-training-plan.v3"
+PROJ_SCHEMA = "unifyweaver.sm-fs-ranking-train-projection.v1"
+FIT_SCHEMA = "unifyweaver.sm-fs-ranking-fit-receipt.v2"
+EVAL_SCHEMA = "unifyweaver.sm-fs-ranking-eval-receipt.v2"
+DEC_SCHEMA = "unifyweaver.sm-fs-ranking-decision.v2"
 
 
 class PipelineError(RuntimeError):
@@ -82,8 +90,7 @@ def sha_bytes(b):
     return hashlib.sha256(b).hexdigest()
 
 
-def read_bound(path, expect_sha=None, description="input"):
-    """Descriptor-bound read: open once (no-follow), verify identity, return the exact bytes."""
+def read_bound(path, expect_sha=None, description="input", private=False):
     flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:
         fd = os.open(path, flags)
@@ -93,6 +100,9 @@ def read_bound(path, expect_sha=None, description="input"):
         st = os.fstat(fd)
         need(stat.S_ISREG(st.st_mode), f"{description} is not a regular file")
         need(st.st_nlink == 1, f"{description} must have exactly one hard link")
+        if private:
+            need(stat.S_IMODE(st.st_mode) == 0o600, f"{description} is not mode 0600")
+            need(st.st_uid == os.geteuid(), f"{description} is not owned by this user")
         chunks = []
         while True:
             c = os.read(fd, 1 << 20)
@@ -108,42 +118,62 @@ def read_bound(path, expect_sha=None, description="input"):
     return data
 
 
+def _check_parent(d):
+    st = os.lstat(d)
+    need(stat.S_ISDIR(st.st_mode) and not stat.S_ISLNK(st.st_mode),
+         f"parent {d} is not a real directory")
+    need(st.st_uid == os.geteuid(), f"parent {d} not owned by this user")
+    need(stat.S_IMODE(st.st_mode) == 0o700, f"parent {d} is not mode 0700")
+
+
+def _fsync_dir(d):
+    dfd = os.open(d, os.O_RDONLY)
+    try:
+        os.fsync(dfd)
+    finally:
+        os.close(dfd)
+
+
 def install_private(path, data):
-    """Crash-atomic private install: same-dir 0600 stage + fsync, hard-link no-replace,
-    parent fsync, rollback on failure, post-install verification."""
+    """Crash-atomic private install: parent checks, 0600 staging + fsync, hard-link no-replace,
+    dir fsync, staging cleanup + dir fsync, post-install verification with TARGET ROLLBACK."""
     d = os.path.dirname(path)
     os.makedirs(d, mode=0o700, exist_ok=True)
+    _check_parent(d)
     stage = os.path.join(d, f".stage-{os.path.basename(path)}-{os.getpid()}")
     fd = os.open(stage, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    installed = False
     try:
         with os.fdopen(fd, "wb") as f:
             f.write(data)
             f.flush()
             os.fsync(f.fileno())
         try:
-            os.link(stage, path)                       # fails if target exists: no-replace
+            os.link(stage, path)
         except FileExistsError as exc:
             raise PipelineError(f"no-replace target exists: {path}") from exc
-        dfd = os.open(d, os.O_RDONLY)
-        try:
-            os.fsync(dfd)
-        finally:
-            os.close(dfd)
-    finally:
-        try:
-            os.unlink(stage)                           # rollback/cleanup either way
-        except OSError:
-            pass
-    st = os.lstat(path)
-    need(stat.S_ISREG(st.st_mode) and not stat.S_ISLNK(st.st_mode), "installed non-regular file")
-    need(stat.S_IMODE(st.st_mode) == 0o600, "installed mode is not 0600")
-    need(st.st_nlink == 1, "installed link count != 1")
-    read_bound(path, expect_sha=sha_bytes(data), description=f"installed {path}")
-    return sha_bytes(data)
+        installed = True
+        _fsync_dir(d)
+        os.unlink(stage)
+        _fsync_dir(d)                                  # final one-link namespace made durable
+        st = os.lstat(path)
+        need(stat.S_ISREG(st.st_mode), "installed non-regular file")
+        need(stat.S_IMODE(st.st_mode) == 0o600, "installed mode is not 0600")
+        need(st.st_nlink == 1, "installed link count != 1")
+        read_bound(path, expect_sha=sha_bytes(data), private=True,
+                   description=f"installed {path}")
+        return sha_bytes(data)
+    except BaseException:
+        for p in (stage, path if installed else None):
+            if p:
+                try:
+                    os.unlink(p)                       # rollback the partial target too
+                except OSError:
+                    pass
+        raise
 
 
 def enforce_environment():
-    """Set determinism BEFORE any model construction; return OBSERVED provenance (CAND-7)."""
     os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
     import numpy
     import torch
@@ -154,13 +184,9 @@ def enforce_environment():
     torch.backends.cudnn.allow_tf32 = False
     torch.set_float32_matmul_precision("highest")
     torch.set_num_threads(4)
-    torch.set_num_interop_threads(1) if torch.get_num_interop_threads() != 1 else None
-    obs = {
+    invariant = {
         "python": platform.python_version(), "numpy": numpy.__version__,
-        "torch": torch.__version__, "cuda_available": torch.cuda.is_available(),
-        "cuda_version": getattr(torch.version, "cuda", None),
-        "device_name": torch.cuda.get_device_name(0) if torch.cuda.is_available() else None,
-        "driver": None, "dtype": "float32",
+        "torch": torch.__version__, "dtype": "float32",
         "deterministic_algorithms": torch.are_deterministic_algorithms_enabled(),
         "cudnn_deterministic": torch.backends.cudnn.deterministic,
         "cudnn_benchmark": torch.backends.cudnn.benchmark,
@@ -168,25 +194,21 @@ def enforce_environment():
         "tf32_cudnn": torch.backends.cudnn.allow_tf32,
         "matmul_precision": torch.get_float32_matmul_precision(),
         "cublas_workspace": os.environ.get("CUBLAS_WORKSPACE_CONFIG"),
-        "threads": torch.get_num_threads(), "interop_threads": torch.get_num_interop_threads(),
+        "threads": torch.get_num_threads(),
         "rng_reset_order": "torch.manual_seed(seed) once before checkpoint load; "
-                           "numpy default_rng(seed+1) for augmentation, consumed in row order "
-                           "within each step; sampler is counter-based (consumes no RNG)",
+                           "numpy default_rng(seed+1) for augmentation, consumed in row order; "
+                           "training sampler and bootstrap are counter-based (no RNG)",
     }
-    if obs["cuda_available"]:
-        try:
-            smi = subprocess.run(["nvidia-smi", "--query-gpu=driver_version",
-                                  "--format=csv,noheader"], capture_output=True, text=True)
-            need(smi.returncode == 0, "nvidia-smi failed")
-            obs["driver"] = smi.stdout.strip()
-        except FileNotFoundError:
-            obs["driver"] = "unavailable"
+    runtime = {"cuda_available": torch.cuda.is_available(),
+               "cuda_version": getattr(torch.version, "cuda", None),
+               "device_name": (torch.cuda.get_device_name(0)
+                               if torch.cuda.is_available() else None)}
     for key, want in (("deterministic_algorithms", True), ("cudnn_deterministic", True),
                       ("cudnn_benchmark", False), ("tf32_matmul", False),
                       ("tf32_cudnn", False), ("matmul_precision", "highest"),
                       ("cublas_workspace", ":4096:8")):
-        need(obs[key] == want, f"environment {key}={obs[key]!r} != required {want!r}")
-    return obs
+        need(invariant[key] == want, f"environment {key}={invariant[key]!r} != {want!r}")
+    return {"invariant": invariant, "runtime": runtime}
 
 
 def git_head():
@@ -196,7 +218,6 @@ def git_head():
 
 
 def lane_clean():
-    """Honest scope: tracked files under prototypes/mu_cosine only (stated, not implied)."""
     r = subprocess.run(["git", "status", "--porcelain", "--untracked-files=no",
                         "--", "prototypes/mu_cosine"],
                        cwd=os.path.join(ROOT, "..", ".."), capture_output=True, text=True)
@@ -209,72 +230,66 @@ def load_pairs_verified():
                                 description="ranking manifest"))
     data = read_bound(os.path.join(RANK_DIR, "pairs.jsonl"),
                       expect_sha=man["outputs"]["pairs.jsonl"], description="pairs")
-    return man, [json.loads(l) for l in data.decode().splitlines()]
+    folds = read_bound(os.path.join(RANK_DIR, "fold_assignment.tsv"),
+                       expect_sha=man["outputs"]["fold_assignment.tsv"],
+                       description="fold assignment")
+    return man, [json.loads(l) for l in data.decode().splitlines()], folds.decode()
 
 
-def fitting_allowed(final_lock_path, receipt_path):
-    """CAND-2: cycle-free. Requires (a) LIVE prereg authorizes fitting; (b) an independently
-    emitted verification receipt binds the exact final-lock bytes; (c) every hash the lock
-    binds is recomputed from disk. Returns (lock, receipt) or raises."""
-    doc = json.loads(read_bound(os.path.join(ROOT, "SM_FS_LINEAGE_RANKING_PREREG.json"),
-                                description="live preregistration"))
-    need(doc.get("model_fitting_authorized") is True,
-         "live preregistration does not authorize model fitting")
-    lock_bytes = read_bound(final_lock_path, description="final lock")
-    lock = json.loads(lock_bytes)
-    need(lock.get("schema") == "unifyweaver.sm-fs-ranking-execution-lock.final.v1",
-         "lock schema is not final.v1")
-    receipt = json.loads(read_bound(receipt_path, description="verification receipt"))
-    need(receipt.get("schema") == "unifyweaver.sm-fs-ranking-final-verification-receipt.v1",
-         "receipt schema mismatch")
-    need(receipt.get("final_lock_sha256") == sha_bytes(lock_bytes),
-         "receipt does not bind these exact final-lock bytes")
-    need(receipt.get("verifier") not in (None, "", "self"),
-         "receipt must name an independent verifier")
-    derived = sha_bytes(canon({k: v for k, v in doc.items() if k != "prereg_id"}))
-    need(lock.get("prereg_id") == doc.get("prereg_id") == receipt.get("prereg_id"),
-         "prereg id mismatch across lock/receipt/live document")
-    need(lock.get("prereg_id_derived") == derived, "lock's derived prereg id is stale")
-    from sm_fs_ranking_lock_verify import verify_final_lock
-    verify_final_lock(lock, root=ROOT, rank_dir=RANK_DIR, run_dir=RUN_DIR)   # recomputes hashes
-    return lock, receipt
+def load_checkpoint_bytes(ckpt_bytes, dev):
+    """CAND2-1: established loader over verified bytes (0600 tempfile → load_expanded)."""
+    from fine_tune_channel_heads import load_expanded
+    fd, tmp = tempfile.mkstemp(prefix=".ckpt-bound-", suffix=".pt")
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb") as f:
+            f.write(ckpt_bytes)
+        model, cfg = load_expanded(tmp, dev=dev)
+        return model, cfg
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
 
 
 def resolve_allowlist(model):
-    """Exact ordered 18-tensor allowlist; freeze everything, enable exactly these (CAND-4)."""
     names = []
     for prefix in ("judge_name.resid.weight", "corpus_name.resid.weight",
                    "op_name.resid.weight"):
         obj = model
-        ok = True
+        found = True
         for part in prefix.split("."):
             obj = getattr(obj, part, None)
             if obj is None:
-                ok = False
+                found = False
                 break
-        if ok:
+        if found:
             names.append(prefix)
     li = len(model.encoder.layers) - 1
     names += [f"encoder.layers.{li}.{n}" for n, _ in
               model.encoder.layers[li].named_parameters()]
     names += ["readout_w", "readout_b", "nodetype_emb.weight"]
     by_name = dict(model.named_parameters())
-    by_name.update({"readout_w": model.readout_w, "readout_b": model.readout_b})
+    by_name.setdefault("readout_w", model.readout_w)
+    by_name.setdefault("readout_b", model.readout_b)
     need(all(n in by_name for n in names), "allowlist name missing from model")
     need(len(names) == 18, f"allowlist has {len(names)} tensors, requires 18")
     for p in model.parameters():
         p.requires_grad = False
     tensors = []
+    shapes = []
     for n in names:
         by_name[n].requires_grad = True
         tensors.append(by_name[n])
+        shapes.append([n, list(by_name[n].shape)])
     count = sum(p.numel() for p in tensors)
     need(count == 1195782, f"trainable param count {count} != 1195782")
-    return names, tensors
+    return names, shapes, tensors
 
 
 def sample_step(fold, seed, step, train_q, pos, buckets, arm):
-    from sm_fs_protocols import sampler_index
+    from sm_fs_sampler import sampler_index
     common, contrast = [], []
     for draw in range(DRAWS):
         qi, _, _ = sampler_index(len(train_q), fold=fold, seed=seed, step=step,
@@ -305,67 +320,145 @@ def sample_step(fold, seed, step, train_q, pos, buckets, arm):
     return common, contrast
 
 
-def cmd_project(a):
-    """Trusted coordinator (CAND-3): per-fold TRAIN-ONLY projection. Held queries' rows are
-    excluded entirely; the fitter consumes only this artifact."""
-    man, pairs = load_pairs_verified()
-    held_q = {p["query"] for p in pairs if p["fold"] == a.fold}
-    train_rows = [p for p in pairs if p["query"] not in held_q]
-    for p in train_rows:
-        need(p["fold"] != a.fold, "held-fold row leaked into train projection")
+def fit_one_step(model, ref, tensors, opt, tok, rows, sel_common, sel_contrast,
+                 aug_rng, dev):
+    """The exact per-step objective — factored so tests can execute it (CAND2-8)."""
+    import torch
+
+    from fine_tune_channel_heads import mu_batch
+    from mu_attention import CORPORA, JUDGES, NODETYPE, OPS
+    C, J, MM = CORPORA["mindmap"], JUDGES["graph"], NODETYPE["mindmap_node"]
+
+    def items(sel):
+        return [(rows[i]["query"], rows[i]["candidate"], OPS["LINEAGE"], C, J, MM, MM)
+                for i in sel]
+    sel = sel_common + sel_contrast
+    tgt = torch.tensor([rows[i]["target"] for i in sel], dtype=torch.float32, device=dev)
+    mu = mu_batch(model, tok, items(sel), dev, train=True, rng=aug_rng)
+    loss = torch.mean((mu - tgt) ** 2)
+    ag = [(it[0], it[1], it[2]) for it in items(sel_common)]
+    mu_ag = mu_batch(model, tok, ag, dev)
+    with torch.no_grad():
+        mu_ref = mu_batch(ref, tok, ag, dev)
+    loss = loss + ANCHOR_W * torch.mean((mu_ag - mu_ref) ** 2)
+    opt.zero_grad()
+    loss.backward()
+    torch.nn.utils.clip_grad_norm_(tensors, CLIP)
+    opt.step()
+    return float(loss.detach().cpu())
+
+
+def score_catalog(mu_scores, catalog, dest_index):
+    """Frozen tie rule with fail-closed finiteness (CAND2-6): any nonfinite score aborts."""
+    for j, v in enumerate(mu_scores):
+        need(math.isfinite(v), f"nonfinite score at catalog column {j}")
+    d = mu_scores[dest_index]
+    rank = 1
+    for j, v in enumerate(mu_scores):
+        if v > d or (v == d and j < dest_index):
+            rank += 1
+    return rank
+
+
+def plan_projection_identity(pairs, fold):
+    held_q = sorted({p["query"] for p in pairs if p["fold"] == fold})
+    train_rows = [p for p in pairs if p["query"] not in set(held_q)]
     payload = b"".join(canon(p) for p in train_rows)
-    out = os.path.join(RUN_DIR, f"fold{a.fold}", "train_projection.jsonl")
-    sha = install_private(out, payload)
-    meta = {"schema": "unifyweaver.sm-fs-ranking-train-projection.v1", "fold": a.fold,
-            "rows": len(train_rows), "held_queries_excluded": len(held_q),
-            "projection_sha256": sha,
-            "source_manifest_sha256": sha_bytes(read_bound(
-                os.path.join(RANK_DIR, "manifest.json"))),
-            "capability_note": "held query-to-destination associations are ABSENT from this "
-                               "artifact; the fitter receives nothing else"}
-    install_private(os.path.join(RUN_DIR, f"fold{a.fold}", "train_projection.meta.json"),
-                    canon(meta))
-    print(f"fold {a.fold}: train projection {len(train_rows)} rows "
-          f"({len(held_q)} held queries excluded) sha {sha[:16]}")
+    return held_q, train_rows, sha_bytes(payload), payload
+
+
+def cmd_plan(a):
+    man, pairs, fold_txt = load_pairs_verified()
+    projections = {}
+    for f in range(5):
+        held_q, train_rows, proj_sha, payload = plan_projection_identity(pairs, f)
+        out = os.path.join(RUN_DIR, f"fold{f}", "train_projection.jsonl")
+        if not os.path.exists(out):
+            install_private(out, payload)
+        else:
+            read_bound(out, expect_sha=proj_sha, private=True,
+                       description=f"existing fold{f} projection")
+        pos_counts = defaultdict(int)
+        bucket_counts = defaultdict(lambda: defaultdict(int))
+        for p in train_rows:
+            if p["class"].startswith("positive"):
+                pos_counts[p["query"]] += 1
+            else:
+                bucket_counts[p["query"]][p["hardness"]] += 1
+        projections[str(f)] = {
+            "projection_sha256": proj_sha, "rows": len(train_rows),
+            "held_queries": len(held_q),
+            "train_query_list_sha256": sha_bytes("\n".join(sorted(pos_counts)).encode()),
+            "population_sha256": sha_bytes(canon(
+                {q: {"positives": pos_counts[q],
+                     "buckets": dict(sorted(bucket_counts[q].items()))}
+                 for q in sorted(pos_counts)})),
+        }
+    plan = {
+        "schema": PLAN_SCHEMA,
+        "bundle_manifest_sha256": sha_bytes(read_bound(
+            os.path.join(RANK_DIR, "manifest.json"))),
+        "jobs": [{"fold": f, "arm": arm, "seed": s}
+                 for f in range(5) for s in SEEDS for arm in ARMS],
+        "job_count": 30, "steps": STEPS, "batch_size": BS, "query_draws_per_step": DRAWS,
+        "adam": ADAM, "anchor_weight": ANCHOR_W, "grad_clip": CLIP, "early_stopping": False,
+        "projections": projections,
+        "sampler_module_sha256": sha_bytes(read_bound(
+            os.path.join(ROOT, "sm_fs_sampler.py"))),
+        "bootstrap_module_sha256": sha_bytes(read_bound(
+            os.path.join(ROOT, "sm_fs_bootstrap.py"))),
+        "initialized_checkpoints": {str(s): INIT_SHA[s] for s in SEEDS},
+        "receipt_schemas": [PROJ_SCHEMA, FIT_SCHEMA, EVAL_SCHEMA, DEC_SCHEMA],
+        "fitting_authorized": False,
+    }
+    data = canon(plan)
+    out = os.path.join(RUN_DIR, "training_plan.json")
+    if os.path.exists(out):
+        need(read_bound(out, private=True) == data,
+             "training_plan.json exists and differs — no-replace contract")
+        print(f"plan unchanged -> {out}")
+    else:
+        install_private(out, data)
+        print(f"plan v3 -> {out} (sha {sha_bytes(data)[:16]}, 30 jobs, all 5 projections)")
+
+
+def _load_plan():
+    return json.loads(read_bound(os.path.join(RUN_DIR, "training_plan.json"),
+                                 private=True, description="training plan"))
 
 
 def cmd_fit(a):
-    lock, receipt = fitting_allowed(a.final_lock, a.verification_receipt)   # raises when blocked
-    obs = enforce_environment()
+    from sm_fs_ranking_lock_verify import fitting_allowed
+    lock, receipt = fitting_allowed(a.final_lock, a.verification_receipt)   # raises today
+    env = enforce_environment()
     import copy
 
     import numpy as np
     import torch
 
-    from fine_tune_channel_heads import mu_batch
-    from mu_attention import CORPORA, E5_REVISION, JUDGES, NODETYPE, OPS, Tokenizer, \
-        build_e5_tables
-    meta = json.loads(read_bound(
-        os.path.join(RUN_DIR, f"fold{a.fold}", "train_projection.meta.json"),
-        description="projection meta"))
+    from mu_attention import E5_REVISION, Tokenizer, build_e5_tables
+    plan = _load_plan()
+    proj = plan["projections"][str(a.fold)]
     rows_bytes = read_bound(os.path.join(RUN_DIR, f"fold{a.fold}", "train_projection.jsonl"),
-                            expect_sha=meta["projection_sha256"],
-                            description="train projection")
+                            expect_sha=proj["projection_sha256"], private=True,
+                            description="plan-bound train projection")
     rows = [json.loads(l) for l in rows_bytes.decode().splitlines()]
-    titles = json.loads(read_bound(os.path.join(RUN_DIR, "titles.json"),
+    for p in rows:
+        need(p["fold"] != a.fold, "held-fold row inside plan-bound projection")
+    titles = json.loads(read_bound(os.path.join(RUN_DIR, "titles.json"), private=True,
                                    description="title table"))
     torch.manual_seed(a.seed)
     aug_rng = np.random.default_rng(a.seed + 1)
-    ckpt_path = os.path.join(RANK_DIR, f"init_seed{a.seed}.pt")
-    ckpt_bytes = read_bound(ckpt_path, expect_sha=INIT_SHA[a.seed],
+    ckpt_bytes = read_bound(os.path.join(RANK_DIR, f"init_seed{a.seed}.pt"),
+                            expect_sha=INIT_SHA[a.seed], private=True,
                             description="initialized checkpoint")
-    import io
-    blob = torch.load(io.BytesIO(ckpt_bytes), map_location="cpu", weights_only=False)
-    from mu_attention import MuAttention  # constructed from cfg then loaded from exact bytes
-    model = MuAttention(**blob["cfg"])
-    model.load_state_dict(blob["state"])
     dev = "cuda" if torch.cuda.is_available() else "cpu"
-    model = model.to(dev)
+    model, cfg = load_checkpoint_bytes(ckpt_bytes, dev)
     ref = copy.deepcopy(model)
     ref.eval()
     for p in ref.parameters():
         p.requires_grad = False
-    names, tensors = resolve_allowlist(model)
+    names, shapes, tensors = resolve_allowlist(model)
     opt = torch.optim.Adam(tensors, lr=ADAM["lr"], betas=tuple(ADAM["betas"]),
                            eps=ADAM["eps"], weight_decay=ADAM["weight_decay"],
                            amsgrad=ADAM["amsgrad"])
@@ -377,78 +470,80 @@ def cmd_fit(a):
         (pos[p["query"]].append(i) if p["class"].startswith("positive")
          else buckets[p["query"]][p["hardness"]].append(i))
     train_q = sorted(pos)
-    C, J, MM = CORPORA["mindmap"], JUDGES["graph"], NODETYPE["mindmap_node"]
-
-    def items_of(sel):
-        return [(rows[i]["query"], rows[i]["candidate"], OPS["LINEAGE"], C, J, MM, MM)
-                for i in sel]
     model.train()
+    losses = []
     for step in range(STEPS):
-        common, contrast = sample_step(a.fold, a.seed, step, train_q, pos, buckets, a.arm)
-        sel = common + contrast
-        tgt = torch.tensor([rows[i]["target"] for i in sel], dtype=torch.float32, device=dev)
-        mu = mu_batch(model, tok, items_of(sel), dev, train=True, rng=aug_rng)
-        loss = torch.mean((mu - tgt) ** 2)
-        ag = [(it[0], it[1], it[2]) for it in items_of(common)]
-        mu_ag = mu_batch(model, tok, ag, dev)
-        with torch.no_grad():
-            mu_ref = mu_batch(ref, tok, ag, dev)
-        loss = loss + ANCHOR_W * torch.mean((mu_ag - mu_ref) ** 2)
-        opt.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(tensors, CLIP)
-        opt.step()
+        c, k = sample_step(a.fold, a.seed, step, train_q, pos, buckets, a.arm)
+        losses.append(fit_one_step(model, ref, tensors, opt, tok, rows, c, k, aug_rng, dev))
     model.eval()
+    import io
     buf = io.BytesIO()
-    torch.save({"state": model.state_dict(), "cfg": blob["cfg"]}, buf)
+    torch.save({"state": model.state_dict(), "cfg": cfg}, buf)
     out_dir = os.path.join(RUN_DIR, f"fold{a.fold}")
     ck_sha = install_private(os.path.join(out_dir, f"fit_{a.arm}_{a.seed}.pt"), buf.getvalue())
     fit_receipt = {
-        "schema": "unifyweaver.sm-fs-ranking-fit-receipt.v1",
-        "fold": a.fold, "arm": a.arm, "seed": a.seed,
+        "schema": FIT_SCHEMA, "fold": a.fold, "arm": a.arm, "seed": a.seed,
         "init_sha256": INIT_SHA[a.seed], "checkpoint_sha256": ck_sha,
-        "projection_sha256": meta["projection_sha256"],
+        "projection_sha256": proj["projection_sha256"],
+        "plan_sha256": sha_bytes(read_bound(os.path.join(RUN_DIR, "training_plan.json"),
+                                            private=True)),
         "final_lock_sha256": receipt["final_lock_sha256"],
         "steps": STEPS, "batch_size": BS, "adam": ADAM, "anchor_weight": ANCHOR_W,
-        "grad_clip": CLIP, "trainable_names": names, "environment": obs,
-        "git_commit": git_head(),
+        "grad_clip": CLIP, "trainable_names_shapes": shapes,
+        "loss_first_last": [losses[0], losses[-1]],
+        "environment": env, "git_commit": git_head(),
     }
     install_private(os.path.join(out_dir, f"fit_{a.arm}_{a.seed}.receipt.json"),
                     canon(fit_receipt))
     print(f"sealed fit fold={a.fold} arm={a.arm} seed={a.seed} ckpt {ck_sha[:16]}")
 
 
-def cmd_evaluate(a):
-    """Held rows open ONLY after the sealed fit receipt verifies (CAND-3)."""
-    out_dir = os.path.join(RUN_DIR, f"fold{a.fold}")
-    receipt = json.loads(read_bound(
-        os.path.join(out_dir, f"fit_{a.arm}_{a.seed}.receipt.json"),
-        description="fit receipt"))
-    ck_bytes = read_bound(os.path.join(out_dir, f"fit_{a.arm}_{a.seed}.pt"),
-                          expect_sha=receipt["checkpoint_sha256"],
-                          description="sealed checkpoint")
-    obs = enforce_environment()
-    import io
+def validate_fit_receipt(rec, fold, arm, seed, plan):
+    need(rec.get("schema") == FIT_SCHEMA, "fit receipt schema mismatch")
+    need((rec.get("fold"), rec.get("arm"), rec.get("seed")) == (fold, arm, seed),
+         "fit receipt job identity mismatch")
+    need(rec.get("init_sha256") == INIT_SHA[seed],
+         "fit receipt init hash is not the countersigned checkpoint")
+    need(rec.get("projection_sha256")
+         == plan["projections"][str(fold)]["projection_sha256"],
+         "fit receipt projection is not the plan-bound projection")
+    need(isinstance(rec.get("trainable_names_shapes"), list)
+         and len(rec["trainable_names_shapes"]) == 18, "fit receipt trainable inventory")
+    need(isinstance(rec.get("environment"), dict)
+         and rec["environment"].get("invariant", {}).get("dtype") == "float32",
+         "fit receipt environment missing")
+    need(isinstance(rec.get("checkpoint_sha256"), str)
+         and len(rec["checkpoint_sha256"]) == 64, "fit receipt checkpoint hash malformed")
 
+
+def cmd_evaluate(a):
+    plan = _load_plan()
+    out_dir = os.path.join(RUN_DIR, f"fold{a.fold}")
+    rec = json.loads(read_bound(
+        os.path.join(out_dir, f"fit_{a.arm}_{a.seed}.receipt.json"), private=True,
+        description="fit receipt"))
+    validate_fit_receipt(rec, a.fold, a.arm, a.seed, plan)          # BEFORE held bytes
+    ck_bytes = read_bound(os.path.join(out_dir, f"fit_{a.arm}_{a.seed}.pt"),
+                          expect_sha=rec["checkpoint_sha256"], private=True,
+                          description="sealed checkpoint")
+    env = enforce_environment()
     import numpy as np
     import torch
 
     from fine_tune_channel_heads import mu_batch
-    from mu_attention import CORPORA, E5_REVISION, JUDGES, MuAttention, NODETYPE, OPS, \
-        Tokenizer, build_e5_tables
-    man, pairs = load_pairs_verified()
+    from mu_attention import CORPORA, E5_REVISION, JUDGES, NODETYPE, OPS, Tokenizer, \
+        build_e5_tables
+    dev = "cuda" if torch.cuda.is_available() else "cpu"
+    model, _ = load_checkpoint_bytes(ck_bytes, dev)                 # checkpoint verified first
+    model.eval()
+    man, pairs, _ = load_pairs_verified()                           # held bytes open ONLY now
     catalog = sorted({p["candidate"] for p in pairs})
+    catalog_sha = sha_bytes("\n".join(catalog).encode())
     held = defaultdict(dict)
     for p in pairs:
         if p["fold"] == a.fold:
             held[p["query"]][p["candidate"]] = p
-    titles = json.loads(read_bound(os.path.join(RUN_DIR, "titles.json"),
-                                   description="title table"))
-    blob = torch.load(io.BytesIO(ck_bytes), map_location="cpu", weights_only=False)
-    model = MuAttention(**blob["cfg"])
-    model.load_state_dict(blob["state"])
-    dev = "cuda" if torch.cuda.is_available() else "cpu"
-    model = model.to(dev).eval()
+    titles = json.loads(read_bound(os.path.join(RUN_DIR, "titles.json"), private=True))
     qtbl, ptbl, idx = build_e5_tables(sorted(titles), cache_path=None, texts=titles,
                                       model_revision=E5_REVISION)
     tok = Tokenizer(qtbl, ptbl, idx, {}, {})
@@ -457,88 +552,106 @@ def cmd_evaluate(a):
     with torch.no_grad():
         for q in sorted(held):
             items = [(q, c, OPS["LINEAGE"], C, J, MM, MM) for c in catalog]
-            mu = np.array(mu_batch(model, tok, items, dev).cpu())
+            mu = [float(v) for v in mu_batch(model, tok, items, dev).cpu()]
             dest = next(c for c, p in held[q].items() if p["class"] == "positive_parent")
             di = catalog.index(dest)
-            # tie rule: exact ties break by ascending frozen catalog column
-            rank = 1 + int(np.sum(mu > mu[di])) + int(
-                np.sum((mu == mu[di]) & (np.arange(len(catalog)) < di)))
+            rank = score_catalog(mu, catalog, di)                   # fail-closed nonfinite
+            errs = [(mu[catalog.index(c)], p["target"], p.get("relation"),
+                     p.get("hardness")) for c, p in held[q].items()]
+            mse = sum((m - t) ** 2 for m, t, _, _ in errs) / len(errs)
+            mae = sum(abs(m - t) for m, t, _, _ in errs) / len(errs)
+            pos_set = {c for c, p in held[q].items() if p["class"].startswith("positive")}
+            pos_scores = [mu[catalog.index(c)] for c in pos_set]
+            neg_scores = [mu[catalog.index(c)] for c in held[q] if c not in pos_set]
+            wins = sum(1 for ps in pos_scores for ns in neg_scores if ps > ns)
+            ties = sum(1 for ps in pos_scores for ns in neg_scores if ps == ns)
+            auc = ((wins + 0.5 * ties) / (len(pos_scores) * len(neg_scores))
+                   if pos_scores and neg_scores else None)
+            order = sorted(range(len(catalog)), key=lambda j: (-mu[j], j))
+            dcg = sum(held[q].get(catalog[j], {}).get("target", 0.0)
+                      / math.log2(r + 2) for r, j in enumerate(order[:10]))
+            ideal = sorted((p["target"] for p in held[q].values()), reverse=True)[:10]
+            idcg = sum(t / math.log2(r + 2) for r, t in enumerate(ideal))
             out_rows.append({"query": q, "destination": dest, "rank": rank,
-                             "rr": 1.0 / rank})
-    pred = {"schema": "unifyweaver.sm-fs-ranking-eval-receipt.v1",
-            "fold": a.fold, "arm": a.arm, "seed": a.seed,
-            "checkpoint_sha256": receipt["checkpoint_sha256"],
-            "catalog_size": len(catalog), "tie_rule": "ascending-frozen-catalog-column",
-            "rows": out_rows, "environment": obs, "git_commit": git_head()}
+                             "rr": 1.0 / rank, "scores": mu, "mse": mse, "mae": mae,
+                             "auc": auc, "ndcg10": (dcg / idcg if idcg else None)})
+    pred = {"schema": EVAL_SCHEMA, "fold": a.fold, "arm": a.arm, "seed": a.seed,
+            "checkpoint_sha256": rec["checkpoint_sha256"],
+            "fit_receipt_sha256": sha_bytes(canon(rec)),
+            "catalog_sha256": catalog_sha, "catalog_size": len(catalog),
+            "tie_rule": "ascending-frozen-catalog-column", "rows": out_rows,
+            "held_query_count": len(out_rows), "environment": env,
+            "git_commit": git_head()}
     install_private(os.path.join(out_dir, f"eval_{a.arm}_{a.seed}.receipt.json"), canon(pred))
-    print(f"sealed eval fold={a.fold} arm={a.arm} seed={a.seed} "
-          f"MRR {sum(r['rr'] for r in out_rows)/len(out_rows):.4f} n={len(out_rows)}")
+    mrr = sum(r["rr"] for r in out_rows) / len(out_rows)
+    print(f"sealed eval fold={a.fold} arm={a.arm} seed={a.seed} MRR {mrr:.4f} n={len(out_rows)}")
 
 
 def cmd_decide(a):
-    import numpy as np
-    man, pairs = load_pairs_verified()
-    block_of = {}
-    fold_of = {}
-    for p in pairs:
-        fold_of[p["query"]] = p["fold"]
-    rr = {arm: defaultdict(list) for arm in ARMS}
+    from sm_fs_bootstrap import decide as boot_decide
+    plan = _load_plan()
+    man, pairs, fold_txt = load_pairs_verified()
+    catalog = sorted({p["candidate"] for p in pairs})
+    catalog_sha = sha_bytes("\n".join(catalog).encode())
+    fold_of = {p["query"]: p["fold"] for p in pairs}
+    dest_of = {p["query"]: p["candidate"] for p in pairs if p["class"] == "positive_parent"}
+    rr = {arm: defaultdict(dict) for arm in ARMS}
+    per_seed_mrr = defaultdict(dict)
     for f in range(5):
         for arm in ARMS:
             for seed in SEEDS:
                 rec = json.loads(read_bound(
                     os.path.join(RUN_DIR, f"fold{f}", f"eval_{arm}_{seed}.receipt.json"),
-                    description="eval receipt"))
-                for r in rec["rows"]:
-                    rr[arm][r["query"]].append(r["rr"])
-    queries = sorted(rr["positive_only"])
-    need(queries == sorted(rr["graded_negative"]), "arm query sets differ")
-    d = {}
-    for q in queries:
-        need(len(rr["positive_only"][q]) == 3 and len(rr["graded_negative"][q]) == 3,
-             f"query {q} lacks 3 seeds per arm")
-        d[q] = (sum(rr["graded_negative"][q]) - sum(rr["positive_only"][q])) / 3.0
-    fold_lines = read_bound(os.path.join(RANK_DIR, "fold_assignment.tsv"),
-                            description="fold assignment").decode().splitlines()
-    qb = {}
-    for p in pairs:
-        qb.setdefault(p["query"], None)
-    # adaptive lineage blocks: reuse the frozen fold file's block column via query dest prefix
-    dest_of = {p["query"]: p["candidate"] for p in pairs if p["class"] == "positive_parent"}
-    block_map = {}
-    blocks = [ln.split("\t")[0] for ln in fold_lines]
-    for q, dst in dest_of.items():
-        cands = [b for b in blocks if dst == b or dst.startswith(b + "/")]
-        need(bool(cands), f"no block for {q}")
-        block_map[q] = max(cands, key=len)
-    by_block = defaultdict(list)
-    for q in queries:
-        by_block[block_map[q]].append(d[q])
-    bl = sorted(by_block)
-    need(len(bl) >= BOOT["min_blocks"], f"only {len(bl)} blocks (<{BOOT['min_blocks']})")
-    rng = np.random.default_rng(BOOT["seed"])
-    point = float(np.mean([v for q in queries for v in [d[q]]]))
-    stats = []
-    for _ in range(BOOT["resamples"]):
-        pick = rng.integers(0, len(bl), len(bl))
-        vals = [v for i in pick for v in by_block[bl[i]]]
-        stats.append(float(np.mean(vals)))
-    lo, hi = np.percentile(stats, [2.5, 97.5])
-    passed = bool(point >= 0.010 and lo > 0.0)
-    out = {"schema": "unifyweaver.sm-fs-ranking-decision.v1",
-           "delta_mrr": point, "ci95": [float(lo), float(hi)], "blocks": len(bl),
-           "bootstrap": BOOT, "passed_exploratory_gate": passed,
-           "authorizes": "new-reserve-preregistration-only" if passed else "nothing",
-           "git_commit": git_head()}
-    install_private(os.path.join(RUN_DIR, "decision.json"), canon(out))
-    print(json.dumps(out, indent=1))
+                    private=True, description="eval receipt"))
+                need(rec.get("schema") == EVAL_SCHEMA, "eval receipt schema")
+                need((rec["fold"], rec["arm"], rec["seed"]) == (f, arm, seed),
+                     "eval receipt job identity mismatch")
+                need(rec.get("catalog_sha256") == catalog_sha, "eval catalog mismatch")
+                need(rec.get("tie_rule") == "ascending-frozen-catalog-column", "tie rule")
+                seen = set()
+                for row in rec["rows"]:
+                    q = row["query"]
+                    need(q not in seen, f"duplicate query {q} in receipt")
+                    seen.add(q)
+                    need(fold_of.get(q) == f, f"query {q} not in fold {f}")
+                    need(math.isfinite(row["rr"]) and 0 < row["rr"] <= 1, "rr out of range")
+                    rr[arm].setdefault(q, {})[seed] = row["rr"]
+                per_seed_mrr[arm][(f, seed)] = (
+                    sum(r["rr"] for r in rec["rows"]) / len(rec["rows"]))
+    all_held = {q for q, f in fold_of.items()}
+    for arm in ARMS:
+        need(sorted(rr[arm]) == sorted(all_held),
+             f"{arm} evaluated {len(rr[arm])} queries; population requires {len(all_held)}")
+        for q, by_seed in rr[arm].items():
+            need(sorted(by_seed) == sorted(SEEDS), f"query {q} lacks all 3 seeds ({arm})")
+    d = {q: (sum(rr["graded_negative"][q].values()) / 3.0
+             - sum(rr["positive_only"][q].values()) / 3.0) for q in sorted(all_held)}
+    blocks = [ln.split("\t")[0] for ln in fold_txt.splitlines()]
+    block_values = {b: [] for b in blocks}
+    for q, val in d.items():
+        cands = [b for b in blocks if dest_of[q] == b or dest_of[q].startswith(b + "/")]
+        need(bool(cands), f"no lineage block for {q}")
+        block_values[max(cands, key=len)].append(val)
+    result = boot_decide(block_values)
+    result.update({
+        "schema": DEC_SCHEMA, "catalog_sha256": catalog_sha,
+        "unique_destinations": len(set(dest_of[q] for q in all_held)),
+        "per_seed_mrr": {arm: {f"fold{f}/seed{s}": per_seed_mrr[arm][(f, s)]
+                               for f in range(5) for s in SEEDS} for arm in ARMS},
+        "plan_sha256": sha_bytes(canon(plan)),
+        "authorizes": ("new-reserve-preregistration-only"
+                       if result["passed_exploratory_gate"] else "nothing"),
+        "git_commit": git_head(),
+    })
+    install_private(os.path.join(RUN_DIR, "decision.json"), canon(result))
+    print(json.dumps({k: result[k] for k in
+                      ("delta_mrr", "ci95", "passed_exploratory_gate", "authorizes")}, indent=1))
 
 
 def main(argv=None):
     ap = argparse.ArgumentParser()
     sub = ap.add_subparsers(dest="cmd", required=True)
-    p = sub.add_parser("project")
-    p.add_argument("--fold", type=int, required=True)
+    sub.add_parser("plan")
     f = sub.add_parser("fit")
     f.add_argument("--fold", type=int, required=True)
     f.add_argument("--arm", choices=ARMS, required=True)
@@ -551,7 +664,7 @@ def main(argv=None):
     e.add_argument("--seed", type=int, required=True, choices=SEEDS)
     sub.add_parser("decide")
     a = ap.parse_args(argv)
-    return {"project": cmd_project, "fit": cmd_fit,
+    return {"plan": cmd_plan, "fit": cmd_fit,
             "evaluate": cmd_evaluate, "decide": cmd_decide}[a.cmd](a)
 
 

--- a/prototypes/mu_cosine/sm_fs_sampler.py
+++ b/prototypes/mu_cosine/sm_fs_sampler.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""ID-free training-sampler seam (CAND2-2).
+
+Byte-identical re-export of the frozen counter-based ranking sampler, importable WITHOUT binding
+any preregistration ID: candidate locks bind THIS file's hash, so a step-4 prereg amendment that
+changes sm_fs_protocols.py's hard-coded document IDs cannot invalidate the reviewed sampler.
+The algorithm, key schema, sampler ID, and KAVs are unchanged from sm_fs_protocols
+(`sm-fs-ranking-sampler-v1`, `unifyweaver.sm-fs-ranking-sampler-key.v1`).
+"""
+import hashlib
+import json
+
+SAMPLER_ID = "sm-fs-ranking-sampler-v1"
+KEY_SCHEMA = "unifyweaver.sm-fs-ranking-sampler-key.v1"
+ROLES = ("query", "common-positive", "contrast-positive",
+         "negative-bucket", "negative-candidate")
+
+
+class SamplerError(ValueError):
+    pass
+
+
+def _need(c, m):
+    if not c:
+        raise SamplerError(m)
+
+
+def canonical_json_bytes(value):
+    return (json.dumps(value, ensure_ascii=False, sort_keys=True,
+                       separators=(",", ":"), allow_nan=False) + "\n").encode("utf-8")
+
+
+def sampler_key_bytes(*, fold, seed, step, draw, role, query_id="", bucket="", retry=0):
+    for v, n in ((fold, "fold"), (seed, "seed"), (step, "step"),
+                 (draw, "draw"), (retry, "retry")):
+        _need(type(v) is int and v >= 0, f"sampler {n} must be a nonnegative integer")
+    _need(role in ROLES, "unknown sampler role")
+    _need(isinstance(query_id, str) and isinstance(bucket, str), "key fields must be strings")
+    _need(role != "query" or (query_id == "" and bucket == ""),
+          "query draw must not bind a selected query or bucket")
+    _need(role == "query" or query_id != "", "post-query draw must bind the selected query")
+    _need(role == "negative-candidate" or bucket == "",
+          "only a negative-candidate draw may bind a bucket")
+    _need(role != "negative-candidate" or bucket in {"hard", "medium", "easy"},
+          "negative-candidate draw must bind its bucket")
+    return canonical_json_bytes({
+        "bucket": bucket, "draw": draw, "fold": fold, "query_id": query_id,
+        "retry": retry, "role": role, "sampler_id": SAMPLER_ID,
+        "schema": KEY_SCHEMA, "seed": seed, "step": step,
+    })
+
+
+def sampler_index(n, *, fold, seed, step, draw, role, query_id="", bucket=""):
+    _need(type(n) is int and n > 0, "sampler population must be positive")
+    modulus = 1 << 256
+    limit = (modulus // n) * n
+    retry = 0
+    while True:
+        digest = hashlib.sha256(sampler_key_bytes(
+            fold=fold, seed=seed, step=step, draw=draw, role=role,
+            query_id=query_id, bucket=bucket, retry=retry)).digest()
+        value = int.from_bytes(digest, "big", signed=False)
+        if value < limit:
+            return value % n, digest.hex(), retry
+        retry += 1

--- a/prototypes/mu_cosine/test_sm_fs_ranking_pipeline.py
+++ b/prototypes/mu_cosine/test_sm_fs_ranking_pipeline.py
@@ -1,5 +1,7 @@
-"""CAND-2/3/6 replacement tests: gate, capability separation, transactions."""
+"""CAND2-8 executable tests: real loader+optimizer+one fit step, scoring, receipts,
+bootstrap KAVs, decision path, transactions."""
 import json
+import math
 import os
 
 import pytest
@@ -7,52 +9,110 @@ import pytest
 import sm_fs_ranking_pipeline as pl
 
 
-def test_install_private_no_replace_and_verification(tmp_path):
-    p = str(tmp_path / "a.json")
+def test_install_private_no_replace_rollback_and_parent_checks(tmp_path):
+    base = tmp_path / "run"
+    p = str(base / "a.json")
     pl.install_private(p, b"one\n")
     with pytest.raises(pl.PipelineError, match="no-replace"):
         pl.install_private(p, b"two\n")
     st = os.lstat(p)
     assert oct(st.st_mode & 0o777) == "0o600" and st.st_nlink == 1
-    assert not list(tmp_path.glob(".stage-*"))            # rollback/cleanup ran
+    assert not list(base.glob(".stage-*"))
+    os.chmod(base, 0o755)                                   # parent must be 0700
+    with pytest.raises(pl.PipelineError, match="0700"):
+        pl.install_private(str(base / "b.json"), b"x")
+    os.chmod(base, 0o700)
 
 
-def test_read_bound_rejects_tamper_and_symlink(tmp_path):
+def test_read_bound_private_mode_and_tamper(tmp_path):
     p = tmp_path / "x"
     p.write_bytes(b"data")
-    good = pl.sha_bytes(b"data")
-    assert pl.read_bound(str(p), expect_sha=good) == b"data"
+    os.chmod(p, 0o644)
+    with pytest.raises(pl.PipelineError, match="0600"):
+        pl.read_bound(str(p), private=True)
+    os.chmod(p, 0o600)
+    assert pl.read_bound(str(p), private=True) == b"data"
     with pytest.raises(pl.PipelineError, match="sha"):
         pl.read_bound(str(p), expect_sha="0" * 64)
-    ln = tmp_path / "link"
-    ln.symlink_to(p)
-    with pytest.raises(pl.PipelineError, match="unavailable"):
-        pl.read_bound(str(ln))                            # O_NOFOLLOW refuses symlinks
 
 
-def test_fitting_gate_rejects_hand_written_lock(tmp_path):
-    # live prereg says model_fitting_authorized=false -> gate refuses BEFORE looking at the lock
-    lock = tmp_path / "lock.json"
-    lock.write_bytes(b"{}")
-    rcpt = tmp_path / "r.json"
-    rcpt.write_bytes(b"{}")
-    with pytest.raises(pl.PipelineError, match="does not authorize model fitting"):
-        pl.fitting_allowed(str(lock), str(rcpt))
+def test_score_catalog_frozen_tie_rule_and_nan_fail_closed():
+    assert pl.score_catalog([0.5, 0.9, 0.9, 0.1], ["a", "b", "c", "d"], 2) == 2
+    assert pl.score_catalog([0.5, 0.9, 0.9, 0.1], ["a", "b", "c", "d"], 1) == 1
+    with pytest.raises(pl.PipelineError, match="nonfinite"):
+        pl.score_catalog([0.5, float("nan"), 0.2], ["a", "b", "c"], 0)
+    with pytest.raises(pl.PipelineError, match="nonfinite"):
+        pl.score_catalog([0.5, 0.2, float("inf")], ["a", "b", "c"], 2)
 
 
-def test_projection_excludes_held_associations(tmp_path, monkeypatch):
-    pairs = [
-        {"query": "q1", "candidate": "c", "class": "positive_parent", "fold": 0, "target": 1.0},
-        {"query": "q2", "candidate": "c", "class": "positive_parent", "fold": 1, "target": 1.0},
-        {"query": "q2", "candidate": "d", "class": "structural_nonancestor", "fold": 1,
-         "hardness": "easy", "target": 0.02},
-    ]
-    monkeypatch.setattr(pl, "load_pairs_verified", lambda: ({}, pairs))
-    monkeypatch.setattr(pl, "RUN_DIR", str(tmp_path))
-    class A: fold = 0
-    pl.cmd_project(A)
-    rows = [json.loads(l) for l in open(tmp_path / "fold0" / "train_projection.jsonl")]
-    assert all(r["query"] != "q1" for r in rows)          # held query absent entirely
-    assert len(rows) == 2
-    meta = json.loads(open(tmp_path / "fold0" / "train_projection.meta.json").read())
-    assert meta["held_queries_excluded"] == 1
+def test_bootstrap_known_answers_and_gate():
+    from sm_fs_bootstrap import BootstrapError, N_BLOCKS, block_draw, decide
+    assert block_draw(3997999, 0, 0) == (60, 0)
+    assert block_draw(3997999, 0, 1) == (57, 0)
+    assert block_draw(3997999, 4999, 41) == (14, 0)
+    assert block_draw(3997999, 9998, 81) == (63, 0)
+    with pytest.raises(BootstrapError, match="82"):
+        decide({"b0": [0.1]})                              # wrong observed block count
+    blocks = {f"b{i:02d}": [] for i in range(N_BLOCKS)}
+    for i in range(19):
+        blocks[f"b{i:02d}"] = [0.02]
+    with pytest.raises(BootstrapError, match="nonempty"):
+        decide(blocks)                                     # <20 nonempty observed blocks
+    for i in range(30):
+        blocks[f"b{i:02d}"] = [float("nan")]
+    with pytest.raises(BootstrapError, match="nonfinite"):
+        decide(blocks)
+
+
+def test_fit_receipt_validation_rejects_substitution():
+    plan = {"projections": {"0": {"projection_sha256": "p" * 64}}}
+    good = {"schema": pl.FIT_SCHEMA, "fold": 0, "arm": "positive_only", "seed": 3997001,
+            "init_sha256": pl.INIT_SHA[3997001], "projection_sha256": "p" * 64,
+            "trainable_names_shapes": [["n", [1]]] * 18,
+            "environment": {"invariant": {"dtype": "float32"}},
+            "checkpoint_sha256": "c" * 64}
+    pl.validate_fit_receipt(dict(good), 0, "positive_only", 3997001, plan)
+    for key, val, err in (
+        ("schema", "wrong", "schema"),
+        ("seed", 3997002, "identity"),
+        ("init_sha256", "0" * 64, "countersigned"),
+        ("projection_sha256", "0" * 64, "plan-bound"),
+        ("trainable_names_shapes", [], "inventory"),
+    ):
+        bad = dict(good)
+        bad[key] = val
+        with pytest.raises(pl.PipelineError, match=err):
+            pl.validate_fit_receipt(bad, 0, "positive_only", 3997001, plan)
+
+
+def test_real_checkpoint_loads_optimizer_constructs_and_one_step_runs():
+    """CAND2-1/8: the countersigned checkpoint, the established loader, a real optimizer,
+    and one executed fit step on synthetic rows (not decision-bearing; outputs discarded)."""
+    torch = pytest.importorskip("torch")
+    import copy
+
+    import numpy as np
+
+    from mu_attention import E5_REVISION, Tokenizer, build_e5_tables
+    ckpt_bytes = pl.read_bound(
+        os.path.join(pl.RANK_DIR, "init_seed3997001.pt"),
+        expect_sha=pl.INIT_SHA[3997001], private=True)
+    model, cfg = pl.load_checkpoint_bytes(ckpt_bytes, "cpu")   # legacy cfg loads (CAND2-1)
+    names, shapes, tensors = pl.resolve_allowlist(model)
+    assert len(shapes) == 18
+    opt = torch.optim.Adam(tensors, lr=pl.ADAM["lr"])
+    ref = copy.deepcopy(model)
+    ref.eval()
+    for p in ref.parameters():
+        p.requires_grad = False
+    titles = {"q/path": "Query Title", "c/path": "Candidate Title"}
+    qtbl, ptbl, idx = build_e5_tables(sorted(titles), cache_path=None, texts=titles,
+                                      model_revision=E5_REVISION)
+    tok = Tokenizer(qtbl, ptbl, idx, {}, {})
+    rows = [{"query": "q/path", "candidate": "c/path", "target": 1.0},
+            {"query": "q/path", "candidate": "c/path", "target": 0.02}]
+    before = tensors[0].detach().clone()
+    loss = pl.fit_one_step(model, ref, tensors, opt, tok, rows, [0], [1],
+                           np.random.default_rng(1), "cpu")
+    assert math.isfinite(loss)
+    assert not torch.equal(before, tensors[0].detach())        # the step really updated


### PR DESCRIPTION
Replacement per #4026's findings, all addressed structurally: established-loader checkpoint path with an executable real-checkpoint one-step fit test (CAND2-1); ID-free sampler seam + fresh v3 plan with the 30-job matrix and all five projection identities (CAND2-2); finalization chain binding the reviewed candidate SHA + review ID against the rigor lane's committed review artifact (CAND2-3); full receipt-chain validation with checkpoint-before-held-bytes ordering and complete per-candidate scores + registered diagnostics (CAND2-4); all-fields lock verification with environment split invariant-enforced/runtime-descriptive (CAND2-5); frozen SHA-256 rejection bootstrap with KAVs + fail-closed nonfinite scoring (CAND2-6); hardened transactions with target rollback and parent checks (CAND2-7); six executable tests through the decision-bearing paths incl. a real one-step fit on the countersigned checkpoint (CAND2-8). New namespace sm_fs_ranking_run_v3; plan sha ff81a8fda9f2cea9; candidate v3 emission follows the merge (binds the landed commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fB4ZfA4bW4XNEnboUncgc